### PR TITLE
refactor(search): extract shared useSearchPage hook to packages/ui

### DIFF
--- a/.indexion/wiki/server-tauri-parity.md
+++ b/.indexion/wiki/server-tauri-parity.md
@@ -61,7 +61,7 @@
 
 ページルートの対応関係自体は高いが、route 本体の責務分割、nav action の配置、refresh 挙動、restore/import UX はまだ揃い切っていない。server側のみAPIルート群が存在し、tauriはRust IPCで代替。
 
-厳格基準では、`search.tsx` / `manager.tsx` / `config.tsx` / `sources/$mediaSourceId/index.tsx` は route レベルの状態管理と action がまだ大きく、`packages/ui` や shared route helper へ寄せられる余地が残る。
+厳格基準では、`search.tsx` の infinite query / dedup / scroll restoration / intersection observer は `packages/ui/src/hooks/use-search-page.ts` へ共通化済み。app 側は JSX レイアウト、nav action 配置、refresh 戦略（server: 即時 / tauri: debounce）、`sourceRootPath` 注入など platform 固有差分のみを残す。`manager.tsx` / `config.tsx` / `sources/$mediaSourceId/index.tsx` は route レベルの状態管理と action がまだ大きく、shared route helper へ寄せられる余地が残る。
 
 | server                                                    | tauri                                              | 備考                               |
 | --------------------------------------------------------- | -------------------------------------------------- | ---------------------------------- |
@@ -91,6 +91,7 @@ hook 本体は `packages/ui/src/hooks` へ寄り、app 側は transport adapter 
 | ----------------------------------- | ------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------- |
 | `use-media-source-events.ts`        | `packages/ui` の shared hook + oRPC SSE transport | `packages/ui` の shared hook + Tauri event transport | transport 実装と event relevance filter が異なる | `onJobProgress` を含む callback I/F は shared hook 側へ統合済み |
 | `use-current-search-persistence.ts` | `packages/ui` 経由で `@solid-imager/core`         | `packages/ui` 経由で `@solid-imager/core`            | 共通化済み                                       | deepEqualはcore/utils/deep-equal                                |
+| `use-search-page.ts`                | `packages/ui` の shared hook                      | `packages/ui` の shared hook                         | 共通化済み                                       | infinite query / dedup / scroll restore / observer を shared 化 |
 
 ## Components（対応度: ~80%）
 
@@ -321,7 +322,7 @@ server も `DB_HOST=pglite` で PGlite に切替可能なため、PGlite は DB 
 
 ## さらに厳しく見たときの未共通化ポイント
 
-- routes: `search.tsx` / `manager.tsx` / `config.tsx` / `sources/$mediaSourceId/index.tsx` は state・loader・event refresh・action 群を shared helper か shared screen component に寄せる余地がある
+- routes: `search.tsx` の infinite query / dedup / scroll restoration / intersection observer は `packages/ui/src/hooks/use-search-page.ts` へ共通化済み。残る差分は JSX レイアウト（nav action / mobile filter 配置）、refresh 戦略、および `sourceRootPath` 注入など platform 固有層。`manager.tsx` / `config.tsx` / `sources/$mediaSourceId/index.tsx` は state・loader・event refresh・action 群を shared helper か shared screen component に寄せる余地がある
 - hooks: `use-media-source-events.ts` 本体は shared 化済み。今後は transport adapter と event relevance filter の責務をさらに薄くできるかを確認する
 - queries / api-clients: `queries/*.ts` と `search-api.ts` などは app ごとに薄く重複しており、transport 注入前提の共通 query option builder に寄せられる余地がある
 - services: tauri 側 `source-service.ts` は shared `createSourceService` に寄ったが、`media-service.ts` / `source-backup-service.ts` はまだ shared package 前提の thin adapter にはなっていない
@@ -348,4 +349,5 @@ server も `DB_HOST=pglite` で PGlite に切替可能なため、PGlite は DB 
 - **Services**: `packages/application` は増えており、tauri 側 source は shared service 利用へ前進した。watcher / sync の削除・変更経路は shared helper を使う段階まで寄ったが、media / backup はまだ app 固有責務が大きい
 - **Services対応度**: 単純 CRUD と config / maintenance は前進したが、source / media / search / backup / ai / tagging を含む主機能の parity はなお過渡期
 - **Jobs**: media-processing job の step 定義・payload helper に加え、canonical job type / shared dispatcher / deferred actions executor / background coordinator / download runner / tagging runner / watcher runtime / event publish contract / processMedia batch runner / source progress tracker を `packages/application` に移動。server / tauri は共通 runtime を使い、差分は downloader / thumbnail I/O / watcher ingress / SSE or Tauri event transport に縮退
