### PR TITLE
fix(DirectorySyncService): correct deletion check and dynamic extensions

### DIFF
--- a/apps/server/src/application/services/directory-sync-service.ts
+++ b/apps/server/src/application/services/directory-sync-service.ts
@@ -137,11 +137,11 @@ export const DirectorySyncService = {
       });
 
       const mediaExtensions = services.getConfigService().getConfig().media.supportedExtensions;
-      const allowedExts = new Set([
-        ...mediaExtensions.image,
-        ...mediaExtensions.video,
-        ...mediaExtensions.audio,
-      ].map(ext => ext.toLowerCase()));
+      const allowedExts = new Set(
+        Object.values(mediaExtensions)
+          .flat()
+          .map((ext) => ext.toLowerCase())
+      );
 
       const actualMediaPaths = fsPaths.filter((p) => {
         const ext = path.extname(p).toLowerCase();

--- a/apps/server/src/application/services/directory-sync-service.ts
+++ b/apps/server/src/application/services/directory-sync-service.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import fg from "fast-glob";
+import { services } from "~/application/registry";
 import { MediaProcessingService } from "~/application/services/media-processing-service";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
 import { deleteThumbnail } from "~/infrastructure/jobs/thumbnails";
@@ -9,18 +10,6 @@ import { MediaRepository } from "~/infrastructure/repositories/media-repository"
 import { DrizzleSourceRepository } from "~/infrastructure/repositories/source-repository";
 
 const sourceRepo = new DrizzleSourceRepository();
-
-const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"];
-const VIDEO_EXTENSIONS = [".mp4", ".webm", ".mov"];
-const AUDIO_EXTENSIONS = [".mp3", ".wav"];
-const ALL_MEDIA_EXTENSIONS = [
-  ...IMAGE_EXTENSIONS,
-  ...VIDEO_EXTENSIONS,
-  ...AUDIO_EXTENSIONS,
-];
-
-// Helper to check extensions
-const ALLOWED_EXTS = new Set(ALL_MEDIA_EXTENSIONS);
 
 type SyncResult = {
   sourceId: string;
@@ -147,11 +136,18 @@ export const DirectorySyncService = {
         caseSensitiveMatch: false,
       });
 
+      const mediaExtensions = services.getConfigService().getConfig().media.supportedExtensions;
+      const allowedExts = new Set([
+        ...mediaExtensions.image,
+        ...mediaExtensions.video,
+        ...mediaExtensions.audio,
+      ].map(ext => ext.toLowerCase()));
+
       const actualMediaPaths = fsPaths.filter((p) => {
         const ext = path.extname(p).toLowerCase();
-        return ALLOWED_EXTS.has(ext);
+        return allowedExts.has(ext);
       });
-      const fsPathSet = new Set(actualMediaPaths);
+      const allFilesPathSet = new Set(fsPaths);
 
       // 3. Calculate diffs
       const filesToAdd: string[] = [];
@@ -163,7 +159,7 @@ export const DirectorySyncService = {
 
       const filesToDelete: { id: string; relativePath: string }[] = [];
       for (const [p, id] of dbPathMap.entries()) {
-        if (!fsPathSet.has(p)) {
+        if (!allFilesPathSet.has(p)) {
           filesToDelete.push({ id, relativePath: p.split("/").join(path.sep) });
         }
       }

--- a/apps/server/src/tests/unit/application/services/directory-sync-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/directory-sync-service.test.ts
@@ -59,6 +59,22 @@ vi.mock("~/infrastructure/jobs/sse-manager", () => ({
   },
 }));
 
+vi.mock("~/application/registry", () => ({
+  services: {
+    getConfigService: vi.fn().mockReturnValue({
+      getConfig: vi.fn().mockReturnValue({
+        media: {
+          supportedExtensions: {
+            image: [".jpg", ".png"],
+            video: [".mp4"],
+            audio: [".mp3"],
+          },
+        },
+      }),
+    }),
+  },
+}));
+
 import { MediaProcessingService } from "~/application/services/media-processing-service";
 import { MediaRepository } from "~/infrastructure/repositories/media-repository";
 


### PR DESCRIPTION
Fixes a bug where media files on the filesystem could be improperly deleted from the DB during start-up sync if they had an extension that was missing from the service's internal list. The fix checks the database entries against *all* physical files for deletions, and uses dynamically loaded config extensions for additions.

---
*PR created automatically by Jules for task [11888808549547980313](https://jules.google.com/task/11888808549547980313) started by @hmjn023*