### PR TITLE
Add Tauri user repository wrapper

### DIFF
--- a/apps/tauri/src/infrastructure/local-api/repositories/user-repository.ts
+++ b/apps/tauri/src/infrastructure/local-api/repositories/user-repository.ts
@@ -1,0 +1,11 @@
+import { createUserRepository } from "@solid-imager/db/repositories/user-repository";
+import type { DrizzleExecutor } from "@solid-imager/db/types";
+import { getTauriAppServices } from "~/app-services";
+
+function getExecutor(tx?: unknown): DrizzleExecutor {
+	return (tx ?? getTauriAppServices().db) as DrizzleExecutor;
+}
+
+export const TauriUserRepository = createUserRepository(getExecutor, {
+	orderByName: true,
+});


### PR DESCRIPTION
## Summary
- add `apps/tauri/src/infrastructure/local-api/repositories/user-repository.ts`
- wire the Tauri DB executor into `createUserRepository`
- keep this change parity-only with no service refactor

## Wrapper scope
- touched wrapper: `TauriUserRepository`
- shared factory options required: `orderByName: true`
- behavior change: no new behavior, only parity wiring for the missing Tauri wrapper