### PR TITLE
Add remote source support to sources UI

### DIFF
--- a/apps/server/src/components/source-card.tsx
+++ b/apps/server/src/components/source-card.tsx
@@ -31,6 +31,8 @@ const getTypeLabel = (type: string) => {
 			return "SFTP";
 		case "s3":
 			return "S3 Compatible Storage";
+		case "remote":
+			return "Remote Server";
 		default:
 			return type;
 	}
@@ -47,6 +49,9 @@ const getConnectionDetails = (source: SafeMediaSource | MediaSourceInfo) => {
 	}
 	if (source.type === "s3") {
 		return `S3: ${info.bucket || "?"} (${info.region || "?"})`;
+	}
+	if (source.type === "remote") {
+		return `Remote: ${info.url || "?"} (${info.remoteSourceId || "?"})`;
 	}
 	return "Unknown Connection";
 };

--- a/apps/server/src/components/source-form-modal.tsx
+++ b/apps/server/src/components/source-form-modal.tsx
@@ -1,5 +1,6 @@
 import type {
 	MediaSourceInfo,
+	MediaSourceTypeEnum,
 	SafeMediaSource,
 } from "@solid-imager/core/domain/sources/schemas";
 import { Button } from "@solid-imager/ui/button";
@@ -24,6 +25,15 @@ import { createEffect, createSignal, Show } from "solid-js";
 import { createStore } from "solid-js/store";
 
 const DEFAULT_SFTP_PORT = 22;
