### PR TITLE
feat(tauri): extract metadata (ComfyUI prompt/workflow) during media processing (#252)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+tab_width = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
+++ b/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
@@ -111,7 +111,7 @@ class TauriJobQueue {
 					);
 				await TauriMediaRepository.upsertGenerationInfo(
 					job.mediaId,
-					typeof metadata.prompt === "object"
+					metadata.prompt !== null && typeof metadata.prompt === "object"
 						? JSON.stringify(metadata.prompt)
 						: (metadata.prompt as string | null),
 					metadata.workflow as object | null,

--- a/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
+++ b/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
@@ -2,6 +2,8 @@ import { defaultAppConfig } from "@solid-imager/core/domain/config/config-schema
 import { emit } from "@tauri-apps/api/event";
 import { appDataDir, isAbsolute, join } from "@tauri-apps/api/path";
 import { getTauriAppServices } from "~/app-services";
+import { TauriMediaRepository } from "../local-api/repositories/media-repository";
+import { TauriTagRepository } from "../local-api/repositories/tag-repository";
 import { TauriJobRepository } from "../local-api/repositories/tauri-job-repository";
 import { TauriConfigService } from "../local-api/services/config-service";
 import type { PersistedThumbnailJob, ThumbnailJob } from "./thumbnail-job";
@@ -100,6 +102,36 @@ class TauriJobQueue {
 	private async processJob(job: PersistedThumbnailJob): Promise<void> {
 		try {
 			await TauriJobRepository.markAsInProgress(job.id);
+
+			// Step 1: Metadata extraction
+			try {
+				const metadata =
+					await getTauriAppServices().imageProcessor.extractMetadata(
+						job.fullPath,
+					);
+				await TauriMediaRepository.upsertGenerationInfo(
+					job.mediaId,
+					typeof metadata.prompt === "object"
+						? JSON.stringify(metadata.prompt)
+						: (metadata.prompt as string | null),
+					metadata.workflow as object | null,
+				);
+				if (metadata.tags.length > 0) {
+					await TauriTagRepository.addTagsToMedia(
+						job.mediaId,
+						metadata.tags,
+						"comfyui_workflow",
+					);
+				}
+			} catch (err) {
+				console.warn(
+					"[jobs] metadata extraction failed, continuing:",
+					job.mediaId,
+					err,
+				);
+			}
+
+			// Step 2: Thumbnail generation
 			const config = await TauriConfigService.getConfig();
 			const basePath = await resolveThumbnailBasePath(
 				config.storage.thumbnailDir,

--- a/apps/tauri/src/infrastructure/local-api/repositories/tag-repository.ts
+++ b/apps/tauri/src/infrastructure/local-api/repositories/tag-repository.ts
@@ -117,16 +117,24 @@ export const TauriTagRepository = {
 			.from(tags)
 			.where(inArray(tags.name, uniqueTagNames));
 
-		const rows = tagsToInsert.map((t) => {
-			const found = allTags.find((tag) => tag.name === t.name);
-			if (!found) throw new Error(`Tag ${t.name} not found after insertion`);
-			return {
-				mediaId,
-				tagId: found.id,
-				tagType: t.type,
-				confidence: t.confidence ?? null,
-				source,
-			};
+		const tagMap = new Map(allTags.map((tag) => [tag.name, tag]));
+		const rows = tagsToInsert.flatMap((t) => {
+			const found = tagMap.get(t.name);
+			if (!found) {
+				console.warn(
+					`[tag-repository] Tag ${t.name} not found after insertion, skipping`,
+				);
+				return [];
+			}
+			return [
+				{
+					mediaId,
+					tagId: found.id,
+					tagType: t.type,
+					confidence: t.confidence ?? null,
+					source,
+				},
+			];
 		});
 
 		if (rows.length === 0) return;

--- a/apps/tauri/src/infrastructure/local-api/repositories/tag-repository.ts
+++ b/apps/tauri/src/infrastructure/local-api/repositories/tag-repository.ts
@@ -9,9 +9,12 @@ import {
 	tagResponseSchema,
 	type UpdateTag,
 } from "@solid-imager/core/domain/tags/schemas";
-import { asc, eq } from "drizzle-orm";
+import { asc, eq, inArray, sql } from "drizzle-orm";
 import { getTauriAppServices } from "~/app-services";
-import { tags } from "../../../../../server/src/infrastructure/db/schema";
+import {
+	mediaTags,
+	tags,
+} from "../../../../../server/src/infrastructure/db/schema";
 
 function toTag(row: typeof tags.$inferSelect): TagResponse {
 	return tagResponseSchema.parse(row);
@@ -89,6 +92,62 @@ export const TauriTagRepository = {
 		}
 
 		return toTag(rows[0]);
+	},
+
+	async addTagsToMedia(
+		mediaId: string,
+		tagsToInsert: {
+			name: string;
+			type: "positive" | "negative";
+			confidence?: number;
+		}[],
+		source = "manual",
+	): Promise<void> {
+		const db = getTauriAppServices().db;
+		const uniqueTagNames = [...new Set(tagsToInsert.map((t) => t.name))];
+		if (uniqueTagNames.length === 0) return;
+
+		await db
+			.insert(tags)
+			.values(uniqueTagNames.map((name) => ({ name, source })))
+			.onConflictDoNothing();
+
+		const allTags = await db
+			.select()
+			.from(tags)
+			.where(inArray(tags.name, uniqueTagNames));
+
+		const rows = tagsToInsert.map((t) => {
+			const found = allTags.find((tag) => tag.name === t.name);
+			if (!found) throw new Error(`Tag ${t.name} not found after insertion`);
+			return {
+				mediaId,
+				tagId: found.id,
+				tagType: t.type,
+				confidence: t.confidence ?? null,
+				source,
+			};
+		});
+
+		if (rows.length === 0) return;
+
+		let sourceSet = sql`excluded.source`;
+		let confSet = sql`excluded.confidence`;
+		if (source === "AI") {
+			sourceSet = sql`CASE WHEN media_tags.source = 'AI' THEN excluded.source ELSE media_tags.source END`;
+			confSet = sql`CASE WHEN media_tags.source = 'AI' THEN excluded.confidence ELSE media_tags.confidence END`;
+		} else if (source === "manual") {
+			sourceSet = sql`CASE WHEN media_tags.source IN ('AI', 'manual') THEN excluded.source ELSE media_tags.source END`;
+			confSet = sql`CASE WHEN media_tags.source IN ('AI', 'manual') THEN excluded.confidence ELSE media_tags.confidence END`;
+		}
+
+		await db
+			.insert(mediaTags)
+			.values(rows)
+			.onConflictDoUpdate({
+				target: [mediaTags.mediaId, mediaTags.tagId, mediaTags.tagType],
+				set: { source: sourceSet, confidence: confSet },
+			});
 	},
 
 	async delete(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

- `TauriTagRepository.addTagsToMedia()` を新規実装（サーバ実装と同じ `comfyui_workflow > manual > AI` 優先度ロジック）
- `processJob()` にメタデータ抽出ステップを追加（サムネイル生成前）
- 抽出したプロンプト・ワークフローを `media_generation_info` に保存、ComfyUI タグを `media_tags` へ `source = "comfyui_workflow"` で保存
- 抽出失敗時は warn のみでサムネイル生成を継続（サーバ実装と同等の挙動）

Closes #252

## Test plan

- [ ] Tauri dev 起動 (`bun run dev:tauri`)
- [ ] ローカルソースに ComfyUI 生成画像を追加して sync 実行
- [ ] `media_generation_info` にプロンプト・ワークフローが保存されていること
- [ ] `media_tags` に `source = "comfyui_workflow"` でタグが保存されていること
- [ ] メタデータなし画像でもサムネイルが正常生成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)