### PR TITLE
feat: add configurable rate limiting for bulk downloads

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,7 +22,7 @@
     "test:unit": "vp test run -c vitest.unit.config.ts",
     "test:integration": "vp test run -c vitest.integration.config.ts",
     "test:e2e": "playwright test",
-    "typecheck": "tsc --noEmit --project ./tsconfig.json",
+    "typecheck": "sh -c 'tsc --noEmit --project ./tsconfig.json'",
     "gen:spec": "bun scripts/generate-swagger-spec.ts",
     "docs:generate": "typedoc"
   },

--- a/apps/server/src/application/services/server-config-service.ts
+++ b/apps/server/src/application/services/server-config-service.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import type { IConfigService } from "@solid-imager/core";
 import {
 	type AppConfig,
@@ -48,9 +49,7 @@ export class ServerConfigService implements IConfigService {
 
 				const parsedFromFile = AppConfigSchema.safeParse(fileContent);
 				if (parsedFromFile.success) {
-					if (
-						JSON.stringify(parsedFromFile.data) !== JSON.stringify(fileContent)
-					) {
+					if (!isDeepStrictEqual(parsedFromFile.data, fileContent)) {
 						fs.writeFileSync(
 							this.configPath,
 							JSON.stringify(parsedFromFile.data, null, 2),

--- a/apps/server/src/application/services/server-config-service.ts
+++ b/apps/server/src/application/services/server-config-service.ts
@@ -45,6 +45,20 @@ export class ServerConfigService implements IConfigService {
 						}`,
 					);
 				}
+
+				const parsedFromFile = AppConfigSchema.safeParse(fileContent);
+				if (parsedFromFile.success) {
+					if (
+						JSON.stringify(parsedFromFile.data) !== JSON.stringify(fileContent)
+					) {
+						fs.writeFileSync(
+							this.configPath,
+							JSON.stringify(parsedFromFile.data, null, 2),
+						);
+						logger.info("config.json migrated with new default fields");
+					}
+					fileContent = parsedFromFile.data;
+				}
 			} else {
 				logger.info("config.json not found, creating default");
 				// For init, we can write sync.

--- a/apps/server/src/infrastructure/bootstrap.ts
+++ b/apps/server/src/infrastructure/bootstrap.ts
@@ -43,13 +43,11 @@ export function initServices() {
 
 	// Initialize log level from config and subscribe to changes
 	updateLogLevel(config.logging.level);
-	configService.onChange((newConfig) =>
-		updateLogLevel(newConfig.logging.level),
-	);
 	updateDownloadRateLimitConfig(config.downloads);
-	configService.onChange((newConfig) =>
-		updateDownloadRateLimitConfig(newConfig.downloads),
-	);
+	configService.onChange((newConfig) => {
+		updateLogLevel(newConfig.logging.level);
+		updateDownloadRateLimitConfig(newConfig.downloads);
+	});
 
 	// Register Repositories
 	services.registerMediaRepository(MediaRepository);

--- a/apps/server/src/infrastructure/bootstrap.ts
+++ b/apps/server/src/infrastructure/bootstrap.ts
@@ -7,6 +7,7 @@ import { ServerConfigService } from "~/application/services/server-config-servic
 import { PythonClient } from "~/infrastructure/ai/python-client";
 import { DrizzleTransactionManager } from "~/infrastructure/db/transaction-manager";
 import { NodeFileSystem } from "~/infrastructure/file-system/node-file-system";
+import { updateDownloadRateLimitConfig } from "~/infrastructure/jobs/download-rate-limiter";
 import { JobWorker } from "~/infrastructure/jobs/job-worker";
 import { logger, updateLogLevel } from "~/infrastructure/logger";
 import { ImageProcessor } from "~/infrastructure/processing/image-processor";
@@ -44,6 +45,10 @@ export function initServices() {
 	updateLogLevel(config.logging.level);
 	configService.onChange((newConfig) =>
 		updateLogLevel(newConfig.logging.level),
+	);
+	updateDownloadRateLimitConfig(config.downloads);
+	configService.onChange((newConfig) =>
+		updateDownloadRateLimitConfig(newConfig.downloads),
 	);
 
 	// Register Repositories

--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -15,6 +15,7 @@ import ffmpegPath from "ffmpeg-static";
 import youtubedl from "youtube-dl-exec";
 import { services } from "~/application/registry";
 import type { Job } from "~/infrastructure/db/schema";
+import { waitForDownloadRateLimit } from "~/infrastructure/jobs/download-rate-limiter";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
 import { logger } from "~/infrastructure/logger";
 import { MediaRepository } from "~/infrastructure/repositories/media-repository";
@@ -244,6 +245,8 @@ async function handleYtDlpDownload(
 	logger.info({ url: item.targetUrl }, "[DownloadJob] Using yt-dlp");
 
 	try {
+		await waitForDownloadRateLimit();
+
 		const results = await downloadWithYtDlp(
 			item.targetUrl,
 			basePath,
@@ -434,6 +437,8 @@ async function handleDirectImageDownload(
 	try {
 		// Download the image
 		const headers = buildFetchHeaders(item);
+
+		await waitForDownloadRateLimit();
 
 		const response = await fetch(item.targetUrl, {
 			headers,

--- a/apps/server/src/infrastructure/jobs/download-rate-limiter.ts
+++ b/apps/server/src/infrastructure/jobs/download-rate-limiter.ts
@@ -1,0 +1,35 @@
+import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+
+type DownloadRateLimitConfig = AppConfig["downloads"];
+
+let config: DownloadRateLimitConfig = {
+	rateLimitEnabled: true,
+	requestIntervalMs: 1_000,
+};
+let lastRequestTime = 0;
+let pendingChain: Promise<void> = Promise.resolve();
+
+export function updateDownloadRateLimitConfig(
+	newConfig: DownloadRateLimitConfig,
+): void {
+	config = newConfig;
+}
+
+export async function waitForDownloadRateLimit(): Promise<void> {
+	if (!config.rateLimitEnabled || config.requestIntervalMs <= 0) {
+		return;
+	}
+
+	const previous = pendingChain;
+	pendingChain = (async () => {
+		await previous;
+		const elapsed = Date.now() - lastRequestTime;
+		const delay = config.requestIntervalMs - elapsed;
+		if (delay > 0) {
+			await new Promise<void>((resolve) => setTimeout(resolve, delay));
+		}
+		lastRequestTime = Date.now();
+	})();
+
+	await pendingChain;
+}

--- a/apps/server/src/routes/config.tsx
+++ b/apps/server/src/routes/config.tsx
@@ -62,9 +62,10 @@ function ConfigForm(props: { data: AppConfig }) {
 			</div>
 
 			<Tabs class="w-full" defaultValue="jobs">
-				<TabsList class="grid w-full grid-cols-5">
+				<TabsList class="grid w-full grid-cols-6">
 					<TabsTrigger value="jobs">Jobs</TabsTrigger>
 					<TabsTrigger value="ai">AI</TabsTrigger>
+					<TabsTrigger value="downloads">Downloads</TabsTrigger>
 					<TabsTrigger value="storage">Storage</TabsTrigger>
 					<TabsTrigger value="media">Media</TabsTrigger>
 					<TabsTrigger value="logging">Logging</TabsTrigger>
@@ -216,6 +217,57 @@ function ConfigForm(props: { data: AppConfig }) {
 											type="number"
 											value={(field().state.value as number) ?? ""}
 										/>
+									</div>
+								)}
+							</form.Field>
+						</div>
+					</TabsContent>
+
+					<TabsContent value="downloads">
+						<div class="space-y-4 rounded-md border p-4">
+							<h2 class="mb-4 font-semibold text-xl">Downloads</h2>
+
+							<form.Field name="downloads.rateLimitEnabled">
+								{(field) => (
+									<div class="flex items-center space-x-2">
+										<Switch
+											checked={(field().state.value as boolean) ?? false}
+											onChange={field().handleChange}
+										>
+											<SwitchControl>
+												<SwitchThumb />
+											</SwitchControl>
+											<SwitchLabel>レートリミット有効</SwitchLabel>
+										</Switch>
+									</div>
+								)}
+							</form.Field>
+
+							<form.Field name="downloads.requestIntervalMs">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>リクエスト間隔 (ms)</Label>
+										<Input
+											id={field().name}
+											max="60000"
+											min="0"
+											onBlur={field().handleBlur}
+											onInput={(e) => {
+												const val = e.target.value;
+												field().handleChange(
+													(val === ""
+														? undefined
+														: Number(val)) as unknown as number,
+												);
+											}}
+											type="number"
+											value={(field().state.value as number) ?? ""}
+										/>
+										<Show when={field().state.meta.errors.length}>
+											<div class="text-red-500 text-sm">
+												{field().state.meta.errors[0]}
+											</div>
+										</Show>
 									</div>
 								)}
 							</form.Field>

--- a/apps/server/src/tests/unit/infrastructure/jobs/download-rate-limiter.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/download-rate-limiter.test.ts
@@ -1,0 +1,55 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vite-plus/test";
+import {
+	updateDownloadRateLimitConfig,
+	waitForDownloadRateLimit,
+} from "~/infrastructure/jobs/download-rate-limiter";
+
+describe("download-rate-limiter", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-01T00:00:00.000Z"));
+		updateDownloadRateLimitConfig({
+			rateLimitEnabled: true,
+			requestIntervalMs: 1_000,
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("should not wait when rate limiting is disabled", async () => {
+		updateDownloadRateLimitConfig({
+			rateLimitEnabled: false,
+			requestIntervalMs: 1_000,
+		});
+
+		await expect(waitForDownloadRateLimit()).resolves.toBeUndefined();
+	});
+
+	it("should serialize requests using the configured interval", async () => {
+		const first = waitForDownloadRateLimit();
+		await vi.runAllTimersAsync();
+		await first;
+
+		const second = waitForDownloadRateLimit();
+		await vi.advanceTimersByTimeAsync(999);
+		let settled = false;
+		void second.then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(1);
+		await second;
+		expect(settled).toBe(true);
+	});
+});

--- a/apps/server/src/tests/unit/server-config-service.test.ts
+++ b/apps/server/src/tests/unit/server-config-service.test.ts
@@ -51,6 +51,33 @@ describe("ConfigService", () => {
 		expect(service.getConfig().jobs.concurrency).toBe(10);
 	});
 
+	it("should migrate existing config with new default fields", () => {
+		const legacyConfig = {
+			version: defaultAppConfig.version,
+			jobs: defaultAppConfig.jobs,
+			ai: defaultAppConfig.ai,
+			storage: defaultAppConfig.storage,
+			media: defaultAppConfig.media,
+			logging: defaultAppConfig.logging,
+		};
+		vi.mocked(fs.existsSync).mockReturnValue(true);
+		vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(legacyConfig));
+
+		service.load();
+
+		expect(service.getConfig().downloads).toEqual(defaultAppConfig.downloads);
+		expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(fs.writeFileSync).mock.calls[0]?.[0]).toContain(
+			"config.json",
+		);
+		expect(
+			JSON.parse(String(vi.mocked(fs.writeFileSync).mock.calls[0]?.[1])),
+		).toEqual({
+			...legacyConfig,
+			downloads: defaultAppConfig.downloads,
+		});
+	});
+
 	it("should override config with environment variables", () => {
 		vi.mocked(fs.existsSync).mockReturnValue(false);
 		vi.stubEnv("CONFIG_JOBS_CONCURRENCY", "50");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "check": "biome check --fix --unsafe ./src",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "sh -c 'tsc --noEmit'",
     "lint": "biome lint ./src",
     "test": "vp test run",
     "test:unit": "vp test run"

--- a/packages/core/src/domain/config/config-schema.ts
+++ b/packages/core/src/domain/config/config-schema.ts
@@ -30,6 +30,20 @@ export const AiConfigSchema = z.object({
 });
 const defaultAiConfig = AiConfigSchema.parse({});
 
+const DEFAULT_DOWNLOAD_RATE_LIMIT_ENABLED = true;
+const DEFAULT_DOWNLOAD_REQUEST_INTERVAL_MS = 1_000;
+const MAX_DOWNLOAD_REQUEST_INTERVAL_MS = 60_000;
+
+export const DownloadsConfigSchema = z.object({
+	rateLimitEnabled: z.boolean().default(DEFAULT_DOWNLOAD_RATE_LIMIT_ENABLED),
+	requestIntervalMs: z
+		.number()
+		.min(0)
+		.max(MAX_DOWNLOAD_REQUEST_INTERVAL_MS)
+		.default(DEFAULT_DOWNLOAD_REQUEST_INTERVAL_MS),
+});
+const defaultDownloadsConfig = DownloadsConfigSchema.parse({});
+
 const DEFAULT_THUMB_DIR = ".cache/thumbnails";
 const DEFAULT_THUMB_SIZE = 512;
 const DEFAULT_THUMB_QUALITY = 80;
@@ -96,6 +110,7 @@ export const AppConfigSchema = z.object({
 	version: z.string().default("1.0.0"),
 	jobs: JobsConfigSchema.default(defaultJobsConfig),
 	ai: AiConfigSchema.default(defaultAiConfig),
+	downloads: DownloadsConfigSchema.default(defaultDownloadsConfig),
 	storage: StorageConfigSchema.default(defaultStorageConfig),
 	media: MediaConfigSchema.default(defaultMediaConfig),
 	logging: LoggingConfigSchema.default(defaultLoggingConfig),

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
+    passWithNoTests: true,
   },
 });


### PR DESCRIPTION
## Summary

- xtracter 経由の bulk download（`downloadImage` ジョブ）にリクエスト間隔ベースのレートリミットを追加
- `config.json` の `downloads` セクションで有効/無効と間隔（ms）を設定可能
- 既存の `config.json`（`downloads` キーなし）は起動時に自動マイグレーション

## 変更内容

- `packages/core/.../config-schema.ts` — `DownloadsConfigSchema` 追加（`rateLimitEnabled: true`, `requestIntervalMs: 1000`）
- `download-rate-limiter.ts` — Promise チェーンで直列化するシングルトンレートリミッター（新規）
- `download-jobs.ts` — `handleDirectImageDownload` / `handleYtDlpDownload` の fetch 直前に `waitForDownloadRateLimit()` を挿入
- `bootstrap.ts` — 初期設定と `configService.onChange` リスナー登録
- `server-config-service.ts` — 起動時マイグレーションロジック追加
- `config.tsx` — Downloads タブ追加（UI）
- `apps/server/package.json`, `packages/core/package.json` — `vp staged` でファイルパスが typecheck コマンドに混入するバグを `sh -c` ラップで修正（既存バグ）
- `packages/core/vitest.config.ts` — `passWithNoTests: true` 追加（既存バグ）

## 影響範囲

`processMedia`（サムネイル生成）・`auto_tagging`・`restoreSource`（ローカルファイル）は別コードパスのため影響なし。

## Test plan

- [ ] `vp check` & `vp test` がパスすること
- [ ] 既存 `config.json`（`downloads` キーなし）でサーバー起動後、ファイルに `downloads` が追記されること
- [ ] config UI の Downloads タブから `requestIntervalMs` を変更し、ログで間隔が反映されること
- [ ] `rateLimitEnabled: false` 時にレートリミットが掛からないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)