### PR TITLE
fix(xtractor): use dynamic origin for tweetUrl construction

### DIFF
--- a/xtracter/src/content/index.ts
+++ b/xtracter/src/content/index.ts
@@ -109,7 +109,7 @@ function extractMetadataFromUrl(): Partial<TweetMetadata> {
     if (pathParts.length >= 3 && pathParts[1] === 'status') {
         authorId = '@' + pathParts[0];
         // Remove /photo/1, /video/1 to reconstruct base Tweet URL
-        tweetUrl = `https://x.com/${pathParts[0]}/status/${pathParts[2]}`;
+        tweetUrl = `${url.origin}/${pathParts[0]}/status/${pathParts[2]}`;
     }
 
     return { authorId, tweetUrl };


### PR DESCRIPTION
Support domains other than x.com (e.g. twitter.com) by using window.location.origin