### PR TITLE
feat: enhance backup/restore to include source and confidence for relations

### DIFF
--- a/src/application/services/backup-service.ts
+++ b/src/application/services/backup-service.ts
@@ -428,7 +428,7 @@ export const BackupService = {
                 ? t.type
                 : "positive") as "positive" | "negative",
               confidence: t.confidence ?? null,
-              source: "restored",
+              source: t.source || "restored",
             });
           }
         }
@@ -456,7 +456,12 @@ export const BackupService = {
         for (const i of item.ips) {
           const ipId = i.name ? ipMap.get(i.name) : undefined;
           if (ipId) {
-            mediaIpsData.push({ mediaId, ipId, source: "restored" });
+            mediaIpsData.push({
+              mediaId,
+              ipId,
+              confidence: i.confidence ?? null,
+              source: i.source || "restored",
+            });
           }
         }
       }
@@ -472,7 +477,7 @@ export const BackupService = {
               mediaId,
               characterId: charId,
               confidence: c.confidence ?? null,
-              source: "restored",
+              source: c.source || "restored",
             });
 
             // Determine which IPs to link to this character
@@ -910,6 +915,7 @@ export const BackupService = {
         name: mt.tag.name,
         type: mt.tagType,
         confidence: mt.confidence,
+        source: mt.source,
       }));
 
       // Extract authors
@@ -927,6 +933,7 @@ export const BackupService = {
         confidence: mc.confidence,
         // biome-ignore lint/suspicious/noExplicitAny: inferrence failing
         linkedIps: mc.character.ips?.map((ci: any) => ci.ip.name),
+        source: mc.source,
       }));
 
       // Extract IPs
@@ -934,6 +941,8 @@ export const BackupService = {
       const simpleIps = media.ips.map((mi: any) => ({
         name: mi.ip.name,
         description: mi.ip.description,
+        confidence: mi.confidence,
+        source: mi.source,
       }));
 
       // Extract Projects

--- a/src/domain/media/schemas.ts
+++ b/src/domain/media/schemas.ts
@@ -261,6 +261,7 @@ export const mediaMetadataContextSchema = z.object({
         name: z.string(),
         type: z.enum(["positive", "negative"]).optional(),
         confidence: z.number().optional(),
+        source: z.string().optional(),
       })
     )
     .optional(),
@@ -271,6 +272,7 @@ export const mediaMetadataContextSchema = z.object({
         description: z.string().nullable().optional(),
         confidence: z.number().optional(),
         linkedIps: z.array(z.string()).optional(),
+        source: z.string().optional(),
       })
     )
     .optional(),
