### PR TITLE
Implement AI auto-tagging persistence and batch processing

### DIFF
--- a/drizzle/0007_amused_nightshade.sql
+++ b/drizzle/0007_amused_nightshade.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "media_ips" ADD COLUMN "confidence" real;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,2587 @@
+{
+  "id": "7b500850-e180-4e2b-80d5-26b0f716236a",
+  "prevId": "5674d4c3-c8c9-4333-b01e-384546bb0ef7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_authors_account_id": {
+          "name": "idx_authors_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authors_name": {
+          "name": "idx_authors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#808080'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_id": {
+          "name": "ip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_characters_ip_id": {
+          "name": "idx_characters_ip_id",
+          "columns": [
+            {
+              "expression": "ip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_ip_id_ips_id_fk": {
+          "name": "characters_ip_id_ips_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "ips",
+          "columnsFrom": [
+            "ip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "name_ipId_unique": {
+          "name": "name_ipId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "ip_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ips": {
+      "name": "ips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ips_name_unique": {
+          "name": "ips_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "jobs_source_id_media_sources_id_fk": {
+          "name": "jobs_source_id_media_sources_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_authors": {
+      "name": "media_authors",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_authors_author_id_media_id": {
+          "name": "idx_media_authors_author_id_media_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_authors_media_id_media_id_fk": {
+          "name": "media_authors_media_id_media_id_fk",
+          "tableFrom": "media_authors",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_authors_author_id_authors_id_fk": {
+          "name": "media_authors_author_id_authors_id_fk",
+          "tableFrom": "media_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_authors_media_id_author_id_pk": {
+          "name": "media_authors_media_id_author_id_pk",
+          "columns": [
+            "media_id",
+            "author_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_categories": {
+      "name": "media_categories",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_categories_category_id_media_id": {
+          "name": "idx_media_categories_category_id_media_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_categories_media_id_media_id_fk": {
+          "name": "media_categories_media_id_media_id_fk",
+          "tableFrom": "media_categories",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_categories_category_id_categories_id_fk": {
+          "name": "media_categories_category_id_categories_id_fk",
+          "tableFrom": "media_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_categories_media_id_category_id_pk": {
+          "name": "media_categories_media_id_category_id_pk",
+          "columns": [
+            "media_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_characters": {
+      "name": "media_characters",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_characters_character_id_media_id": {
+          "name": "idx_media_characters_character_id_media_id",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_characters_media_id_media_id_fk": {
+          "name": "media_characters_media_id_media_id_fk",
+          "tableFrom": "media_characters",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_characters_character_id_characters_id_fk": {
+          "name": "media_characters_character_id_characters_id_fk",
+          "tableFrom": "media_characters",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_characters_media_id_character_id_pk": {
+          "name": "media_characters_media_id_character_id_pk",
+          "columns": [
+            "media_id",
+            "character_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_collections": {
+      "name": "media_collections",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_collections_media_id": {
+          "name": "idx_media_collections_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_collections_collection_id_collections_id_fk": {
+          "name": "media_collections_collection_id_collections_id_fk",
+          "tableFrom": "media_collections",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_collections_media_id_media_id_fk": {
+          "name": "media_collections_media_id_media_id_fk",
+          "tableFrom": "media_collections",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_collections_collection_id_media_id_pk": {
+          "name": "media_collections_collection_id_media_id_pk",
+          "columns": [
+            "collection_id",
+            "media_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_details": {
+      "name": "media_details",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1970-01-01 00:00:00'"
+        }
+      },
+      "indexes": {
+        "idx_media_details_rating": {
+          "name": "idx_media_details_rating",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_details_favorite": {
+          "name": "idx_media_details_favorite",
+          "columns": [
+            {
+              "expression": "favorite",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_details_view_count": {
+          "name": "idx_media_details_view_count",
+          "columns": [
+            {
+              "expression": "view_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_details_media_id_media_id_fk": {
+          "name": "media_details_media_id_media_id_fk",
+          "tableFrom": "media_details",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_generation_info": {
+      "name": "media_generation_info",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negative_prompt": {
+          "name": "negative_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loras": {
+          "name": "loras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vae": {
+          "name": "vae",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hypernetworks": {
+          "name": "hypernetworks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddings": {
+          "name": "embeddings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "seed": {
+          "name": "seed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": -1
+        },
+        "cfg_scale": {
+          "name": "cfg_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_media_generation_info_metadata": {
+          "name": "idx_media_generation_info_metadata",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_generation_info_ai_generated": {
+          "name": "idx_media_generation_info_ai_generated",
+          "columns": [
+            {
+              "expression": "ai_generated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_generation_info_model_name": {
+          "name": "idx_media_generation_info_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_generation_info_media_id_media_id_fk": {
+          "name": "media_generation_info_media_id_media_id_fk",
+          "tableFrom": "media_generation_info",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_ips": {
+      "name": "media_ips",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_id": {
+          "name": "ip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_ips_ip_id_media_id": {
+          "name": "idx_media_ips_ip_id_media_id",
+          "columns": [
+            {
+              "expression": "ip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_ips_media_id_media_id_fk": {
+          "name": "media_ips_media_id_media_id_fk",
+          "tableFrom": "media_ips",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_ips_ip_id_ips_id_fk": {
+          "name": "media_ips_ip_id_ips_id_fk",
+          "tableFrom": "media_ips",
+          "tableTo": "ips",
+          "columnsFrom": [
+            "ip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_ips_media_id_ip_id_pk": {
+          "name": "media_ips_media_id_ip_id_pk",
+          "columns": [
+            "media_id",
+            "ip_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_projects": {
+      "name": "media_projects",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_projects_project_id_media_id": {
+          "name": "idx_media_projects_project_id_media_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_projects_media_id_media_id_fk": {
+          "name": "media_projects_media_id_media_id_fk",
+          "tableFrom": "media_projects",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_projects_project_id_projects_id_fk": {
+          "name": "media_projects_project_id_projects_id_fk",
+          "tableFrom": "media_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_projects_media_id_project_id_pk": {
+          "name": "media_projects_media_id_project_id_pk",
+          "columns": [
+            "media_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_relations": {
+      "name": "media_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_media_id": {
+          "name": "parent_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_media_id": {
+          "name": "child_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "media_relation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_relations_child": {
+          "name": "idx_media_relations_child",
+          "columns": [
+            {
+              "expression": "child_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_relations_type": {
+          "name": "idx_media_relations_type",
+          "columns": [
+            {
+              "expression": "relation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_relations_parent_media_id_media_id_fk": {
+          "name": "media_relations_parent_media_id_media_id_fk",
+          "tableFrom": "media_relations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "parent_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_relations_child_media_id_media_id_fk": {
+          "name": "media_relations_child_media_id_media_id_fk",
+          "tableFrom": "media_relations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "child_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_child_type_unique": {
+          "name": "parent_child_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "parent_media_id",
+            "child_media_id",
+            "relation_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_sources": {
+      "name": "media_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "media_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_info": {
+          "name": "connection_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_sync": {
+      "name": "media_sync",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "media_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'synced'"
+        },
+        "backup_urls": {
+          "name": "backup_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_attempts": {
+          "name": "sync_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_sync_media_id_media_id_fk": {
+          "name": "media_sync_media_id_media_id_fk",
+          "tableFrom": "media_sync",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_tags": {
+      "name": "media_tags",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_type": {
+          "name": "tag_type",
+          "type": "tag_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'positive'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_tags_tag_id_tag_type_media_id": {
+          "name": "idx_media_tags_tag_id_tag_type_media_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_tags_media_id_media_id_fk": {
+          "name": "media_tags_media_id_media_id_fk",
+          "tableFrom": "media_tags",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_tags_tag_id_tags_id_fk": {
+          "name": "media_tags_tag_id_tags_id_fk",
+          "tableFrom": "media_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_tags_media_id_tag_id_tag_type_pk": {
+          "name": "media_tags_media_id_tag_id_tag_type_pk",
+          "columns": [
+            "media_id",
+            "tag_id",
+            "tag_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_technical_info": {
+      "name": "media_technical_info",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color_profile": {
+          "name": "color_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "exif_data": {
+          "name": "exif_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "hash_md5": {
+          "name": "hash_md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hash_perceptual": {
+          "name": "hash_perceptual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frame_rate": {
+          "name": "frame_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitrate_kbps": {
+          "name": "bitrate_kbps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_codec": {
+          "name": "video_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_technical_info_hash_md5": {
+          "name": "idx_media_technical_info_hash_md5",
+          "columns": [
+            {
+              "expression": "hash_md5",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_technical_info_media_id_media_id_fk": {
+          "name": "media_technical_info_media_id_media_id_fk",
+          "tableFrom": "media_technical_info",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_urls": {
+      "name": "media_urls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_urls_media_id": {
+          "name": "idx_media_urls_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_urls_url": {
+          "name": "idx_media_urls_url",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_urls_media_id_url_unique": {
+          "name": "idx_media_urls_media_id_url_unique",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_urls_media_id_media_id_fk": {
+          "name": "media_urls_media_id_media_id_fk",
+          "tableFrom": "media_urls",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "media_organization_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "idx_media_source_id": {
+          "name": "idx_media_source_id",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_file_size": {
+          "name": "idx_media_file_size",
+          "columns": [
+            {
+              "expression": "file_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_file_name": {
+          "name": "idx_media_file_name",
+          "columns": [
+            {
+              "expression": "file_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_created_at": {
+          "name": "idx_media_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_description": {
+          "name": "idx_media_description",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_source_id_media_sources_id_fk": {
+          "name": "media_source_id_media_sources_id_fk",
+          "tableFrom": "media",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_id_file_path_unique": {
+          "name": "source_id_file_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "file_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presets": {
+      "name": "presets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "presets_name_unique": {
+          "name": "presets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.similar_media": {
+      "name": "similar_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media1_id": {
+          "name": "media1_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media2_id": {
+          "name": "media2_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "similarity_score": {
+          "name": "similarity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'perceptual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_similar_media_score": {
+          "name": "idx_similar_media_score",
+          "columns": [
+            {
+              "expression": "similarity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "similar_media_media1_id_media_id_fk": {
+          "name": "similar_media_media1_id_media_id_fk",
+          "tableFrom": "similar_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "similar_media_media2_id_media_id_fk": {
+          "name": "similar_media_media2_id_media_id_fk",
+          "tableFrom": "similar_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media1Id_media2Id_algorithm_unique": {
+          "name": "media1Id_media2Id_algorithm_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "media1_id",
+            "media2_id",
+            "algorithm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tags_author_id": {
+          "name": "idx_tags_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_author_id_authors_id_fk": {
+          "name": "tags_author_id_authors_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.view_history": {
+      "name": "view_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "view_history_media_id_media_id_fk": {
+          "name": "view_history_media_id_media_id_fk",
+          "tableFrom": "view_history",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.media_organization_status": {
+      "name": "media_organization_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived",
+        "deleted"
+      ]
+    },
+    "public.media_relation_type": {
+      "name": "media_relation_type",
+      "schema": "public",
+      "values": [
+        "variant",
+        "version",
+        "page",
+        "derivative",
+        "edit",
+        "source"
+      ]
+    },
+    "public.media_source_type": {
+      "name": "media_source_type",
+      "schema": "public",
+      "values": [
+        "local",
+        "sftp",
+        "s3"
+      ]
+    },
+    "public.media_sync_status": {
+      "name": "media_sync_status",
+      "schema": "public",
+      "values": [
+        "synced",
+        "pending",
+        "failed"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "video",
+        "audio"
+      ]
+    },
+    "public.tag_type": {
+      "name": "tag_type",
+      "schema": "public",
+      "values": [
+        "positive",
+        "negative"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1769322227565,
       "tag": "0006_overjoyed_vindicator",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1769527302323,
+      "tag": "0007_amused_nightshade",
+      "breakpoints": true
     }
   ]
 }

--- a/src/application/services/job-dispatch-service.ts
+++ b/src/application/services/job-dispatch-service.ts
@@ -1,6 +1,10 @@
 import { services } from "~/application/registry";
 import type { Job as DbJob } from "~/infrastructure/db/schema";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
+import {
+  processAutoTaggingJob,
+  processBulkTaggingDispatchJob,
+} from "~/infrastructure/jobs/tagging-jobs";
 import { logger } from "~/infrastructure/logger";
 
 export type DeferredJob = {
@@ -46,6 +50,10 @@ export async function processJob(job: DbJob) {
       "~/infrastructure/jobs/download-jobs"
     );
     await processDownloadJob(job);
+  } else if (job.type === "auto_tagging") {
+    await processAutoTaggingJob(job);
+  } else if (job.type === "bulk_tagging_dispatch") {
+    await processBulkTaggingDispatchJob(job);
   } else {
     logger.warn({ jobId: job.id, type: job.type }, "Unknown job type");
   }

--- a/src/application/services/job-dispatch-service.ts
+++ b/src/application/services/job-dispatch-service.ts
@@ -36,7 +36,7 @@ export type DeferredActions = {
 // Helper for unified job processing (Called by JobWorker)
 export async function processJob(job: DbJob) {
   const mediaSourceId = job.mediaSourceId;
-  if (!mediaSourceId) {
+  if (!mediaSourceId && job.type !== "bulk_tagging_dispatch") {
     throw new Error(`Job ${job.id} missing mediaSourceId`);
   }
 

--- a/src/application/services/media-processing-service.ts
+++ b/src/application/services/media-processing-service.ts
@@ -204,7 +204,10 @@ export class MediaProcessingServiceImpl {
     // Step 3: AI tagging
     if (this.enableAutoTagging && !payload?.skipMetadataExtraction) {
       try {
-        logger.info({ mediaId }, "AI tagging not yet implemented");
+        const { taggingService } = await import(
+          "~/application/services/tagging-service"
+        );
+        await taggingService.getTagsForMedia(mediaSourceId, mediaId);
       } catch (e) {
         logger.warn({ err: e, mediaId }, "AI tagging failed, skipping");
       }

--- a/src/application/services/media-service.ts
+++ b/src/application/services/media-service.ts
@@ -891,6 +891,7 @@ export class MediaServiceImpl {
       await this.characterRepository.addToMediaBulk(
         newMediaId,
         sourceCharacters.map((c) => ({ id: c.id })),
+        "manual", // source
         tx
       );
     }
@@ -900,7 +901,8 @@ export class MediaServiceImpl {
     if (sourceIps.length > 0) {
       await this.ipRepository.addMediaBulk(
         newMediaId,
-        sourceIps.map((i) => i.id),
+        sourceIps.map((i) => ({ id: i.id })),
+        "manual", // source
         tx
       );
     }

--- a/src/application/services/tagging-service.ts
+++ b/src/application/services/tagging-service.ts
@@ -187,13 +187,19 @@ export class TaggingService {
     }
 
     // 3. Characters
-    // ips_mapping: { ipName: [charName] }
+    // ips_mapping: { charName: [ipName] } - Note: The key is character name, value is list of IP names
     const charToIpMap = new Map<string, string>(); // charName -> ipId
-    for (const [ipName, charNames] of Object.entries(response.ips_mapping)) {
-      const ipId = ipNameIdMap.get(ipName);
-      if (ipId) {
-        for (const charName of charNames) {
+
+    for (const [charName, linkedIpNames] of Object.entries(
+      response.ips_mapping
+    )) {
+      // Find the first linked IP that exists in our DB map
+      // (Currently we only support 1 IP per character in the DB schema)
+      for (const linkedIpName of linkedIpNames) {
+        const ipId = ipNameIdMap.get(linkedIpName);
+        if (ipId) {
           charToIpMap.set(charName, ipId);
+          break; // Use the first matching IP
         }
       }
     }

--- a/src/application/services/tagging-service.ts
+++ b/src/application/services/tagging-service.ts
@@ -161,9 +161,13 @@ export class TaggingService {
     await this.tagRepo.addTagsToMedia(mediaId, tagsToInsert, "AI");
 
     // 2. IPs
+    const ipNames = response.ips;
     const ipNameIdMap = new Map<string, string>();
+    const ipsToLink: { id: string; confidence?: number }[] = [];
 
-    for (const ipName of response.ips) {
+    // Process IPs sequentially to handle potential creations (bulk create/find not fully supported by repo yet without refactor)
+    // TODO: Refactor IpRepository to support findOrCreateBulk for true bulk performance
+    for (const ipName of ipNames) {
       let ip = await this.ipRepo.findByName(ipName);
       if (!ip) {
         try {
@@ -174,8 +178,12 @@ export class TaggingService {
       }
       if (ip) {
         ipNameIdMap.set(ipName, ip.id);
-        await this.ipRepo.addMedia(mediaId, ip.id, undefined, "AI");
+        ipsToLink.push({ id: ip.id });
       }
+    }
+
+    if (ipsToLink.length > 0) {
+      await this.ipRepo.addMediaBulk(mediaId, ipsToLink, "AI");
     }
 
     // 3. Characters
@@ -190,9 +198,14 @@ export class TaggingService {
       }
     }
 
+    const charsToLink: { id: string; confidence: number }[] = [];
+
+    // Process Characters sequentially for creation/update
+    // TODO: Refactor CharacterRepository to support bulk operations
     for (const [charName, confidence] of Object.entries(response.character)) {
       const ipId = charToIpMap.get(charName) ?? undefined;
       let char = await this.characterRepo.findByName(charName);
+
       if (!char) {
         try {
           char = await this.characterRepo.create({
@@ -203,10 +216,22 @@ export class TaggingService {
         } catch (_e) {
           char = await this.characterRepo.findByName(charName);
         }
+      } else if (!char.ipId && ipId) {
+        // Link orphaned character to detected IP
+        try {
+          await this.characterRepo.update(char.id, { ipId });
+        } catch (_e) {
+          // Ignore update errors (e.g. race conditions)
+        }
       }
+
       if (char) {
-        await this.characterRepo.addToMedia(mediaId, char.id, confidence, "AI");
+        charsToLink.push({ id: char.id, confidence });
       }
+    }
+
+    if (charsToLink.length > 0) {
+      await this.characterRepo.addToMediaBulk(mediaId, charsToLink, "AI");
     }
   }
 

--- a/src/application/services/tagging-service.ts
+++ b/src/application/services/tagging-service.ts
@@ -174,12 +174,7 @@ export class TaggingService {
       }
       if (ip) {
         ipNameIdMap.set(ipName, ip.id);
-        await this.ipRepo.addMedia(
-          mediaId,
-          ip.id,
-          DEFAULT_MANUAL_CONFIDENCE,
-          "AI"
-        );
+        await this.ipRepo.addMedia(mediaId, ip.id, undefined, "AI");
       }
     }
 

--- a/src/application/services/tagging-service.ts
+++ b/src/application/services/tagging-service.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import { services } from "~/application/registry";
 import type { IAiClient } from "~/domain/interfaces/ai-client";
+import type { CharacterRepository } from "~/domain/repositories/character-repository";
+import type { IIpRepository } from "~/domain/repositories/ip-repository";
 import type { SourceRepository } from "~/domain/repositories/source-repository";
+import type { TagRepository as TagRepositoryDef } from "~/domain/repositories/tag-repository";
 import type {
   CcipFeatureResponse,
   TaggingResponse,
@@ -13,10 +16,23 @@ import { MediaService } from "./media-service";
 export class TaggingService {
   private readonly aiClient: IAiClient;
   private readonly sourceRepo: SourceRepository;
+  private readonly tagRepo: TagRepositoryDef;
+  private readonly characterRepo: CharacterRepository;
+  private readonly ipRepo: IIpRepository;
 
-  constructor(aiClient: IAiClient, sourceRepo: SourceRepository) {
+  // biome-ignore lint/nursery/useMaxParams: Dependency injection
+  constructor(
+    aiClient: IAiClient,
+    sourceRepo: SourceRepository,
+    tagRepo: TagRepositoryDef,
+    characterRepo: CharacterRepository,
+    ipRepo: IIpRepository
+  ) {
     this.aiClient = aiClient;
     this.sourceRepo = sourceRepo;
+    this.tagRepo = tagRepo;
+    this.characterRepo = characterRepo;
+    this.ipRepo = ipRepo;
   }
 
   async isServiceAvailable(): Promise<boolean> {
@@ -27,9 +43,11 @@ export class TaggingService {
     return await this.aiClient.tagImage(imageBuffer);
   }
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Complex logic
   async getTagsForMedia(
     mediaSourceId: string,
-    mediaId: string
+    mediaId: string,
+    options?: { skipCache?: boolean }
   ): Promise<TaggingResponse> {
     const media = await MediaService.getMedia(mediaSourceId, mediaId);
     if (media.mediaType !== "image") {
@@ -41,11 +59,65 @@ export class TaggingService {
         ips_mapping: {},
       };
     }
+
+    // 1. Check Cache (DB)
+    if (!options?.skipCache) {
+      const existingTags = await this.tagRepo.findByMediaId(mediaId);
+      const aiTags = existingTags.filter((t) => t.source === "AI");
+
+      if (aiTags.length > 0) {
+        const aiCharacters = (
+          await this.characterRepo.getMediaCharacters(mediaId)
+        ).filter((c) => c.associationSource === "AI");
+        const aiIps = (await this.ipRepo.getMediaIps(mediaId)).filter(
+          (i) => i.associationSource === "AI"
+        );
+
+        // Reconstruct response
+        const response: TaggingResponse = {
+          general: {},
+          character: {},
+          ips: aiIps.map((i) => i.name),
+          // biome-ignore lint/style/useNamingConvention: External API uses snake_case
+          ips_mapping: {},
+        };
+
+        for (const tag of aiTags) {
+          // biome-ignore lint/style/noMagicNumbers: Default confidence
+          response.general[tag.name] = tag.confidence ?? 1.0;
+        }
+        for (const char of aiCharacters) {
+          // biome-ignore lint/style/noMagicNumbers: Default confidence
+          response.character[char.name] = char.confidence ?? 1.0;
+        }
+
+        // ips_mapping: We need to know which IP a character belongs to.
+        const ipMap = new Map<string, string>(); // id -> name
+        for (const ip of aiIps) {
+          ipMap.set(ip.id, ip.name);
+          response.ips_mapping[ip.name] = [];
+        }
+
+        for (const char of aiCharacters) {
+          if (char.ipId && ipMap.has(char.ipId)) {
+            const ipName = ipMap.get(char.ipId);
+            if (ipName) {
+              response.ips_mapping[ipName].push(char.name);
+            }
+          }
+        }
+
+        return response;
+      }
+    }
+
     const mediaSource = await this.sourceRepo.findById(mediaSourceId);
 
     if (!mediaSource) {
       throw new Error("Media source not found");
     }
+
+    let response: TaggingResponse;
 
     // Check if AI service is accessible locally (can use path-based API)
     // If AI service is on remote host, we must send the file buffer
@@ -54,16 +126,88 @@ export class TaggingService {
     if (mediaSource.type === "local" && canUsePathApi) {
       const connectionInfo = mediaSource.connectionInfo as { path: string };
       const fullPath = path.join(connectionInfo.path, media.filePath);
-      return await this.aiClient.tagImageByPath(fullPath);
+      response = await this.aiClient.tagImageByPath(fullPath);
+    } else {
+      // Send file buffer when:
+      // - AI service is remote (can't access local paths)
+      // - Media source is not local
+      const { buffer } = await MediaService.getMediaContent(
+        mediaSourceId,
+        mediaId
+      );
+      response = await this.aiClient.tagImage(buffer.buffer as ArrayBuffer);
     }
-    // Send file buffer when:
-    // - AI service is remote (can't access local paths)
-    // - Media source is not local
-    const { buffer } = await MediaService.getMediaContent(
-      mediaSourceId,
-      mediaId
+
+    // Save to DB
+    await this.saveTags(mediaId, response);
+
+    return response;
+  }
+
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Complex logic
+  private async saveTags(
+    mediaId: string,
+    response: TaggingResponse
+  ): Promise<void> {
+    // 1. Tags
+    const tagsToInsert = Object.entries(response.general).map(
+      ([name, confidence]) => ({
+        name,
+        type: "positive" as const,
+        confidence,
+      })
     );
-    return await this.aiClient.tagImage(buffer.buffer as ArrayBuffer);
+    await this.tagRepo.addTagsToMedia(mediaId, tagsToInsert, "AI");
+
+    // 2. IPs
+    const ipNameIdMap = new Map<string, string>();
+
+    for (const ipName of response.ips) {
+      let ip = await this.ipRepo.findByName(ipName);
+      if (!ip) {
+        try {
+          ip = await this.ipRepo.create({ name: ipName, source: "AI" });
+        } catch (_e) {
+          ip = await this.ipRepo.findByName(ipName);
+        }
+      }
+      if (ip) {
+        ipNameIdMap.set(ipName, ip.id);
+        // biome-ignore lint/style/noMagicNumbers: Default confidence
+        await this.ipRepo.addMedia(mediaId, ip.id, 1.0, "AI");
+      }
+    }
+
+    // 3. Characters
+    // ips_mapping: { ipName: [charName] }
+    const charToIpMap = new Map<string, string>(); // charName -> ipId
+    for (const [ipName, charNames] of Object.entries(response.ips_mapping)) {
+      const ipId = ipNameIdMap.get(ipName);
+      if (ipId) {
+        for (const charName of charNames) {
+          charToIpMap.set(charName, ipId);
+        }
+      }
+    }
+
+    for (const [charName, confidence] of Object.entries(response.character)) {
+      const ipId = charToIpMap.get(charName) ?? undefined;
+      let char = await this.characterRepo.findByName(charName);
+      if (!char) {
+        try {
+          char = await this.characterRepo.create({
+            name: charName,
+            ipId, // Link to IP if known
+            source: "AI",
+          });
+        } catch (_e) {
+          char = await this.characterRepo.findByName(charName);
+        }
+      }
+      if (char) {
+        await this.characterRepo.addToMedia(mediaId, char.id, confidence, "AI");
+      }
+    }
   }
 
   async getCcipFeature(imageBuffer: ArrayBuffer): Promise<CcipFeatureResponse> {
@@ -142,7 +286,10 @@ const getTaggingService = () => {
   if (!_taggingService) {
     _taggingService = new TaggingService(
       services.getAiClient(),
-      services.getSourceRepository()
+      services.getSourceRepository(),
+      services.getTagRepository(),
+      services.getCharacterRepository(),
+      services.getIpRepository()
     );
   }
   return _taggingService;

--- a/src/application/services/tagging-service.ts
+++ b/src/application/services/tagging-service.ts
@@ -5,6 +5,7 @@ import type { CharacterRepository } from "~/domain/repositories/character-reposi
 import type { IIpRepository } from "~/domain/repositories/ip-repository";
 import type { SourceRepository } from "~/domain/repositories/source-repository";
 import type { TagRepository as TagRepositoryDef } from "~/domain/repositories/tag-repository";
+import { DEFAULT_MANUAL_CONFIDENCE } from "~/domain/tagging/constants";
 import type {
   CcipFeatureResponse,
   TaggingResponse,
@@ -83,12 +84,12 @@ export class TaggingService {
         };
 
         for (const tag of aiTags) {
-          // biome-ignore lint/style/noMagicNumbers: Default confidence
-          response.general[tag.name] = tag.confidence ?? 1.0;
+          response.general[tag.name] =
+            tag.confidence ?? DEFAULT_MANUAL_CONFIDENCE;
         }
         for (const char of aiCharacters) {
-          // biome-ignore lint/style/noMagicNumbers: Default confidence
-          response.character[char.name] = char.confidence ?? 1.0;
+          response.character[char.name] =
+            char.confidence ?? DEFAULT_MANUAL_CONFIDENCE;
         }
 
         // ips_mapping: We need to know which IP a character belongs to.
@@ -173,8 +174,12 @@ export class TaggingService {
       }
       if (ip) {
         ipNameIdMap.set(ipName, ip.id);
-        // biome-ignore lint/style/noMagicNumbers: Default confidence
-        await this.ipRepo.addMedia(mediaId, ip.id, 1.0, "AI");
+        await this.ipRepo.addMedia(
+          mediaId,
+          ip.id,
+          DEFAULT_MANUAL_CONFIDENCE,
+          "AI"
+        );
       }
     }
 

--- a/src/components/media/media-sidebar.tsx
+++ b/src/components/media/media-sidebar.tsx
@@ -415,7 +415,21 @@ export default function MediaSidebar(props: MediaSidebarProps) {
           <h2 class="font-semibold text-lg">Positive Tags</h2>
           <div class="flex flex-wrap gap-2">
             <For each={positiveTags()}>
-              {(tag) => <Badge>{tag.name}</Badge>}
+              {(tag) => {
+                let badgeClass = "";
+                if (tag.source === "AI") {
+                  badgeClass =
+                    "bg-blue-100 text-blue-800 hover:bg-blue-200 border-blue-200";
+                } else if (tag.source === "comfyui_workflow") {
+                  badgeClass =
+                    "bg-green-100 text-green-800 hover:bg-green-200 border-green-200";
+                }
+                return (
+                  <Badge class={badgeClass} title={`Source: ${tag.source}`}>
+                    {tag.name}
+                  </Badge>
+                );
+              }}
             </For>
           </div>
         </div>
@@ -426,7 +440,25 @@ export default function MediaSidebar(props: MediaSidebarProps) {
           <h2 class="font-semibold text-lg">Negative Tags</h2>
           <div class="flex flex-wrap gap-2">
             <For each={negativeTags()}>
-              {(tag) => <Badge variant="destructive">{tag.name}</Badge>}
+              {(tag) => {
+                let badgeClass = "";
+                if (tag.source === "AI") {
+                  badgeClass =
+                    "bg-blue-50 text-blue-800 hover:bg-blue-100 border-blue-200 border";
+                } else if (tag.source === "comfyui_workflow") {
+                  badgeClass =
+                    "bg-green-50 text-green-800 hover:bg-green-100 border-green-200 border";
+                }
+                return (
+                  <Badge
+                    class={badgeClass}
+                    title={`Source: ${tag.source}`}
+                    variant="destructive"
+                  >
+                    {tag.name}
+                  </Badge>
+                );
+              }}
             </For>
           </div>
         </div>

--- a/src/domain/characters/schemas.ts
+++ b/src/domain/characters/schemas.ts
@@ -11,6 +11,7 @@ export const newCharacterSchema = z.object({
   name: z.string().min(1),
   ipId: z.string().uuid().optional(),
   description: z.string().optional(),
+  source: z.string().optional(),
 });
 
 export const updateCharacterSchema = newCharacterSchema.partial();

--- a/src/domain/ips/schemas.ts
+++ b/src/domain/ips/schemas.ts
@@ -10,6 +10,14 @@ import { z } from "zod";
 export const newIpSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
+  source: z.string().optional(),
+});
+
+export const newCharacterSchema = z.object({
+  name: z.string().min(1),
+  ipId: z.string().uuid().optional(),
+  description: z.string().optional(),
+  source: z.string().optional(),
 });
 
 export const updateIpSchema = newIpSchema.partial();

--- a/src/domain/media/schemas.ts
+++ b/src/domain/media/schemas.ts
@@ -176,6 +176,7 @@ export const tagSchema = z.object({
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
   type: z.enum(["positive", "negative"]), // from mediaTags
+  confidence: z.number().nullable().optional(), // from mediaTags
 });
 export type MediaTag = z.infer<typeof tagSchema>;
 

--- a/src/domain/repositories/character-repository.ts
+++ b/src/domain/repositories/character-repository.ts
@@ -14,6 +14,7 @@ export type {
 export type CharacterRepository = {
   findAll(): Promise<Character[]>;
   findById(id: string, tx?: Transaction): Promise<Character | null>;
+  findByName(name: string, tx?: Transaction): Promise<Character | null>;
   create(character: NewCharacter, tx?: Transaction): Promise<Character>;
   update(
     id: string,
@@ -22,10 +23,17 @@ export type CharacterRepository = {
   ): Promise<Character>;
   delete(id: string, tx?: Transaction): Promise<void>;
   findByMediaId(mediaId: string, tx?: Transaction): Promise<Character[]>;
+  getMediaCharacters(
+    mediaId: string,
+    tx?: Transaction
+  ): Promise<
+    (Character & { confidence: number | null; associationSource: string })[]
+  >;
   addToMedia(
     mediaId: string,
     characterId: string,
     confidence?: number,
+    source?: string,
     tx?: Transaction
   ): Promise<void>;
   removeFromMedia(
@@ -36,6 +44,7 @@ export type CharacterRepository = {
   addToMediaBulk(
     mediaId: string,
     characters: { id: string; confidence?: number }[],
+    source?: string,
     tx?: Transaction
   ): Promise<void>;
 };

--- a/src/domain/repositories/ip-repository.ts
+++ b/src/domain/repositories/ip-repository.ts
@@ -5,17 +5,29 @@ import type { Ip, NewIp, UpdateIp } from "~/domain/ips/schemas";
 export type IIpRepository = {
   findAll(): Promise<Ip[]>;
   findById(id: string, tx?: Transaction): Promise<Ip | null>;
+  findByName(name: string, tx?: Transaction): Promise<Ip | null>;
   create(ip: NewIp, tx?: Transaction): Promise<Ip>;
   update(id: string, ip: UpdateIp, tx?: Transaction): Promise<Ip>;
   delete(id: string, tx?: Transaction): Promise<void>;
 
   // Associations
   findByMediaId(mediaId: string, tx?: Transaction): Promise<Ip[]>;
-  addMedia(mediaId: string, ipId: string, tx?: Transaction): Promise<void>;
+  getMediaIps(
+    mediaId: string,
+    tx?: Transaction
+  ): Promise<(Ip & { confidence: number | null; associationSource: string })[]>;
+  addMedia(
+    mediaId: string,
+    ipId: string,
+    confidence?: number,
+    source?: string,
+    tx?: Transaction
+  ): Promise<void>;
   removeMedia(mediaId: string, ipId: string, tx?: Transaction): Promise<void>;
   addMediaBulk(
     mediaId: string,
-    ipIds: string[],
+    ipsData: { id: string; confidence?: number }[],
+    source?: string,
     tx?: Transaction
   ): Promise<void>;
 };

--- a/src/domain/tagging/constants.ts
+++ b/src/domain/tagging/constants.ts
@@ -1,0 +1,3 @@
+// Constants for tagging domain
+
+export const DEFAULT_MANUAL_CONFIDENCE = 1.0;

--- a/src/domain/tagging/schemas.ts
+++ b/src/domain/tagging/schemas.ts
@@ -43,4 +43,5 @@ export const ccipDifferenceRequestSchema = z.object({
 export const batchTaggingRequestSchema = z.object({
   force: z.boolean().optional(),
   batchSize: z.number().optional(),
+  mediaSourceId: z.string().optional(),
 });

--- a/src/domain/tagging/schemas.ts
+++ b/src/domain/tagging/schemas.ts
@@ -39,3 +39,8 @@ export const ccipDifferenceRequestSchema = z.object({
   feature1: z.array(z.number()),
   feature2: z.array(z.number()),
 });
+
+export const batchTaggingRequestSchema = z.object({
+  force: z.boolean().optional(),
+  batchSize: z.number().optional(),
+});

--- a/src/infrastructure/api/routers/ai-router.ts
+++ b/src/infrastructure/api/routers/ai-router.ts
@@ -1,7 +1,9 @@
 import { os } from "@orpc/server";
 import { z } from "zod";
+import { services } from "~/application/registry";
 import { taggingService } from "~/application/services/tagging-service";
 import {
+  batchTaggingRequestSchema,
   ccipDifferenceRequestSchema,
   ccipFeatureRequestSchema,
   tagImageRequestSchema,
@@ -65,4 +67,15 @@ export const aiRouter = {
       async ({ input }) =>
         await taggingService.getCcipDifference(input.feature1, input.feature2)
     ),
+
+  batchTagging: os
+    .input(batchTaggingRequestSchema)
+    .handler(async ({ input }) => {
+      const jobRepo = services.getJobRepository();
+      await jobRepo.create({
+        type: "bulk_tagging_dispatch",
+        payload: input,
+      });
+      return { success: true, message: "Batch tagging started" };
+    }),
 };

--- a/src/infrastructure/api/routers/ai-router.ts
+++ b/src/infrastructure/api/routers/ai-router.ts
@@ -74,6 +74,7 @@ export const aiRouter = {
       const jobRepo = services.getJobRepository();
       await jobRepo.create({
         type: "bulk_tagging_dispatch",
+        mediaSourceId: input.mediaSourceId, // Optional but good for tracking if provided
         payload: input,
       });
       return { success: true, message: "Batch tagging started" };

--- a/src/infrastructure/db/schema.ts
+++ b/src/infrastructure/db/schema.ts
@@ -493,6 +493,8 @@ export const mediaIps = pgTable(
     ipId: uuid("ip_id")
       .notNull()
       .references(() => ips.id, { onDelete: "cascade" }),
+    /** AIがIPを抽出した際の信頼度スコア (0.0-1.0)。手動の場合はNULL */
+    confidence: real("confidence"),
     /** メディアへのIP付与の起源 (manual, ai_generatedなど) */
     source: text("source").notNull().default("manual"),
   },

--- a/src/infrastructure/jobs/tagging-jobs.ts
+++ b/src/infrastructure/jobs/tagging-jobs.ts
@@ -48,6 +48,11 @@ export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
   const batchSize = payload?.batchSize ?? 1000;
   const mediaSourceId = payload?.mediaSourceId;
 
+  logger.info(
+    { jobId: job.id, mediaSourceId, force, batchSize },
+    "Starting bulk tagging dispatch job"
+  );
+
   const jobRepo = services.getJobRepository();
 
   // Find images
@@ -107,6 +112,12 @@ export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
       .offset(offset);
 
     if (results.length === 0) {
+      if (processedCount === 0) {
+        logger.info(
+          { jobId: job.id, mediaSourceId, force },
+          "No matching images found for bulk tagging"
+        );
+      }
       break;
     }
 

--- a/src/infrastructure/jobs/tagging-jobs.ts
+++ b/src/infrastructure/jobs/tagging-jobs.ts
@@ -1,0 +1,98 @@
+import { and, asc, eq, notExists } from "drizzle-orm";
+import { services } from "~/application/registry";
+import { taggingService } from "~/application/services/tagging-service";
+import { db } from "~/infrastructure/db";
+import { type Job, medias, mediaTags } from "~/infrastructure/db/schema";
+import { logger } from "~/infrastructure/logger";
+
+export async function processAutoTaggingJob(job: Job): Promise<void> {
+  // biome-ignore lint/suspicious/noExplicitAny: Payload type
+  const payload = job.payload as any;
+  const { mediaId, mediaSourceId, force } = payload;
+
+  if (!(mediaId && mediaSourceId)) {
+    throw new Error("Missing mediaId or mediaSourceId");
+  }
+
+  try {
+    await taggingService.getTagsForMedia(mediaSourceId, mediaId, {
+      skipCache: force,
+    });
+  } catch (error) {
+    logger.error({ err: error, mediaId }, "Auto tagging failed");
+    throw error;
+  }
+}
+
+export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
+  // biome-ignore lint/suspicious/noExplicitAny: Payload type
+  const payload = job.payload as any;
+  const force = payload?.force ?? false;
+  // biome-ignore lint/style/noMagicNumbers: Default batch size
+  const batchSize = payload?.batchSize ?? 1000;
+
+  const jobRepo = services.getJobRepository();
+
+  // Find images
+  // Logic: media_type = 'image' AND (force OR NOT EXISTS(AI tags))
+  const whereClause = and(
+    eq(medias.mediaType, "image"),
+    force
+      ? undefined
+      : notExists(
+          db
+            .select()
+            .from(mediaTags)
+            .where(
+              and(eq(mediaTags.mediaId, medias.id), eq(mediaTags.source, "AI"))
+            )
+        )
+  );
+
+  let offset = 0;
+  let processedCount = 0;
+
+  while (true) {
+    const results = await db
+      .select({
+        id: medias.id,
+        mediaSourceId: medias.mediaSourceId,
+      })
+      .from(medias)
+      .where(whereClause)
+      .orderBy(asc(medias.id))
+      .limit(batchSize)
+      .offset(offset);
+
+    if (results.length === 0) {
+      break;
+    }
+
+    // Create jobs
+    for (const row of results) {
+      await jobRepo.create({
+        type: "auto_tagging",
+        mediaSourceId: row.mediaSourceId,
+        payload: {
+          mediaId: row.id,
+          mediaSourceId: row.mediaSourceId,
+          force,
+        },
+      });
+    }
+
+    processedCount += results.length;
+    offset += batchSize;
+
+    // Log progress
+    logger.info(
+      { jobId: job.id, processedCount },
+      "Bulk tagging dispatch progress"
+    );
+  }
+
+  logger.info(
+    { jobId: job.id, processedCount },
+    "Bulk tagging dispatch completed"
+  );
+}

--- a/src/infrastructure/jobs/tagging-jobs.ts
+++ b/src/infrastructure/jobs/tagging-jobs.ts
@@ -5,9 +5,19 @@ import { db } from "~/infrastructure/db";
 import { type Job, medias, mediaTags } from "~/infrastructure/db/schema";
 import { logger } from "~/infrastructure/logger";
 
+type AutoTaggingJobPayload = {
+  mediaId: string;
+  mediaSourceId: string;
+  force?: boolean;
+};
+
+type BulkTaggingDispatchJobPayload = {
+  force?: boolean;
+  batchSize?: number;
+};
+
 export async function processAutoTaggingJob(job: Job): Promise<void> {
-  // biome-ignore lint/suspicious/noExplicitAny: Payload type
-  const payload = job.payload as any;
+  const payload = job.payload as AutoTaggingJobPayload;
   const { mediaId, mediaSourceId, force } = payload;
 
   if (!(mediaId && mediaSourceId)) {
@@ -25,8 +35,7 @@ export async function processAutoTaggingJob(job: Job): Promise<void> {
 }
 
 export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
-  // biome-ignore lint/suspicious/noExplicitAny: Payload type
-  const payload = job.payload as any;
+  const payload = job.payload as BulkTaggingDispatchJobPayload;
   const force = payload?.force ?? false;
   // biome-ignore lint/style/noMagicNumbers: Default batch size
   const batchSize = payload?.batchSize ?? 1000;

--- a/src/infrastructure/jobs/tagging-jobs.ts
+++ b/src/infrastructure/jobs/tagging-jobs.ts
@@ -14,6 +14,7 @@ type AutoTaggingJobPayload = {
 type BulkTaggingDispatchJobPayload = {
   force?: boolean;
   batchSize?: number;
+  mediaSourceId?: string;
 };
 
 export async function processAutoTaggingJob(job: Job): Promise<void> {
@@ -39,13 +40,15 @@ export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
   const force = payload?.force ?? false;
   // biome-ignore lint/style/noMagicNumbers: Default batch size
   const batchSize = payload?.batchSize ?? 1000;
+  const mediaSourceId = payload?.mediaSourceId;
 
   const jobRepo = services.getJobRepository();
 
   // Find images
-  // Logic: media_type = 'image' AND (force OR NOT EXISTS(AI tags))
+  // Logic: media_type = 'image' AND (source_id = ? IF set) AND (force OR NOT EXISTS(AI tags))
   const whereClause = and(
     eq(medias.mediaType, "image"),
+    mediaSourceId ? eq(medias.mediaSourceId, mediaSourceId) : undefined,
     force
       ? undefined
       : notExists(

--- a/src/infrastructure/jobs/tagging-jobs.ts
+++ b/src/infrastructure/jobs/tagging-jobs.ts
@@ -2,7 +2,13 @@ import { and, asc, eq, notExists } from "drizzle-orm";
 import { services } from "~/application/registry";
 import { taggingService } from "~/application/services/tagging-service";
 import { db } from "~/infrastructure/db";
-import { type Job, medias, mediaTags } from "~/infrastructure/db/schema";
+import {
+  type Job,
+  mediaCharacters,
+  mediaIps,
+  medias,
+  mediaTags,
+} from "~/infrastructure/db/schema";
 import { logger } from "~/infrastructure/logger";
 
 type AutoTaggingJobPayload = {
@@ -45,19 +51,43 @@ export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
   const jobRepo = services.getJobRepository();
 
   // Find images
-  // Logic: media_type = 'image' AND (source_id = ? IF set) AND (force OR NOT EXISTS(AI tags))
+  // Logic: media_type = 'image' AND (source_id = ? IF set) AND (force OR NOT (EXISTS(AI tags) OR EXISTS(AI chars) OR EXISTS(AI IPs)))
   const whereClause = and(
     eq(medias.mediaType, "image"),
     mediaSourceId ? eq(medias.mediaSourceId, mediaSourceId) : undefined,
     force
       ? undefined
-      : notExists(
-          db
-            .select()
-            .from(mediaTags)
-            .where(
-              and(eq(mediaTags.mediaId, medias.id), eq(mediaTags.source, "AI"))
-            )
+      : and(
+          notExists(
+            db
+              .select()
+              .from(mediaTags)
+              .where(
+                and(
+                  eq(mediaTags.mediaId, medias.id),
+                  eq(mediaTags.source, "AI")
+                )
+              )
+          ),
+          notExists(
+            db
+              .select()
+              .from(mediaCharacters)
+              .where(
+                and(
+                  eq(mediaCharacters.mediaId, medias.id),
+                  eq(mediaCharacters.source, "AI")
+                )
+              )
+          ),
+          notExists(
+            db
+              .select()
+              .from(mediaIps)
+              .where(
+                and(eq(mediaIps.mediaId, medias.id), eq(mediaIps.source, "AI"))
+              )
+          )
         )
   );
 

--- a/src/infrastructure/repositories/character-repository.ts
+++ b/src/infrastructure/repositories/character-repository.ts
@@ -227,6 +227,21 @@ export class DrizzleCharacterRepository implements CharacterRepository {
   ): Promise<void> {
     try {
       const client = (tx as unknown as TransactionClient) || db;
+
+      let sourceUpdateSql = sql`excluded.source`;
+      let confidenceUpdateSql = sql`excluded.confidence`;
+
+      if (source === "AI") {
+        // Only update if current is 'AI'
+        sourceUpdateSql = sql`CASE WHEN media_characters.source = 'AI' THEN excluded.source ELSE media_characters.source END`;
+        confidenceUpdateSql = sql`CASE WHEN media_characters.source = 'AI' THEN excluded.confidence ELSE media_characters.confidence END`;
+      } else if (source === "manual") {
+        // Update if current is 'AI' or 'manual' (always update basically, unless we have higher prio than manual which we don't for chars yet)
+        // Assuming manual is highest priority for characters for now.
+        sourceUpdateSql = sql`excluded.source`;
+        confidenceUpdateSql = sql`excluded.confidence`;
+      }
+
       await client
         .insert(mediaCharacters)
         .values({
@@ -238,7 +253,8 @@ export class DrizzleCharacterRepository implements CharacterRepository {
         .onConflictDoUpdate({
           target: [mediaCharacters.mediaId, mediaCharacters.characterId],
           set: {
-            confidence: sql`excluded.confidence`,
+            confidence: confidenceUpdateSql,
+            source: sourceUpdateSql,
           },
         });
     } catch (error: unknown) {
@@ -282,6 +298,14 @@ export class DrizzleCharacterRepository implements CharacterRepository {
       return;
     }
 
+    let sourceUpdateSql = sql`excluded.source`;
+    let confidenceUpdateSql = sql`excluded.confidence`;
+
+    if (source === "AI") {
+      sourceUpdateSql = sql`CASE WHEN media_characters.source = 'AI' THEN excluded.source ELSE media_characters.source END`;
+      confidenceUpdateSql = sql`CASE WHEN media_characters.source = 'AI' THEN excluded.confidence ELSE media_characters.confidence END`;
+    }
+
     try {
       await client
         .insert(mediaCharacters)
@@ -296,7 +320,8 @@ export class DrizzleCharacterRepository implements CharacterRepository {
         .onConflictDoUpdate({
           target: [mediaCharacters.mediaId, mediaCharacters.characterId],
           set: {
-            confidence: sql`excluded.confidence`,
+            confidence: confidenceUpdateSql,
+            source: sourceUpdateSql,
           },
         });
     } catch (error) {

--- a/src/infrastructure/repositories/character-repository.ts
+++ b/src/infrastructure/repositories/character-repository.ts
@@ -304,6 +304,9 @@ export class DrizzleCharacterRepository implements CharacterRepository {
     if (source === "AI") {
       sourceUpdateSql = sql`CASE WHEN media_characters.source = 'AI' THEN excluded.source ELSE media_characters.source END`;
       confidenceUpdateSql = sql`CASE WHEN media_characters.source = 'AI' THEN excluded.confidence ELSE media_characters.confidence END`;
+    } else if (source === "manual") {
+      sourceUpdateSql = sql`CASE WHEN media_characters.source IN ('AI', 'manual') THEN excluded.source ELSE media_characters.source END`;
+      confidenceUpdateSql = sql`CASE WHEN media_characters.source IN ('AI', 'manual') THEN excluded.confidence ELSE media_characters.confidence END`;
     }
 
     try {

--- a/src/infrastructure/repositories/character-repository.ts
+++ b/src/infrastructure/repositories/character-repository.ts
@@ -43,6 +43,25 @@ export class DrizzleCharacterRepository implements CharacterRepository {
     }
   }
 
+  async findByName(name: string, tx?: Transaction): Promise<Character | null> {
+    try {
+      const client = (tx as unknown as TransactionClient) || db;
+      const result = await client
+        .select()
+        .from(characters)
+        .where(eq(characters.name, name));
+      if (result.length === 0) {
+        return null;
+      }
+      return result[0] as Character;
+    } catch (error) {
+      throw new UnexpectedError(
+        `Failed to select character by name: ${name}`,
+        error
+      );
+    }
+  }
+
   async create(character: NewCharacter, tx?: Transaction): Promise<Character> {
     try {
       const client = (tx as unknown as TransactionClient) || db;
@@ -159,10 +178,51 @@ export class DrizzleCharacterRepository implements CharacterRepository {
     }
   }
 
+  async getMediaCharacters(
+    mediaId: string,
+    tx?: Transaction
+  ): Promise<
+    (Character & { confidence: number | null; associationSource: string })[]
+  > {
+    try {
+      const client = (tx as unknown as TransactionClient) || db;
+      const results = await client
+        .select({
+          id: characters.id,
+          name: characters.name,
+          description: characters.description,
+          ipId: characters.ipId,
+          createdAt: characters.createdAt,
+          updatedAt: characters.updatedAt,
+          source: characters.source,
+          aliases: characters.aliases,
+          confidence: mediaCharacters.confidence,
+          associationSource: mediaCharacters.source,
+        })
+        .from(characters)
+        .innerJoin(
+          mediaCharacters,
+          eq(characters.id, mediaCharacters.characterId)
+        )
+        .where(eq(mediaCharacters.mediaId, mediaId));
+      return results as (Character & {
+        confidence: number | null;
+        associationSource: string;
+      })[];
+    } catch (error) {
+      throw new UnexpectedError(
+        `Failed to find media characters for media: ${mediaId}`,
+        error
+      );
+    }
+  }
+
+  // biome-ignore lint/nursery/useMaxParams: Repo method
   async addToMedia(
     mediaId: string,
     characterId: string,
     confidence?: number,
+    source = "manual",
     tx?: Transaction
   ): Promise<void> {
     try {
@@ -173,6 +233,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
           mediaId,
           characterId,
           confidence: confidence ?? null,
+          source,
         })
         .onConflictDoUpdate({
           target: [mediaCharacters.mediaId, mediaCharacters.characterId],
@@ -213,6 +274,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
   async addToMediaBulk(
     mediaId: string,
     charactersData: { id: string; confidence?: number }[],
+    source = "manual",
     tx?: Transaction
   ): Promise<void> {
     const client = (tx as unknown as TransactionClient) || db;
@@ -228,6 +290,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
             mediaId,
             characterId: char.id,
             confidence: char.confidence ?? null,
+            source,
           }))
         )
         .onConflictDoUpdate({

--- a/src/infrastructure/repositories/ip-repository.ts
+++ b/src/infrastructure/repositories/ip-repository.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import {
   ResourceConflictError,
   ResourceNotFoundError,
@@ -28,6 +28,12 @@ export const IpRepository: IIpRepository = {
   async findById(id: string, tx?: Transaction): Promise<Ip | null> {
     const client = (tx as unknown as TransactionClient) || db;
     const result = await client.select().from(ips).where(eq(ips.id, id));
+    return result[0] ? mapToDomain(result[0]) : null;
+  },
+
+  async findByName(name: string, tx?: Transaction): Promise<Ip | null> {
+    const client = (tx as unknown as TransactionClient) || db;
+    const result = await client.select().from(ips).where(eq(ips.name, name));
     return result[0] ? mapToDomain(result[0]) : null;
   },
 
@@ -104,13 +110,58 @@ export const IpRepository: IIpRepository = {
     );
   },
 
+  async getMediaIps(
+    mediaId: string,
+    tx?: Transaction
+  ): Promise<
+    (Ip & { confidence: number | null; associationSource: string })[]
+  > {
+    const client = (tx as unknown as TransactionClient) || db;
+    const result = await client
+      .select({
+        id: ips.id,
+        name: ips.name,
+        description: ips.description,
+        source: ips.source,
+        createdAt: ips.createdAt,
+        updatedAt: ips.updatedAt,
+        confidence: mediaIps.confidence,
+        associationSource: mediaIps.source,
+      })
+      .from(ips)
+      .innerJoin(mediaIps, eq(ips.id, mediaIps.ipId))
+      .where(eq(mediaIps.mediaId, mediaId));
+
+    return result.map((i) => ({
+      ...i,
+      createdAt: i.createdAt || new Date(),
+      updatedAt: i.updatedAt || new Date(),
+    }));
+  },
+
+  // biome-ignore lint/nursery/useMaxParams: Repo method
   async addMedia(
     mediaId: string,
     ipId: string,
+    confidence?: number,
+    source = "manual",
     tx?: Transaction
   ): Promise<void> {
     const client = (tx as unknown as TransactionClient) || db;
-    await client.insert(mediaIps).values({ mediaId, ipId }).returning();
+    await client
+      .insert(mediaIps)
+      .values({
+        mediaId,
+        ipId,
+        confidence: confidence ?? null,
+        source,
+      })
+      .onConflictDoUpdate({
+        target: [mediaIps.mediaId, mediaIps.ipId],
+        set: {
+          confidence: sql`excluded.confidence`,
+        },
+      });
   },
 
   async removeMedia(
@@ -130,22 +181,30 @@ export const IpRepository: IIpRepository = {
   },
   async addMediaBulk(
     mediaId: string,
-    ipIds: string[],
+    ipsData: { id: string; confidence?: number }[],
+    source = "manual",
     tx?: Transaction
   ): Promise<void> {
     const client = (tx as unknown as TransactionClient) || db;
-    if (ipIds.length === 0) {
+    if (ipsData.length === 0) {
       return;
     }
 
     await client
       .insert(mediaIps)
       .values(
-        ipIds.map((ipId) => ({
+        ipsData.map((data) => ({
           mediaId,
-          ipId,
+          ipId: data.id,
+          confidence: data.confidence ?? null,
+          source,
         }))
       )
-      .onConflictDoNothing();
+      .onConflictDoUpdate({
+        target: [mediaIps.mediaId, mediaIps.ipId],
+        set: {
+          confidence: sql`excluded.confidence`,
+        },
+      });
   },
 };

--- a/src/infrastructure/repositories/ip-repository.ts
+++ b/src/infrastructure/repositories/ip-repository.ts
@@ -156,8 +156,8 @@ export const IpRepository: IIpRepository = {
       sourceUpdateSql = sql`CASE WHEN media_ips.source = 'AI' THEN excluded.source ELSE media_ips.source END`;
       confidenceUpdateSql = sql`CASE WHEN media_ips.source = 'AI' THEN excluded.confidence ELSE media_ips.confidence END`;
     } else if (source === "manual") {
-      sourceUpdateSql = sql`excluded.source`;
-      confidenceUpdateSql = sql`excluded.confidence`;
+      sourceUpdateSql = sql`CASE WHEN media_ips.source IN ('AI', 'manual') THEN excluded.source ELSE media_ips.source END`;
+      confidenceUpdateSql = sql`CASE WHEN media_ips.source IN ('AI', 'manual') THEN excluded.confidence ELSE media_ips.confidence END`;
     }
 
     await client
@@ -209,6 +209,9 @@ export const IpRepository: IIpRepository = {
     if (source === "AI") {
       sourceUpdateSql = sql`CASE WHEN media_ips.source = 'AI' THEN excluded.source ELSE media_ips.source END`;
       confidenceUpdateSql = sql`CASE WHEN media_ips.source = 'AI' THEN excluded.confidence ELSE media_ips.confidence END`;
+    } else if (source === "manual") {
+      sourceUpdateSql = sql`CASE WHEN media_ips.source IN ('AI', 'manual') THEN excluded.source ELSE media_ips.source END`;
+      confidenceUpdateSql = sql`CASE WHEN media_ips.source IN ('AI', 'manual') THEN excluded.confidence ELSE media_ips.confidence END`;
     }
 
     await client

--- a/src/infrastructure/repositories/ip-repository.ts
+++ b/src/infrastructure/repositories/ip-repository.ts
@@ -148,6 +148,18 @@ export const IpRepository: IIpRepository = {
     tx?: Transaction
   ): Promise<void> {
     const client = (tx as unknown as TransactionClient) || db;
+
+    let sourceUpdateSql = sql`excluded.source`;
+    let confidenceUpdateSql = sql`excluded.confidence`;
+
+    if (source === "AI") {
+      sourceUpdateSql = sql`CASE WHEN media_ips.source = 'AI' THEN excluded.source ELSE media_ips.source END`;
+      confidenceUpdateSql = sql`CASE WHEN media_ips.source = 'AI' THEN excluded.confidence ELSE media_ips.confidence END`;
+    } else if (source === "manual") {
+      sourceUpdateSql = sql`excluded.source`;
+      confidenceUpdateSql = sql`excluded.confidence`;
+    }
+
     await client
       .insert(mediaIps)
       .values({
@@ -159,7 +171,8 @@ export const IpRepository: IIpRepository = {
       .onConflictDoUpdate({
         target: [mediaIps.mediaId, mediaIps.ipId],
         set: {
-          confidence: sql`excluded.confidence`,
+          confidence: confidenceUpdateSql,
+          source: sourceUpdateSql,
         },
       });
   },
@@ -190,6 +203,14 @@ export const IpRepository: IIpRepository = {
       return;
     }
 
+    let sourceUpdateSql = sql`excluded.source`;
+    let confidenceUpdateSql = sql`excluded.confidence`;
+
+    if (source === "AI") {
+      sourceUpdateSql = sql`CASE WHEN media_ips.source = 'AI' THEN excluded.source ELSE media_ips.source END`;
+      confidenceUpdateSql = sql`CASE WHEN media_ips.source = 'AI' THEN excluded.confidence ELSE media_ips.confidence END`;
+    }
+
     await client
       .insert(mediaIps)
       .values(
@@ -203,7 +224,8 @@ export const IpRepository: IIpRepository = {
       .onConflictDoUpdate({
         target: [mediaIps.mediaId, mediaIps.ipId],
         set: {
-          confidence: sql`excluded.confidence`,
+          confidence: confidenceUpdateSql,
+          source: sourceUpdateSql,
         },
       });
   },

--- a/src/infrastructure/repositories/media-repository.ts
+++ b/src/infrastructure/repositories/media-repository.ts
@@ -98,6 +98,8 @@ function mapToMediaDetails(row: MediaWithRelations): MediaDetails {
     tags: row.tags.map((mt) => ({
       ...mt.tag,
       type: mt.tagType,
+      source: mt.source,
+      confidence: mt.confidence,
     })),
     generationInfo: row.generationInfo
       ? {

--- a/src/infrastructure/repositories/tag-repository.ts
+++ b/src/infrastructure/repositories/tag-repository.ts
@@ -43,6 +43,7 @@ type MediaTagResult = {
   createdAt: Date;
   updatedAt: Date;
   type: "positive" | "negative";
+  confidence: number | null;
 };
 
 function mapToMediaTag(row: MediaTagResult): MediaTag {
@@ -57,6 +58,7 @@ function mapToMediaTag(row: MediaTagResult): MediaTag {
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     type: row.type,
+    confidence: row.confidence,
   };
 }
 
@@ -174,11 +176,12 @@ export class DrizzleTagRepository implements TagRepositoryDef {
           description: tags.description,
           attribute: tags.attribute,
           color: tags.color,
-          source: tags.source,
+          source: mediaTags.source,
           authorId: tags.authorId,
           createdAt: tags.createdAt,
           updatedAt: tags.updatedAt,
           type: mediaTags.tagType,
+          confidence: mediaTags.confidence,
         })
         .from(mediaTags)
         .innerJoin(tags, eq(mediaTags.tagId, tags.id))

--- a/src/infrastructure/repositories/tag-repository.ts
+++ b/src/infrastructure/repositories/tag-repository.ts
@@ -255,13 +255,45 @@ export class DrizzleTagRepository implements TagRepositoryDef {
         });
 
         if (mediaTagsToInsert.length > 0) {
+          // Priority: comfyui_workflow > manual > AI
+          // Update source and confidence ONLY if the new source has higher or equal priority
+          // or if the current source is lower priority.
+          // Since we can't easily express "if new is manual and old is AI" in a single static SQL statement
+          // without extensive CASE WHENs that depend on the input row's source (which is constant per batch here but conceptually row-dependent),
+          // we use a CASE statement.
+
+          // Logic:
+          // If existing is comfyui_workflow: NEVER update (unless new is also comfyui_workflow, then update confidence)
+          // If existing is manual: Update if new is comfyui_workflow.
+          // If existing is AI: Update if new is anything (manual, comfyui, or AI update).
+
+          // However, `source` argument is constant for the whole batch.
+          // We can simplify the logic based on the *input* source.
+
+          let sourceUpdateSql = sql`excluded.source`;
+          let confidenceUpdateSql = sql`excluded.confidence`;
+
+          if (source === "AI") {
+            // Only update if current is 'AI' (or implicitly if it didn't exist, which insert handles)
+            // If current is 'manual' or 'comfyui_workflow', DO NOT update.
+            sourceUpdateSql = sql`CASE WHEN media_tags.source = 'AI' THEN excluded.source ELSE media_tags.source END`;
+            confidenceUpdateSql = sql`CASE WHEN media_tags.source = 'AI' THEN excluded.confidence ELSE media_tags.confidence END`;
+          } else if (source === "manual") {
+            // Update if current is 'AI' or 'manual'.
+            // If current is 'comfyui_workflow', DO NOT update.
+            sourceUpdateSql = sql`CASE WHEN media_tags.source IN ('AI', 'manual') THEN excluded.source ELSE media_tags.source END`;
+            confidenceUpdateSql = sql`CASE WHEN media_tags.source IN ('AI', 'manual') THEN excluded.confidence ELSE media_tags.confidence END`;
+          }
+          // If source is 'comfyui_workflow', it overrides everything (default behavior of upsert is fine, or we can be explicit)
+
           await (t as unknown as TransactionClient)
             .insert(mediaTags)
             .values(mediaTagsToInsert)
             .onConflictDoUpdate({
               target: [mediaTags.mediaId, mediaTags.tagId, mediaTags.tagType],
               set: {
-                confidence: sql`excluded.confidence`,
+                confidence: confidenceUpdateSql,
+                source: sourceUpdateSql,
               },
             });
         }

--- a/src/routes/manager.tsx
+++ b/src/routes/manager.tsx
@@ -52,14 +52,14 @@ import {
   fetchAllIps,
   updateIp,
 } from "~/infrastructure/api-clients/ips-api";
-import { client } from "~/infrastructure/api-clients/orpc-client";
+import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import {
   createProject,
   deleteProject,
   fetchAllProjects,
   updateProject,
 } from "~/infrastructure/api-clients/projects-api";
-import { fetchSources } from "~/infrastructure/api-clients/sources-api";
+import { fetchMediaSources } from "~/infrastructure/api-clients/sources-api";
 
 type EntityType = "projects" | "ips" | "characters" | "tagging";
 type Entity = Project | Ip | Character;
@@ -99,7 +99,7 @@ export default function ManagerPage() {
   }));
   const sources = createQuery(() => ({
     queryKey: ["allSources"],
-    queryFn: fetchSources,
+    queryFn: fetchMediaSources,
   }));
 
   const invalidateQueries = () => {
@@ -210,7 +210,7 @@ export default function ManagerPage() {
   const handleStartBatchTagging = async () => {
     try {
       setTaggingStatus("Starting...");
-      const result = await client.ai.batchTagging({
+      const result = await orpc.ai.batchTagging({
         force: forceRetag(),
         mediaSourceId: selectedSourceId(),
       });
@@ -294,20 +294,34 @@ export default function ManagerPage() {
               <div class="grid gap-2">
                 <Label>Target Media Source (Optional)</Label>
                 <Select
-                  onChange={(value) => setSelectedSourceId(value?.id)}
-                  options={sources.data || []}
+                  itemComponent={(props) => (
+                    <SelectItem item={props.item}>
+                      {props.item.rawValue.name}
+                    </SelectItem>
+                  )}
+                  onChange={(val) => setSelectedSourceId(val?.id || "")}
+                  options={Array.isArray(sources.data) ? sources.data : []}
                   optionTextValue="name"
                   optionValue="id"
                   placeholder="All Sources"
                   value={
                     selectedSourceId()
-                      ? sources.data?.find((s) => s.id === selectedSourceId())
-                      : undefined
+                      ? (Array.isArray(sources.data) ? sources.data : []).find(
+                          (s) => s.id === selectedSourceId()
+                        )
+                      : null
                   }
                 >
                   <SelectTrigger>
-                    <SelectValue>
-                      {(state) => state.selectedOption()?.name || "All Sources"}
+                    <SelectValue<unknown>>
+                      {(state) => {
+                        const option = state.selectedOption();
+                        return option &&
+                          typeof option === "object" &&
+                          "name" in option
+                          ? (option as { name: string }).name
+                          : "All Sources";
+                      }}
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent />
@@ -444,21 +458,30 @@ export default function ManagerPage() {
                       </SelectItem>
                     )}
                     onChange={(value) =>
-                      setFormData({ ...formData(), ipId: value?.id })
+                      setFormData({ ...formData(), ipId: value?.id || "" })
                     }
-                    options={ips.data || []}
+                    options={Array.isArray(ips.data) ? ips.data : []}
                     optionTextValue="name"
                     optionValue="id"
                     placeholder="Select an IP"
                     value={
                       formData().ipId
-                        ? ips.data?.find((ip) => ip.id === formData().ipId)
-                        : undefined
+                        ? (Array.isArray(ips.data) ? ips.data : []).find(
+                            (ip) => ip.id === formData().ipId
+                          )
+                        : null
                     }
                   >
                     <SelectTrigger>
-                      <SelectValue<Ip>>
-                        {(state) => state.selectedOption()?.name}
+                      <SelectValue<unknown>>
+                        {(state) => {
+                          const option = state.selectedOption();
+                          return option &&
+                            typeof option === "object" &&
+                            "name" in option
+                            ? (option as { name: string }).name
+                            : "Select an IP";
+                        }}
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent />

--- a/src/routes/manager.tsx
+++ b/src/routes/manager.tsx
@@ -19,7 +19,11 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
-import { Checkbox } from "~/components/ui/checkbox";
+import {
+  Checkbox,
+  CheckboxControl,
+  CheckboxLabel,
+} from "~/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -334,10 +338,13 @@ export default function ManagerPage() {
               <div class="flex items-center space-x-2">
                 <Checkbox
                   checked={forceRetag()}
+                  class="flex items-center space-x-2"
                   id="force-retag"
                   onChange={setForceRetag}
-                />
-                <Label for="force-retag">Force Re-tagging</Label>
+                >
+                  <CheckboxControl />
+                  <CheckboxLabel>Force Re-tagging</CheckboxLabel>
+                </Checkbox>
               </div>
               <p class="text-muted-foreground text-xs">
                 If checked, existing AI tags will be ignored and images will be

--- a/src/routes/manager.tsx
+++ b/src/routes/manager.tsx
@@ -19,6 +19,7 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
+import { Checkbox } from "~/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -51,14 +52,16 @@ import {
   fetchAllIps,
   updateIp,
 } from "~/infrastructure/api-clients/ips-api";
+import { client } from "~/infrastructure/api-clients/orpc-client";
 import {
   createProject,
   deleteProject,
   fetchAllProjects,
   updateProject,
 } from "~/infrastructure/api-clients/projects-api";
+import { fetchSources } from "~/infrastructure/api-clients/sources-api";
 
-type EntityType = "projects" | "ips" | "characters";
+type EntityType = "projects" | "ips" | "characters" | "tagging";
 type Entity = Project | Ip | Character;
 
 export default function ManagerPage() {
@@ -73,6 +76,13 @@ export default function ManagerPage() {
     ipId?: string;
   }>({ name: "", description: "" });
 
+  // Tagging State
+  const [selectedSourceId, setSelectedSourceId] = createSignal<
+    string | undefined
+  >(undefined);
+  const [forceRetag, setForceRetag] = createSignal(false);
+  const [taggingStatus, setTaggingStatus] = createSignal<string | null>(null);
+
   const queryClient = useQueryClient();
 
   const projects = createQuery(() => ({
@@ -86,6 +96,10 @@ export default function ManagerPage() {
   const characters = createQuery(() => ({
     queryKey: ["allCharacters"],
     queryFn: fetchAllCharacters,
+  }));
+  const sources = createQuery(() => ({
+    queryKey: ["allSources"],
+    queryFn: fetchSources,
   }));
 
   const invalidateQueries = () => {
@@ -193,6 +207,26 @@ export default function ManagerPage() {
     }
   };
 
+  const handleStartBatchTagging = async () => {
+    try {
+      setTaggingStatus("Starting...");
+      const result = await client.ai.batchTagging({
+        force: forceRetag(),
+        mediaSourceId: selectedSourceId(),
+      });
+      if (result.success) {
+        toast.success(result.message);
+        setTaggingStatus("Batch tagging started successfully.");
+      } else {
+        toast.error("Failed to start batch tagging.");
+        setTaggingStatus("Failed to start batch tagging.");
+      }
+    } catch (e) {
+      toast.error(`Error: ${(e as Error).message}`);
+      setTaggingStatus(`Error: ${(e as Error).message}`);
+    }
+  };
+
   return (
     <div class="container mx-auto p-8">
       <div class="mb-8 flex items-center justify-between">
@@ -234,54 +268,133 @@ export default function ManagerPage() {
         >
           Characters
         </button>
+        <button
+          class={`border-b-2 px-4 py-2 font-medium transition-colors ${
+            activeTab() === "tagging"
+              ? "border-primary text-primary"
+              : "border-transparent text-muted-foreground hover:text-foreground"
+          }`}
+          onClick={() => setActiveTab("tagging")}
+          type="button"
+        >
+          Batch Tagging
+        </button>
       </div>
 
-      <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        <For each={getActiveItems()}>
-          {(item) => (
-            <Card>
-              <CardHeader>
-                <CardTitle>{item.name}</CardTitle>
-                <Show when={item.description}>
-                  <CardDescription>{item.description}</CardDescription>
-                </Show>
-                <Show
-                  when={
-                    activeTab() === "characters" && (item as Character).ipId
+      <Show when={activeTab() === "tagging"}>
+        <div class="max-w-xl space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Batch AI Tagging</CardTitle>
+              <CardDescription>
+                Analyze and tag images across your media sources using AI.
+              </CardDescription>
+            </CardHeader>
+            <CardContent class="space-y-4">
+              <div class="grid gap-2">
+                <Label>Target Media Source (Optional)</Label>
+                <Select
+                  onChange={(value) => setSelectedSourceId(value?.id)}
+                  options={sources.data || []}
+                  optionTextValue="name"
+                  optionValue="id"
+                  placeholder="All Sources"
+                  value={
+                    selectedSourceId()
+                      ? sources.data?.find((s) => s.id === selectedSourceId())
+                      : undefined
                   }
                 >
-                  <CardDescription>
-                    IP:{" "}
-                    {ips.data?.find((ip) => ip.id === (item as Character).ipId)
-                      ?.name || "Unknown"}
-                  </CardDescription>
-                </Show>
-              </CardHeader>
-              <CardContent>
-                <div class="flex justify-end space-x-2">
-                  <Button
-                    onClick={() => openEditDialog(item)}
-                    size="sm"
-                    variant="outline"
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    onClick={() => {
-                      setItemToDelete(item);
-                      setIsDeleteDialogOpen(true);
-                    }}
-                    size="sm"
-                    variant="destructive"
-                  >
-                    Delete
-                  </Button>
+                  <SelectTrigger>
+                    <SelectValue>
+                      {(state) => state.selectedOption()?.name || "All Sources"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent />
+                </Select>
+                <p class="text-muted-foreground text-xs">
+                  Leave empty to process all sources.
+                </p>
+              </div>
+
+              <div class="flex items-center space-x-2">
+                <Checkbox
+                  checked={forceRetag()}
+                  id="force-retag"
+                  onChange={setForceRetag}
+                />
+                <Label for="force-retag">Force Re-tagging</Label>
+              </div>
+              <p class="text-muted-foreground text-xs">
+                If checked, existing AI tags will be ignored and images will be
+                re-analyzed.
+              </p>
+
+              <div class="pt-2">
+                <Button onClick={handleStartBatchTagging}>
+                  Start Batch Tagging
+                </Button>
+              </div>
+
+              <Show when={taggingStatus()}>
+                <div class="mt-4 rounded bg-gray-100 p-2 text-sm">
+                  {taggingStatus()}
                 </div>
-              </CardContent>
-            </Card>
-          )}
-        </For>
-      </div>
+              </Show>
+            </CardContent>
+          </Card>
+        </div>
+      </Show>
+
+      <Show when={activeTab() !== "tagging"}>
+        <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <For each={getActiveItems()}>
+            {(item) => (
+              <Card>
+                <CardHeader>
+                  <CardTitle>{item.name}</CardTitle>
+                  <Show when={item.description}>
+                    <CardDescription>{item.description}</CardDescription>
+                  </Show>
+                  <Show
+                    when={
+                      activeTab() === "characters" && (item as Character).ipId
+                    }
+                  >
+                    <CardDescription>
+                      IP:{" "}
+                      {ips.data?.find(
+                        (ip) => ip.id === (item as Character).ipId
+                      )?.name || "Unknown"}
+                    </CardDescription>
+                  </Show>
+                </CardHeader>
+                <CardContent>
+                  <div class="flex justify-end space-x-2">
+                    <Button
+                      onClick={() => openEditDialog(item)}
+                      size="sm"
+                      variant="outline"
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        setItemToDelete(item);
+                        setIsDeleteDialogOpen(true);
+                      }}
+                      size="sm"
+                      variant="destructive"
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </For>
+        </div>
+      </Show>
 
       <Dialog onOpenChange={setIsDialogOpen} open={isDialogOpen()}>
         <DialogContent>

--- a/src/tests/unit/application/services/tagging-service.test.ts
+++ b/src/tests/unit/application/services/tagging-service.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TaggingService } from "~/application/services/tagging-service";
+import type { IAiClient } from "~/domain/interfaces/ai-client";
+import type { CharacterRepository } from "~/domain/repositories/character-repository";
+import type { IIpRepository } from "~/domain/repositories/ip-repository";
+import type { SourceRepository } from "~/domain/repositories/source-repository";
+import type { TagRepository } from "~/domain/repositories/tag-repository";
+
+// biome-ignore lint/style/noMagicNumbers: Test data
+const MOCK_BUFFER_DATA = [1, 2, 3];
+
+// Mock MediaService
+vi.mock("~/application/services/media-service", () => ({
+  // biome-ignore lint/style/useNamingConvention: Mocking exported module name
+  MediaService: {
+    getMedia: vi.fn(() =>
+      Promise.resolve({
+        id: "media-1",
+        mediaType: "image",
+        filePath: "remote/path.jpg",
+      })
+    ),
+    getMediaContent: vi.fn(() =>
+      Promise.resolve({
+        buffer: new Uint8Array(MOCK_BUFFER_DATA),
+      })
+    ),
+  },
+}));
+
+describe("TaggingService", () => {
+  let taggingService: TaggingService;
+  let mockAiClient: IAiClient;
+  let mockSourceRepo: SourceRepository;
+  let mockTagRepo: TagRepository;
+  let mockCharacterRepo: CharacterRepository;
+  let mockIpRepo: IIpRepository;
+
+  beforeEach(() => {
+    mockAiClient = {
+      healthCheck: vi.fn(() => Promise.resolve(true)),
+      tagImage: vi.fn(),
+      tagImageByPath: vi.fn(),
+      extractCcipFeature: vi.fn(),
+      extractCcipFeatureByPath: vi.fn(),
+      calculateCcipDifference: vi.fn(),
+    } as unknown as IAiClient;
+
+    mockSourceRepo = {
+      findById: vi.fn((id: string) =>
+        Promise.resolve({
+          id,
+          type: "s3", // remote source to trigger buffer flow
+          connectionInfo: {},
+        })
+      ),
+    } as unknown as SourceRepository;
+
+    mockTagRepo = {
+      findByMediaId: vi.fn(() => Promise.resolve([])),
+      addTagsToMedia: vi.fn(() => Promise.resolve()),
+    } as unknown as TagRepository;
+
+    mockIpRepo = {
+      findByName: vi.fn((name: string) =>
+        Promise.resolve(
+          name === "ExistingIP" ? { id: "ip-1", name: "ExistingIP" } : null
+        )
+      ),
+      create: vi.fn((data: { name: string }) =>
+        Promise.resolve({ id: "ip-new", name: data.name })
+      ),
+      addMediaBulk: vi.fn(() => Promise.resolve()),
+      getMediaIps: vi.fn(() => Promise.resolve([])),
+    } as unknown as IIpRepository;
+
+    mockCharacterRepo = {
+      findByName: vi.fn(() => Promise.resolve(null)),
+      create: vi.fn((data: { name: string; ipId?: string }) =>
+        Promise.resolve({ id: "char-new", name: data.name, ipId: data.ipId })
+      ),
+      update: vi.fn(() => Promise.resolve()),
+      addToMediaBulk: vi.fn(() => Promise.resolve()),
+      getMediaCharacters: vi.fn(() => Promise.resolve([])),
+    } as unknown as CharacterRepository;
+
+    taggingService = new TaggingService(
+      mockAiClient,
+      mockSourceRepo,
+      mockTagRepo,
+      mockCharacterRepo,
+      mockIpRepo
+    );
+  });
+
+  it("should correctly link characters to IPs based on ips_mapping", async () => {
+    // Setup AI response with character -> ip mapping
+    (mockAiClient.tagImage as any).mockResolvedValue({
+      general: { "1girl": 0.9 },
+      // biome-ignore lint/style/useNamingConvention: Simulating external API response
+      character: { HatsuneMiku: 0.95 },
+      ips: ["Vocaloid"],
+      // biome-ignore lint/style/useNamingConvention: External API uses snake_case
+      ips_mapping: {
+        // Character Name -> List of IP Names
+        // biome-ignore lint/style/useNamingConvention: Simulating external API response
+        HatsuneMiku: ["Vocaloid"],
+      },
+    });
+
+    // Mock IP repo to return an IP for "Vocaloid"
+    (mockIpRepo.findByName as any).mockImplementation((name: string) => {
+      if (name === "Vocaloid") {
+        return Promise.resolve({ id: "ip-vocaloid", name: "Vocaloid" });
+      }
+      return Promise.resolve(null);
+    });
+
+    await taggingService.getTagsForMedia("source-1", "media-1");
+
+    // Verify IP was looked up/created and linked to media
+    expect(mockIpRepo.addMediaBulk).toHaveBeenCalledWith(
+      "media-1",
+      expect.arrayContaining([expect.objectContaining({ id: "ip-vocaloid" })]),
+      "AI"
+    );
+
+    // Verify character creation included the ipId
+    expect(mockCharacterRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "HatsuneMiku",
+        ipId: "ip-vocaloid", // Crucial: Character should be linked to IP
+        source: "AI",
+      })
+    );
+
+    // Verify character was linked to media
+    expect(mockCharacterRepo.addToMediaBulk).toHaveBeenCalledWith(
+      "media-1",
+      expect.arrayContaining([
+        expect.objectContaining({ id: "char-new", confidence: 0.95 }),
+      ]),
+      "AI"
+    );
+  });
+});


### PR DESCRIPTION
This PR implements the persistence and automation of AI tagging.
It adds `confidence` to the `media_ips` table, updates repositories to handle metadata sources and confidence scores, and implements a caching mechanism in `TaggingService`.
It also introduces background jobs for auto-tagging new media and bulk-tagging existing media, exposed via a new API endpoint.

---
*PR created automatically by Jules for task [9595466781331218916](https://jules.google.com/task/9595466781331218916) started by @hmjn023*