### PR TITLE
docs: Add Tauri gap analysis and implementation spec

### DIFF
--- a/docs/report/tauri-gap-analysis.md
+++ b/docs/report/tauri-gap-analysis.md
@@ -23,7 +23,7 @@
     *   **問題点**:
         *   `sharp`: Node.js バイナリ依存。Tauri では Rust Image crate または Canvas API で代用が必要。
         *   `fluent-ffmpeg`: 子プロセス起動 (`spawn`) が必要。Tauri では Sidecar としてバンドルし、Command 経由で呼び出す必要がある。
-        *   `pg`: `node-postgres` はブラウザ不可。PGlite (`@electric-sql/pglite`) への完全な切り替えが必要。
+        *   `pg`: `node-postgres` はブラウザ不可。クライアント側では PGlite (`@electric-sql/pglite`) への切り替えが必要。
 
 ### 2.2 データベース接続のハードコード
 `src/infrastructure/db/index.ts` は `process.env` を読み取り、条件分岐で `pg` または `pglite` を初期化しています。

--- a/docs/report/tauri-gap-analysis.md
+++ b/docs/report/tauri-gap-analysis.md
@@ -1,0 +1,63 @@
+# Tauri対応に向けた現状調査レポート (Gap Analysis)
+
+## 1. 概要
+本レポートは、現在の `solid-imager` (SolidStart版) を、`docs/spec/client-server-proposal.md` で提案されたクライアント・サーバ分割アーキテクチャ（Tauri + TanStack Start）へ移行するために必要な対応と、現状の乖離（Gap）をまとめたものです。
+
+## 2. 依存関係と結合度 (Dependency Coupling)
+
+### 2.1 Node.js 固有 API への依存
+現在のコードベース（特に `infrastructure` 層）は、Node.js ランタイムに強く依存しており、そのままでは Tauri（ブラウザ環境）で動作しません。
+
+*   **ファイルシステム (`node:fs`, `node:path`)**:
+    *   **影響箇所**: `src/infrastructure/storage/local-media-storage.ts`, `src/domain/media/utils/hash-utils.ts` (ドメイン層での違反あり)
+    *   **問題点**: ブラウザには `fs` が存在しない。Tauri では Rust 側のコマンド経由または `tauri-plugin-fs` を利用する必要がある。
+    *   **改善策**: `IFileSystem` インターフェースによる抽象化と、環境別（Server/Client）の実装注入。
+
+*   **暗号化 (`node:crypto`)**:
+    *   **影響箇所**: `src/domain/media/utils/hash-utils.ts`
+    *   **問題点**: ドメイン層で使用されており、純粋な TypeScript ロジックになっていない。
+    *   **改善策**: Web Crypto API への書き換え、または `ICryptoProvider` による抽象化。
+
+*   **ネイティブモジュール (`sharp`, `fluent-ffmpeg`, `pg`)**:
+    *   **影響箇所**: `src/infrastructure/storage/local-media-storage.ts`, `src/infrastructure/db/index.ts`
+    *   **問題点**:
+        *   `sharp`: Node.js バイナリ依存。Tauri では Rust Image crate または Canvas API で代用が必要。
+        *   `fluent-ffmpeg`: 子プロセス起動 (`spawn`) が必要。Tauri では Sidecar としてバンドルし、Command 経由で呼び出す必要がある。
+        *   `pg`: `node-postgres` はブラウザ不可。PGlite (`@electric-sql/pglite`) への完全な切り替えが必要。
+
+### 2.2 データベース接続のハードコード
+`src/infrastructure/db/index.ts` は `process.env` を読み取り、条件分岐で `pg` または `pglite` を初期化しています。
+*   **問題点**: `import { Pool } from "pg"` がトップレベルにあるため、バンドラー（Vite）がブラウザ向けビルドを行う際にエラーとなる可能性が高い。
+*   **改善策**: DB初期化ロジックをファクトリーパターン化し、依存性の注入（DI）を行うことで、クライアントビルドから `pg` を完全に排除する。
+
+## 3. フレームワークとアーキテクチャ (Framework & Architecture)
+
+### 3.1 SolidStart vs TanStack Start
+現状は `@solidjs/start` (Vinxiベース) と `FileRoutes` を使用しています。提案にある `TanStack Start` への移行は、アプリケーションの根幹に関わる大規模な変更となります。
+
+*   **ルーティング**: `FileRoutes` から TanStack Router のファイルベースルーティングへの書き換えが必要。
+*   **コンポーネント**: `<A>`, `<Router>` などの Solid Router コンポーネントの置換。
+*   **データフェッチ**: 現状の `createQuery` (TanStack Query) は維持できるが、SSR/ローダーの仕組みがフレームワークごとに異なるため調整が必要。
+
+### 3.2 環境変数の扱い
+*   **現状**: `process.env` を多用 (`src/application/services/config-service.ts` 等)。
+*   **Tauri**: `import.meta.env` または Tauri の `loadConfig` API を使用する必要がある。
+*   **改善策**: `IConfigService` を定義し、環境変数の取得元を隠蔽する。
+
+## 4. モノレポ構成への移行
+現状は単一の `package.json` で管理されています。
+*   **必要な分割**:
+    1.  `packages/core`: ドメインモデル、Zodスキーマ、純粋なユーティリティ（Node依存なし）。
+    2.  `apps/server`: 現在のバックエンドロジック、Node.js API実装、Elysia サーバー。
+    3.  `apps/client`: Tauri + Solid フロントエンド、PGlite、クライアント用ドライバ実装。
+
+## 5. 機能的な不足 (Missing Features)
+
+*   **更新メカニズム**: デスクトップアプリとしての自動更新機能が未実装。
+*   **同期ロジック**: クライアント(PGlite)とサーバ(Postgres)間のデータ同期ロジック（提案書の「同期戦略」）が実装されていない。
+*   **設定UI**: サーバのURLや認証情報を入力するための「接続設定」画面が必要。
+
+## 6. 結論
+最もリスクが高いのは **「Node.js 依存の排除と抽象化」** です。特に `LocalMediaStorage` は全面的にリファクタリングが必要です。
+フレームワーク移行（SolidStart -> TanStack Start）は工数が大きいものの、技術的な不確実性は低いです。
+まずは **「抽象化レイヤーの導入」** を Phase 2 として最優先で実施することを推奨します。