@@ -279,6 +281,8 @@ export const mediaMetadataContextSchema = z.object({
       z.object({
         name: z.string(),
         description: z.string().nullable().optional(),
+        confidence: z.number().optional(),
+        source: z.string().optional(),
       })
     )
     .optional(),

--- a/src/tests/unit/application/services/backup-service.test.ts
+++ b/src/tests/unit/application/services/backup-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { BackupService } from "~/application/services/backup-service";
+import type { MediaDumpItem } from "~/domain/media/schemas";
 import { db } from "~/infrastructure/db";
 import {
   mediaTags,
@@ -130,7 +131,7 @@ describe("BackupService", () => {
 
   describe("_restoreRelations", () => {
     it("should restore source and confidence for relations", async () => {
-      const validItems = [
+      const validItems: MediaDumpItem[] = [
         {
           filePath: "media1.jpg",
           tags: [
@@ -165,7 +166,7 @@ describe("BackupService", () => {
       ]);
 
       await BackupService._restoreRelations({
-        validItems: validItems as any,
+        validItems,
         mediaPathToId,
         tagMap,
         authorMap: new Map(),

--- a/src/tests/unit/application/services/backup-service.test.ts
+++ b/src/tests/unit/application/services/backup-service.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { BackupService } from "~/application/services/backup-service";
+import { db } from "~/infrastructure/db";
+import {
+  mediaTags,
+  mediaCharacters,
+  mediaIps,
+} from "~/infrastructure/db/schema";
+
+const { mockValues, mockDelete, mockFindMany } = vi.hoisted(() => ({
+  mockValues: vi.fn(() => ({
+    onConflictDoNothing: vi.fn(),
+    onConflictDoUpdate: vi.fn(),
+  })),
+  mockDelete: vi.fn(() => ({
+    where: vi.fn(),
+  })),
+  mockFindMany: vi.fn(),
+}));
+
+vi.mock("~/infrastructure/db", () => ({
+  db: {
+    query: {
+      medias: {
+        findMany: mockFindMany,
+        findFirst: vi.fn(),
+      },
+      mediaSources: {
+        findFirst: vi.fn(),
+      },
+    },
+    insert: vi.fn(() => ({
+      values: mockValues,
+    })),
+    delete: mockDelete,
+    select: vi.fn(),
+  },
+}));
+
+describe("BackupService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("_transformMediaList", () => {
+    it("should include source and confidence in the exported dump", () => {
+      const mockMediaList = [
+        {
+          id: "media-1",
+          filePath: "path/to/media.jpg",
+          fileName: "media.jpg",
+          // ... other fields
+          tags: [
+            {
+              tag: { name: "tag1" },
+              tagType: "positive",
+              confidence: 0.95,
+              source: "AI",
+            },
+            {
+              tag: { name: "tag2" },
+              tagType: "negative",
+              confidence: null,
+              source: "manual",
+            },
+          ],
+          characters: [
+            {
+              character: {
+                name: "char1",
+                description: "desc",
+                ips: [{ ip: { name: "ip1" } }],
+              },
+              confidence: 0.8,
+              source: "AI",
+            },
+          ],
+          ips: [
+            {
+              ip: { name: "ip1", description: "desc" },
+              confidence: 0.7,
+              source: "AI",
+            },
+          ],
+          authors: [],
+          projects: [],
+          urls: [],
+          generationInfo: null,
+        },
+      ];
+
+      const result = BackupService._transformMediaList(mockMediaList);
+
+      expect(result).toHaveLength(1);
+      const item = result[0];
+
+      // Verify Tags
+      expect(item.tags).toHaveLength(2);
+      expect(item.tags?.[0]).toMatchObject({
+        name: "tag1",
+        type: "positive",
+        confidence: 0.95,
+        source: "AI",
+      });
+      expect(item.tags?.[1]).toMatchObject({
+        name: "tag2",
+        type: "negative",
+        confidence: null,
+        source: "manual",
+      });
+
+      // Verify Characters
+      expect(item.characters).toHaveLength(1);
+      expect(item.characters?.[0]).toMatchObject({
+        name: "char1",
+        confidence: 0.8,
+        source: "AI",
+      });
+      expect(item.characters?.[0].linkedIps).toContain("ip1");
+
+      // Verify IPs
+      expect(item.ips).toHaveLength(1);
+      expect(item.ips?.[0]).toMatchObject({
+        name: "ip1",
+        confidence: 0.7,
+        source: "AI",
+      });
+    });
+  });
+
+  describe("_restoreRelations", () => {
+    it("should restore source and confidence for relations", async () => {
+      const validItems = [
+        {
+          filePath: "media1.jpg",
+          tags: [
+            { name: "tag1", type: "positive", confidence: 0.9, source: "AI" },
+            { name: "tag2", type: "positive", source: "manual" }, // no confidence
+            { name: "tag3", type: "positive" }, // no source, no confidence (should default)
+          ],
+          characters: [
+            { name: "char1", confidence: 0.85, source: "AI" },
+            { name: "char2" }, // defaults
+          ],
+          ips: [
+            { name: "ip1", confidence: 0.75, source: "AI" },
+            { name: "ip2" }, // defaults
+          ],
+        },
+      ];
+
+      const mediaPathToId = new Map([["media1.jpg", "media-uuid"]]);
+      const tagMap = new Map([
+        ["tag1", "tag-1-uuid"],
+        ["tag2", "tag-2-uuid"],
+        ["tag3", "tag-3-uuid"],
+      ]);
+      const charMap = new Map([
+        ["char1", "char-1-uuid"],
+        ["char2", "char-2-uuid"],
+      ]);
+      const ipMap = new Map([
+        ["ip1", "ip-1-uuid"],
+        ["ip2", "ip-2-uuid"],
+      ]);
+
+      await BackupService._restoreRelations({
+        validItems: validItems as any,
+        mediaPathToId,
+        tagMap,
+        authorMap: new Map(),
+        projectMap: new Map(),
+        ipMap,
+        charMap,
+      });
+
+      // Filter calls for each table
+      const insertCalls = (db.insert as any).mock.calls;
+
+      const tagsData: any[] = [];
+      const charsData: any[] = [];
+      const ipsData: any[] = [];
+
+      insertCalls.forEach((args: any[], index: number) => {
+          const table = args[0];
+          const valuesCall = mockValues.mock.calls[index];
+          if (!valuesCall) {
+              return;
+          }
+          const values = valuesCall[0];
+
+          if (table === mediaTags) {
+              tagsData.push(...values);
+          } else if (table === mediaCharacters) {
+              charsData.push(...values);
+          } else if (table === mediaIps) {
+              ipsData.push(...values);
+          }
+      });
+
+      const expectedTagsCount = 3;
+      const expectedCharsCount = 2;
+      const expectedIpsCount = 2;
+
+      // Assert Tags
+      expect(tagsData).toHaveLength(expectedTagsCount);
+      expect(tagsData).toContainEqual(expect.objectContaining({
+          tagId: "tag-1-uuid",
+          confidence: 0.9,
+          source: "AI"
+      }));
+      expect(tagsData).toContainEqual(expect.objectContaining({
+          tagId: "tag-2-uuid",
+          confidence: null,
+          source: "manual"
+      }));
+       expect(tagsData).toContainEqual(expect.objectContaining({
+          tagId: "tag-3-uuid",
+          confidence: null,
+          source: "restored" // Default
+      }));
+
+      // Assert Characters
+      expect(charsData).toHaveLength(expectedCharsCount);
+      expect(charsData).toContainEqual(expect.objectContaining({
+          characterId: "char-1-uuid",
+          confidence: 0.85,
+          source: "AI"
+      }));
+      expect(charsData).toContainEqual(expect.objectContaining({
+          characterId: "char-2-uuid",
+          confidence: null,
+          source: "restored" // Default
+      }));
+
+      // Assert IPs
+      expect(ipsData).toHaveLength(expectedIpsCount);
+      expect(ipsData).toContainEqual(expect.objectContaining({
+          ipId: "ip-1-uuid",
+          confidence: 0.75,
+          source: "AI"
+      }));
+      expect(ipsData).toContainEqual(expect.objectContaining({
+          ipId: "ip-2-uuid",
+          confidence: null,
+          source: "restored" // Default
+      }));
+
+    });
+  });
+});

--- a/src/tests/unit/application/services/backup-service.test.ts
+++ b/src/tests/unit/application/services/backup-service.test.ts
@@ -175,29 +175,23 @@ describe("BackupService", () => {
         charMap,
       });
 
-      // Filter calls for each table
-      const insertCalls = (db.insert as any).mock.calls;
-
-      const tagsData: any[] = [];
-      const charsData: any[] = [];
-      const ipsData: any[] = [];
-
-      insertCalls.forEach((args: any[], index: number) => {
-          const table = args[0];
-          const valuesCall = mockValues.mock.calls[index];
-          if (!valuesCall) {
-              return;
+      // Helper to extract values for a specific table in a robust way
+      const getValuesForTable = (tableSchema: any) => {
+        const values: any[] = [];
+        (db.insert as any).mock.calls.forEach((insertArgs: any[], index: number) => {
+          if (insertArgs[0] === tableSchema) {
+            const valuesCall = mockValues.mock.calls[index];
+            if (valuesCall) {
+              values.push(...valuesCall[0]);
+            }
           }
-          const values = valuesCall[0];
+        });
+        return values;
+      };
 
-          if (table === mediaTags) {
-              tagsData.push(...values);
-          } else if (table === mediaCharacters) {
-              charsData.push(...values);
-          } else if (table === mediaIps) {
-              ipsData.push(...values);
-          }
-      });
+      const tagsData = getValuesForTable(mediaTags);
+      const charsData = getValuesForTable(mediaCharacters);
+      const ipsData = getValuesForTable(mediaIps);
 
       const expectedTagsCount = 3;
       const expectedCharsCount = 2;


### PR DESCRIPTION
This PR enhances the backup and restore functionality to preserve `source` (e.g., 'AI', 'manual') and `confidence` metadata for media relations (Tags, Characters, IPs). This ensures that metadata provenance is not lost during backup/restore cycles. Backward compatibility with older backups is maintained by defaulting the source to 'restored'.

---
*PR created automatically by Jules for task [10390622171940382254](https://jules.google.com/task/10390622171940382254) started by @hmjn023*