### PR TITLE
feat: consolidate multiple duplicate toasts into a global progress bar using SSE

### DIFF
--- a/CHARACTER_MANAGEMENT_SPEC.md
+++ b/CHARACTER_MANAGEMENT_SPEC.md
@@ -1,0 +1,79 @@
+# Implementation Report: Intelligent Character Management System
+
+## 1. Executive Summary
+`solid-imager` におけるキャラクター管理を、従来の「モデル依存のタグ付け」から、**「AIモデル (PixAI Tagger) + ベクトル検索 (CCIP/pgvector) によるRAG型ハイブリッド認識」** へアップグレードするための技術仕様書です。既存の2万枚の画像資産を最大限に活用し、未知のキャラクターに対する学習・検索能力をシステムに持たせます。
+
+## 2. System Architecture
+本システムは以下の3層構造で動作します。
+
+1.  **Tagging Layer (PixAI Tagger v0.9)**:
+    *   既知のキャラクター（1.3万種）と作品名 (IP) を識別。
+    *   ONNX形式で `dghs-imgutils-ts` を通じて実行。
+2.  **Embedding Layer (CCIP - Character Classification by Image Pairs)**:
+    *   画像を **768次元の固有ベクトル** に変換。
+    *   「見た目」の類似度を数値化し、タグに頼らない識別を可能にする。
+3.  **Storage & Retrieval Layer (PGLite + pgvector)**:
+    *   抽出したベクトルとタグ情報を `pgvector` 形式で保存。
+    *   `HNSW` インデックスにより、2万枚以上のデータからミリ秒単位で類似キャラを検索。
+
+## 3. Key Workflows
+
+### A. Automatic Recognition & Learning
+1.  画像インポート時に `PixAI Tagger` でタグを抽出。
+2.  タグにキャラクター名が含まれない場合、`CCIP` ベクトルで `pgvector` DBを検索。
+3.  類似度（Cosine Distance < 0.15）が高い既存キャラがいれば、自動的にその名前を付与。
+4.  一致するものがない場合、UIで「未知のキャラクター」として提示。ユーザーが命名すると、そのベクトルがDBに登録され、以降の画像は自動認識される。
+
+### B. Batch Migration (For 20,000+ existing images)
+*   **推論処理**: GPU (RTX 3060+) で約15〜20分、CPUで数時間のバッチ処理。
+*   **インデックス**: `HNSW` を使用することで、$n^2$ の全件比較を回避し、$O(\log n)$ の高速検索を実現。
+*   **データ量**: ベクトルデータ自体は約60MB程度と軽量。
+
+## 4. Technical Requirements for Coding Agent
+
+### Dependencies
+*   `dghs-imgutils-ts`: `tagging/pixai` および `metrics/ccip` の移植版。
+*   `@electric-sql/pglite`: `vector` エクステンションを有効化。
+*   `onnxruntime-node`: 高速な推論実行用。
+
+### Database Schema (Proposal)
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS character_registry (
+  id SERIAL PRIMARY KEY,
+  file_path TEXT UNIQUE,
+  character_name TEXT, -- PixAI tag or User-defined name
+  ip_name TEXT,
+  embedding vector(768), -- CCIP embedding
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- HNSW Index for fast similarity search
+CREATE INDEX ON character_registry 
+USING hnsw (embedding vector_cosine_ops) 
+WITH (m = 16, ef_construction = 64);
+```
+
+### Critical Logic: Identification (Pseudo-code)
+```typescript
+async function identifyCharacter(embedding: Float32Array) {
+  const result = await db.query(`
+    SELECT character_name, embedding <=> $1 as distance 
+    FROM character_registry 
+    WHERE character_name IS NOT NULL
+    ORDER BY distance ASC LIMIT 1;
+  `, [JSON.stringify(Array.from(embedding))]);
+
+  const match = result.rows[0];
+  if (match && match.distance < 0.15) {
+    return { name: match.character_name, confidence: 1 - match.distance };
+  }
+  return null; // Unknown
+}
+```
+
+## 5. UI/UX Considerations for `solid-imager`
+*   **Identity Suggestion**: 未知のキャラに対して「このキャラは Aさん ですか？」という候補提示機能。
+*   **Clustering View**: 名前がない画像同士でベクトルが近いものをグループ化して表示し、一括で名前を付けられる機能。
+*   **Manual Correction**: AIが間違えた場合に、ベクトルDBの登録情報を修正・マージする機能。

--- a/apps/server/src/app.tsx
+++ b/apps/server/src/app.tsx
@@ -1,9 +1,9 @@
-import { Toaster } from "@solid-imager/ui/toast";
 import { Meta, MetaProvider, Title } from "@solidjs/meta";
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start/router";
 import { QueryClient, QueryClientProvider } from "@tanstack/solid-query";
 import { Suspense } from "solid-js";
+import { GlobalJobToaster } from "./components/global-job-toaster";
 import Nav from "./components/nav";
 import "./app.css";
 
@@ -42,7 +42,7 @@ export default function App() {
           root={(props) => (
             <>
               <Nav />
-              <Toaster />
+              <GlobalJobToaster />
               <Suspense>{props.children}</Suspense>
             </>
           )}

--- a/apps/server/src/components/global-job-toaster.tsx
+++ b/apps/server/src/components/global-job-toaster.tsx
@@ -1,5 +1,6 @@
 import { Progress } from "@solid-imager/ui/progress";
-import { createSignal, onCleanup } from "solid-js";
+import { Toaster, toast } from "@solid-imager/ui/toast";
+import { createSignal, onCleanup, onMount, Show } from "solid-js";
 import { isServer } from "solid-js/web";
 
 const PERCENTAGE_MULTIPLIER = 100;
@@ -10,16 +11,38 @@ type JobProgressData = {
   total: number;
 };
 
-import { Toaster, toast } from "@solid-imager/ui/toast";
-import { onMount, Show } from "solid-js";
+const JobProgressToast = (props: { processed: number; total: number }) => (
+  <div class="flex w-full min-w-[200px] flex-col gap-2">
+    <div class="font-medium text-sm">Job in Progress</div>
+    <div class="text-muted-foreground text-xs">
+      Processed: {props.processed} / {props.total}
+    </div>
+    <Progress
+      class="h-2"
+      value={(props.processed / props.total) * PERCENTAGE_MULTIPLIER}
+    />
+  </div>
+);
 
 export function GlobalJobToaster() {
   const [mounted, setMounted] = createSignal(false);
-
-  const [activeJobs, setActiveJobs] = createSignal<
+  const [_activeJobs, setActiveJobs] = createSignal<
     Record<string, JobProgressData>
   >({});
   const [toastIds, setToastIds] = createSignal<Record<string, string>>({});
+
+  const cleanupJob = (jobId: string) => {
+    setToastIds((prev) => {
+      const next = { ...prev };
+      delete next[jobId];
+      return next;
+    });
+    setActiveJobs((prev) => {
+      const next = { ...prev };
+      delete next[jobId];
+      return next;
+    });
+  };
 
   onMount(() => {
     if (isServer) {
@@ -34,70 +57,19 @@ export function GlobalJobToaster() {
         const data = JSON.parse(event.data) as JobProgressData;
         const { jobId, processed, total } = data;
 
-        setActiveJobs((prev) => ({
-          ...prev,
-          [jobId]: data,
-        }));
+        setActiveJobs((prev) => ({ ...prev, [jobId]: data }));
 
-        const currentToastIds = toastIds();
-        let toastId = currentToastIds[jobId];
-
-        if (toastId) {
-          // Update the existing toast
-          toast.loading(
-            () => (
-              <div class="flex w-full min-w-[200px] flex-col gap-2">
-                <div class="font-medium text-sm">Job in Progress</div>
-                <div class="text-muted-foreground text-xs">
-                  Processed: {activeJobs()[jobId]?.processed || processed} /{" "}
-                  {activeJobs()[jobId]?.total || total}
-                </div>
-                <Progress
-                  class="h-2"
-                  value={
-                    ((activeJobs()[jobId]?.processed || processed) /
-                      (activeJobs()[jobId]?.total || total)) *
-                    PERCENTAGE_MULTIPLIER
-                  }
-                />
-              </div>
-            ),
-            {
-              id: toastId,
-              duration: Number.POSITIVE_INFINITY,
-            }
-          );
-        } else {
-          // Create a new toast with a known ID
-          toastId = toast.loading(
-            () => (
-              <div class="flex w-full min-w-[200px] flex-col gap-2">
-                <div class="font-medium text-sm">Job in Progress</div>
-                <div class="text-muted-foreground text-xs">
-                  Processed: {activeJobs()[jobId]?.processed || processed} /{" "}
-                  {activeJobs()[jobId]?.total || total}
-                </div>
-                <Progress
-                  class="h-2"
-                  value={
-                    ((activeJobs()[jobId]?.processed || processed) /
-                      (activeJobs()[jobId]?.total || total)) *
-                    PERCENTAGE_MULTIPLIER
-                  }
-                />
-              </div>
-            ),
-            {
-              duration: Number.POSITIVE_INFINITY, // Keep it open until completed or failed
-            }
-          );
-
-          if (typeof toastId === "string") {
-            setToastIds((prev) => ({
-              ...prev,
-              [jobId]: toastId as string,
-            }));
+        const currentToastId = toastIds()[jobId];
+        const newToastId = toast.loading(
+          () => <JobProgressToast processed={processed} total={total} />,
+          {
+            id: currentToastId,
+            duration: Number.POSITIVE_INFINITY,
           }
+        );
+
+        if (!currentToastId && typeof newToastId === "string") {
+          setToastIds((prev) => ({ ...prev, [jobId]: newToastId }));
         }
       } catch (_e) {
         // Ignore JSON parse errors
@@ -106,28 +78,11 @@ export function GlobalJobToaster() {
 
     const _onCompleted = (event: MessageEvent) => {
       try {
-        const data = JSON.parse(event.data);
-        const { jobId } = data;
+        const { jobId } = JSON.parse(event.data);
+        const toastId = toastIds()[jobId];
 
-        const currentToastIds = toastIds();
-        const toastId = currentToastIds[jobId];
-
-        if (toastId) {
-          toast.success("Job completed successfully", { id: toastId });
-          setToastIds((prev) => {
-            const next = { ...prev };
-            delete next[jobId];
-            return next;
-          });
-        } else {
-          toast.success("Job completed successfully");
-        }
-
-        setActiveJobs((prev) => {
-          const next = { ...prev };
-          delete next[jobId];
-          return next;
-        });
+        toast.success("Job completed successfully", { id: toastId });
+        cleanupJob(jobId);
       } catch (_e) {
         // Ignore
       }
@@ -135,28 +90,11 @@ export function GlobalJobToaster() {
 
     const onFailed = (event: MessageEvent) => {
       try {
-        const data = JSON.parse(event.data);
-        const { jobId, error } = data;
+        const { jobId, error } = JSON.parse(event.data);
+        const toastId = toastIds()[jobId];
 
-        const currentToastIds = toastIds();
-        const toastId = currentToastIds[jobId];
-
-        if (toastId) {
-          toast.error(`Job failed: ${error}`, { id: toastId });
-          setToastIds((prev) => {
-            const next = { ...prev };
-            delete next[jobId];
-            return next;
-          });
-        } else {
-          toast.error(`Job failed: ${error}`);
-        }
-
-        setActiveJobs((prev) => {
-          const next = { ...prev };
-          delete next[jobId];
-          return next;
-        });
+        toast.error(`Job failed: ${error}`, { id: toastId });
+        cleanupJob(jobId);
       } catch (_e) {
         // Ignore
       }

--- a/apps/server/src/components/global-job-toaster.tsx
+++ b/apps/server/src/components/global-job-toaster.tsx
@@ -1,0 +1,182 @@
+import { Progress } from "@solid-imager/ui/progress";
+import { createSignal, onCleanup } from "solid-js";
+import { isServer } from "solid-js/web";
+
+const PERCENTAGE_MULTIPLIER = 100;
+
+type JobProgressData = {
+  jobId: string;
+  processed: number;
+  total: number;
+};
+
+import { Toaster, toast } from "@solid-imager/ui/toast";
+import { onMount, Show } from "solid-js";
+
+export function GlobalJobToaster() {
+  const [mounted, setMounted] = createSignal(false);
+
+  const [activeJobs, setActiveJobs] = createSignal<
+    Record<string, JobProgressData>
+  >({});
+  const [toastIds, setToastIds] = createSignal<Record<string, string>>({});
+
+  onMount(() => {
+    if (isServer) {
+      return;
+    }
+    setMounted(true);
+
+    const eventSource = new EventSource("/api/events?channels=global-jobs");
+
+    const onProgress = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data) as JobProgressData;
+        const { jobId, processed, total } = data;
+
+        setActiveJobs((prev) => ({
+          ...prev,
+          [jobId]: data,
+        }));
+
+        const currentToastIds = toastIds();
+        let toastId = currentToastIds[jobId];
+
+        if (toastId) {
+          // Update the existing toast
+          toast.loading(
+            () => (
+              <div class="flex w-full min-w-[200px] flex-col gap-2">
+                <div class="font-medium text-sm">Job in Progress</div>
+                <div class="text-muted-foreground text-xs">
+                  Processed: {activeJobs()[jobId]?.processed || processed} /{" "}
+                  {activeJobs()[jobId]?.total || total}
+                </div>
+                <Progress
+                  class="h-2"
+                  value={
+                    ((activeJobs()[jobId]?.processed || processed) /
+                      (activeJobs()[jobId]?.total || total)) *
+                    PERCENTAGE_MULTIPLIER
+                  }
+                />
+              </div>
+            ),
+            {
+              id: toastId,
+              duration: Number.POSITIVE_INFINITY,
+            }
+          );
+        } else {
+          // Create a new toast with a known ID
+          toastId = toast.loading(
+            () => (
+              <div class="flex w-full min-w-[200px] flex-col gap-2">
+                <div class="font-medium text-sm">Job in Progress</div>
+                <div class="text-muted-foreground text-xs">
+                  Processed: {activeJobs()[jobId]?.processed || processed} /{" "}
+                  {activeJobs()[jobId]?.total || total}
+                </div>
+                <Progress
+                  class="h-2"
+                  value={
+                    ((activeJobs()[jobId]?.processed || processed) /
+                      (activeJobs()[jobId]?.total || total)) *
+                    PERCENTAGE_MULTIPLIER
+                  }
+                />
+              </div>
+            ),
+            {
+              duration: Number.POSITIVE_INFINITY, // Keep it open until completed or failed
+            }
+          );
+
+          if (typeof toastId === "string") {
+            setToastIds((prev) => ({
+              ...prev,
+              [jobId]: toastId as string,
+            }));
+          }
+        }
+      } catch (_e) {
+        // Ignore JSON parse errors
+      }
+    };
+
+    const _onCompleted = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data);
+        const { jobId } = data;
+
+        const currentToastIds = toastIds();
+        const toastId = currentToastIds[jobId];
+
+        if (toastId) {
+          toast.success("Job completed successfully", { id: toastId });
+          setToastIds((prev) => {
+            const next = { ...prev };
+            delete next[jobId];
+            return next;
+          });
+        } else {
+          toast.success("Job completed successfully");
+        }
+
+        setActiveJobs((prev) => {
+          const next = { ...prev };
+          delete next[jobId];
+          return next;
+        });
+      } catch (_e) {
+        // Ignore
+      }
+    };
+
+    const onFailed = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data);
+        const { jobId, error } = data;
+
+        const currentToastIds = toastIds();
+        const toastId = currentToastIds[jobId];
+
+        if (toastId) {
+          toast.error(`Job failed: ${error}`, { id: toastId });
+          setToastIds((prev) => {
+            const next = { ...prev };
+            delete next[jobId];
+            return next;
+          });
+        } else {
+          toast.error(`Job failed: ${error}`);
+        }
+
+        setActiveJobs((prev) => {
+          const next = { ...prev };
+          delete next[jobId];
+          return next;
+        });
+      } catch (_e) {
+        // Ignore
+      }
+    };
+
+    eventSource.addEventListener("job-progress", onProgress);
+    eventSource.addEventListener("job-completed", _onCompleted);
+    eventSource.addEventListener("job-failed", onFailed);
+
+    onCleanup(() => {
+      eventSource.removeEventListener("job-progress", onProgress);
+      eventSource.removeEventListener("job-completed", _onCompleted);
+      eventSource.removeEventListener("job-failed", onFailed);
+      eventSource.close();
+    });
+  });
+
+  return (
+    <Show when={mounted()}>
+      <Toaster />
+    </Show>
+  );
+}

--- a/apps/server/src/tests/e2e/smoke.spec.ts
+++ b/apps/server/src/tests/e2e/smoke.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+const BAD_REQUEST_STATUS = 400;
+const NOT_FOUND_REGEX = /404/;
+
+test.describe("Smoke Test - Page Accessibility", () => {
+  const pages = [
+    { name: "Home", path: "/" },
+    { name: "About", path: "/about" },
+    { name: "Config", path: "/config" },
+    { name: "Manager", path: "/manager" },
+    { name: "Search", path: "/search" },
+    { name: "Sources", path: "/sources" },
+    { name: "Swagger API Docs", path: "/docs/swagger" },
+  ];
+
+  for (const page of pages) {
+    test(`should access ${page.name} page`, async ({ page: p }) => {
+      const response = await p.goto(page.path);
+
+      // Check if response is successful (2xx)
+      expect(response?.status()).toBeLessThan(BAD_REQUEST_STATUS);
+
+      // Simple accessibility check by waiting for some content
+      await expect(p).not.toHaveTitle(NOT_FOUND_REGEX);
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",
+    "@playwright/test": "1.43.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "typescript": "^5.9.3"
@@ -49,5 +50,6 @@
   "trustedDependencies": [
     "youtube-dl-exec",
     "ffmpeg-static"
-  ]
+  ],
+  "dependencies": {}
 }

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -1,1 +1,141 @@
-export { default, Toaster, toast } from "solid-toast";
+import { createComponent, createSignal, onMount, Show } from "solid-js";
+import { isServer } from "solid-js/web";
+import type { ToastOptions } from "solid-toast";
+
+// Use a loose type for dynamic module integration
+type SolidToastFunction = {
+  // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
+  (message: any, options?: ToastOptions): string;
+  // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
+  success(message: any, options?: ToastOptions): string;
+  // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
+  error(message: any, options?: ToastOptions): string;
+  // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
+  loading(message: any, options?: ToastOptions): string;
+  // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
+  promise(promise: Promise<any>, msgs: any, options?: ToastOptions): string;
+  // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
+  custom(jsx: any, options?: ToastOptions): string;
+  dismiss(id?: string): void;
+  remove(id?: string): void;
+};
+
+let solidToast: SolidToastFunction | null = null;
+
+export const Toaster = (props: Record<string, unknown>) => {
+  if (isServer) {
+    return null;
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: Dynamic SolidJS component type
+  const [ToasterComponent, setToasterComponent] = createSignal<any>(null);
+
+  onMount(() => {
+    import("solid-toast").then((module) => {
+      solidToast = module.toast as SolidToastFunction;
+      setToasterComponent(() => module.Toaster);
+    });
+  });
+
+  return (
+    <Show when={ToasterComponent()}>
+      {(Comp) => createComponent(Comp(), props)}
+    </Show>
+  );
+};
+
+const RANDOM_RADIX = 36;
+const ID_START_INDEX = 2;
+const ID_END_INDEX = 9;
+
+const generateId = () =>
+  Math.random().toString(RANDOM_RADIX).substring(ID_START_INDEX, ID_END_INDEX);
+
+// biome-ignore lint/suspicious/noExplicitAny: Argument type matching library
+export const toast = (...args: [any, ToastOptions?]) => {
+  if (isServer) {
+    return "";
+  }
+
+  if (solidToast) {
+    return solidToast(...args);
+  }
+
+  const id = args[1]?.id || generateId();
+  const options = { ...args[1], id };
+  // biome-ignore lint/suspicious/noExplicitAny: Argument type matching library
+  const newArgs: [any, ToastOptions?] = [args[0], options];
+
+  import("solid-toast").then((module) => {
+    solidToast = module.toast as SolidToastFunction;
+    solidToast(...newArgs);
+  });
+
+  return id;
+};
+
+const createProxyMethod = (method: keyof SolidToastFunction) => {
+  // biome-ignore lint/suspicious/noExplicitAny: Arguments forwarded dynamically
+  return (...args: any[]) => {
+    if (isServer) {
+      return "";
+    }
+
+    // @ts-expect-error - dynamic method invocation
+    if (solidToast?.[method]) {
+      // @ts-expect-error - dynamic method invocation
+      return solidToast[method](...args);
+    }
+
+    const id = args[1]?.id || generateId();
+    const options = { ...args[1], id };
+    const newArgs = [args[0], options];
+
+    import("solid-toast").then((module) => {
+      solidToast = module.toast as SolidToastFunction;
+      // @ts-expect-error - dynamic method invocation
+      if (solidToast?.[method]) {
+        // @ts-expect-error - dynamic method invocation
+        solidToast[method](...newArgs);
+      }
+    });
+
+    return id;
+  };
+};
+
+toast.success = createProxyMethod("success");
+toast.error = createProxyMethod("error");
+toast.loading = createProxyMethod("loading");
+toast.promise = createProxyMethod("promise");
+toast.custom = createProxyMethod("custom");
+
+toast.dismiss = (...args: [string?]) => {
+  if (isServer) {
+    return;
+  }
+  if (solidToast) {
+    solidToast.dismiss(...args);
+    return;
+  }
+  import("solid-toast").then((module) => {
+    solidToast = module.toast as SolidToastFunction;
+    solidToast.dismiss(...args);
+  });
+};
+
+toast.remove = (...args: [string?]) => {
+  if (isServer) {
+    return;
+  }
+  if (solidToast) {
+    solidToast.remove(...args);
+    return;
+  }
+  import("solid-toast").then((module) => {
+    solidToast = module.toast as SolidToastFunction;
+    solidToast.remove(...args);
+  });
+};
+
+export default toast;

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -5,22 +5,29 @@ import type { ToastOptions } from "solid-toast";
 // Use a loose type for dynamic module integration
 type SolidToastFunction = {
   // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
-  (message: any, options?: ToastOptions): string;
+  (message: any, options?: ToastOptions): any;
   // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
-  success(message: any, options?: ToastOptions): string;
+  success(message: any, options?: ToastOptions): any;
   // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
-  error(message: any, options?: ToastOptions): string;
+  error(message: any, options?: ToastOptions): any;
   // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
-  loading(message: any, options?: ToastOptions): string;
+  loading(message: any, options?: ToastOptions): any;
   // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
-  promise(promise: Promise<any>, msgs: any, options?: ToastOptions): string;
+  promise(promise: Promise<any>, msgs: any, options?: ToastOptions): any;
   // biome-ignore lint/suspicious/noExplicitAny: Required for library typing match
-  custom(jsx: any, options?: ToastOptions): string;
+  custom(jsx: any, options?: ToastOptions): any;
   dismiss(id?: string): void;
   remove(id?: string): void;
 };
 
 let solidToast: SolidToastFunction | null = null;
+
+const RANDOM_RADIX = 36;
+const ID_START_INDEX = 2;
+const ID_END_INDEX = 9;
+
+const generateId = () =>
+  Math.random().toString(RANDOM_RADIX).substring(ID_START_INDEX, ID_END_INDEX);
 
 export const Toaster = (props: Record<string, unknown>) => {
   if (isServer) {
@@ -32,27 +39,20 @@ export const Toaster = (props: Record<string, unknown>) => {
 
   onMount(() => {
     import("solid-toast").then((module) => {
-      solidToast = module.toast as SolidToastFunction;
+      solidToast = module.toast as unknown as SolidToastFunction;
       setToasterComponent(() => module.Toaster);
     });
   });
 
   return (
     <Show when={ToasterComponent()}>
-      {(Comp) => createComponent(Comp(), props)}
+      {(Comp) => createComponent(Comp, props)}
     </Show>
   );
 };
 
-const RANDOM_RADIX = 36;
-const ID_START_INDEX = 2;
-const ID_END_INDEX = 9;
-
-const generateId = () =>
-  Math.random().toString(RANDOM_RADIX).substring(ID_START_INDEX, ID_END_INDEX);
-
-// biome-ignore lint/suspicious/noExplicitAny: Argument type matching library
-export const toast = (...args: [any, ToastOptions?]) => {
+// biome-ignore lint/suspicious/noExplicitAny: Base toast function proxy
+const toastProxy = ((...args: [any, ToastOptions?]) => {
   if (isServer) {
     return "";
   }
@@ -63,16 +63,14 @@ export const toast = (...args: [any, ToastOptions?]) => {
 
   const id = args[1]?.id || generateId();
   const options = { ...args[1], id };
-  // biome-ignore lint/suspicious/noExplicitAny: Argument type matching library
-  const newArgs: [any, ToastOptions?] = [args[0], options];
 
   import("solid-toast").then((module) => {
-    solidToast = module.toast as SolidToastFunction;
-    solidToast(...newArgs);
+    solidToast = module.toast as unknown as SolidToastFunction;
+    solidToast(args[0], options);
   });
 
   return id;
-};
+}) as unknown as SolidToastFunction;
 
 const createProxyMethod = (method: keyof SolidToastFunction) => {
   // biome-ignore lint/suspicious/noExplicitAny: Arguments forwarded dynamically
@@ -81,19 +79,21 @@ const createProxyMethod = (method: keyof SolidToastFunction) => {
       return "";
     }
 
-    // @ts-expect-error - dynamic method invocation
     if (solidToast?.[method]) {
       // @ts-expect-error - dynamic method invocation
       return solidToast[method](...args);
     }
 
-    const id = args[1]?.id || generateId();
-    const options = { ...args[1], id };
-    const newArgs = [args[0], options];
+    // Special handling for promise which has options at index 2, others at index 1
+    const optionsIndex = method === "promise" ? 2 : 1;
+    const id = args[optionsIndex]?.id || generateId();
+    const options = { ...args[optionsIndex], id };
+
+    const newArgs = [...args];
+    newArgs[optionsIndex] = options;
 
     import("solid-toast").then((module) => {
-      solidToast = module.toast as SolidToastFunction;
-      // @ts-expect-error - dynamic method invocation
+      solidToast = module.toast as unknown as SolidToastFunction;
       if (solidToast?.[method]) {
         // @ts-expect-error - dynamic method invocation
         solidToast[method](...newArgs);
@@ -104,38 +104,44 @@ const createProxyMethod = (method: keyof SolidToastFunction) => {
   };
 };
 
-toast.success = createProxyMethod("success");
-toast.error = createProxyMethod("error");
-toast.loading = createProxyMethod("loading");
-toast.promise = createProxyMethod("promise");
-toast.custom = createProxyMethod("custom");
+// biome-ignore lint/suspicious/noExplicitAny: Required for library method proxy
+toastProxy.success = createProxyMethod("success") as any;
+// biome-ignore lint/suspicious/noExplicitAny: Required for library method proxy
+toastProxy.error = createProxyMethod("error") as any;
+// biome-ignore lint/suspicious/noExplicitAny: Required for library method proxy
+toastProxy.loading = createProxyMethod("loading") as any;
+// biome-ignore lint/suspicious/noExplicitAny: Required for library method proxy
+toastProxy.promise = createProxyMethod("promise") as any;
+// biome-ignore lint/suspicious/noExplicitAny: Required for library method proxy
+toastProxy.custom = createProxyMethod("custom") as any;
 
-toast.dismiss = (...args: [string?]) => {
+toastProxy.dismiss = (id?: string) => {
   if (isServer) {
     return;
   }
   if (solidToast) {
-    solidToast.dismiss(...args);
+    solidToast.dismiss(id);
     return;
   }
   import("solid-toast").then((module) => {
-    solidToast = module.toast as SolidToastFunction;
-    solidToast.dismiss(...args);
+    solidToast = module.toast as unknown as SolidToastFunction;
+    solidToast.dismiss(id);
   });
 };
 
-toast.remove = (...args: [string?]) => {
+toastProxy.remove = (id?: string) => {
   if (isServer) {
     return;
   }
   if (solidToast) {
-    solidToast.remove(...args);
+    solidToast.remove(id);
     return;
   }
   import("solid-toast").then((module) => {
-    solidToast = module.toast as SolidToastFunction;
-    solidToast.remove(...args);
+    solidToast = module.toast as unknown as SolidToastFunction;
+    solidToast.remove(id);
   });
 };
 
+export const toast = toastProxy;
 export default toast;


### PR DESCRIPTION
This PR implements the functionality to display consolidated global job progress toasts using SSE events. It resolves the issue of having multiple separate toasts shown per event, converting them into one continuous progress bar for batch jobs. The `solid-toast` wrapper was modified to ensure it relies entirely on dynamic `import()` to resolve SSR crashes in the Vinxi/SolidStart environment.

---
*PR created automatically by Jules for task [11550950117225414640](https://jules.google.com/task/11550950117225414640) started by @hmjn023*