### PR TITLE
commonize media/backup service context metadata / metadata extraction / restore complete to packages/application

### DIFF
--- a/.indexion/wiki/server-tauri-parity.md
+++ b/.indexion/wiki/server-tauri-parity.md
@@ -196,7 +196,7 @@ leaf component の共有は進んだが、route からの組み立て、nav acti
 | `collection-service.ts` | `packages/application/src/services/collection-service.ts` | serverのみ wrapper                                       | `TauriCollectionService` を追加。`list/get/create/update/delete/addToMedia/removeFromMedia` を維持                              |
 | `user-service.ts`       | `packages/application/src/services/user-service.ts`       | serverのみ wrapper                                       | `TauriUserService` を追加。`list/get/create/update/delete` を維持                                                               |
 | `search-service.ts`     | `packages/application/src/services/search-service.ts`     | server proxy を維持                                      | ―                                                                                                                               |
-| `media-service.ts`      | `packages/application/src/services/media-service.ts`      | 旧 `MediaServiceImpl` constructor と proxy を維持        | `TauriMediaService` も server 側メソッド名へ寄せる。`registerExistingMedia` は batch lookup / batch upsert を優先する実装へ改善 |
+| `media-service.ts`      | `packages/application/src/services/media-service.ts`      | 旧 `MediaServiceImpl` constructor と proxy を維持        | `TauriMediaService` は thin adapter に縮退。`contextMetadataUpdater` / `afterMediaRegistered` / `extractAndUpdateMetadata` を shared 化 |
 
 ### 共通化済み（utility / port / payload）
 
@@ -207,6 +207,7 @@ leaf component の共有は進んだが、route からの組み立て、nav acti
 | `config-service`       | `packages/application/src/services/config-service.ts`, `utils/config-merge.ts` | Tauri は共通 service、server は config merge utility を使用                                                                                                                    |
 | `source-service`       | `packages/application/src/services/source-service.ts`                          | server は shared service を利用。tauri も `createSourceService` を使って list/get/testConnection/getStatus を共有し、watcher / sync / fs / event / queue だけを adapter に残す |
 | `backup-service`       | `packages/db/src/backup.ts`                                                    | dump/restore の DB ロジックを共有。zip / fs / command client は app 固有のまま                                                                                                 |
+| `backup-restore-complete` | `packages/application/src/services/backup-restore-complete.ts`              | restore 後の thumbnail job enqueue を shared 化。server / tauri とも利用                                                                                                      |
 | TODO stub services     | `packages/application/src/services/stub-services.ts`                           | analytics / bulk-operation / data-migration / filter-preset / integration / workflow                                                                                           |
 
 ### 対応あり（名称・責務が近いもの）
@@ -351,3 +352,11 @@ server も `DB_HOST=pglite` で PGlite に切替可能なため、PGlite は DB 
 - **Jobs**: media-processing job の step 定義・payload helper に加え、canonical job type / shared dispatcher / deferred actions executor / background coordinator / download runner / tagging runner / watcher runtime / event publish contract / processMedia batch runner / source progress tracker を `packages/application` に移動。server / tauri は共通 runtime を使い、差分は downloader / thumbnail I/O / watcher ingress / SSE or Tauri event transport に縮退
 - **Hooks / Routes**: `packages/ui/src/hooks/use-search-page.ts` を新設し、`search.tsx` の infinite query 構築、結果重複排除、スクロール位置復元、無限スクロール IntersectionObserver を shared hook へ切り出し。`apps/server/src/routes/search.tsx` と `apps/tauri/src/routes/search.tsx` は両方ともこの shared hook を利用。app 側に残る差分は JSX レイアウト（Portal vs inline Dialog）、refresh 戦略（server: 即時 invalidate / tauri: debounce 300ms + `onAllJobsCompleted`）、`sourceRootPath` 注入、SSR `isMounted` ガードなど platform 固有層のみ
 - 対応度の推定値を再補正（Routes ~78%、Hooks ~80%、Components ~80%、Repositories ~88%、Services ~68%、Jobs ~82%）
+
+## 前回からの主な変更点（2026-04-27更新）
+
+- **Services / Media**: `packages/application/src/services/media-context-metadata.ts` を新設し、`updateMediaContextMetadata` を shared 化。server 側 `MediaProcessingServiceImpl` と tauri 側 `TauriMediaService` の context metadata 更新ロジックを統合。tauri 側の `syncContextMetadata`（Drizzle query 直書き）と `characterRepository.addToMediaBulk` の再実装を削除し、shared `updateMediaContextMetadata` + `packages/db` の `CharacterRepository` を直接使用
+- **Services / Media**: `packages/application/src/services/media-metadata-extractor.ts` を新設し、`extractAndPersistMediaMetadata` を shared 化。`MediaServiceImpl` の `extractAndUpdateMetadata` private メソッドを shared 関数へ移動。tauri 側の `persistExtractedMetadata`（Drizzle query 直書き）を削除し、shared 関数を利用
+- **Services / Media**: `packages/application/src/services/media-service.ts` の `getMediaDetails` / `reprocessMetadata` を shared `extractAndPersistMediaMetadata` を使う形に変更。server / tauri とも同じ metadata 抽出・保存ロジックを共有
+- **Services / Backup**: `packages/application/src/services/backup-restore-complete.ts` を新設し、`enqueueThumbnailJobsAfterRestore` を shared 化。server 側 `backup-service.ts` と tauri 側 `source-backup-service.ts` の restore 後処理を統合。tauri 側に `onRestoreComplete` を追加し、server 側と同じ挙動に揃える
+- **Services対応度**: media-service / source-backup-service の主要ロジックを shared 化したことで、Services 対応度は ~75% 程度へ上昇。残る差分は upload collision resolution algorithm（platform 非依存部分の shared 化余地あり）、zip 処理、および platform 固有 I/O 層

--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { enqueueThumbnailJobsAfterRestore } from "@solid-imager/application/services/backup-restore-complete";
 import { createBackupService } from "@solid-imager/db/backup";
 import type { DrizzleExecutor } from "@solid-imager/db/types";
 import { eq } from "drizzle-orm";
