### PR TITLE
fix(server): restore createdAt metadata from JSON

### DIFF
--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -333,6 +333,7 @@ export const BackupService = {
 					set: {
 						description: sql`excluded.description`,
 						modifiedAt: sql`excluded.modified_at`,
+						createdAt: sql`excluded.created_at`,
 						width: sql`excluded.width`,
 						height: sql`excluded.height`,
 						fileSize: sql`excluded.file_size`,


### PR DESCRIPTION
Ensure that restored date metadata from JSON takes precedence even if records already exist (e.g., from recent file scans using system timestamps).