### PR TITLE
Add Tauri category repository wrapper

### DIFF
--- a/apps/tauri/src/infrastructure/local-api/repositories/category-repository.ts
+++ b/apps/tauri/src/infrastructure/local-api/repositories/category-repository.ts
@@ -1,0 +1,11 @@
+import { createCategoryRepository } from "@solid-imager/db/repositories/category-repository";
+import type { DrizzleExecutor } from "@solid-imager/db/types";
+import { getTauriAppServices } from "~/app-services";
+
+function getExecutor(tx?: unknown): DrizzleExecutor {
+	return (tx ?? getTauriAppServices().db) as DrizzleExecutor;
+}
+
+export const TauriCategoryRepository = createCategoryRepository(getExecutor, {
+	orderByName: true,
+});


### PR DESCRIPTION
## Summary
- add `apps/tauri/src/infrastructure/local-api/repositories/category-repository.ts`
- wire the Tauri DB executor into `createCategoryRepository`
- keep this change parity-only with no service refactor

## Wrapper scope
- touched wrapper: `TauriCategoryRepository`
- shared factory options required: `orderByName: true`
- behavior change: no new behavior, only parity wiring for the missing Tauri wrapper