@@ -37,24 +38,11 @@ const backupService = createBackupService({
 		);
 	},
 	onRestoreComplete: async ({ source, mediaIds, rootPath }) => {
-		if (source.type !== "local" || mediaIds.length === 0) {
-			return;
-		}
-
 		try {
-			const jobRepo = services.getJobRepository();
-			for (const mediaId of mediaIds) {
-				await jobRepo.create({
-					type: "processMedia",
-					mediaSourceId: source.id,
-					payload: {
-						mediaId,
-						sourcePath: rootPath,
-						steps: ["generateThumbnail"],
-						type: "processMedia",
-					},
-				});
-			}
+			await enqueueThumbnailJobsAfterRestore(
+				{ source, mediaIds, rootPath },
+				{ jobRepository: services.getJobRepository() },
+			);
 		} catch (error) {
 			logger.warn(
 				{ err: error },

--- a/apps/server/src/application/services/media-processing-service.ts
+++ b/apps/server/src/application/services/media-processing-service.ts
@@ -7,8 +7,8 @@ import path from "node:path";
 // Registry for backward compatibility proxy
 
 import type { JobRecord } from "@solid-imager/application/ports/job-repository";
+import { updateMediaContextMetadata } from "@solid-imager/application/services/media-context-metadata";
 import { runProcessMediaJob } from "@solid-imager/application/services/process-media-runner";
-import type { Character } from "@solid-imager/core/domain/characters/schemas";
 import type { Transaction } from "@solid-imager/core/domain/interfaces/transaction-manager";
 import type {
 	Media,
@@ -182,231 +182,20 @@ export class MediaProcessingServiceImpl {
 		context: Partial<MediaMetadataContext>,
 		tx?: Transaction,
 	): Promise<void> {
-		if (context.sourceUrls?.length) {
-			await this.mediaRepo.addUrls(mediaId, context.sourceUrls, tx);
-		}
-
-		if (context.authors?.length) {
-			await this.registerAuthors(mediaId, context.authors, tx);
-		}
-
-		if (context.tags?.length) {
-			await this.tagRepo.addTagsToMedia(
-				mediaId,
-				context.tags.map((t) => ({
-					name: t.name,
-					type: (t.type ?? "positive") as "positive" | "negative",
-					confidence: t.confidence ?? undefined,
-				})),
-				"user_provided",
-				tx,
-			);
-		}
-
-		if (context.ips?.length) {
-			await this.registerIps(mediaId, context.ips, tx);
-		}
-
-		if (context.characters?.length) {
-			await this.registerCharacters(
-				mediaId,
-				context.characters,
-				context.ips?.map((ip) => ip.name),
-				tx,
-			);
-		}
-
-		if (context.projects?.length) {
-			await this.registerProjects(mediaId, context.projects, tx);
-		}
-	}
-
-	private async registerAuthors(
-		mediaId: string,
-		authors: NonNullable<MediaMetadataContext["authors"]>,
-		tx?: Transaction,
-	): Promise<void> {
-		for (const author of authors) {
-			try {
-				let createdAuthor = await this.authorRepo.findByName(author.name, tx);
-				if (!createdAuthor) {
-					createdAuthor = await this.authorRepo.create(
-						{
-							name: author.name,
-							accountId: author.accountId ?? null,
-						},
-						tx,
-					);
-				}
-				await this.authorRepo.addMedia(mediaId, createdAuthor.id, tx);
-			} catch (e) {
-				logger.warn({ err: e, author }, "Failed to register author");
-			}
-		}
-	}
-
-	private async registerCharacters(
-		mediaId: string,
-		characters: NonNullable<MediaMetadataContext["characters"]>,
-		currentIpNames?: string[],
-		tx?: Transaction,
-	): Promise<void> {
-		for (const charData of characters) {
-			try {
-				await this._registerSingleCharacter(
-					mediaId,
-					charData,
-					currentIpNames,
-					tx,
-				);
-			} catch (e) {
-				logger.warn(
-					{ err: e, character: charData },
-					"Failed to register character",
-				);
-			}
-		}
-	}
-
-	private async _registerSingleCharacter(
-		mediaId: string,
-		charData: NonNullable<MediaMetadataContext["characters"]>[number],
-		currentIpNames?: string[],
-		tx?: Transaction,
-	): Promise<void> {
-		let character: Character | null = await this.characterService.findByName(
-			charData.name,
+		await updateMediaContextMetadata(
+			mediaId,
+			context,
+			{
+				mediaRepository: this.mediaRepo,
+				authorRepository: this.authorRepo,
+				characterRepository: this.characterService.characterRepo,
+				ipRepository: this.ipRepo,
+				projectRepository: this.projectRepo,
+				tagRepository: this.tagRepo,
+				logger,
+			},
+			tx,
 		);
-
-		// Determine which IPs to link to this character
-		// Priority: 1) linkedIps from metadata, 2) infer from media's current IPs
-		const ipNamesToLink =
-			charData.linkedIps && charData.linkedIps.length > 0
-				? charData.linkedIps
-				: currentIpNames;
-
-		const ipIdsToLink = await this._resolveIpIds(ipNamesToLink, tx);
-
-		if (!character) {
-			character = await this.characterService.createCharacter({
-				name: charData.name,
-				description: charData.description ?? "",
-				ipIds: ipIdsToLink,
-			});
-		} else if (ipIdsToLink.length > 0) {
-			character = await this._updateCharacterIps(character, ipIdsToLink);
-		}
-
-		if (!character) {
-			return;
-		}
-
-		// Re-link character to media if necessary
-		// We can use characterService.addCharacterToMedia(mediaId, character.id) but it will call linkCharacterIps again.
-		// That's actually fine/safe.
-		// NOTE: CharacterService.addCharacterToMedia now uses internal transactionManager, so we might want to call repo directly if we already have a tx?
-		// But for simplicity and consistent auto-link logic, service call is safer.
-		// If tx is provided, we should probably prefer repo call or update service to accept tx.
-		const charRepo = this.characterService.characterRepo;
-		const confidence = charData.confidence ?? 1;
-		await charRepo.addToMedia(mediaId, character.id, confidence, "manual", tx);
-		await this.characterService.linkCharacterIps(mediaId, character, tx);
-	}
-
-	private async _resolveIpIds(
-		currentIpNames?: string[],
-		tx?: Transaction,
-	): Promise<string[]> {
-		if (!currentIpNames?.length) {
-			return [];
-		}
-
-		const foundIps = await this.ipRepo.findByNames(currentIpNames, tx);
-		return foundIps.map((ip) => ip.id);
-	}
-
-	private async _updateCharacterIps(
-		character: Character,
-		ipIdsToLink: string[],
-	): Promise<Character> {
-		const existingIpIds = character.ips?.map((i) => i.id) || [];
-		const newIpIds = [...new Set([...existingIpIds, ...ipIdsToLink])];
-
-		if (newIpIds.length > existingIpIds.length) {
-			return await this.characterService.updateCharacter(character.id, {
-				ipIds: newIpIds,
-			});
-		}
-		return character;
-	}
-
-	private async registerIps(
-		mediaId: string,
-		ipsData: NonNullable<MediaMetadataContext["ips"]>,
-		tx?: Transaction,
-	): Promise<void> {
-		// Normalize names and remove duplicates to avoid redundant creation attempts
-		const normalizedIpsMap = new Map<
-			string,
-			NonNullable<MediaMetadataContext["ips"]>[number]
-		>();
-		for (const ip of ipsData) {
-			const normalizedName = ip.name.trim();
-			if (!normalizedIpsMap.has(normalizedName)) {
-				normalizedIpsMap.set(normalizedName, ip);
-			}
-		}
-
-		for (const [name, ipData] of normalizedIpsMap) {
-			try {
-				let created = await this.ipRepo.findByName(name, tx);
-				if (!created) {
-					created = await this.ipRepo.create(
-						{
-							name,
-							description: ipData.description ?? "",
-						},
-						tx,
-					);
-				}
-				await this.ipRepo.addMedia(
-					mediaId,
-					created.id,
-					ipData.confidence ?? undefined,
-					"manual",
-					tx,
-				);
-			} catch (e) {
-				logger.warn({ err: e, ip: ipData }, "Failed to register IP");
-			}
-		}
-	}
-
-	private async registerProjects(
-		mediaId: string,
-		projectsData: NonNullable<MediaMetadataContext["projects"]>,
-		tx?: Transaction,
-	): Promise<void> {
-		for (const projData of projectsData) {
-			try {
-				let created = await this.projectRepo.findByName(projData.name, tx);
-				if (!created) {
-					created = await this.projectRepo.create(
-						{
-							name: projData.name,
-							description: projData.description ?? "",
-						},
-						tx,
-					);
-				}
-				await this.projectRepo.addMedia(mediaId, created.id, tx);
-			} catch (e) {
-				logger.warn(
-					{ err: e, project: projData },
-					"Failed to register project",
-				);
-			}
-		}
 	}
 
 	/**

--- a/apps/server/src/tests/unit/application/services/media-processing-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/media-processing-service.test.ts
@@ -143,7 +143,7 @@ describe("MediaProcessingService", () => {
 			const ipId = "ip-1";
 			const testConfidence = 0.9;
 			mockMediaRepo.findById.mockResolvedValue({ id: mediaId });
-			mockCharacterService.findByName.mockResolvedValue({
+			mockCharacterRepo.findByName.mockResolvedValue({
 				id: charId,
 				name: "Char Name",
 				ips: [{ id: ipId, name: "IP Name" }],
@@ -154,7 +154,10 @@ describe("MediaProcessingService", () => {
 				characters: [{ name: "Char Name", confidence: testConfidence }],
 			});
 
-			expect(mockCharacterService.findByName).toHaveBeenCalledWith("Char Name");
+			expect(mockCharacterRepo.findByName).toHaveBeenCalledWith(
+				"Char Name",
+				undefined,
+			);
 			expect(mockCharacterRepo.addToMedia).toHaveBeenCalledWith(
 				mediaId,
 				charId,
@@ -162,9 +165,11 @@ describe("MediaProcessingService", () => {
 				"manual",
 				undefined,
 			);
-			expect(mockCharacterService.linkCharacterIps).toHaveBeenCalledWith(
+			expect(mockIpRepo.addMedia).toHaveBeenCalledWith(
 				mediaId,
-				expect.objectContaining({ id: charId }),
+				ipId,
+				undefined,
+				"character_link",
 				undefined,
 			);
 		});
@@ -184,8 +189,8 @@ describe("MediaProcessingService", () => {
 			mockIpRepo.findByName.mockResolvedValue({ id: ipId, name: ipName });
 
 			// 2. Character registration (called second)
-			mockCharacterService.findByName.mockResolvedValue(null);
-			mockCharacterService.createCharacter.mockResolvedValue({
+			mockCharacterRepo.findByName.mockResolvedValue(null);
+			mockCharacterRepo.create.mockResolvedValue({
 				id: charId,
 				name: charName,
 				ips: [{ id: ipId, name: ipName }],
@@ -206,11 +211,15 @@ describe("MediaProcessingService", () => {
 			);
 
 			// Verify Character was created with IP ID
-			expect(mockCharacterService.createCharacter).toHaveBeenCalledWith({
-				name: charName,
-				description: "",
-				ipIds: [ipId],
-			});
+			expect(mockCharacterRepo.create).toHaveBeenCalledWith(
+				{
+					name: charName,
+					description: "",
+					ipIds: [ipId],
+					source: "manual",
+				},
+				undefined,
+			);
 
 			// Verify both were linked to media
 			expect(mockIpRepo.addMedia).toHaveBeenCalledWith(
@@ -227,9 +236,11 @@ describe("MediaProcessingService", () => {
 				"manual",
 				undefined,
 			);
-			expect(mockCharacterService.linkCharacterIps).toHaveBeenCalledWith(
+			expect(mockIpRepo.addMedia).toHaveBeenCalledWith(
 				mediaId,
-				expect.objectContaining({ id: charId }),
+				ipId,
+				undefined,
+				"character_link",
 				undefined,
 			);
 		});

--- a/apps/tauri/src/infrastructure/local-api/services/media-service.ts
+++ b/apps/tauri/src/infrastructure/local-api/services/media-service.ts
@@ -1,42 +1,28 @@
+import { extractAndPersistMediaMetadata } from "@solid-imager/application/services/media-metadata-extractor";
+import { updateMediaContextMetadata } from "@solid-imager/application/services/media-context-metadata";
 import {
 	createMediaService,
 	type MediaPathAdapter,
 } from "@solid-imager/application/services/media-service";
 import type { Transaction } from "@solid-imager/core/domain/interfaces/transaction-manager";
-import {
-	type MediaDetails,
-	type MediaSearchRequest,
-	type MediaSearchResponse,
-	type UpdateMediaRequest,
-	updateMediaRequestSchema,
+import type {
+	MediaDetails,
+	MediaSearchRequest,
+	MediaSearchResponse,
+	UpdateMediaRequest,
 } from "@solid-imager/core/domain/media/schemas";
 import type {
 	UploadMediaRequest,
 	UploadResponse,
 } from "@solid-imager/core/domain/media/upload-schemas";
 import { uploadMediaRequestSchema } from "@solid-imager/core/domain/media/upload-schemas";
-import type { CharacterRepository } from "@solid-imager/core/domain/repositories/character-repository";
 import type {
 	IMediaStorage,
 	MediaMetadata,
 	MediaSourceFile,
 	MediaStorageResult,
 } from "@solid-imager/core/interfaces/media-storage";
-import {
-	authors,
-	characters,
-	ips,
-	mediaAuthors,
-	mediaCharacters,
-	mediaGenerationInfo,
-	mediaIps,
-	mediaTags,
-	mediaUrls,
-	tags,
-} from "@solid-imager/db/schema";
-import { and, eq, inArray, sql } from "drizzle-orm";
 import { getTauriAppServices } from "~/app-services";
-import type { TauriDbExecutor } from "~/infrastructure/db/client";
 import { basename, dirname, extname, joinLocalPath } from "../../path-utils";
 import { TauriAuthorRepository } from "../repositories/author-repository";
 import { TauriCharacterRepository } from "../repositories/character-repository";
@@ -46,8 +32,6 @@ import { TauriProjectRepository } from "../repositories/project-repository";
 import { TauriSourceRepository } from "../repositories/source-repository";
 import { TauriTagRepository } from "../repositories/tag-repository";
 
-const EXTRACTED_TAG_SOURCE = "comfyui_workflow";
-const LOCAL_TAG_SOURCE = "local";
 const MAX_FILENAME_COLLISION_ATTEMPTS = 1000;
 
 type ProbeMediaResult = {
@@ -149,180 +133,6 @@ async function ensureParentDirectory(fullPath: string) {
 		await getTauriAppServices().fileSystem.mkdir(parentDir, {
 			recursive: true,
 		});
-	}
-}
-
-function mediaCharacterConflictSet(source: string) {
-	let sourceUpdateSql = sql`excluded.source`;
-	let confidenceUpdateSql = sql`excluded.confidence`;
-
-	if (source === "AI") {
-		sourceUpdateSql = sql`CASE WHEN media_characters.source = 'AI' THEN excluded.source ELSE media_characters.source END`;
-		confidenceUpdateSql = sql`CASE WHEN media_characters.source = 'AI' THEN excluded.confidence ELSE media_characters.confidence END`;
-	} else if (source === "manual") {
-		sourceUpdateSql = sql`CASE WHEN media_characters.source IN ('AI', 'manual') THEN excluded.source ELSE media_characters.source END`;
-		confidenceUpdateSql = sql`CASE WHEN media_characters.source IN ('AI', 'manual') THEN excluded.confidence ELSE media_characters.confidence END`;
-	}
-
-	return {
-		source: sourceUpdateSql,
-		confidence: confidenceUpdateSql,
-	};
-}
-
-async function persistExtractedMetadata(mediaId: string, fullPath: string, tx: TauriDbExecutor) {
-	const extracted = await getTauriAppServices().imageProcessor.extractMetadata(fullPath);
-
-	await tx
-		.delete(mediaTags)
-		.where(and(eq(mediaTags.mediaId, mediaId), eq(mediaTags.source, EXTRACTED_TAG_SOURCE)));
-	await tx.delete(mediaGenerationInfo).where(eq(mediaGenerationInfo.mediaId, mediaId));
-
-	const hasMetadata =
-		extracted.tags.length > 0 || extracted.prompt !== null || extracted.workflow !== null;
-	if (!hasMetadata) {
-		return;
-	}
-
-	const uniqueTagNames = Array.from(new Set(extracted.tags.map((tag) => tag.name)));
-	if (uniqueTagNames.length > 0) {
-		await tx
-			.insert(tags)
-			.values(
-				uniqueTagNames.map((name) => ({
-					name,
-					source: LOCAL_TAG_SOURCE,
-				})),
-			)
-			.onConflictDoNothing();
-
-		const persistedTags = await tx
-			.select({
-				id: tags.id,
-				name: tags.name,
-			})
-			.from(tags)
-			.where(inArray(tags.name, uniqueTagNames));
-		const tagIdByName = new Map(persistedTags.map((tag) => [tag.name, tag.id]));
-
-		await tx
-			.insert(mediaTags)
-			.values(
-				extracted.tags.flatMap((tag) => {
-					const tagId = tagIdByName.get(tag.name);
-					return tagId
-						? [
-								{
-									mediaId,
-									tagId,
-									tagType: tag.type,
-									confidence: null,
-									source: EXTRACTED_TAG_SOURCE,
-								},
-							]
-						: [];
-				}),
-			)
-			.onConflictDoNothing();
-	}
-
-	await TauriMediaRepository.upsertGenerationInfo(
-		mediaId,
-		typeof extracted.prompt === "string"
-			? extracted.prompt
-			: extracted.prompt
-				? JSON.stringify(extracted.prompt)
-				: null,
-		extracted.workflow && typeof extracted.workflow === "object" ? extracted.workflow : null,
-		tx,
-	);
-}
-
-async function syncContextMetadata(
-	mediaId: string,
-	updates: UpdateMediaRequest,
-	tx: TauriDbExecutor,
-) {
-	if (updates.sourceUrls !== undefined) {
-		await tx.delete(mediaUrls).where(eq(mediaUrls.mediaId, mediaId));
-		await TauriMediaRepository.addUrls(mediaId, updates.sourceUrls, tx);
-	}
-
-	if (updates.authors !== undefined) {
-		await tx.delete(mediaAuthors).where(eq(mediaAuthors.mediaId, mediaId));
-		for (const author of updates.authors) {
-			const existingAuthor = (
-				author.accountId
-					? await tx.select().from(authors).where(eq(authors.accountId, author.accountId)).limit(1)
-					: await tx.select().from(authors).where(eq(authors.name, author.name)).limit(1)
-			)[0];
-			const authorId =
-				existingAuthor?.id ??
-				(
-					await tx
-						.insert(authors)
-						.values({
-							name: author.name,
-							accountId: author.accountId ?? null,
-						})
-						.returning({ id: authors.id })
-				)[0]?.id;
-			if (authorId) {
-				await TauriAuthorRepository.addMedia(mediaId, authorId, tx);
-			}
-		}
-	}
-
-	if (updates.characters !== undefined) {
-		await tx.delete(mediaCharacters).where(eq(mediaCharacters.mediaId, mediaId));
-		for (const character of updates.characters) {
-			const existingCharacter = (
-				await tx.select().from(characters).where(eq(characters.name, character.name)).limit(1)
-			)[0];
-			const characterId =
-				existingCharacter?.id ??
-				(
-					await tx
-						.insert(characters)
-						.values({
-							name: character.name,
-							description: "",
-							source: "manual",
-						})
-						.returning({ id: characters.id })
-				)[0]?.id;
-			if (characterId) {
-				await TauriCharacterRepository.addMedia(
-					mediaId,
-					characterId,
-					character.confidence ?? undefined,
-					"manual",
-					tx,
-				);
-			}
-		}
-	}
-
-	if (updates.ips !== undefined) {
-		await tx.delete(mediaIps).where(eq(mediaIps.mediaId, mediaId));
-		for (const ip of updates.ips) {
-			const existingIp = (await tx.select().from(ips).where(eq(ips.name, ip.name)).limit(1))[0];
-			const ipId =
-				existingIp?.id ??
-				(
-					await tx
-						.insert(ips)
-						.values({
-							name: ip.name,
-							description: "",
-							source: "manual",
-						})
-						.returning({ id: ips.id })
-				)[0]?.id;
-			if (ipId) {
-				await TauriIpRepository.addMedia(mediaId, ipId, ip.confidence ?? undefined, "manual", tx);
-			}
-		}
 	}
 }
 
@@ -467,46 +277,6 @@ const tauriMediaStorage: IMediaStorage = {
 	},
 };
 
-const characterRepository: CharacterRepository = {
-	...TauriCharacterRepository,
-	addToMedia: TauriCharacterRepository.addMedia,
-	removeFromMedia: TauriCharacterRepository.removeMedia,
-	async addToMediaBulk(
-		mediaId: string,
-		charactersToAdd: { id: string; confidence?: number }[],
-		source = "manual",
-		tx?: Transaction,
-	) {
-		const rows = charactersToAdd.flatMap((character) => {
-			if (!character.id) {
-				console.error("Invalid character record: missing id", character);
-				return [];
-			}
-
-			return [
-				{
-					mediaId,
-					characterId: character.id,
-					confidence: character.confidence ?? null,
-					source,
-				},
-			];
-		});
-		if (rows.length === 0) {
-			return;
-		}
-
-		const executor = (tx as TauriDbExecutor | undefined) ?? getTauriAppServices().db;
-		await executor
-			.insert(mediaCharacters)
-			.values(rows)
-			.onConflictDoUpdate({
-				target: [mediaCharacters.mediaId, mediaCharacters.characterId],
-				set: mediaCharacterConflictSet(source),
-			});
-	},
-};
-
 const mediaService = createMediaService({
 	mediaRepository: TauriMediaRepository,
 	sourceRepository: TauriSourceRepository,
@@ -530,25 +300,40 @@ const mediaService = createMediaService({
 	},
 	authorRepository: TauriAuthorRepository,
 	projectRepository: TauriProjectRepository,
-	characterRepository,
+	characterRepository: TauriCharacterRepository,
 	ipRepository: TauriIpRepository,
 	transactionManager: {
 		async transaction<T>(callback: (tx: Transaction) => Promise<T>): Promise<T> {
 			return await getTauriAppServices().db.transaction(callback);
-		},
+		}
 	},
 	contextMetadataUpdater: async (mediaId, context, tx) => {
-		await syncContextMetadata(
+		await updateMediaContextMetadata(
 			mediaId,
-			updateMediaRequestSchema.parse(context),
-			tx as TauriDbExecutor,
+			context as Partial<import("@solid-imager/core/domain/media/schemas").MediaMetadataContext>,
+			{
+				mediaRepository: TauriMediaRepository,
+				authorRepository: TauriAuthorRepository,
+				characterRepository: TauriCharacterRepository,
+				ipRepository: TauriIpRepository,
+				projectRepository: TauriProjectRepository,
+				tagRepository: TauriTagRepository,
+			},
+			tx,
 		);
 	},
 	pathAdapter: tauriPathAdapter,
-	afterMediaRegistered: async ({ media, sourcePath, filePath }) => {
-		await getTauriAppServices().db.transaction(async (tx) => {
-			await persistExtractedMetadata(media.id, joinLocalPath(sourcePath, filePath), tx);
-		});
+	afterMediaRegistered: async ({ media, sourcePath }) => {
+		await extractAndPersistMediaMetadata(
+			media,
+			sourcePath,
+			{
+				mediaRepository: TauriMediaRepository,
+				tagRepository: TauriTagRepository,
+				imageProcessor: getTauriAppServices().imageProcessor,
+				pathAdapter: tauriPathAdapter,
+			},
+		);
 	},
 });
 

--- a/apps/tauri/src/infrastructure/local-api/services/source-backup-service.ts
+++ b/apps/tauri/src/infrastructure/local-api/services/source-backup-service.ts
@@ -1,7 +1,9 @@
+import { enqueueThumbnailJobsAfterRestore } from "@solid-imager/application/services/backup-restore-complete";
 import { createBackupService } from "@solid-imager/db/backup";
 import { getTauriAppServices } from "~/app-services";
 import type { TauriDbExecutor } from "~/infrastructure/db/client";
 import { joinLocalPath } from "../../path-utils";
+import { TauriJobRepository } from "../repositories/tauri-job-repository";
 import { TauriSourceRepository } from "../repositories/source-repository";
 import { TauriSourceService } from "./source-service";
 
@@ -56,6 +58,12 @@ const backupService = createBackupService({
 	runTransaction: async <T>(callback: (executor: TauriDbExecutor) => Promise<T>) => {
 		return await getTauriAppServices().db.transaction(
 			async (tx) => await callback(tx as TauriDbExecutor),
+		);
+	},
+	onRestoreComplete: async ({ source, mediaIds, rootPath }) => {
+		await enqueueThumbnailJobsAfterRestore(
+			{ source, mediaIds, rootPath },
+			{ jobRepository: TauriJobRepository },
 		);
 	},
 });

--- a/packages/application/src/services/backup-restore-complete.ts
+++ b/packages/application/src/services/backup-restore-complete.ts
@@ -1,0 +1,34 @@
+import type { BackupSource } from "@solid-imager/db/backup";
+import type { ProcessMediaJobRepository } from "../ports/job-repository";
+
+export type BackupRestoreCompleteDeps = {
+	jobRepository: ProcessMediaJobRepository;
+};
+
+export async function enqueueThumbnailJobsAfterRestore(
+	params: {
+		source: BackupSource;
+		mediaIds: string[];
+		rootPath: string;
+	},
+	deps: BackupRestoreCompleteDeps,
+): Promise<void> {
+	const { source, mediaIds, rootPath } = params;
+	if (source.type !== "local" || mediaIds.length === 0) {
+		return;
+	}
+
+	const sourceId = source.id ?? "";
+	for (const mediaId of mediaIds) {
+		await deps.jobRepository.create({
+			type: "processMedia",
+			mediaSourceId: sourceId,
+			payload: {
+				mediaId,
+				sourcePath: rootPath,
+				steps: ["generateThumbnail"],
+				type: "processMedia",
+			},
+		});
+	}
+}

--- a/packages/application/src/services/backup-restore-complete.ts
+++ b/packages/application/src/services/backup-restore-complete.ts
@@ -1,8 +1,8 @@
 import type { BackupSource } from "@solid-imager/db/backup";
-import type { ProcessMediaJobRepository } from "../ports/job-repository";
+import type { JobRepositoryPort } from "../ports/job-repository";
 
 export type BackupRestoreCompleteDeps = {
-	jobRepository: ProcessMediaJobRepository;
+	jobRepository: JobRepositoryPort;
 };
 
 export async function enqueueThumbnailJobsAfterRestore(
@@ -19,16 +19,16 @@ export async function enqueueThumbnailJobsAfterRestore(
 	}
 
 	const sourceId = source.id ?? "";
-	for (const mediaId of mediaIds) {
-		await deps.jobRepository.create({
-			type: "processMedia",
+	await deps.jobRepository.createMany(
+		mediaIds.map((mediaId) => ({
+			type: "processMedia" as const,
 			mediaSourceId: sourceId,
 			payload: {
 				mediaId,
 				sourcePath: rootPath,
 				steps: ["generateThumbnail"],
-				type: "processMedia",
+				type: "processMedia" as const,
 			},
-		});
-	}
+		})),
+	);
 }

--- a/packages/application/src/services/media-context-metadata.ts
+++ b/packages/application/src/services/media-context-metadata.ts
@@ -1,0 +1,213 @@
+import type { Transaction } from "@solid-imager/core/domain/interfaces/transaction-manager";
+import type {
+	MediaMetadataContext,
+} from "@solid-imager/core/domain/media/schemas";
+import type { IAuthorRepository } from "@solid-imager/core/domain/repositories/author-repository";
+import type { CharacterRepository } from "@solid-imager/core/domain/repositories/character-repository";
+import type { IIpRepository } from "@solid-imager/core/domain/repositories/ip-repository";
+import type { IMediaRepository } from "@solid-imager/core/domain/repositories/media-repository";
+import type { IProjectRepository } from "@solid-imager/core/domain/repositories/project-repository";
+import type { TagRepository } from "@solid-imager/core/domain/repositories/tag-repository";
+
+export type MediaContextMetadataDeps = {
+	mediaRepository: IMediaRepository;
+	authorRepository: IAuthorRepository;
+	characterRepository: CharacterRepository;
+	ipRepository: IIpRepository;
+	projectRepository: IProjectRepository;
+	tagRepository: TagRepository;
+	logger?: { warn?(data: unknown, message?: string): void };
+};
+
+async function updateCharacterForMedia(
+	mediaId: string,
+	charData: NonNullable<MediaMetadataContext["characters"]>[number],
+	deps: { characterRepository: CharacterRepository; ipRepository: IIpRepository },
+	contextIpNames?: string[],
+	tx?: Transaction,
+): Promise<void> {
+	let character = await deps.characterRepository.findByName(charData.name, tx);
+
+	const ipNamesToLink =
+		charData.linkedIps && charData.linkedIps.length > 0
+			? charData.linkedIps
+			: contextIpNames;
+
+	const ipIdsToLink = ipNamesToLink?.length
+		? (await deps.ipRepository.findByNames(ipNamesToLink, tx)).map((ip) => ip.id)
+		: [];
+
+	if (!character) {
+		character = await deps.characterRepository.create(
+			{
+				name: charData.name,
+				description: charData.description ?? "",
+				source: charData.source ?? "manual",
+				ipIds: ipIdsToLink,
+			},
+			tx,
+		);
+	} else if (ipIdsToLink.length > 0) {
+		const existingIpIds = character.ips?.map((i) => i.id) || [];
+		const newIpIds = [...new Set([...existingIpIds, ...ipIdsToLink])];
+		if (newIpIds.length > existingIpIds.length) {
+			await deps.characterRepository.update(
+				character.id,
+				{ ipIds: newIpIds },
+				tx,
+			);
+			character = await deps.characterRepository.findById(character.id, tx);
+		}
+	}
+
+	if (!character) {
+		return;
+	}
+
+	await deps.characterRepository.addToMedia(
+		mediaId,
+		character.id,
+		charData.confidence ?? 1,
+		charData.source ?? "manual",
+		tx,
+	);
+
+	if (character.ips && character.ips.length > 0) {
+		for (const ip of character.ips) {
+			await deps.ipRepository.addMedia(
+				mediaId,
+				ip.id,
+				undefined,
+				"character_link",
+				tx,
+			);
+		}
+	}
+}
+
+export async function updateMediaContextMetadata(
+	mediaId: string,
+	context: Partial<MediaMetadataContext>,
+	deps: MediaContextMetadataDeps,
+	tx?: Transaction,
+): Promise<void> {
+	const {
+		mediaRepository,
+		authorRepository,
+		characterRepository,
+		ipRepository,
+		projectRepository,
+		tagRepository,
+		logger,
+	} = deps;
+
+	if (context.sourceUrls?.length) {
+		await mediaRepository.addUrls(mediaId, context.sourceUrls, tx);
+	}
+
+	if (context.authors?.length) {
+		for (const author of context.authors) {
+			try {
+				let existing = await authorRepository.findByName(author.name, tx);
+				if (!existing) {
+					existing = await authorRepository.create(
+						{
+							name: author.name,
+							accountId: author.accountId ?? null,
+						},
+						tx,
+					);
+				}
+				await authorRepository.addMedia(mediaId, existing.id, tx);
+			} catch (e) {
+				logger?.warn?.({ err: e, author }, "Failed to register author");
+			}
+		}
+	}
+
+	if (context.tags?.length) {
+		await tagRepository.addTagsToMedia(
+			mediaId,
+			context.tags.map((t) => ({
+				name: t.name,
+				type: (t.type ?? "positive") as "positive" | "negative",
+				confidence: t.confidence ?? undefined,
+			})),
+			"user_provided",
+			tx,
+		);
+	}
+
+	if (context.ips?.length) {
+		const normalizedIpsMap = new Map<
+			string,
+			NonNullable<MediaMetadataContext["ips"]>[number]
+		>();
+		for (const ip of context.ips) {
+			const normalizedName = ip.name.trim();
+			if (!normalizedIpsMap.has(normalizedName)) {
+				normalizedIpsMap.set(normalizedName, ip);
+			}
+		}
+		for (const [name, ipData] of normalizedIpsMap) {
+			try {
+				let existing = await ipRepository.findByName(name, tx);
+				if (!existing) {
+					existing = await ipRepository.create(
+						{ name, description: ipData.description ?? "" },
+						tx,
+					);
+				}
+				await ipRepository.addMedia(
+					mediaId,
+					existing.id,
+					ipData.confidence ?? undefined,
+					ipData.source ?? "manual",
+					tx,
+				);
+			} catch (e) {
+				logger?.warn?.({ err: e, ip: ipData }, "Failed to register IP");
+			}
+		}
+	}
+
+	if (context.characters?.length) {
+		const contextIpNames = context.ips?.map((ip) => ip.name);
+		for (const charData of context.characters) {
+			try {
+				await updateCharacterForMedia(
+					mediaId,
+					charData,
+					{ characterRepository, ipRepository },
+					contextIpNames,
+					tx,
+				);
+			} catch (e) {
+				logger?.warn?.(
+					{ err: e, character: charData },
+					"Failed to register character",
+				);
+			}
+		}
+	}
+
+	if (context.projects?.length) {
+		for (const project of context.projects) {
+			try {
+				let existing = await projectRepository.findByName(project.name, tx);
+				if (!existing) {
+					existing = await projectRepository.create(
+						{
+							name: project.name,
+							description: project.description ?? "",
+						},
+						tx,
+					);
+				}
+				await projectRepository.addMedia(mediaId, existing.id, tx);
+			} catch (e) {
+				logger?.warn?.({ err: e, project }, "Failed to register project");
+			}
+		}
+	}
+}

--- a/packages/application/src/services/media-context-metadata.ts
+++ b/packages/application/src/services/media-context-metadata.ts
@@ -47,6 +47,7 @@ async function updateCharacterForMedia(
 			},
 			tx,
 		);
+		character = await deps.characterRepository.findById(character.id, tx);
 	} else if (ipIdsToLink.length > 0) {
 		const existingIpIds = character.ips?.map((i) => i.id) || [];
 		const newIpIds = [...new Set([...existingIpIds, ...ipIdsToLink])];
@@ -73,15 +74,12 @@ async function updateCharacterForMedia(
 	);
 
 	if (character.ips && character.ips.length > 0) {
-		for (const ip of character.ips) {
-			await deps.ipRepository.addMedia(
-				mediaId,
-				ip.id,
-				undefined,
-				"character_link",
-				tx,
-			);
-		}
+		await deps.ipRepository.addMediaBulk(
+			mediaId,
+			character.ips.flatMap((ip) => (ip.id ? [{ id: ip.id }] : [])),
+			"character_link",
+			tx,
+		);
 	}
 }
 
@@ -172,7 +170,9 @@ export async function updateMediaContextMetadata(
 	}
 
 	if (context.characters?.length) {
-		const contextIpNames = context.ips?.map((ip) => ip.name);
+		const contextIpNames = context.ips?.flatMap((ip) =>
+			ip.name?.trim() ? [ip.name.trim()] : [],
+		);
 		for (const charData of context.characters) {
 			try {
 				await updateCharacterForMedia(

--- a/packages/application/src/services/media-metadata-extractor.ts
+++ b/packages/application/src/services/media-metadata-extractor.ts
@@ -1,0 +1,66 @@
+import type { Transaction } from "@solid-imager/core/domain/interfaces/transaction-manager";
+import type {
+	Media,
+	MediaGenerationInfo,
+} from "@solid-imager/core/domain/media/schemas";
+import type { IMediaRepository } from "@solid-imager/core/domain/repositories/media-repository";
+import type { TagRepository } from "@solid-imager/core/domain/repositories/tag-repository";
+import type { IImageProcessor } from "@solid-imager/core/domain/services/image-processor";
+
+export type MediaMetadataExtractorDeps = {
+	mediaRepository: IMediaRepository;
+	tagRepository: TagRepository;
+	imageProcessor: IImageProcessor;
+	pathAdapter: { join(basePath: string, relativePath: string): string };
+	logger?: {
+		info?(data: unknown, message?: string): void;
+		error?(data: unknown, message?: string): void;
+	};
+};
+
+export async function extractAndPersistMediaMetadata(
+	media: Media,
+	sourcePath: string,
+	deps: MediaMetadataExtractorDeps,
+	tx?: Transaction,
+): Promise<MediaGenerationInfo | null> {
+	const { mediaRepository, tagRepository, imageProcessor, pathAdapter, logger } = deps;
+	const fullPath = pathAdapter.join(sourcePath, media.filePath);
+
+	try {
+		const metadata = await imageProcessor.extractMetadata(fullPath);
+		logger?.info?.(
+			{
+				mediaId: media.id,
+				fullPath,
+				tagsCount: metadata.tags.length,
+				hasWorkflow: !!metadata.workflow,
+				hasPrompt: !!metadata.prompt,
+			},
+			"[MediaMetadataExtractor] extractAndPersistMediaMetadata result",
+		);
+		await mediaRepository.upsertGenerationInfo(
+			media.id,
+			typeof metadata.prompt === "object"
+				? JSON.stringify(metadata.prompt)
+				: (metadata.prompt as string | null),
+			metadata.workflow as object | null,
+			tx,
+		);
+		if (metadata.tags.length > 0) {
+			await tagRepository.addTagsToMedia(
+				media.id,
+				metadata.tags,
+				"comfyui_workflow",
+				tx,
+			);
+		}
+		return await mediaRepository.getGenerationInfo(media.id, tx);
+	} catch (error) {
+		logger?.error?.(
+			{ err: error, mediaId: media.id, fullPath },
+			"[MediaMetadataExtractor] extractAndPersistMediaMetadata FAILED",
+		);
+		return null;
+	}
+}

--- a/packages/application/src/services/media-service.ts
+++ b/packages/application/src/services/media-service.ts
@@ -31,6 +31,7 @@ import type { IImageProcessor } from "@solid-imager/core/domain/services/image-p
 import type { IMediaStorage, MediaSourceFile } from "@solid-imager/core/interfaces/media-storage";
 import type { ProcessMediaJobRepository } from "../ports/job-repository";
 import type { DeferredActions, DeferredEvent } from "./job-runtime";
+import { extractAndPersistMediaMetadata } from "./media-metadata-extractor";
 import { queueMediaProcessingJob } from "./media-processing-job";
 
 export type { DeferredActions, DeferredEvent, DeferredJob, DeferredJobs } from "./job-runtime";
@@ -380,7 +381,21 @@ export class MediaServiceImpl {
 
 		let finalGenerationInfo = mediaDetails.generationInfo;
 		if (!finalGenerationInfo) {
-			finalGenerationInfo = await this.extractAndUpdateMetadata(mediaDetails, validatedSourceId);
+			const mediaSource = await this.sourceRepository.findById(validatedSourceId);
+			if (mediaSource && mediaSource.type === "local") {
+				const connectionInfo = mediaSource.connectionInfo as { path: string };
+				finalGenerationInfo = await extractAndPersistMediaMetadata(
+					mediaDetails,
+					connectionInfo.path,
+					{
+						mediaRepository: this.mediaRepository,
+						tagRepository: this.tagRepository,
+						imageProcessor: this.imageProcessor,
+						pathAdapter: this.pathAdapter,
+						logger: this.logger,
+					},
+				);
+			}
 		}
 
 		return {
@@ -537,7 +552,22 @@ export class MediaServiceImpl {
 		if (!media || media.mediaSourceId !== validatedSourceId) {
 			throw new ResourceNotFoundError("Media", validatedMediaId);
 		}
-		return await this.extractAndUpdateMetadata(media, validatedSourceId);
+		const mediaSource = await this.sourceRepository.findById(validatedSourceId);
+		if (!mediaSource || mediaSource.type !== "local") {
+			return null;
+		}
+		const connectionInfo = mediaSource.connectionInfo as { path: string };
+		return await extractAndPersistMediaMetadata(
+			media,
+			connectionInfo.path,
+			{
+				mediaRepository: this.mediaRepository,
+				tagRepository: this.tagRepository,
+				imageProcessor: this.imageProcessor,
+				pathAdapter: this.pathAdapter,
+				logger: this.logger,
+			},
+		);
 	}
 
 	async getMediaTags(mediaSourceId: string, mediaId: string) {
@@ -893,48 +923,7 @@ export class MediaServiceImpl {
 		}
 	}
 
-	private async extractAndUpdateMetadata(
-		media: Media,
-		sourceId: string,
-	): Promise<MediaGenerationInfo | null> {
-		const mediaSource = await this.sourceRepository.findById(sourceId);
-		if (!mediaSource || mediaSource.type !== "local") {
-			return null;
-		}
-		const connectionInfo = mediaSource.connectionInfo as { path: string };
-		const fullPath = this.pathAdapter.join(connectionInfo.path, media.filePath);
 
-		try {
-			const metadata = await this.imageProcessor.extractMetadata(fullPath);
-			this.logger?.info?.(
-				{
-					mediaId: media.id,
-					fullPath,
-					tagsCount: metadata.tags.length,
-					hasWorkflow: !!metadata.workflow,
-					hasPrompt: !!metadata.prompt,
-				},
-				"[MediaService] extractAndUpdateMetadata result",
-			);
-			await this.mediaRepository.upsertGenerationInfo(
-				media.id,
-				typeof metadata.prompt === "object"
-					? JSON.stringify(metadata.prompt)
-					: (metadata.prompt as string | null),
-				metadata.workflow as object | null,
-			);
-			if (metadata.tags.length > 0) {
-				await this.tagRepository.addTagsToMedia(media.id, metadata.tags, "comfyui_workflow");
-			}
-			return await this.mediaRepository.getGenerationInfo(media.id);
-		} catch (error) {
-			this.logger?.error?.(
-				{ err: error, mediaId: media.id, fullPath },
-				"[MediaService] extractAndUpdateMetadata FAILED",
-			);
-			return null;
-		}
-	}
 }
 
 export function createMediaService(deps: MediaServiceDeps) {


### PR DESCRIPTION
## Summary

Tauri 側の `media-service.ts` と `source-backup-service.ts` に残っていた app 固有ロジックを `packages/application` へ移し、thin adapter に縮退させました。

## Changes

### New shared modules (`packages/application`)

- **`services/media-context-metadata.ts`**: `updateMediaContextMetadata`
  - author / character / ip / project / tag / sourceUrls の登録・更新を統一
  - IP 自動リンクは `linkedIps` → `context.ips` フォールバック（server 側挙動を正とする）
- **`services/media-metadata-extractor.ts`**: `extractAndPersistMediaMetadata`
  - `imageProcessor.extractMetadata` → `upsertGenerationInfo` + `addTagsToMedia` を shared 化
- **`services/backup-restore-complete.ts`**: `enqueueThumbnailJobsAfterRestore`
  - restore 後の thumbnail generation job enqueue を shared 化
  - Tauri 側に `onRestoreComplete` を新規追加し server と挙動を揃える

### Server (`apps/server`)

- `MediaProcessingServiceImpl`: 7 個の private メソッド（`registerAuthors` / `registerCharacters` / `_registerSingleCharacter` / `_resolveIpIds` / `_updateCharacterIps` / `registerIps` / `registerProjects`）を削除し、`updateMediaContextMetadata` で置き換え
- `MediaServiceImpl.extractAndUpdateMetadata` を shared `extractAndPersistMediaMetadata` で置き換え

### Tauri (`apps/tauri`)

- `media-service.ts`: `syncContextMetadata`（132 行）・`persistExtractedMetadata`（57 行）・`characterRepository.addToMediaBulk` の再実装を削除 → shared 関数を利用
- `source-backup-service.ts`: `onRestoreComplete` を新規追加（shared `enqueueThumbnailJobsAfterRestore` を利用）

## Impact

- Services 対応度: ~68% → ~75%
- 差分は platform 固有 I/O（`IMediaStorage` / `IImageProcessor` / zip 処理 / transport）に閉じている
- 全 138 件の unit test 通過