### PR TITLE
docs: レビュー指摘事項の修正

### DIFF
--- a/docs/design/browser-extension.md
+++ b/docs/design/browser-extension.md
@@ -349,7 +349,20 @@ formData.append('metadata', JSON.stringify({
 ```json
 {
   "success": true,
-  "mediaId": "uuid-of-uploaded-media"
+  "filePath": "path/to/uploaded/image.jpg"
+}
+```
+
+ファイル名の競合が発生した場合:
+
+```json
+{
+  "success": false,
+  "filePath": "",
+  "conflict": {
+    "existingFile": "image.jpg",
+    "suggestedName": "image_1.jpg"
+  }
 }
 ```
 

--- a/docs/design/orpc-guide.md
+++ b/docs/design/orpc-guide.md
@@ -98,7 +98,7 @@ export const mediaSearchRequestSchema = z.object({
  * メディア検索レスポンス
  */
 export const mediaSearchResponseSchema = z.object({
-  items: z.array(mediaSchema),
+  items: z.array(mediaSchema), // mediaSchema は同ファイル内で定義されたメディア単体のスキーマ
   total: z.number(),
   offset: z.number(),
   limit: z.number().nullable(),

--- a/docs/design/technology-stack.md
+++ b/docs/design/technology-stack.md
@@ -192,8 +192,8 @@ Dependency Management (Python): uv
   - メディアソースのインポート
   - メタデータの復元
 - **実装場所**: 
-  - エクスポート: `src/infrastructure/api/routers/sources-router.ts`
-  - インポート: `src/infrastructure/api/routers/sources-router.ts`
+  - エクスポート: `src/infrastructure/api/app.ts` (REST エンドポイント)
+  - インポート: `src/infrastructure/api/app.ts` (REST エンドポイント)
 
 ### ブラウザ拡張機能 (xtracter)
 - **Chrome Extension**: X (Twitter) から画像を抽出


### PR DESCRIPTION
## 概要
PR #64 のレビューで指摘された3つの問題点を修正しました。

## 修正内容

### 1. **browser-extension.md** - アップロードAPIのレスポンス修正
実際の実装 (`uploadResponseSchema`) に合わせて修正しました。

**修正前**:
```json
{
  "success": true,
  "mediaId": "uuid-of-uploaded-media"
}
```

**修正後**:
```json
{
  "success": true,
  "filePath": "path/to/uploaded/image.jpg"
}
```

さらに、ファイル名競合時のレスポンス例も追加:
```json
{
  "success": false,
  "filePath": "",
  "conflict": {
    "existingFile": "image.jpg",
    "suggestedName": "image_1.jpg"
  }
}
```

### 2. **orpc-guide.md** - mediaSchemaの説明コメント追加
`mediaSchema` が未定義に見える問題を解決するため、説明コメントを追加しました。

```typescript
items: z.array(mediaSchema), // mediaSchema は同ファイル内で定義されたメディア単体のスキーマ
```

### 3. **technology-stack.md** - アーカイブ処理の実装場所修正
`api-design.md` との整合性を取るため、実装場所を修正しました。

**修正前**: `src/infrastructure/api/routers/sources-router.ts`  
**修正後**: `src/infrastructure/api/app.ts` (REST エンドポイント)

実際の実装は `app.ts` の以下の場所にあります:
- `/api/sources/:mediaSourceId/dump` (155行目)
- `/api/sources/:mediaSourceId/import` (191行目)

## 影響範囲
ドキュメントのみの修正で、コードへの影響はありません。

## 関連
- 元PR: #64 (マージ済み)
- レビュー指摘事項を反映