### PR TITLE
Improve Infinite Scroll Performance

### DIFF
--- a/src/routes/sources/[mediaSourceId]/index.tsx
+++ b/src/routes/sources/[mediaSourceId]/index.tsx
@@ -220,7 +220,7 @@ export default function MediaListPage() {
           mediaQuery.fetchNextPage();
         }
       },
-      { threshold: 0.5 }
+      { threshold: 0.5, rootMargin: "1000px" }
     );
 
     if (loadMoreRef) {


### PR DESCRIPTION
This change improves the user experience of the infinite scroll on the media list page by pre-fetching the next page of media before the user reaches the end of the list. This is achieved by adding a `rootMargin` to the `IntersectionObserver`, which triggers the data fetch earlier.

Fixes #93

---
*PR created automatically by Jules for task [6737073681169678605](https://jules.google.com/task/6737073681169678605) started by @hmjn023*