### PR TITLE
xtracterのファイル命名規則の統一

### DIFF
--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -282,11 +282,13 @@ async function handleYtDlpDownload(
         // Check if target already exists (unlikely given it's a new job, but good for safety)
         let finalPath = targetPath;
         let collisionIndex = 1;
+        const ext = path.extname(unifiedName);
+        const base = path.basename(unifiedName, ext);
+
         while (true) {
+          if (finalPath === filePath) break; // Not a collision if it's the current file
           try {
             await fs.access(finalPath);
-            const ext = path.extname(unifiedName);
-            const base = path.basename(unifiedName, ext);
             finalPath = path.join(path.dirname(filePath), `${base}_(${collisionIndex})${ext}`);
             collisionIndex++;
           } catch {

--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -9,6 +9,7 @@ import type {
   AddMediaRequest,
   DownloadItem,
 } from "@solid-imager/core/domain/media/schemas";
+import { generateMediaFilename } from "@solid-imager/core/domain/media/utils/filename-utils";
 import { getMediaTypeFromExtension } from "@solid-imager/core/domain/media/utils/media-type-utils";
 import ffmpegPath from "ffmpeg-static";
 import youtubedl from "youtube-dl-exec";
@@ -260,8 +261,47 @@ async function handleYtDlpDownload(
       "[DownloadJob] yt-dlp download completed"
     );
 
+    let index = 0;
     for (const res of results) {
-      const { filePath, metadata } = res;
+      let { filePath, metadata } = res;
+
+      // Unify filename
+      const extension = path.extname(filePath);
+      let unifiedName = generateMediaFilename(item, extension);
+
+      // If multiple results for the same item, append index
+      if (results.length > 1) {
+        const ext = path.extname(unifiedName);
+        const base = path.basename(unifiedName, ext);
+        unifiedName = `${base}_${index}${ext}`;
+      }
+
+      const targetPath = path.join(path.dirname(filePath), unifiedName);
+
+      try {
+        // Check if target already exists (unlikely given it's a new job, but good for safety)
+        let finalPath = targetPath;
+        let collisionIndex = 1;
+        while (true) {
+          try {
+            await fs.access(finalPath);
+            const ext = path.extname(unifiedName);
+            const base = path.basename(unifiedName, ext);
+            finalPath = path.join(path.dirname(filePath), `${base}_(${collisionIndex})${ext}`);
+            collisionIndex++;
+          } catch {
+            break;
+          }
+        }
+
+        await fs.rename(filePath, finalPath);
+        filePath = finalPath;
+        logger.info({ from: res.filePath, to: filePath }, "[DownloadJob] Renamed yt-dlp output to unified name");
+      } catch (e) {
+        logger.warn({ err: e, filePath, targetPath }, "[DownloadJob] Failed to rename yt-dlp output");
+        // Continue with original path if rename fails
+      }
+      index++;
 
       // Calculate relative path
       const relativePath = path.relative(basePath, filePath);
@@ -355,16 +395,10 @@ async function handleDirectImageDownload(
     "[DownloadJob] Using direct image download method"
   );
 
-  // Generate filename from URL
+  // Generate unified filename
   const urlPath = new URL(item.targetUrl).pathname;
-  const originalFilename = path.basename(urlPath);
-
-  const { createHash } = await import("node:crypto");
-  const urlHash = createHash("md5")
-    .update(item.targetUrl)
-    .digest("hex")
-    .slice(0, URL_HASH_LENGTH);
-  const filename = `download-${urlHash}-${originalFilename}`;
+  const extension = path.extname(urlPath) || ".png";
+  const filename = generateMediaFilename(item, extension);
 
   try {
     // Download the image

--- a/apps/server/src/tests/unit/infrastructure/jobs/download-jobs.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/download-jobs.test.ts
@@ -87,8 +87,8 @@ vi.mock("node:child_process", () => ({
 const fetchMock = vi.fn();
 global.fetch = fetchMock;
 
-// Regex for download filename pattern (moved to top level for performance)
-const DOWNLOAD_FILENAME_PATTERN = /^download-[a-f0-9]{12}-image\.jpg$/;
+// Regex for download filename pattern (unified format: {author}_{date}_{id}.{ext})
+const DOWNLOAD_FILENAME_PATTERN = /^user_.*123\.jpg$/;
 
 describe("processDownloadJob", () => {
   beforeEach(async () => {

--- a/packages/core/src/domain/media/utils/filename-utils.ts
+++ b/packages/core/src/domain/media/utils/filename-utils.ts
@@ -1,0 +1,113 @@
+import type { DownloadItem } from "../schemas";
+
+/**
+ * Sanitize a string to be used as a filename part.
+ */
+export function sanitizeFilenamePart(part: string): string {
+  // Remove or replace characters that are invalid in filenames across OSes
+  // Also remove @ at the beginning of Twitter IDs for cleaner filenames
+  const cleaned = part.startsWith("@") ? part.slice(1) : part;
+  return cleaned.replace(/[/\\?%*:|"<>]/g, "").replace(/\s+/g, "_");
+}
+
+/**
+ * Extract a unique ID from common media source URLs (Twitter, Danbooru).
+ */
+export function extractIdFromUrl(url: string): string | null {
+  try {
+    const urlObj = new URL(url);
+    // Twitter/X: https://twitter.com/user/status/123456789
+    if (
+      urlObj.hostname.includes("twitter.com") ||
+      urlObj.hostname.includes("x.com")
+    ) {
+      const match = urlObj.pathname.match(/\/status\/(\d+)/);
+      return match ? match[1] : null;
+    }
+    // Danbooru: https://danbooru.donmai.us/posts/123456
+    if (urlObj.hostname.includes("danbooru.donmai.us")) {
+      const match = urlObj.pathname.match(/\/posts\/(\d+)/);
+      return match ? match[1] : null;
+    }
+  } catch (_e) {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Generate a unified filename based on media metadata.
+ * Format: {authorId}_{date}_{contentId}.{extension}
+ */
+export function generateMediaFilename(
+  item: DownloadItem,
+  extension: string
+): string {
+  // 1. Author ID
+  const author = item.authors?.[0];
+  let authorId = "";
+  if (author?.accountId) {
+    authorId = sanitizeFilenamePart(author.accountId);
+  } else if (author?.name) {
+    authorId = sanitizeFilenamePart(author.name);
+  }
+
+  // 2. Date (YYYYMMDD)
+  let dateStr = "";
+  if (item.createdAt) {
+    const date = new Date(item.createdAt);
+    if (!isNaN(date.getTime())) {
+      dateStr = date.toISOString().slice(0, 10).replace(/-/g, "");
+    }
+  }
+
+  // 3. Content ID (Twitter status ID, Danbooru post ID, etc.)
+  let contentId = "";
+  if (item.sourceUrls) {
+    for (const url of item.sourceUrls) {
+      const id = extractIdFromUrl(url);
+      if (id) {
+        contentId = id;
+        break;
+      }
+    }
+  }
+
+  if (!contentId && item.targetUrl) {
+    contentId = extractIdFromUrl(item.targetUrl) || "";
+  }
+
+  // Fallback: If we still don't have enough info, use URL hash or timestamp
+  if (!authorId && !dateStr && !contentId) {
+    if (item.targetUrl) {
+      try {
+        const url = new URL(item.targetUrl);
+        const filename = url.pathname.split("/").pop();
+        if (filename && filename.includes(".")) {
+          return filename; // Use original filename from URL
+        }
+        // Hash-like from URL
+        contentId = url.pathname.replace(/[^a-zA-Z0-9]/g, "_").slice(-12);
+      } catch (_e) {
+        contentId = Date.now().toString();
+      }
+    } else {
+      contentId = Date.now().toString();
+    }
+  }
+
+  // Build filename
+  const parts = [];
+  if (authorId) parts.push(authorId);
+  if (dateStr) parts.push(dateStr);
+  if (contentId) parts.push(contentId);
+
+  let base = parts.join("_");
+  if (!base) base = "media";
+
+  const ext = extension.startsWith(".") ? extension : `.${extension}`;
+  // Ensure no double dots and the extension is at the end
+  const cleanExt = ext.split("?")[0].split("#")[0]; // remove query/hash if any
+
+  return `${base}${cleanExt}`;
+}

--- a/packages/core/src/domain/media/utils/filename-utils.ts
+++ b/packages/core/src/domain/media/utils/filename-utils.ts
@@ -6,8 +6,10 @@ import type { DownloadItem } from "../schemas";
 export function sanitizeFilenamePart(part: string): string {
   // Remove or replace characters that are invalid in filenames across OSes
   // Also remove @ at the beginning of Twitter IDs for cleaner filenames
-  const cleaned = part.startsWith("@") ? part.slice(1) : part;
-  return cleaned.replace(/[/\\?%*:|"<>]/g, "").replace(/\s+/g, "_");
+  const trimmed = part.trim();
+  const cleaned = trimmed.startsWith("@") ? trimmed.slice(1) : trimmed;
+  // Remove dots and other path characters to prevent path traversal
+  return cleaned.replace(/[/\\?%*:|"<>.]/g, "").replace(/\s+/g, "_");
 }
 
 /**
@@ -82,9 +84,11 @@ export function generateMediaFilename(
     if (item.targetUrl) {
       try {
         const url = new URL(item.targetUrl);
-        const filename = url.pathname.split("/").pop();
-        if (filename && filename.includes(".")) {
-          return filename; // Use original filename from URL
+        const originalFilename = url.pathname.split("/").pop();
+        if (originalFilename && originalFilename.includes(".")) {
+          const ext = originalFilename.split(".").pop() || "";
+          const baseName = originalFilename.split(".").slice(0, -1).join(".");
+          return `${sanitizeFilenamePart(baseName)}.${sanitizeFilenamePart(ext)}`;
         }
         // Hash-like from URL
         contentId = url.pathname.replace(/[^a-zA-Z0-9]/g, "_").slice(-12);
@@ -105,9 +109,14 @@ export function generateMediaFilename(
   let base = parts.join("_");
   if (!base) base = "media";
 
-  const ext = extension.startsWith(".") ? extension : `.${extension}`;
-  // Ensure no double dots and the extension is at the end
-  const cleanExt = ext.split("?")[0].split("#")[0]; // remove query/hash if any
+  let cleanExt = extension.split("?")[0].split("#")[0];
+  if (cleanExt) {
+    // Sanitize extension (e.g., remove "../" or other junk)
+    cleanExt = sanitizeFilenamePart(cleanExt);
+    if (cleanExt) {
+      cleanExt = `.${cleanExt}`;
+    }
+  }
 
   return `${base}${cleanExt}`;
 }

--- a/packages/core/tests/filename-utils.test.ts
+++ b/packages/core/tests/filename-utils.test.ts
@@ -8,12 +8,16 @@ describe("filename-utils", () => {
       expect(sanitizeFilenamePart("@user_name")).toBe("user_name");
     });
 
-    it("should remove invalid characters", () => {
-      expect(sanitizeFilenamePart("user/name?%")).toBe("username");
+    it("should remove invalid characters including dots", () => {
+      expect(sanitizeFilenamePart("user/name.ext?%")).toBe("usernameext");
     });
 
     it("should replace spaces with underscores", () => {
       expect(sanitizeFilenamePart("user name")).toBe("user_name");
+    });
+
+    it("should trim leading and trailing spaces", () => {
+      expect(sanitizeFilenamePart("  artist_name  ")).toBe("artist_name");
     });
   });
 
@@ -69,6 +73,14 @@ describe("filename-utils", () => {
         sourceUrls: ["https://danbooru.donmai.us/posts/123456"]
       };
       expect(generateMediaFilename(item, ".png")).toBe("20231027_123456.png");
+    });
+
+    it("should not have a trailing dot if extension is empty", () => {
+      const item: DownloadItem = {
+        targetUrl: "https://example.com/image",
+        authors: [{ name: "Artist" }]
+      };
+      expect(generateMediaFilename(item, "")).toBe("Artist");
     });
   });
 });

--- a/packages/core/tests/filename-utils.test.ts
+++ b/packages/core/tests/filename-utils.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { generateMediaFilename, sanitizeFilenamePart, extractIdFromUrl } from "../src/domain/media/utils/filename-utils";
+import type { DownloadItem } from "../src/domain/media/schemas";
+
+describe("filename-utils", () => {
+  describe("sanitizeFilenamePart", () => {
+    it("should remove @ from the beginning", () => {
+      expect(sanitizeFilenamePart("@user_name")).toBe("user_name");
+    });
+
+    it("should remove invalid characters", () => {
+      expect(sanitizeFilenamePart("user/name?%")).toBe("username");
+    });
+
+    it("should replace spaces with underscores", () => {
+      expect(sanitizeFilenamePart("user name")).toBe("user_name");
+    });
+  });
+
+  describe("extractIdFromUrl", () => {
+    it("should extract Twitter status ID", () => {
+      expect(extractIdFromUrl("https://twitter.com/user/status/123456789?s=20")).toBe("123456789");
+      expect(extractIdFromUrl("https://x.com/user/status/987654321")).toBe("987654321");
+    });
+
+    it("should extract Danbooru post ID", () => {
+      expect(extractIdFromUrl("https://danbooru.donmai.us/posts/123456")).toBe("123456");
+    });
+
+    it("should return null for other URLs", () => {
+      expect(extractIdFromUrl("https://google.com")).toBeNull();
+    });
+  });
+
+  describe("generateMediaFilename", () => {
+    it("should generate unified filename with author, date, and ID", () => {
+      const item: DownloadItem = {
+        targetUrl: "https://pbs.twimg.com/media/abc.jpg",
+        authors: [{ name: "Artist", accountId: "@artist_id" }],
+        createdAt: "2023-10-27T10:00:00Z",
+        sourceUrls: ["https://twitter.com/artist_id/status/1717891234"]
+      };
+      expect(generateMediaFilename(item, ".jpg")).toBe("artist_id_20231027_1717891234.jpg");
+    });
+
+    it("should fallback to name if accountId is missing", () => {
+      const item: DownloadItem = {
+        targetUrl: "https://pbs.twimg.com/media/abc.jpg",
+        authors: [{ name: "Artist Name" }],
+        createdAt: "2023-10-27T10:00:00Z",
+        sourceUrls: ["https://twitter.com/artist_id/status/1717891234"]
+      };
+      expect(generateMediaFilename(item, ".jpg")).toBe("Artist_Name_20231027_1717891234.jpg");
+    });
+
+    it("should handle missing date", () => {
+      const item: DownloadItem = {
+        targetUrl: "https://pbs.twimg.com/media/abc.jpg",
+        authors: [{ name: "Artist" }],
+        sourceUrls: ["https://danbooru.donmai.us/posts/123456"]
+      };
+      expect(generateMediaFilename(item, ".png")).toBe("Artist_123456.png");
+    });
+
+    it("should handle missing author", () => {
+      const item: DownloadItem = {
+        targetUrl: "https://pbs.twimg.com/media/abc.jpg",
+        createdAt: "2023-10-27T10:00:00Z",
+        sourceUrls: ["https://danbooru.donmai.us/posts/123456"]
+      };
+      expect(generateMediaFilename(item, ".png")).toBe("20231027_123456.png");
+    });
+  });
+});

--- a/xtracter/src/background/index.ts
+++ b/xtracter/src/background/index.ts
@@ -1,4 +1,5 @@
 import type { SafeMediaSource } from "@core/domain/sources/schemas";
+import { generateMediaFilename } from "@core/domain/media/utils/filename-utils";
 import { APIError, getClient } from "@ext/api";
 import type {
   DownloadBulkMessage,
@@ -10,6 +11,21 @@ import type {
 } from "@ext/schema";
 
 const DATE_STRING_LENGTH = 19; // "YYYY-MM-DDTHH-mm-ss"
+
+function getExtensionFromUrl(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    const pathname = urlObj.pathname;
+    const filename = pathname.split("/").pop() || "";
+    const extMatch = filename.match(/\.([a-z0-9]+)$/i);
+    if (extMatch) {
+      return `.${extMatch[1]}`;
+    }
+  } catch (_e) {
+    // ignore
+  }
+  return ".png"; // default
+}
 
 /**
  * リトライ付きでAPI呼び出しを実行する
@@ -212,19 +228,13 @@ chrome.runtime.onMessage.addListener(
 
     // Handle Content Script Requests
     if (isDownloadMessage(message)) {
-      const { targetUrl, authors, createdAt } = message.data;
-      const authorId =
-        authors && authors.length > 0 && authors[0].accountId
-          ? authors[0].accountId
-          : "unknown";
-      const safeAuthorId = authorId.replace(/[^a-zA-Z0-9@_-]/g, "");
-      const safeTimestamp = createdAt
-        ? new Date(createdAt).getTime()
-        : Date.now();
-      const filenameBase = `xtracter/${safeAuthorId}_${safeTimestamp}`;
+      const { targetUrl } = message.data;
+      const extension = getExtensionFromUrl(targetUrl);
+      const filename = generateMediaFilename(message.data, extension);
+
       chrome.downloads.download({
         url: targetUrl,
-        filename: `${filenameBase}.png`,
+        filename: `xtracter/${filename}`,
       });
     } else if (isDownloadBulkMessage(message)) {
       const now = new Date();


### PR DESCRIPTION
xtracterのファイル命名規則を `{投稿者ID}_{日付}_{投稿ID}.{拡張子}` に統一しました。
ブラウザでの直接ダウンロード、サーバーでのダウンロード（画像・動画）のすべてに同じ規則が適用されます。
また、メタデータが不足している場合や、同名のファイルが存在する場合の処理も含まれています。

---
*PR created automatically by Jules for task [8493659205176308012](https://jules.google.com/task/8493659205176308012) started by @hmjn023*