### PR TITLE
perf: reduce image preview load in ImportReviewModal

### DIFF
--- a/apps/server/src/components/imports/import-review-modal.tsx
+++ b/apps/server/src/components/imports/import-review-modal.tsx
@@ -25,6 +25,14 @@ type Props = {
 	onImportCompleted: () => void;
 };
 
+function getPreviewUrl(url?: string): string {
+	if (!url) return "";
+	if (url.includes("pbs.twimg.com")) {
+		return url.replace("name=orig", "name=small");
+	}
+	return url;
+}
+
 export default function ImportReviewModal(props: Props) {
 	const [selectedJobIds, setSelectedJobIds] = createSignal<Set<string>>(
 		new Set(),
@@ -195,16 +203,13 @@ export default function ImportReviewModal(props: Props) {
 													}
 													when={job.item.targetUrl}
 												>
-													{/* biome-ignore lint/performance/noImgElement: Dynamic content */}
-													{/* biome-ignore lint: Dynamic content */}
-													{/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: onError handler required */}
 													<img
 														alt="Preview"
 														class="h-full w-full object-cover"
 														onError={(e) => {
 															e.currentTarget.style.display = "none";
 														}}
-														src={job.item.targetUrl}
+														src={getPreviewUrl(job.item.targetUrl)}
 													/>
 												</Show>
 											</div>

--- a/apps/server/src/components/imports/import-review-modal.tsx
+++ b/apps/server/src/components/imports/import-review-modal.tsx
@@ -27,8 +27,17 @@ type Props = {
 
 function getPreviewUrl(url?: string): string {
 	if (!url) return "";
-	if (url.includes("pbs.twimg.com")) {
-		return url.replace("name=orig", "name=small");
+	try {
+		const urlObj = new URL(url);
+		if (
+			urlObj.hostname === "pbs.twimg.com" &&
+			urlObj.searchParams.get("name") === "orig"
+		) {
+			urlObj.searchParams.set("name", "small");
+			return urlObj.toString();
+		}
+	} catch {
+		// Not a valid URL, return original string below
 	}
 	return url;
 }


### PR DESCRIPTION
Twitter image URLs in the Review Pending Imports modal are now transformed to use 'name=small' for preview, while keeping 'name=orig' for the actual download process. This reduces the network load when reviewing many pending imports.

- Added getPreviewUrl helper in ImportReviewModal.tsx
- Updated img src to use the helper
- Cleaned up redundant Biome suppressions

---
*PR created automatically by Jules for task [16036708333197576056](https://jules.google.com/task/16036708333197576056) started by @hmjn023*