-- 対応度の推定値を再補正（Routes ~75%、Hooks ~75%、Components ~80%、Repositories ~88%、Services ~68%、Jobs ~82%）
+- **Hooks / Routes**: `packages/ui/src/hooks/use-search-page.ts` を新設し、`search.tsx` の infinite query 構築、結果重複排除、スクロール位置復元、無限スクロール IntersectionObserver を shared hook へ切り出し。`apps/server/src/routes/search.tsx` と `apps/tauri/src/routes/search.tsx` は両方ともこの shared hook を利用。app 側に残る差分は JSX レイアウト（Portal vs inline Dialog）、refresh 戦略（server: 即時 invalidate / tauri: debounce 300ms + `onAllJobsCompleted`）、`sourceRootPath` 注入、SSR `isMounted` ガードなど platform 固有層のみ
+- 対応度の推定値を再補正（Routes ~78%、Hooks ~80%、Components ~80%、Repositories ~88%、Services ~68%、Jobs ~82%）

--- a/apps/server/src/routes/search.tsx
+++ b/apps/server/src/routes/search.tsx
@@ -32,22 +32,10 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@solid-imager/ui/dialog";
+import { useSearchPage } from "@solid-imager/ui/hooks/use-search-page";
 import { SearchControlPanel } from "@solid-imager/ui/search-control-panel";
-import {
-	createInfiniteQuery,
-	createQuery,
-	keepPreviousData,
-	useQueryClient,
-} from "@tanstack/solid-query";
-import {
-	createEffect,
-	createMemo,
-	createSignal,
-	For,
-	onCleanup,
-	onMount,
-	Show,
-} from "solid-js";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import { createSignal, For, onMount, Show } from "solid-js";
 import { isServer, Portal } from "solid-js/web";
 import { MediaGridItem } from "~/components/media/media-grid-item";
 import { useCurrentSearchPersistence } from "~/hooks/use-current-search-persistence";
@@ -66,109 +54,31 @@ import {
 	setSearchState,
 } from "~/presentation/store/search-store";
 
