### PR TITLE
Unify search controls and enhance global search features

### DIFF
--- a/apps/server/src/components/media/unified-search-controls.tsx
+++ b/apps/server/src/components/media/unified-search-controls.tsx
@@ -1,0 +1,120 @@
+import type { Author } from "@solid-imager/core/domain/authors/schemas";
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import { type JSX, Show } from "solid-js";
+import { Button } from "~/components/ui/button";
+import {
+  searchState,
+  setSearchMode,
+  setSearchState,
+} from "~/presentation/store/search-store";
+import { PresetManager } from "./preset-manager";
+import { ProSearchBuilder } from "./pro-search-builder";
+import { ProSearchDialog } from "./pro-search-dialog";
+import { SearchFilters } from "./search-filters";
+import { SortControls } from "./sort-controls";
+
+type Props = {
+  tags?: TagResponse[];
+  projects?: Project[];
+  ips?: Ip[];
+  characters?: Character[];
+  authors?: Author[];
+  onSearch: () => void;
+  usePopover?: boolean;
+  children?: JSX.Element;
+};
+
+export function UnifiedSearchControls(props: Props) {
+  return (
+    <div class="space-y-4">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2 rounded-lg border bg-muted p-1">
+          <Button
+            class="h-7 flex-1 text-xs px-2"
+            onClick={() => setSearchMode("simple")}
+            size="sm"
+            type="button"
+            variant={searchState.mode === "simple" ? "default" : "ghost"}
+          >
+            簡易検索
+          </Button>
+          <Button
+            class="h-7 flex-1 text-xs px-2"
+            onClick={() => setSearchMode("pro")}
+            size="sm"
+            type="button"
+            variant={searchState.mode === "pro" ? "default" : "ghost"}
+          >
+            詳細検索
+          </Button>
+        </div>
+      </div>
+
+      {props.children}
+
+      <SortControls
+        onSortByChange={(val) => setSearchState("sortBy", val)}
+        onSortOrderChange={(val) => setSearchState("sortOrder", val)}
+        sortBy={searchState.sortBy}
+        sortOrder={searchState.sortOrder}
+      />
+
+      <div classList={{ hidden: searchState.mode !== "simple" }}>
+        <SearchFilters
+          authors={props.authors}
+          characters={props.characters}
+          ips={props.ips}
+          onSearch={props.onSearch}
+          projects={props.projects}
+          setState={setSearchState}
+          state={searchState}
+          tags={props.tags}
+          usePopover={props.usePopover}
+        />
+      </div>
+
+      <div
+        class="space-y-4"
+        classList={{ hidden: searchState.mode !== "pro" }}
+      >
+        <Show
+          fallback={
+            <>
+              <ProSearchBuilder
+                authors={props.authors}
+                characters={props.characters}
+                ips={props.ips}
+                onChange={(val) => setSearchState("advancedCondition", val)}
+                projects={props.projects}
+                tags={props.tags}
+                value={searchState.advancedCondition || null}
+              />
+              <Button class="w-full" onClick={props.onSearch} type="button">
+                検索 (詳細)
+              </Button>
+            </>
+          }
+          when={props.usePopover === false}
+        >
+          <PresetManager class="w-full flex-col items-stretch" />
+          <ProSearchDialog
+            authors={props.authors}
+            characters={props.characters}
+            ips={props.ips}
+            onChange={(val) => setSearchState("advancedCondition", val)}
+            onSearch={props.onSearch}
+            projects={props.projects}
+            tags={props.tags}
+            value={searchState.advancedCondition || null}
+          />
+          <Button class="w-full" onClick={props.onSearch} type="button">
+            検索 (詳細)
+          </Button>
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/apps/server/src/hooks/use-current-search-persistence.ts
+++ b/apps/server/src/hooks/use-current-search-persistence.ts
@@ -98,6 +98,7 @@ export function useCurrentSearchPersistence(
       searchState.advancedCondition,
       searchState.sortBy,
       searchState.sortOrder,
+      searchState.selectedSource,
     ];
 
     if (isInitialLoad() || !getCurrentPresetName()) {
@@ -131,6 +132,7 @@ export function useCurrentSearchPersistence(
       sort: searchState.sortBy,
       order: searchState.sortOrder,
       mode: searchState.mode,
+      selectedSource: searchState.selectedSource,
     };
 
     try {

--- a/apps/server/src/infrastructure/db/schema.ts
+++ b/apps/server/src/infrastructure/db/schema.ts
@@ -887,6 +887,8 @@ export const presets = pgTable("presets", {
   order: text("order"),
   /** 検索モード ("simple" または "pro") */
   mode: text("mode"),
+  /** 選択されたソースID */
+  selectedSource: text("selected_source"),
   /** 作成日時 */
   createdAt: timestamp("created_at").notNull().defaultNow(),
 });

--- a/apps/server/src/infrastructure/repositories/preset-repository.ts
+++ b/apps/server/src/infrastructure/repositories/preset-repository.ts
@@ -42,6 +42,7 @@ export class DrizzlePresetRepository implements PresetRepository {
         sort: data.sort,
         order: data.order,
         mode: data.mode,
+        selectedSource: data.selectedSource,
       })
       .returning();
     return this.mapToEntity(results[0]);
@@ -56,6 +57,9 @@ export class DrizzlePresetRepository implements PresetRepository {
         ...(data.sort !== undefined ? { sort: data.sort } : {}),
         ...(data.order !== undefined ? { order: data.order } : {}),
         ...(data.mode !== undefined ? { mode: data.mode } : {}),
+        ...(data.selectedSource !== undefined
+          ? { selectedSource: data.selectedSource }
+          : {}),
       })
       .where(eq(presets.id, id))
       .returning();
@@ -78,6 +82,7 @@ export class DrizzlePresetRepository implements PresetRepository {
       sort: row.sort as Preset["sort"],
       order: row.order as Preset["order"],
       mode: row.mode as Preset["mode"],
+      selectedSource: row.selectedSource ?? undefined,
       createdAt: row.createdAt,
     };
   }

--- a/apps/server/src/routes/search.tsx
+++ b/apps/server/src/routes/search.tsx
@@ -4,7 +4,7 @@ import { A } from "@solidjs/router";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { createEffect, createSignal, For, onCleanup, Show } from "solid-js";
 import { isServer, Portal } from "solid-js/web";
-import { SearchFilters } from "~/components/media/search-filters";
+import { UnifiedSearchControls } from "~/components/media/unified-search-controls";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import {
@@ -31,32 +31,14 @@ import { fetchAllProjects } from "~/infrastructure/api-clients/projects-api";
 import { searchMedia } from "~/infrastructure/api-clients/search-api";
 import { fetchMediaSources } from "~/infrastructure/api-clients/sources-api";
 import { fetchTags } from "~/infrastructure/api-clients/tags-api";
-import { searchState, setSearchState } from "~/presentation/store/search-store";
+import {
+  getSearchCondition,
+  searchState,
+  setSearchState,
+} from "~/presentation/store/search-store";
 
 // Type alias to avoid conflict with DOM MediaSource API
 type Source = SafeMediaSource;
-
-const buildSearchParams = (state: typeof searchState) => ({
-  q: state.searchQuery,
-  tags:
-    state.selectedTags.length > 0 ? state.selectedTags.join(",") : undefined,
-  excludeTags:
-    state.excludeTags.length > 0 ? state.excludeTags.join(",") : undefined,
-  tagMode: state.tagMode,
-  projects:
-    state.selectedProjects.length > 0
-      ? state.selectedProjects.join(",")
-      : undefined,
-  ips: state.selectedIps.length > 0 ? state.selectedIps.join(",") : undefined,
-  characters:
-    state.selectedCharacters.length > 0
-      ? state.selectedCharacters.join(",")
-      : undefined,
-  sort: state.sortBy,
-  order: state.sortOrder,
-  limit: state.limit,
-  offset: state.offset,
-});
 
 type SourceSelectorProps = {
   sources: Source[] | undefined;
@@ -154,14 +136,28 @@ export default function Search() {
 
   // Search function
   const searchResults = createQuery(() => ({
-    queryKey: ["searchResults", { ...searchState }],
+    queryKey: [
+      "searchResults",
+      searchState.selectedSource,
+      getSearchCondition(),
+      searchState.sortBy,
+      searchState.sortOrder,
+      searchState.offset,
+      searchState.limit,
+    ],
     queryFn: async () => {
       const source = searchState.selectedSource;
       if (!source) {
         return { media: [], total: 0 };
       }
 
-      return await searchMedia(source, buildSearchParams(searchState));
+      return await searchMedia(source, {
+        condition: getSearchCondition(),
+        sort: searchState.sortBy,
+        order: searchState.sortOrder,
+        limit: searchState.limit,
+        offset: searchState.offset,
+      });
     },
     enabled: !!searchState.selectedSource,
   }));
@@ -231,23 +227,20 @@ export default function Search() {
               <DialogHeader>
                 <DialogTitle>検索フィルター</DialogTitle>
               </DialogHeader>
-              <div class="space-y-4">
+              <UnifiedSearchControls
+                authors={allAuthors.data}
+                characters={allCharacters.data}
+                ips={allIps.data}
+                onSearch={handleSearch}
+                projects={allProjects.data}
+                tags={tags.data}
+              >
                 <SourceSelector
                   onSelect={(id) => setSearchState("selectedSource", id)}
                   selectedSource={searchState.selectedSource}
                   sources={sources.data}
                 />
-                <SearchFilters
-                  authors={allAuthors.data}
-                  characters={allCharacters.data}
-                  ips={allIps.data}
-                  onSearch={handleSearch}
-                  projects={allProjects.data}
-                  setState={setSearchState}
-                  state={searchState}
-                  tags={tags.data}
-                />
-              </div>
+              </UnifiedSearchControls>
             </DialogContent>
           </Dialog>
         </Portal>
@@ -266,23 +259,22 @@ export default function Search() {
           <CardHeader>
             <CardTitle>検索フィルター</CardTitle>
           </CardHeader>
-          <CardContent class="space-y-4">
-            <SourceSelector
-              onSelect={(id) => setSearchState("selectedSource", id)}
-              selectedSource={searchState.selectedSource}
-              sources={sources.data}
-            />
-            <SearchFilters
+          <CardContent>
+            <UnifiedSearchControls
               authors={allAuthors.data}
               characters={allCharacters.data}
               ips={allIps.data}
               onSearch={handleSearch}
               projects={allProjects.data}
-              setState={setSearchState}
-              state={searchState}
               tags={tags.data}
               usePopover={false}
-            />
+            >
+              <SourceSelector
+                onSelect={(id) => setSearchState("selectedSource", id)}
+                selectedSource={searchState.selectedSource}
+                sources={sources.data}
+              />
+            </UnifiedSearchControls>
           </CardContent>
         </Card>
 

--- a/apps/server/src/routes/sources/[mediaSourceId]/index.tsx
+++ b/apps/server/src/routes/sources/[mediaSourceId]/index.tsx
@@ -24,11 +24,7 @@ import { isServer, Portal } from "solid-js/web";
 import { toast } from "solid-toast";
 import { z } from "zod";
 import { MoveCopyMediaDialog } from "~/components/media/move-copy-media-dialog";
-import { PresetManager } from "~/components/media/preset-manager";
-import { ProSearchBuilder } from "~/components/media/pro-search-builder";
-import { ProSearchDialog } from "~/components/media/pro-search-dialog";
-import { SearchFilters } from "~/components/media/search-filters";
-import { SortControls } from "~/components/media/sort-controls";
+import { UnifiedSearchControls } from "~/components/media/unified-search-controls";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import {
@@ -798,66 +794,14 @@ export default function MediaListPage() {
               <DialogHeader>
                 <DialogTitle>検索フィルター</DialogTitle>
               </DialogHeader>
-              <div class="space-y-4">
-                <div class="flex items-center gap-2 rounded-lg border bg-muted p-1">
-                  <Button
-                    class="h-7 flex-1 text-xs"
-                    onClick={() => setSearchMode("simple")}
-                    size="sm"
-                    type="button"
-                    variant={
-                      searchState.mode === "simple" ? "default" : "ghost"
-                    }
-                  >
-                    簡易検索
-                  </Button>
-                  <Button
-                    class="h-7 flex-1 text-xs"
-                    onClick={() => setSearchMode("pro")}
-                    size="sm"
-                    type="button"
-                    variant={searchState.mode === "pro" ? "default" : "ghost"}
-                  >
-                    詳細検索
-                  </Button>
-                </div>
-
-                <SortControls
-                  onSortByChange={(val) => setSearchState("sortBy", val)}
-                  onSortOrderChange={(val) => setSearchState("sortOrder", val)}
-                  sortBy={searchState.sortBy}
-                  sortOrder={searchState.sortOrder}
-                />
-
-                <div classList={{ hidden: searchState.mode !== "simple" }}>
-                  <SearchFilters
-                    authors={allAuthors.data}
-                    characters={allCharacters.data}
-                    ips={allIps.data}
-                    projects={allProjects.data}
-                    setState={setSearchState}
-                    state={searchState}
-                    tags={tags.data}
-                  />
-                </div>
-                <div
-                  class="space-y-4"
-                  classList={{ hidden: searchState.mode !== "pro" }}
-                >
-                  <ProSearchBuilder
-                    authors={allAuthors.data}
-                    characters={allCharacters.data}
-                    ips={allIps.data}
-                    onChange={(val) => setSearchState("advancedCondition", val)}
-                    projects={allProjects.data}
-                    tags={tags.data}
-                    value={searchState.advancedCondition || null}
-                  />
-                  <Button class="w-full" onClick={handleSearch} type="button">
-                    検索 (詳細)
-                  </Button>
-                </div>
-              </div>
+              <UnifiedSearchControls
+                authors={allAuthors.data}
+                characters={allCharacters.data}
+                ips={allIps.data}
+                onSearch={handleSearch}
+                projects={allProjects.data}
+                tags={tags.data}
+              />
             </DialogContent>
           </Dialog>
         </Portal>
@@ -873,69 +817,16 @@ export default function MediaListPage() {
           <CardHeader>
             <CardTitle>検索フィルター</CardTitle>
           </CardHeader>
-          <CardContent class="space-y-4">
-            {/* Mode Switcher & Presets */}
-            <div class="flex items-center justify-between">
-              <div class="flex items-center gap-2 rounded-lg border bg-muted p-1">
-                <Button
-                  class="h-7 text-xs"
-                  onClick={() => setSearchMode("simple")}
-                  size="sm"
-                  type="button"
-                  variant={searchState.mode === "simple" ? "default" : "ghost"}
-                >
-                  簡易検索
-                </Button>
-                <Button
-                  class="h-7 text-xs"
-                  onClick={() => setSearchMode("pro")}
-                  size="sm"
-                  type="button"
-                  variant={searchState.mode === "pro" ? "default" : "ghost"}
-                >
-                  詳細検索
-                </Button>
-              </div>
-            </div>
-
-            <SortControls
-              onSortByChange={(val) => setSearchState("sortBy", val)}
-              onSortOrderChange={(val) => setSearchState("sortOrder", val)}
-              sortBy={searchState.sortBy}
-              sortOrder={searchState.sortOrder}
+          <CardContent>
+            <UnifiedSearchControls
+              authors={allAuthors.data}
+              characters={allCharacters.data}
+              ips={allIps.data}
+              onSearch={handleSearch}
+              projects={allProjects.data}
+              tags={tags.data}
+              usePopover={false}
             />
-
-            <div classList={{ hidden: searchState.mode !== "simple" }}>
-              <SearchFilters
-                authors={allAuthors.data}
-                characters={allCharacters.data}
-                ips={allIps.data}
-                projects={allProjects.data}
-                setState={setSearchState}
-                state={searchState}
-                tags={tags.data}
-                usePopover={false}
-              />
-            </div>
-            <div
-              class="space-y-4"
-              classList={{ hidden: searchState.mode !== "pro" }}
-            >
-              <PresetManager class="w-full flex-col items-stretch" />
-              <ProSearchDialog
-                authors={allAuthors.data}
-                characters={allCharacters.data}
-                ips={allIps.data}
-                onChange={(val) => setSearchState("advancedCondition", val)}
-                onSearch={handleSearch}
-                projects={allProjects.data}
-                tags={tags.data}
-                value={searchState.advancedCondition || null}
-              />
-              <Button class="w-full" onClick={handleSearch} type="button">
-                検索 (詳細)
-              </Button>
-            </div>
           </CardContent>
         </Card>
 

--- a/packages/core/src/domain/media/schemas.ts
+++ b/packages/core/src/domain/media/schemas.ts
@@ -504,6 +504,7 @@ export const presetSchema = z.object({
   sort: z.enum(["date", "name", "size", "rating", "viewCount"]).optional(),
   order: z.enum(["asc", "desc"]).optional(),
   mode: z.enum(["simple", "pro"]).optional(),
+  selectedSource: z.string().optional(),
   createdAt: z.coerce.date(),
 });
 
@@ -515,6 +516,7 @@ export const createPresetRequestSchema = z.object({
   sort: z.enum(["date", "name", "size", "rating", "viewCount"]).optional(),
   order: z.enum(["asc", "desc"]).optional(),
   mode: z.enum(["simple", "pro"]).optional(),
+  selectedSource: z.string().optional(),
 });
 
 export type CreatePresetRequest = z.infer<typeof createPresetRequestSchema>;
@@ -525,6 +527,7 @@ export const updatePresetRequestSchema = z.object({
   sort: z.enum(["date", "name", "size", "rating", "viewCount"]).optional(),
   order: z.enum(["asc", "desc"]).optional(),
   mode: z.enum(["simple", "pro"]).optional(),
+  selectedSource: z.string().optional(),
 });
 
 export type UpdatePresetRequest = z.infer<typeof updatePresetRequestSchema>;

--- a/packages/core/src/domain/search/logic.ts
+++ b/packages/core/src/domain/search/logic.ts
@@ -201,6 +201,11 @@ export const preparePresetState = (
     sortOrder: (preset.order as SearchState["sortOrder"]) || "desc",
   };
 
+  const commonState = {
+    ...sortState,
+    selectedSource: preset.selectedSource || "",
+  };
+
   if (preset.mode != null) {
     if (preset.mode === "simple" && simpleState) {
       return {
@@ -208,7 +213,7 @@ export const preparePresetState = (
         activePresetId: preset.id,
         advancedCondition: null,
         ...simpleState,
-        ...sortState,
+        ...commonState,
       };
     }
     return {
@@ -222,7 +227,7 @@ export const preparePresetState = (
       selectedIps: [],
       selectedCharacters: [],
       selectedAuthors: [],
-      ...sortState,
+      ...commonState,
     };
   }
 
@@ -234,13 +239,13 @@ export const preparePresetState = (
       activePresetId: preset.id,
       advancedCondition: targetMode === "pro" ? preset.value : null,
       ...(targetMode === "simple" ? simpleState : {}),
-      ...sortState,
+      ...commonState,
     };
   }
   return {
     mode: "pro" as const,
     activePresetId: preset.id,
     advancedCondition: preset.value,
-    ...sortState,
+    ...commonState,
   };
 };


### PR DESCRIPTION
This change unifies the search experience across the application by introducing a reusable `UnifiedSearchControls` component. The global search page now supports advanced search features (Pro mode, presets) previously only available on individual source pages. Additionally, search state persistence is now fully implemented for the global search page using the `current-all` preset key, which now correctly includes the selected source ID to provide a seamless reload experience.

Fixes #124

---
*PR created automatically by Jules for task [4973578656981992863](https://jules.google.com/task/4973578656981992863) started by @hmjn023*