+const SOURCE_TYPE_OPTIONS: Array<{
+	value: MediaSourceTypeEnum;
+	label: string;
+}> = [
+	{ value: "local", label: "Local Filesystem" },
+	{ value: "sftp", label: "SFTP" },
+	{ value: "s3", label: "S3 Compatible Storage" },
+	{ value: "remote", label: "Remote Server" },
+];
 
 type SourceFormModalProps = {
 	isOpen: boolean;
@@ -36,7 +46,7 @@ export default function SourceFormModal(props: SourceFormModalProps) {
 	const [formData, setFormData] = createStore<{
 		name: string;
 		description: string;
-		type: "local" | "sftp" | "s3";
+		type: MediaSourceTypeEnum;
 		connectionInfo: Record<string, string | number>;
 	}>({
 		name: "",
@@ -52,7 +62,7 @@ export default function SourceFormModal(props: SourceFormModalProps) {
 			setFormData({
 				name: props.editingSource.name,
 				description: props.editingSource.description || "",
-				type: props.editingSource.type as "local" | "sftp" | "s3",
+				type: props.editingSource.type,
 				connectionInfo: (props.editingSource.connectionInfo as any) || {},
 			});
 		} else {
@@ -102,6 +112,13 @@ export default function SourceFormModal(props: SourceFormModalProps) {
 					newErrors.secretAccessKey = "Secret Access Key is required";
 				}
 			}
+		} else if (formData.type === "remote") {
+			if (!formData.connectionInfo.url) {
+				newErrors.url = "Server URL is required";
+			}
+			if (!formData.connectionInfo.remoteSourceId) {
+				newErrors.remoteSourceId = "Remote source ID is required";
+			}
 		}
 
 		setErrors(newErrors);
@@ -134,6 +151,9 @@ export default function SourceFormModal(props: SourceFormModalProps) {
 		}
 		if (type === "s3") {
 			return "S3 Compatible Storage";
+		}
+		if (type === "remote") {
+			return "Remote Server";
 		}
 		return type;
 	};
@@ -182,14 +202,8 @@ export default function SourceFormModal(props: SourceFormModalProps) {
 									{itemProps.item.rawValue.label}
 								</SelectItem>
 							)}
-							onChange={(v) =>
-								setFormData("type", v?.value as "local" | "sftp" | "s3")
-							}
-							options={[
-								{ value: "local", label: "Local Filesystem" },
-								{ value: "sftp", label: "SFTP" },
-								{ value: "s3", label: "S3 Compatible Storage" },
-							]}
+							onChange={(v) => setFormData("type", v?.value ?? "local")}
+							options={SOURCE_TYPE_OPTIONS}
 							value={{
 								value: formData.type,
 								label: getTypeLabel(formData.type),
@@ -407,6 +421,43 @@ export default function SourceFormModal(props: SourceFormModalProps) {
 									placeholder="photos/"
 									value={(formData.connectionInfo.prefix as string) || ""}
 								/>
+							</div>
+						</Show>
+
+						<Show when={formData.type === "remote"}>
+							<div class="space-y-2">
+								<Label for="url">Server URL</Label>
+								<Input
+									id="url"
+									onInput={(e) =>
+										setFormData("connectionInfo", "url", e.currentTarget.value)
+									}
+									placeholder="https://remote.example.com"
+									value={(formData.connectionInfo.url as string) || ""}
+								/>
+								<Show when={errors().url}>
+									<p class="text-red-500 text-sm">{errors().url}</p>
+								</Show>
+							</div>
+							<div class="space-y-2">
+								<Label for="remoteSourceId">Remote Source ID</Label>
+								<Input
+									id="remoteSourceId"
+									onInput={(e) =>
+										setFormData(
+											"connectionInfo",
+											"remoteSourceId",
+											e.currentTarget.value,
+										)
+									}
+									placeholder="00000000-0000-4000-8000-000000000000"
+									value={
+										(formData.connectionInfo.remoteSourceId as string) || ""
+									}
+								/>
+								<Show when={errors().remoteSourceId}>
+									<p class="text-red-500 text-sm">{errors().remoteSourceId}</p>
+								</Show>
 							</div>
 						</Show>
 					</div>

--- a/apps/server/src/components/source-form-modal.tsx
+++ b/apps/server/src/components/source-form-modal.tsx
@@ -23,6 +23,7 @@ import {
 } from "@solid-imager/ui/select";
 import { createEffect, createSignal, Show } from "solid-js";
 import { createStore } from "solid-js/store";
+import { z } from "zod";
 
 const DEFAULT_SFTP_PORT = 22;
 const SOURCE_TYPE_OPTIONS: Array<{
@@ -115,9 +116,17 @@ export default function SourceFormModal(props: SourceFormModalProps) {
 		} else if (formData.type === "remote") {
 			if (!formData.connectionInfo.url) {
 				newErrors.url = "Server URL is required";
+			} else if (
+				!z.string().url().safeParse(formData.connectionInfo.url).success
+			) {
+				newErrors.url = "Invalid URL format";
 			}
 			if (!formData.connectionInfo.remoteSourceId) {
 				newErrors.remoteSourceId = "Remote source ID is required";
+			} else if (
+				!z.uuid().safeParse(formData.connectionInfo.remoteSourceId).success
+			) {
+				newErrors.remoteSourceId = "Invalid UUID format";
 			}
 		}
 
@@ -202,7 +211,14 @@ export default function SourceFormModal(props: SourceFormModalProps) {
 									{itemProps.item.rawValue.label}
 								</SelectItem>
 							)}
-							onChange={(v) => setFormData("type", v?.value ?? "local")}
+							onChange={(v) => {
+								const newType = v?.value ?? "local";
+								setFormData({
+									type: newType,
+									connectionInfo:
+										newType === formData.type ? formData.connectionInfo : {},
+								});
+							}}
 							options={SOURCE_TYPE_OPTIONS}
 							value={{
 								value: formData.type,

--- a/apps/server/src/infrastructure/api/routers/sources-router.ts
+++ b/apps/server/src/infrastructure/api/routers/sources-router.ts
@@ -51,6 +51,16 @@ function toSafeMediaSource(source: MediaSource): SafeMediaSource {
 			},
 		};
 	}
+	if (source.type === "remote") {
+		return {
+			...rest,
+			type: source.type,
+			connectionInfo: {
+				url: info.url,
+				remoteSourceId: info.remoteSourceId,
+			},
+		};
+	}
 	// Fallback for local
 	return {
 		...rest,

--- a/packages/core/src/domain/sources/schemas.ts
+++ b/packages/core/src/domain/sources/schemas.ts
@@ -119,6 +119,7 @@ export const safeConnectionInfoSchema = z.union([
 	localConnectionSchema,
 	safeSftpConnectionSchema,
 	safeS3ConnectionSchema,
+	remoteConnectionSchema,
 ]);
 
 export const safeMediaSourceSchema = mediaSourceInfoSchema.extend({


### PR DESCRIPTION
## Summary
- add `remote` as a selectable source type in the `/sources` create/edit modal
- add remote connection fields and validation for server URL and remote source ID
- expose remote connection info in safe source responses and source card rendering

## Verification
- `bun run --cwd apps/server check`
- `bun run --cwd apps/server typecheck`
- commit hook also ran workspace checks/tests/typechecks for the touched packages