--- a/docs/spec/tauri-implementation-plan.md
+++ b/docs/spec/tauri-implementation-plan.md
@@ -1,0 +1,126 @@
+# Tauri実装計画書 (Implementation Plan)
+
+## 1. プロジェクト構成 (Monorepo Structure)
+
+現在の単一パッケージ構成から、以下のモノレポ構成へ移行します。これにより、コードの再利用性を高めつつ、サーバ/クライアント固有の依存関係を分離します。
+
+```text
+.
+├── apps/
+│   ├── client/          # [新規] Tauri + Solid Frontend (Client)
+│   │   ├── src-tauri/   # Rust Backend (Tauri)
+│   │   ├── src/         # Solid UI Code (Client specific)
+│   │   └── package.json
+│   │
+│   └── server/          # [既存を移動] Node.js Backend + Web UI
+│       ├── src/         # Existing Server Code
+│       └── package.json
+│
+├── packages/
+│   ├── core/            # [新規] 共有ロジック (Environment Agnostic)
+│   │   ├── src/
+│   │   │   ├── domain/  # Entities, Zod Schemas
+│   │   │   └── utils/   # Pure TS Utils
+│   │   └── package.json
+│   │
+│   └── db-schema/       # [新規] Drizzle Schema & Migrations
+│       ├── src/
+│       └── package.json
+│
+├── package.json         # Root (Bun Workspaces)
+└── turbo.json           # Turborepo Config (Optional but recommended)
+```
+
+## 2. 抽象化レイヤーの定義 (Abstraction Layers)
+
+クライアント（ブラウザ/Tauri）とサーバ（Node.js）で実装を切り替えるため、以下のインターフェースを定義し、依存性注入（DI）を利用します。
+
+### 2.1 ファイルシステム (`IFileSystem`)
+`node:fs` への直接依存を排除します。
+
+```typescript
+// packages/core/src/interfaces/file-system.ts
+export interface IFileSystem {
+  exists(path: string): Promise<boolean>;
+  readFile(path: string): Promise<Uint8Array>;
+  writeFile(path: string, content: Uint8Array): Promise<void>;
+  deleteFile(path: string): Promise<void>;
+  listDir(path: string): Promise<string[]>; // readdir
+  ensureDir(path: string): Promise<void>;   // mkdir -p
+  stat(path: string): Promise<{ size: number; mtime: Date }>;
+}
+```
+
+*   **Server実装**: `node:fs/promises` をラップ。
+*   **Client実装**: Tauriの `fs` プラグイン (`@tauri-apps/plugin-fs`) をラップ。
+
+### 2.2 メディアストレージ (`IMediaStorage`)
+`LocalMediaStorage` を抽象化し、画像処理 (`sharp`) や動画処理 (`ffmpeg`) の隠蔽を行います。
+
+```typescript
+// packages/core/src/interfaces/media-storage.ts
+export interface IMediaStorage {
+  saveMedia(file: File | Blob, options: SaveOptions): Promise<MediaFileResult>;
+  getThumbnail(path: string): Promise<Uint8Array>;
+  generateThumbnail(path: string): Promise<void>;
+}
+```
+
+### 2.3 設定サービス (`IConfigService`)
+環境変数の取得方法を抽象化します。
+
+```typescript
+// packages/core/src/interfaces/config-service.ts
+export interface IConfigService {
+  get(key: string): string | undefined;
+  getNumber(key: string, defaultValue?: number): number;
+  getBool(key: string, defaultValue?: boolean): boolean;
+}
+```
+
+## 3. 移行ステップ (Migration Steps)
+
+### Step 1: Core パッケージの抽出
+1.  `packages/core` を作成。
+2.  `src/domain` 配下のコードを移動。
+    *   **注意**: `src/domain/media/utils/hash-utils.ts` 内の `node:crypto`, `node:fs` 依存箇所は、一時的に `apps/server` へ退避するか、抽象化インターフェース経由にリファクタリングする。
+3.  Zod スキーマ (`schema.ts`) を全て Core に移動。
+
+### Step 2: 抽象化インターフェースの実装
+1.  `src/infrastructure/interfaces/` ディレクトリを作成（後で `packages/core` へ移動）。
+2.  上記 `IFileSystem`, `IMediaStorage` を定義。
+3.  既存の `LocalMediaStorage` を `ServerMediaStorage` にリネームし、`IMediaStorage` を実装するように修正。
+
+### Step 3: アプリケーション層のリファクタリング
+1.  `MediaService` などのサービスクラスが、具象クラス (`LocalMediaStorage`) ではなくインターフェース (`IMediaStorage`) に依存するように変更。
+2.  DI コンテナ（または簡易的な Factory）を導入し、起動時 (`entry-server.tsx` / `app.tsx`) に実装を注入する仕組みを作る。
+
+### Step 4: モノレポ化とアプリ分割
+1.  ルートの `src` を `apps/server/src` に移動。
+2.  `apps/client` を `npm create tauri-app` (または `bun create`) で新規作成。
+    *   Framework: SolidJS
+    *   Variant: TypeScript
+3.  `package.json` の `workspaces` を設定。
+
+### Step 5: クライアント実装 (Client Implementation)
+1.  `apps/client` に `pglite` をセットアップ。
+2.  `apps/server` から oRPC クライアント定義をインポート（または共有パッケージ化）。
+3.  **Tauri コマンドの実装**:
+    *   Rust側 (`src-tauri`) でファイルアクセスやサムネイル生成の重い処理を実装。
+    *   フロントエンドから `invoke` で呼び出すラッパー (`ClientMediaStorage`) を作成。
+
+## 4. DB接続の分離戦略
+
+`src/infrastructure/db/index.ts` の条件分岐を廃止し、ビルド時に決定されるようにします。
+
+*   **apps/server**: `drizzle-orm/node-postgres` と `pg` を使用。
+*   **apps/client**: `drizzle-orm/pglite` と `@electric-sql/pglite` を使用。
+*   **packages/db-schema**: スキーマ定義のみを持ち、両方から参照される。
+
+## 5. 推奨される作業順序
+
+1.  **Phase 2 (Abstraction)** を現在のリポジトリ構造のまま完了させる。
+    *   コードベースが単一の状態で抽象化を行う方が、リファクタリングが容易であるため。
+2.  テストが全てパスすることを確認。
+3.  **Phase 3 (Monorepo)** を実行し、ディレクトリを物理的に分割する。
+4.  **Phase 4 (Client)** でTauriアプリを構築開始する。

--- a/docs/spec/tauri-implementation-plan.md
+++ b/docs/spec/tauri-implementation-plan.md
@@ -88,7 +88,7 @@ export interface IConfigService {
 
 ### Step 2: 抽象化インターフェースの実装
 1.  `src/infrastructure/interfaces/` ディレクトリを作成（後で `packages/core` へ移動）。
-2.  上記 `IFileSystem`, `IMediaStorage` を定義。
+2.  上記 `IFileSystem`, `IMediaStorage`, `IConfigService` を定義。
 3.  既存の `LocalMediaStorage` を `ServerMediaStorage` にリネームし、`IMediaStorage` を実装するように修正。
 
 ### Step 3: アプリケーション層のリファクタリング


### PR DESCRIPTION
Added docs/report/tauri-gap-analysis.md and docs/spec/tauri-implementation-plan.md detailing the steps to migrate to a Client-Server Tauri architecture.

---
*PR created automatically by Jules for task [17507218659518624076](https://jules.google.com/task/17507218659518624076) started by @hmjn023*