### PR TITLE
feat(tauri): AI自動タグ付けジョブの実装 (#253)

### DIFF
--- a/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
+++ b/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
@@ -4,7 +4,11 @@ import { appDataDir, isAbsolute, join } from "@tauri-apps/api/path";
 import { getTauriAppServices } from "~/app-services";
 import { TauriMediaRepository } from "../local-api/repositories/media-repository";
 import { TauriTagRepository } from "../local-api/repositories/tag-repository";
-import { TauriJobRepository } from "../local-api/repositories/tauri-job-repository";
+import {
+	type PersistedAutoTaggingJob,
+	TauriJobRepository,
+} from "../local-api/repositories/tauri-job-repository";
+import { TauriAiService } from "../local-api/services/ai-service";
 import { TauriConfigService } from "../local-api/services/config-service";
 import type { PersistedThumbnailJob, ThumbnailJob } from "./thumbnail-job";
 
@@ -32,12 +36,17 @@ class TauriJobQueue {
 	private running = 0;
 	private sourceCounters = new Map<string, SourceCounter>();
 	private concurrency = defaultAppConfig.jobs.concurrency;
+	private aiQueue: PersistedAutoTaggingJob[] = [];
+	private aiRunning = 0;
+	private aiConcurrency = defaultAppConfig.jobs.aiConcurrency;
 	private initializationPromise: Promise<void> | null = null;
 
 	constructor() {
 		TauriConfigService.onChange((config) => {
 			this.concurrency = config.jobs.concurrency;
+			this.aiConcurrency = config.jobs.aiConcurrency;
 			this.drain();
+			this.drainAi();
 		});
 	}
 
@@ -67,12 +76,19 @@ class TauriJobQueue {
 	private async initializeInternal(): Promise<void> {
 		const config = await TauriConfigService.getConfig();
 		this.concurrency = config.jobs.concurrency;
+		this.aiConcurrency = config.jobs.aiConcurrency;
 		await TauriJobRepository.resetInProgressToPending();
+		await TauriJobRepository.resetInProgressAutoTaggingToPending();
 		const pendingJobs = await TauriJobRepository.findPending();
 		for (const job of pendingJobs) {
 			this.enqueueInMemory(job);
 		}
+		const pendingAiJobs = await TauriJobRepository.findPendingAutoTagging();
+		for (const job of pendingAiJobs) {
+			this.enqueueAiInMemory(job);
+		}
 		this.drain();
+		this.drainAi();
 	}
 
 	private enqueueInMemory(job: PersistedThumbnailJob): void {
@@ -154,6 +170,19 @@ class TauriJobQueue {
 				timestamp: new Date().toISOString(),
 			});
 			await TauriJobRepository.markAsCompleted(job.id);
+
+			// Step 3: Queue auto_tagging if enabled and media is an image
+			if (config.jobs.enableAutoTagging) {
+				const media = await TauriMediaRepository.findById(job.mediaId);
+				if (media?.mediaType === "image") {
+					const aiJob = await TauriJobRepository.createAutoTaggingJob(
+						job.mediaId,
+						job.sourceId,
+					);
+					this.enqueueAiInMemory(aiJob);
+					this.drainAi();
+				}
+			}
 		} catch (err) {
 			const message =
 				err instanceof Error ? err.message : "Unknown thumbnail job error";
@@ -169,6 +198,43 @@ class TauriJobQueue {
 			}
 		} finally {
 			await this.markDone(job.sourceId);
+		}
+	}
+
+	private enqueueAiInMemory(job: PersistedAutoTaggingJob): void {
+		this.aiQueue.push(job);
+	}
+
+	private drainAi(): void {
+		while (this.aiRunning < this.aiConcurrency && this.aiQueue.length > 0) {
+			const job = this.aiQueue.shift();
+			if (!job) return;
+			this.aiRunning++;
+			void this.processAiJob(job).finally(() => {
+				this.aiRunning--;
+				this.drainAi();
+			});
+		}
+	}
+
+	private async processAiJob(job: PersistedAutoTaggingJob): Promise<void> {
+		try {
+			await TauriJobRepository.markAsInProgress(job.id);
+			await TauriAiService.tagSingleMedia(job.mediaId);
+			await TauriJobRepository.markAsCompleted(job.id);
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : "Unknown AI job error";
+			console.error("[jobs] auto_tagging failed:", job.mediaId, err);
+			try {
+				await TauriJobRepository.markAsFailed(job.id, message);
+			} catch (updateError) {
+				console.error(
+					"[jobs] failed to persist AI job failure:",
+					job.mediaId,
+					updateError,
+				);
+			}
 		}
 	}
 

--- a/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
+++ b/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
@@ -83,12 +83,14 @@ class TauriJobQueue {
 		for (const job of pendingJobs) {
 			this.enqueueInMemory(job);
 		}
-		const pendingAiJobs = await TauriJobRepository.findPendingAutoTagging();
-		for (const job of pendingAiJobs) {
-			this.enqueueAiInMemory(job);
-		}
 		this.drain();
-		this.drainAi();
+		if (config.jobs.enableAutoTagging) {
+			const pendingAiJobs = await TauriJobRepository.findPendingAutoTagging();
+			for (const job of pendingAiJobs) {
+				this.enqueueAiInMemory(job);
+			}
+			this.drainAi();
+		}
 	}
 
 	private enqueueInMemory(job: PersistedThumbnailJob): void {
@@ -173,14 +175,22 @@ class TauriJobQueue {
 
 			// Step 3: Queue auto_tagging if enabled and media is an image
 			if (config.jobs.enableAutoTagging) {
-				const media = await TauriMediaRepository.findById(job.mediaId);
-				if (media?.mediaType === "image") {
-					const aiJob = await TauriJobRepository.createAutoTaggingJob(
+				try {
+					const media = await TauriMediaRepository.findById(job.mediaId);
+					if (media?.mediaType === "image") {
+						const aiJob = await TauriJobRepository.createAutoTaggingJob(
+							job.mediaId,
+							job.sourceId,
+						);
+						this.enqueueAiInMemory(aiJob);
+						this.drainAi();
+					}
+				} catch (err) {
+					console.error(
+						"[jobs] failed to queue auto_tagging:",
 						job.mediaId,
-						job.sourceId,
+						err,
 					);
-					this.enqueueAiInMemory(aiJob);
-					this.drainAi();
 				}
 			}
 		} catch (err) {

--- a/apps/tauri/src/infrastructure/local-api/repositories/tauri-job-repository.ts
+++ b/apps/tauri/src/infrastructure/local-api/repositories/tauri-job-repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, or } from "drizzle-orm";
 import { getTauriAppServices } from "~/app-services";
 import { type Job, jobs, type NewJob } from "../../db/schema";
 import type {
@@ -193,6 +193,25 @@ export const TauriJobRepository = {
 		mediaId: string,
 		mediaSourceId: string,
 	): Promise<PersistedAutoTaggingJob> {
+		const db = getDb();
+		const activeRows = await db
+			.select()
+			.from(jobs)
+			.where(
+				and(
+					eq(jobs.type, AUTO_TAGGING_JOB_TYPE),
+					or(eq(jobs.status, "pending"), eq(jobs.status, "in_progress")),
+				),
+			);
+		const existing = activeRows.find((row) => {
+			const p = row.payload;
+			return typeof p === "object" && p !== null && "mediaId" in p && p.mediaId === mediaId;
+		});
+		if (existing) {
+			const job = toPersistedAutoTaggingJob(existing);
+			if (job) return job;
+		}
+
 		const now = new Date();
 		const value: NewJob = {
 			id: crypto.randomUUID(),
@@ -205,7 +224,7 @@ export const TauriJobRepository = {
 			createdAt: now,
 			updatedAt: now,
 		};
-		const [row] = await getDb().insert(jobs).values(value).returning();
+		const [row] = await db.insert(jobs).values(value).returning();
 		const job = toPersistedAutoTaggingJob(row);
 		if (!job) throw new Error(`Failed to create auto_tagging job for ${mediaId}`);
 		return job;

--- a/apps/tauri/src/infrastructure/local-api/repositories/tauri-job-repository.ts
+++ b/apps/tauri/src/infrastructure/local-api/repositories/tauri-job-repository.ts
@@ -7,6 +7,53 @@ import type {
 } from "../../jobs/thumbnail-job";
 
 const THUMBNAIL_JOB_TYPE = "thumbnail_generation";
+const AUTO_TAGGING_JOB_TYPE = "auto_tagging";
+
+type AutoTaggingJobPayload = {
+	mediaId: string;
+	mediaSourceId: string;
+};
+
+export type PersistedAutoTaggingJob = {
+	id: string;
+	mediaId: string;
+	mediaSourceId: string;
+	status: Job["status"];
+	error: string | null;
+	createdAt: Date;
+	updatedAt: Date;
+};
+
+function isAutoTaggingJobPayload(
+	value: unknown,
+): value is AutoTaggingJobPayload {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"mediaId" in value &&
+		typeof value.mediaId === "string" &&
+		"mediaSourceId" in value &&
+		typeof value.mediaSourceId === "string"
+	);
+}
+
+function toPersistedAutoTaggingJob(
+	row: Job,
+): PersistedAutoTaggingJob | null {
+	if (!isAutoTaggingJobPayload(row.payload)) {
+		console.error(`[jobs] Auto-tagging job ${row.id} has invalid payload.`);
+		return null;
+	}
+	return {
+		id: row.id,
+		mediaId: row.payload.mediaId,
+		mediaSourceId: row.payload.mediaSourceId,
+		status: row.status,
+		error: row.error,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+	};
+}
 
 type ThumbnailJobPayload = {
 	mediaId: string;
@@ -140,5 +187,56 @@ export const TauriJobRepository = {
 				updatedAt: new Date(),
 			})
 			.where(eq(jobs.id, id));
+	},
+
+	async createAutoTaggingJob(
+		mediaId: string,
+		mediaSourceId: string,
+	): Promise<PersistedAutoTaggingJob> {
+		const now = new Date();
+		const value: NewJob = {
+			id: crypto.randomUUID(),
+			type: AUTO_TAGGING_JOB_TYPE,
+			mediaSourceId,
+			status: "pending",
+			payload: { mediaId, mediaSourceId },
+			result: null,
+			error: null,
+			createdAt: now,
+			updatedAt: now,
+		};
+		const [row] = await getDb().insert(jobs).values(value).returning();
+		const job = toPersistedAutoTaggingJob(row);
+		if (!job) throw new Error(`Failed to create auto_tagging job for ${mediaId}`);
+		return job;
+	},
+
+	async findPendingAutoTagging(): Promise<PersistedAutoTaggingJob[]> {
+		const rows = await getDb()
+			.select()
+			.from(jobs)
+			.where(
+				and(
+					eq(jobs.type, AUTO_TAGGING_JOB_TYPE),
+					eq(jobs.status, "pending"),
+				),
+			)
+			.orderBy(asc(jobs.createdAt));
+		return rows.flatMap((row) => {
+			const job = toPersistedAutoTaggingJob(row);
+			return job ? [job] : [];
+		});
+	},
+
+	async resetInProgressAutoTaggingToPending(): Promise<void> {
+		await getDb()
+			.update(jobs)
+			.set({ status: "pending", updatedAt: new Date() })
+			.where(
+				and(
+					eq(jobs.type, AUTO_TAGGING_JOB_TYPE),
+					eq(jobs.status, "in_progress"),
+				),
+			);
 	},
 };

--- a/apps/tauri/src/infrastructure/local-api/services/ai-service.ts
+++ b/apps/tauri/src/infrastructure/local-api/services/ai-service.ts
@@ -334,4 +334,10 @@ export const TauriAiService = {
 		await emitMediaChanged(input.mediaId);
 		return { success: true as const };
 	},
+
+	async tagSingleMedia(mediaId: string): Promise<void> {
+		const response = await tagMediaFromServer(mediaId);
+		await persistAiTags(mediaId, response);
+		await emitMediaChanged(mediaId);
+	},
 };


### PR DESCRIPTION
## Summary

- `TauriJobQueue` に AI 専用スロット（`aiConcurrency = 1`）を追加し、サムネイル生成と独立した並列制御を実現
- サムネイル生成完了後、`enableAutoTagging=true && mediaType=image` の場合に `auto_tagging` ジョブを自動キューイング
- `TauriJobRepository` に `createAutoTaggingJob` / `findPendingAutoTagging` / `resetInProgressAutoTaggingToPending` を追加
- `TauriAiService.tagSingleMedia()` を公開し、単一メディアの AI タグ付け → DB 保存 → `media-changed` emit を一括実行

Closes #253

## Test plan

- [ ] `bun run typecheck` — 型エラーなし（既存の既知エラーのみ）
- [ ] Tauri アプリ起動 (`bun run dev:tauri`)
- [ ] 設定で `enableAutoTagging=true` に変更
- [ ] 画像ファイルをソースに追加 → サムネイル生成後に AI タグが自動付与されることを確認
- [ ] 動画ファイルは `auto_tagging` ジョブが作成されないことを確認
- [ ] アプリ再起動時に未完了の `auto_tagging` ジョブが再開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)