-const buildSearchParams = (state: typeof searchState) => {
-	const condition = getSearchCondition();
-	return {
-		condition: condition || undefined,
-		sort: state.sortBy,
-		order: state.sortOrder,
-		limit: state.limit,
-	};
-};
-
-/**
- * Serialize condition as JSON for stable query key comparison.
- * This prevents mode toggles (simple/pro) with equivalent conditions
- * from producing different query keys due to SolidJS store proxy references.
- */
-const useStableConditionKey = () =>
-	createMemo(() => JSON.stringify(getSearchCondition() ?? null));
-
-const QUERY_GC_TIME = 1000 * 60 * 5;
-
 export default function Search() {
 	const queryClient = useQueryClient();
 
 	// Enable search persistence for global search
 	useCurrentSearchPersistence("all", PresetClient);
 
-	const [isRestored, setIsRestored] = createSignal(false);
 	const [isMounted, setIsMounted] = createSignal(false);
 
 	onMount(() => {
 		setIsMounted(true);
 	});
 
-	createEffect(() => {
-		if (isServer) {
-			return;
-		}
-		// Restoration logic: wait until not loading and haven't restored yet
-		if (
-			!(searchResultQuery.isLoading || isRestored()) &&
-			searchResultQuery.data &&
-			searchResultQuery.data.pages.length > 0 &&
-			searchState.scrollY > 0
-		) {
-			// Restore scroll position
-			// Use requestAnimationFrame to ensure DOM is updated
-			requestAnimationFrame(() => {
-				window.scrollTo(0, searchState.scrollY);
-			});
-			setIsRestored(true);
-		}
-	});
-
-	onCleanup(() => {
-		if (isServer) {
-			return;
-		}
-		setSearchState("scrollY", window.scrollY);
-	});
-
-	// Fetch filter data
-	const tags = createQuery(() => tagsQueryOptions());
-	const sources = createQuery(() => mediaSourcesQueryOptions());
-	const allProjects = createQuery(() => allProjectsQueryOptions());
-	const allIps = createQuery(() => allIpsQueryOptions());
-	const allCharacters = createQuery(() => allCharactersQueryOptions());
-	const allAuthors = createQuery(() => allAuthorsQueryOptions());
-
-	// Use only effective search params as query key to avoid unnecessary refetches
-	// (e.g., mode toggle with equivalent conditions should NOT refetch)
-	const conditionKey = useStableConditionKey();
-
-	const searchResultQuery = createInfiniteQuery(() => {
-		const params = buildSearchParams(searchState);
-		const source = searchState.selectedSource || undefined;
-		return {
-			queryKey: [
-				"searchResults",
-				source,
-				conditionKey(),
-				searchState.sortBy,
-				searchState.sortOrder,
-				searchState.limit,
-			],
-			queryFn: async ({ pageParam }) =>
-				await searchMedia(source, {
-					...params,
-					offset: pageParam as number,
-				}),
-			initialPageParam: 0,
-			getNextPageParam: (lastPage, allPages) => {
-				const loadedCount = allPages.reduce(
-					(sum, page) => sum + page.media.length,
-					0,
-				);
-				if (loadedCount < lastPage.total) {
-					return loadedCount;
-				}
-			},
-			placeholderData: keepPreviousData,
-			gcTime: QUERY_GC_TIME, // Keep cache for 5 minutes for scroll restoration
-		};
-	});
+	const { searchResultQuery, searchResults, handleSearch, setLoadMoreRef } =
+		useSearchPage({
+			searchMedia,
+			queryClient,
+			selectedSource: () => searchState.selectedSource,
+			getSearchCondition,
+			sortBy: () => searchState.sortBy,
+			sortOrder: () => searchState.sortOrder,
+			limit: () => searchState.limit,
+			scrollY: () => searchState.scrollY,
+			setScrollY: (y) => setSearchState("scrollY", y),
+			setOffset: (o) => setSearchState("offset", o),
+		});
 
 	// Subscribe to real-time events
 	useMediaSourceEvents(() => searchState.selectedSource || undefined, {
@@ -183,52 +93,13 @@ export default function Search() {
 		},
 	});
 
-	const searchResults = createMemo(() => {
-		const seen = new Set<string>();
-		return (searchResultQuery.data?.pages.flatMap((p) => p.media) || []).filter(
-			(m) => {
-				if (seen.has(m.id)) {
-					return false;
-				}
-				seen.add(m.id);
-				return true;
-			},
-		);
-	});
-
-	const handleSearch = () => {
-		setSearchState("offset", 0);
-		setSearchState("scrollY", 0);
-		window.scrollTo(0, 0);
-	};
-
-	// Infinite scroll trigger
-	const [loadMoreRef, setLoadMoreRef] = createSignal<
-		HTMLDivElement | undefined
-	>(undefined);
-
-	createEffect(() => {
-		const el = loadMoreRef();
-		if (isServer || !el) {
-			return;
-		}
-
-		const observer = new IntersectionObserver(
-			(entries) => {
-				if (
-					entries[0].isIntersecting &&
-					searchResultQuery.hasNextPage &&
-					!searchResultQuery.isFetchingNextPage
-				) {
-					searchResultQuery.fetchNextPage();
-				}
-			},
-			{ threshold: 0.5, rootMargin: "1000px" },
-		);
-
-		observer.observe(el);
-		onCleanup(() => observer.disconnect());
-	});
+	// Fetch filter data
+	const tags = createQuery(() => tagsQueryOptions());
+	const sources = createQuery(() => mediaSourcesQueryOptions());
+	const allProjects = createQuery(() => allProjectsQueryOptions());
+	const allIps = createQuery(() => allIpsQueryOptions());
+	const allCharacters = createQuery(() => allCharactersQueryOptions());
+	const allAuthors = createQuery(() => allAuthorsQueryOptions());
 
 	return (
 		<main class="container mx-auto p-4">

--- a/apps/tauri/src/routes/search.tsx
+++ b/apps/tauri/src/routes/search.tsx
@@ -1,4 +1,3 @@
-import type { MediaSearchResponse } from "@solid-imager/core/domain/media/schemas";
 import { Button } from "@solid-imager/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@solid-imager/ui/card";
 import {
@@ -9,14 +8,10 @@ import {
 	DialogTrigger,
 } from "@solid-imager/ui/dialog";
 import { SearchControlPanel } from "@solid-imager/ui/search-control-panel";
-import {
-	createInfiniteQuery,
-	createQuery,
-	keepPreviousData,
-	useQueryClient,
-} from "@tanstack/solid-query";
+import { useSearchPage } from "@solid-imager/ui/hooks/use-search-page";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
-import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
+import { createSignal, For, onCleanup, Show } from "solid-js";
 import { MediaGridItem } from "~/components/media/media-grid-item";
 import { useCurrentSearchPersistence } from "~/hooks/use-current-search-persistence";
 import { useMediaSourceEvents } from "~/hooks/use-media-source-events";
@@ -44,62 +39,25 @@ export const Route = createFileRoute("/search")({
 	component: SearchRoute,
 });
 
-const QUERY_GC_TIME = 1000 * 60 * 5;
 const SEARCH_RESULTS_REFRESH_DEBOUNCE_MS = 300;
 
 function SearchRoute() {
 	const queryClient = useQueryClient();
-	const [isRestored, setIsRestored] = createSignal(false);
 	const [refreshTimer, setRefreshTimer] = createSignal<ReturnType<typeof setTimeout> | null>(null);
 
 	useCurrentSearchPersistence("all", PresetClient);
 
-	const tags = createQuery(() => tagsQueryOptions());
-	const sources = createQuery(() => mediaSourcesQueryOptions());
-	const allProjects = createQuery(() => allProjectsQueryOptions());
-	const allIps = createQuery(() => allIpsQueryOptions());
-	const allCharacters = createQuery(() => allCharactersQueryOptions());
-	const allAuthors = createQuery(() => allAuthorsQueryOptions());
-	const getSourceRootPath = (mediaSourceId: string) => {
-		const source = sources.data?.find((item) => item.id === mediaSourceId);
-		if (source?.type !== "local") {
-			return undefined;
-		}
-		const connectionInfo = source.connectionInfo as { path?: string };
-		return connectionInfo.path;
-	};
-
-	const conditionKey = createMemo(() => JSON.stringify(getSearchCondition() ?? null));
-
-	const searchResultQuery = createInfiniteQuery<MediaSearchResponse>(() => {
-		const source = searchState.selectedSource || undefined;
-		return {
-			queryKey: [
-				"searchResults",
-				source,
-				conditionKey(),
-				searchState.sortBy,
-				searchState.sortOrder,
-				searchState.limit,
-			],
-			queryFn: async ({ pageParam }) =>
-				await searchMedia(source, {
-					condition: getSearchCondition() || undefined,
-					sort: searchState.sortBy,
-					order: searchState.sortOrder,
-					limit: searchState.limit,
-					offset: Number(pageParam ?? 0),
-				}),
-			initialPageParam: 0,
-			getNextPageParam: (lastPage, allPages) => {
-				const loadedCount = allPages.reduce((sum, page) => sum + page.media.length, 0);
-				if (loadedCount < lastPage.total) {
-					return loadedCount;
-				}
-			},
-			placeholderData: keepPreviousData,
-			gcTime: QUERY_GC_TIME,
-		};
+	const { searchResultQuery, searchResults, handleSearch, setLoadMoreRef } = useSearchPage({
+		searchMedia,
+		queryClient,
+		selectedSource: () => searchState.selectedSource,
+		getSearchCondition,
+		sortBy: () => searchState.sortBy,
+		sortOrder: () => searchState.sortOrder,
+		limit: () => searchState.limit,
+		scrollY: () => searchState.scrollY,
+		setScrollY: (y) => setSearchState("scrollY", y),
+		setOffset: (o) => setSearchState("offset", o),
 	});
 
 	const scheduleSearchResultsRefresh = () => {
@@ -122,68 +80,26 @@ function SearchRoute() {
 		onAllJobsCompleted: scheduleSearchResultsRefresh,
 	});
 
-	const searchResults = createMemo(() => {
-		const seen = new Set<string>();
-		return (searchResultQuery.data?.pages.flatMap((page) => page.media) || []).filter((media) => {
-			if (seen.has(media.id)) {
-				return false;
-			}
-			seen.add(media.id);
-			return true;
-		});
-	});
-
-	createEffect(() => {
-		if (
-			!(searchResultQuery.isLoading || isRestored()) &&
-			searchResultQuery.data &&
-			searchResultQuery.data.pages.length > 0 &&
-			searchState.scrollY > 0
-		) {
-			requestAnimationFrame(() => {
-				window.scrollTo(0, searchState.scrollY);
-			});
-			setIsRestored(true);
+	const tags = createQuery(() => tagsQueryOptions());
+	const sources = createQuery(() => mediaSourcesQueryOptions());
+	const allProjects = createQuery(() => allProjectsQueryOptions());
+	const allIps = createQuery(() => allIpsQueryOptions());
+	const allCharacters = createQuery(() => allCharactersQueryOptions());
+	const allAuthors = createQuery(() => allAuthorsQueryOptions());
+	const getSourceRootPath = (mediaSourceId: string) => {
+		const source = sources.data?.find((item) => item.id === mediaSourceId);
+		if (source?.type !== "local") {
+			return undefined;
 		}
-	});
+		const connectionInfo = source.connectionInfo as { path?: string };
+		return connectionInfo.path;
+	};
 
 	onCleanup(() => {
-		setSearchState("scrollY", window.scrollY);
 		const timer = refreshTimer();
 		if (timer) {
 			clearTimeout(timer);
 		}
-	});
-
-	const handleSearch = () => {
-		setSearchState("offset", 0);
-		setSearchState("scrollY", 0);
-		window.scrollTo(0, 0);
-	};
-
-	const [loadMoreRef, setLoadMoreRef] = createSignal<HTMLDivElement | undefined>(undefined);
-
-	createEffect(() => {
-		const element = loadMoreRef();
-		if (!element) {
-			return;
-		}
-
-		const observer = new IntersectionObserver(
-			(entries) => {
-				if (
-					entries[0].isIntersecting &&
-					searchResultQuery.hasNextPage &&
-					!searchResultQuery.isFetchingNextPage
-				) {
-					void searchResultQuery.fetchNextPage();
-				}
-			},
-			{ threshold: 0.5, rootMargin: "1000px" },
-		);
-
-		observer.observe(element);
-		onCleanup(() => observer.disconnect());
 	});
 
 	const panel = (

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -1,0 +1,181 @@
+import type {
+	MediaSearchRequest,
+	MediaSearchResponse,
+} from "@solid-imager/core/domain/media/schemas";
+import type { QueryClient } from "@tanstack/solid-query";
+import { createInfiniteQuery, keepPreviousData } from "@tanstack/solid-query";
+import { createEffect, createMemo, createSignal, onCleanup } from "solid-js";
+import { isServer } from "solid-js/web";
+
+const DEFAULT_GC_TIME = 1000 * 60 * 5;
+
+export interface UseSearchPageOptions {
+	searchMedia: (
+		sourceId: string | undefined,
+		params: MediaSearchRequest,
+	) => Promise<MediaSearchResponse>;
+	queryClient: QueryClient;
+	selectedSource: () => string | null | undefined;
+	getSearchCondition: () => MediaSearchRequest["condition"];
+	sortBy: () => MediaSearchRequest["sort"];
+	sortOrder: () => "asc" | "desc";
+	limit: () => number;
+	scrollY: () => number;
+	setScrollY: (y: number) => void;
+	setOffset: (o: number) => void;
+	gcTime?: number;
+}
+
+export interface UseSearchPageResult {
+	searchResultQuery: ReturnType<
+		typeof createInfiniteQuery<MediaSearchResponse>
+	>;
+	searchResults: () => MediaSearchResponse["media"];
+	isRestored: () => boolean;
+	handleSearch: () => void;
+	loadMoreRef: () => HTMLDivElement | undefined;
+	setLoadMoreRef: (el: HTMLDivElement | undefined) => void;
+	conditionKey: () => string;
+}
+
+export function useSearchPage(
+	options: UseSearchPageOptions,
+): UseSearchPageResult {
+	const {
+		searchMedia,
+		selectedSource,
+		getSearchCondition,
+		sortBy,
+		sortOrder,
+		limit,
+		scrollY,
+		setScrollY,
+		setOffset,
+		gcTime = DEFAULT_GC_TIME,
+	} = options;
+
+	const conditionKey = createMemo(() =>
+		JSON.stringify(getSearchCondition() ?? null),
+	);
+
+	const buildSearchParams = (): Pick<
+		MediaSearchRequest,
+		"condition" | "sort" | "order" | "limit"
+	> => {
+		const condition = getSearchCondition();
+		return {
+			condition: condition || undefined,
+			sort: sortBy(),
+			order: sortOrder(),
+			limit: limit(),
+		};
+	};
+
+	const searchResultQuery = createInfiniteQuery<MediaSearchResponse>(() => {
+		const params = buildSearchParams();
+		const source = selectedSource() || undefined;
+		return {
+			queryKey: [
+				"searchResults",
+				source,
+				conditionKey(),
+				sortBy(),
+				sortOrder(),
+				limit(),
+			],
+			queryFn: async ({ pageParam }) =>
+				await searchMedia(source, {
+					...params,
+					offset: pageParam as number,
+				}),
+			initialPageParam: 0,
+			getNextPageParam: (lastPage, allPages) => {
+				const loadedCount = allPages.reduce(
+					(sum, page) => sum + page.media.length,
+					0,
+				);
+				if (loadedCount < lastPage.total) {
+					return loadedCount;
+				}
+			},
+			placeholderData: keepPreviousData,
+			gcTime,
+		};
+	});
+
+	const searchResults = createMemo(() => {
+		const seen = new Set<string>();
+		return (searchResultQuery.data?.pages.flatMap((p) => p.media) || []).filter(
+			(m) => {
+				if (seen.has(m.id)) {
+					return false;
+				}
+				seen.add(m.id);
+				return true;
+			},
+		);
+	});
+
+	const [isRestored, setIsRestored] = createSignal(false);
+
+	createEffect(() => {
+		if (
+			!(searchResultQuery.isLoading || isRestored()) &&
+			searchResultQuery.data &&
+			searchResultQuery.data.pages.length > 0 &&
+			scrollY() > 0
+		) {
+			requestAnimationFrame(() => {
+				window.scrollTo(0, scrollY());
+			});
+			setIsRestored(true);
+		}
+	});
+
+	onCleanup(() => {
+		if (!isServer) {
+			setScrollY(window.scrollY);
+		}
+	});
+
+	const handleSearch = () => {
+		setOffset(0);
+		setScrollY(0);
+		window.scrollTo(0, 0);
+	};
+
+	const [loadMoreRef, setLoadMoreRef] = createSignal<
+		HTMLDivElement | undefined
+	>(undefined);
+
+	createEffect(() => {
+		const el = loadMoreRef();
+		if (!el) {
+			return;
+		}
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (
+					entries[0].isIntersecting &&
+					searchResultQuery.hasNextPage &&
+					!searchResultQuery.isFetchingNextPage
+				) {
+					searchResultQuery.fetchNextPage();
+				}
+			},
+			{ threshold: 0.5, rootMargin: "1000px" },
+		);
+		observer.observe(el);
+		onCleanup(() => observer.disconnect());
+	});
+
+	return {
+		searchResultQuery,
+		searchResults,
+		isRestored,
+		handleSearch,
+		loadMoreRef,
+		setLoadMoreRef,
+		conditionKey,
+	};
+}

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -122,12 +122,13 @@ export function useSearchPage(
 		if (
 			!(searchResultQuery.isLoading || isRestored()) &&
 			searchResultQuery.data &&
-			searchResultQuery.data.pages.length > 0 &&
-			scrollY() > 0
+			searchResultQuery.data.pages.length > 0
 		) {
-			requestAnimationFrame(() => {
-				window.scrollTo(0, scrollY());
-			});
+			if (scrollY() > 0) {
+				requestAnimationFrame(() => {
+					window.scrollTo(0, scrollY());
+				});
+			}
 			setIsRestored(true);
 		}
 	});


### PR DESCRIPTION
- Add packages/ui/src/hooks/use-search-page.ts shared hook
  - infinite query construction, dedup, scroll restoration, intersection observer
- Refactor apps/server/src/routes/search.tsx and apps/tauri/src/routes/search.tsx to use the shared hook, keeping only platform-specific differences (layout, refresh strategy, sourceRootPath injection, SSR guards)
- Update .indexion/wiki/server-tauri-parity.md to reflect progress
- Apply formatting via vp fmt