### PR TITLE
feat(tauri): emit job-progress during thumbnail generation (#251)

### DIFF
--- a/apps/tauri/src/hooks/use-media-source-events.ts
+++ b/apps/tauri/src/hooks/use-media-source-events.ts
@@ -1,6 +1,8 @@
 import {
 	type AllJobsCompletedEvent,
 	allJobsCompletedEventSchema,
+	type JobProgressEvent,
+	jobProgressEventSchema,
 	type MediaAddedEvent,
 	type MediaChangedEvent,
 	type MediaCopiedEvent,
@@ -27,6 +29,7 @@ type MediaSourceEventsOptions = {
 	onMediaCopied?: (data: MediaCopiedEvent) => void;
 	onMediaMoved?: (data: MediaMovedEvent) => void;
 	onThumbnailGenerated?: (data: ThumbnailGeneratedEvent) => void;
+	onJobProgress?: (data: JobProgressEvent) => void;
 	onAllJobsCompleted?: (data: AllJobsCompletedEvent) => void;
 	onWatcherError?: (data: WatcherErrorEvent) => void;
 };
@@ -106,6 +109,15 @@ export function useMediaSourceEvents(
 				);
 				if (payload && payload.mediaSourceId === id) {
 					options.onThumbnailGenerated?.(payload);
+				}
+			}),
+			listen("job-progress", (event) => {
+				const payload = parseEventPayload(
+					jobProgressEventSchema,
+					event.payload,
+				);
+				if (payload && payload.jobId === id) {
+					options.onJobProgress?.(payload);
 				}
 			}),
 			listen("all-jobs-completed", (event) => {

--- a/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
+++ b/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
@@ -144,6 +144,17 @@ class TauriJobQueue {
 		const counter = this.sourceCounters.get(sourceId);
 		if (!counter) return;
 		counter.done++;
+
+		try {
+			await emit("job-progress", {
+				jobId: sourceId,
+				processed: counter.done,
+				total: counter.total,
+			});
+		} catch (err) {
+			console.error("[jobs] failed to emit job-progress:", err);
+		}
+
 		if (counter.done >= counter.total) {
 			this.sourceCounters.delete(sourceId);
 			try {

--- a/apps/tauri/src/routes/sources/$mediaSourceId/index.tsx
+++ b/apps/tauri/src/routes/sources/$mediaSourceId/index.tsx
@@ -2,6 +2,7 @@ import type {
 	DownloadItem,
 	MediaSearchResponse,
 } from "@solid-imager/core/domain/media/schemas";
+import type { JobProgressEvent } from "@solid-imager/core/domain/sources/events";
 import {
 	getScrollPosition,
 	setScrollPosition,
@@ -29,6 +30,7 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@solid-imager/ui/dialog";
+import { Progress } from "@solid-imager/ui/progress";
 import { toast } from "@solid-imager/ui/toast";
 import {
 	createInfiniteQuery,
@@ -200,7 +202,11 @@ function SourceMediaRoute() {
 		onThumbnailGenerated: () => {
 			scheduleMediaRefresh();
 		},
+		onJobProgress: (data) => {
+			setJobProgress(data);
+		},
 		onAllJobsCompleted: (data) => {
+			setJobProgress(null);
 			toast.success(
 				`All jobs completed! Processed: ${data.processed ?? "N/A"}`,
 			);
@@ -314,6 +320,9 @@ function SourceMediaRoute() {
 	const [isSyncingMedia, setIsSyncingMedia] = createSignal(false);
 	const [isScrollRestored, setIsScrollRestored] = createSignal(false);
 	const [addedCount, setAddedCount] = createSignal(0);
+	const [jobProgress, setJobProgress] = createSignal<JobProgressEvent | null>(
+		null,
+	);
 	const [debounceTimer, setDebounceTimer] = createSignal<ReturnType<
 		typeof setTimeout
 	> | null>(null);
@@ -882,6 +891,24 @@ function SourceMediaRoute() {
 				}}
 				type="file"
 			/>
+
+			<Show when={jobProgress()}>
+				{(progress) => (
+					<div class="mb-4 rounded-md border bg-muted/50 px-4 py-3">
+						<div class="mb-2 flex items-center justify-between text-sm">
+							<span class="text-muted-foreground">
+								サムネイル生成中 {progress().processed} / {progress().total}
+							</span>
+							<span class="text-muted-foreground text-xs">
+								{Math.round((progress().processed / progress().total) * 100)}%
+							</span>
+						</div>
+						<Progress
+							value={(progress().processed / progress().total) * 100}
+						/>
+					</div>
+				)}
+			</Show>
 
 			<div class="grid gap-6 md:grid-cols-[300px_1fr]">
 				<Card class="sticky top-20 hidden h-fit max-h-[calc(100vh-6rem)] overflow-y-auto md:block">

--- a/apps/tauri/src/routes/sources/$mediaSourceId/index.tsx
+++ b/apps/tauri/src/routes/sources/$mediaSourceId/index.tsx
@@ -897,14 +897,14 @@ function SourceMediaRoute() {
 					<div class="mb-4 rounded-md border bg-muted/50 px-4 py-3">
 						<div class="mb-2 flex items-center justify-between text-sm">
 							<span class="text-muted-foreground">
-								サムネイル生成中 {progress().processed} / {progress().total}
+								サムネイル生成中 {progress.processed} / {progress.total}
 							</span>
 							<span class="text-muted-foreground text-xs">
-								{Math.round((progress().processed / progress().total) * 100)}%
+								{Math.round((progress.processed / progress.total) * 100)}%
 							</span>
 						</div>
 						<Progress
-							value={(progress().processed / progress().total) * 100}
+							value={(progress.processed / progress.total) * 100}
 						/>
 					</div>
 				)}


### PR DESCRIPTION
- TauriJobQueue.markDone() now emits `job-progress` after each thumbnail job completes, using sourceId as jobId for source-scoped filtering
- useMediaSourceEvents hook gains onJobProgress callback listening for `job-progress` events filtered by jobId === mediaSourceId
- Source detail page displays a live progress banner (processed/total + progress bar) while thumbnails are generating, clearing on all-jobs-completed