### PR TITLE
Add Tauri collection repository wrapper

### DIFF
--- a/apps/tauri/src/infrastructure/local-api/repositories/collection-repository.ts
+++ b/apps/tauri/src/infrastructure/local-api/repositories/collection-repository.ts
@@ -1,0 +1,14 @@
+import { createCollectionRepository } from "@solid-imager/db/repositories/collection-repository";
+import type { DrizzleExecutor } from "@solid-imager/db/types";
+import { getTauriAppServices } from "~/app-services";
+
+function getExecutor(tx?: unknown): DrizzleExecutor {
+	return (tx ?? getTauriAppServices().db) as DrizzleExecutor;
+}
+
+export const TauriCollectionRepository = createCollectionRepository(
+	getExecutor,
+	{
+		orderByName: true,
+	},
+);


### PR DESCRIPTION
## Summary
- add `apps/tauri/src/infrastructure/local-api/repositories/collection-repository.ts`
- wire the Tauri DB executor into `createCollectionRepository`
- keep this change parity-only with no service refactor

## Wrapper scope
- touched wrapper: `TauriCollectionRepository`
- shared factory options required: `orderByName: true`
- behavior change: no new behavior, only parity wiring for the missing Tauri wrapper