### PR TITLE
fix: add duplicate URL cleanup to migration before unique constraint

### DIFF
--- a/drizzle/0004_chemical_klaw.sql
+++ b/drizzle/0004_chemical_klaw.sql
@@ -1,2 +1,15 @@
 DROP INDEX "idx_media_urls_url";--> statement-breakpoint
+
+-- 重複するURLを削除（最新のcreated_atを持つレコードを残す）
+DELETE FROM "media_urls" 
+WHERE "id" IN (
+  SELECT "id"
+  FROM (
+    SELECT "id", 
+           ROW_NUMBER() OVER (PARTITION BY "url" ORDER BY "created_at" DESC) as rn
+    FROM "media_urls"
+  ) t
+  WHERE t.rn > 1
+);--> statement-breakpoint
+
 CREATE UNIQUE INDEX "idx_media_urls_url_unique" ON "media_urls" USING btree ("url");


### PR DESCRIPTION
## Summary

- マイグレーション `0004_chemical_klaw.sql` にUNIQUE制約を追加する前に、重複URLを削除する処理を追加

## 問題

マイグレーション実行時に以下のエラーが発生：
```
error: could not create unique index "idx_media_urls_url_unique"
Detail: Key (url)=(https://x.com/...) is duplicated.
```

`media_urls` テーブルに重複したURLが存在していたため、UNIQUE制約を追加できませんでした。

## 解決策

マイグレーションファイルに重複削除クエリを追加：
- 各URLごとに、最新の `created_at` を持つレコードを残す
- 古いレコードは削除される
- その後、UNIQUE制約を安全に追加

## テスト結果

```bash
# マイグレーション実行前: 10件以上の重複URL
SELECT COUNT(*) FROM (
  SELECT url FROM media_urls GROUP BY url HAVING COUNT(*) > 1
) t;

# マイグレーション実行後: 重複なし
SELECT COUNT(*) FROM (
  SELECT url FROM media_urls GROUP BY url HAVING COUNT(*) > 1
) t;
# → 0件
```

## 影響範囲

- `media_urls` テーブルの重複レコードが削除されます
- 最新の `created_at` を持つレコードのみが保持されます