### PR TITLE
refactor: align tauri MediaListActions with server implementation

### DIFF
--- a/apps/tauri/src/components/nav.tsx
+++ b/apps/tauri/src/components/nav.tsx
@@ -70,7 +70,7 @@ export function Nav() {
 							</li>
 						))}
 					</ul>
-				<div class="ml-auto flex items-center gap-2" id="nav-actions">
+				<div class="flex items-center gap-2" id="nav-actions">
 					<PendingDownloadsIndicator />
 				</div>
 				</div>

--- a/apps/tauri/src/components/nav.tsx
+++ b/apps/tauri/src/components/nav.tsx
@@ -70,9 +70,9 @@ export function Nav() {
 							</li>
 						))}
 					</ul>
-					<div class="ml-4">
-						<PendingDownloadsIndicator />
-					</div>
+				<div class="ml-auto flex items-center gap-2" id="nav-actions">
+					<PendingDownloadsIndicator />
+				</div>
 				</div>
 			</nav>
 			<div class="h-[60px]" />

--- a/apps/tauri/src/routes/sources/$mediaSourceId/components/media-list-actions.tsx
+++ b/apps/tauri/src/routes/sources/$mediaSourceId/components/media-list-actions.tsx
@@ -6,62 +6,139 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@solid-imager/ui/dialog";
-import type { JSX } from "solid-js";
+import { SearchControlPanel } from "@solid-imager/ui/search-control-panel";
+import type { ComponentProps } from "solid-js";
+import { Show } from "solid-js";
+import { isServer, Portal } from "solid-js/web";
+import { PresetClient } from "~/infrastructure/api/clients/preset-client";
+
+type FilterData = ComponentProps<typeof SearchControlPanel>["filterData"];
 
 type MediaListActionsProps = {
-	filterPanel: JSX.Element;
-	isSyncDisabled: boolean;
-	isSyncing: boolean;
-	onAddMedia: () => void;
-	onDumpDownload: () => void;
-	onRestore: () => void;
-	onSyncLoadedMedia: () => void;
-	onZipDumpDownload: () => void;
-	sourceDescription?: string | null;
-	sourceName?: string;
+	filterData: FilterData;
+	onDumpDownload: (mode: "json" | "zip") => void;
+	onSearch: () => void;
 };
 
 export function MediaListActions(props: MediaListActionsProps) {
 	return (
-		<div class="mb-8 flex items-center justify-between">
-			<div>
-				<h1 class="mb-2 font-bold text-3xl">
-					{props.sourceName ?? "Media Source"}
-				</h1>
-				<p class="text-gray-600">{props.sourceDescription}</p>
-			</div>
-			<div class="flex flex-wrap gap-2">
-				<Button onClick={props.onAddMedia}>Add Media</Button>
-				<Button onClick={props.onDumpDownload} variant="outline">
-					Dump JSON
-				</Button>
-				<Button onClick={props.onZipDumpDownload} variant="outline">
-					Dump ZIP
-				</Button>
-				<Button onClick={props.onRestore} variant="outline">
-					Restore
-				</Button>
+		<Show when={!isServer && document.getElementById("nav-actions")}>
+			<Portal mount={document.getElementById("nav-actions") as HTMLElement}>
 				<Button
-					disabled={props.isSyncDisabled}
-					onClick={props.onSyncLoadedMedia}
+					class="mr-2 border-white text-white hover:bg-sky-700"
+					onClick={() => props.onDumpDownload("json")}
+					size="icon"
+					title="Download Backup JSON"
 					variant="outline"
 				>
-					{props.isSyncing ? "Syncing..." : "Sync Loaded Media"}
+					<svg
+						class="lucide lucide-file-json"
+						fill="none"
+						height="20"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						viewBox="0 0 24 24"
+						width="20"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<title>Download JSON</title>
+						<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+						<path d="M14 2v4a2 2 0 0 0 2 2h4" />
+						<path d="M10 12a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1" />
+						<path d="M10 18a1 1 0 0 0-1-1v-1a1 1 0 0 0 1-1" />
+					</svg>
 				</Button>
-				<div class="md:hidden">
-					<Dialog>
-						<DialogTrigger as={Button} variant="outline">
-							Filters
-						</DialogTrigger>
-						<DialogContent class="max-h-[80vh] overflow-y-auto">
-							<DialogHeader>
-								<DialogTitle>検索フィルター</DialogTitle>
-							</DialogHeader>
-							<div class="space-y-4">{props.filterPanel}</div>
-						</DialogContent>
-					</Dialog>
-				</div>
-			</div>
-		</div>
+				<Button
+					class="mr-2 border-white text-white hover:bg-sky-700"
+					onClick={() => props.onDumpDownload("zip")}
+					size="icon"
+					title="Download Backup ZIP (with Images)"
+					variant="outline"
+				>
+					<svg
+						class="lucide lucide-archive"
+						fill="none"
+						height="20"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						viewBox="0 0 24 24"
+						width="20"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<title>Download ZIP</title>
+						<rect height="5" rx="1" width="20" x="2" y="3" />
+						<path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
+						<path d="M10 12h4" />
+					</svg>
+				</Button>
+				<Button
+					class="mr-2 border-white text-white hover:bg-sky-700"
+					onClick={() => document.getElementById("restore-input")?.click()}
+					size="icon"
+					title="Restore Metadata from Dump"
+					variant="outline"
+				>
+					<svg
+						class="lucide lucide-upload-cloud"
+						fill="none"
+						height="20"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						viewBox="0 0 24 24"
+						width="20"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<title>Restore from cloud</title>
+						<path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" />
+						<path d="M12 12v9" />
+						<path d="m16 16-4-4-4 4" />
+					</svg>
+				</Button>
+				<Dialog>
+					<DialogTrigger
+						as={Button}
+						class="border-white text-white hover:bg-sky-700 md:hidden"
+						size="icon"
+						variant="outline"
+					>
+						<svg
+							class="lucide lucide-filter"
+							fill="none"
+							height="24"
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							viewBox="0 0 24 24"
+							width="24"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<title>Filter results</title>
+							<polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+						</svg>
+					</DialogTrigger>
+					<DialogContent class="max-h-[80vh] overflow-y-auto">
+						<DialogHeader>
+							<DialogTitle>検索フィルター</DialogTitle>
+						</DialogHeader>
+						<div class="space-y-4">
+							<SearchControlPanel
+								class="w-full"
+								context="source"
+								filterData={props.filterData}
+								onSearch={props.onSearch}
+								presetClient={PresetClient}
+							/>
+						</div>
+					</DialogContent>
+				</Dialog>
+			</Portal>
+		</Show>
 	);
 }

--- a/apps/tauri/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/tauri/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -1,15 +1,13 @@
 import type { MediaSourceEventTransport } from "@solid-imager/ui/hooks/use-media-source-events";
 import { useSourceMediaPage } from "@solid-imager/ui/hooks/use-source-media-page";
-import { Progress } from "@solid-imager/ui/progress";
 import {
 	SourceMediaScreen,
 	type SourceMediaScreenProps,
 } from "@solid-imager/ui/screens/source-media-screen";
-import { SearchControlPanel } from "@solid-imager/ui/search-control-panel";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { useParams } from "@tanstack/solid-router";
 import { listen } from "@tauri-apps/api/event";
-import { createMemo, Show } from "solid-js";
+import { createMemo } from "solid-js";
 import { MediaGridItem } from "~/components/media/media-grid-item";
 import { MoveCopyMediaDialog } from "~/components/media/move-copy-media-dialog";
 import { UploadMediaModal } from "~/components/upload-media-modal";
@@ -119,11 +117,8 @@ export function SourceMediaPage() {
 	const allAuthors = createQuery(() => allAuthorsQueryOptions());
 	const sources = createQuery(() => mediaSourcesQueryOptions());
 
-	const source = createMemo(() =>
-		sources.data?.find((item) => item.id === mediaSourceId()),
-	);
 	const sourceRootPath = createMemo(() => {
-		const current = source();
+		const current = sources.data?.find((item) => item.id === mediaSourceId());
 		if (current?.type !== "local") {
 			return undefined;
 		}
@@ -163,50 +158,12 @@ export function SourceMediaPage() {
 		onThumbnailReady: notifyThumbnailReady,
 	});
 
-	const renderActions: SourceMediaScreenProps["renderActions"] = (actionProps) => (
+	const renderActions: SourceMediaScreenProps["renderActions"] = () => (
 		<MediaListActions
-			filterPanel={
-				<SearchControlPanel
-					class="w-full"
-					context="source"
-					filterData={page.filterData()}
-					onSearch={page.handleSearch}
-					presetClient={page.presetClient}
-					usePopover={false}
-				/>
-			}
-			isSyncDisabled={actionProps.isSyncDisabled}
-			isSyncing={actionProps.isSyncing}
-			onAddMedia={actionProps.onAddMedia}
-			onDumpDownload={() => actionProps.onDumpDownload("json")}
-			onRestore={actionProps.onRestore}
-			onSyncLoadedMedia={actionProps.onSyncLoadedMedia}
-			onZipDumpDownload={() => actionProps.onDumpDownload("zip")}
-			sourceDescription={source()?.description}
-			sourceName={source()?.name}
+			filterData={page.filterData()}
+			onDumpDownload={page.handleDumpDownload}
+			onSearch={page.handleSearch}
 		/>
-	);
-
-	const renderJobProgress: NonNullable<SourceMediaScreenProps["renderJobProgress"]> = (
-		progressProps,
-	) => (
-		<Show when={progressProps.jobProgress()}>
-			{(progress) => (
-				<div class="mb-4 rounded-md border bg-muted/50 px-4 py-3">
-					<div class="mb-2 flex items-center justify-between text-sm">
-						<span class="text-muted-foreground">
-							サムネイル生成中 {progress().processed} / {progress().total}
-						</span>
-						<span class="text-muted-foreground text-xs">
-							{Math.round((progress().processed / progress().total) * 100)}%
-						</span>
-					</div>
-					<Progress
-						value={(progress().processed / progress().total) * 100}
-					/>
-				</div>
-			)}
-		</Show>
 	);
 
 	return (
@@ -221,7 +178,7 @@ export function SourceMediaPage() {
 					sourceRootPath={sourceRootPath()}
 				/>
 			)}
-			renderJobProgress={renderJobProgress}
+			showOpenInNewTab
 			renderMoveCopyDialog={() => (
 				<MoveCopyMediaDialog
 					currentSourceId={mediaSourceId()}


### PR DESCRIPTION
## Summary

Tauri の `MediaListActions` を Server 側の実装に合わせました。

### Changes

- `apps/tauri/src/components/nav.tsx`: `id="nav-actions"` を追加し、Portal landing zone を確保
- `apps/tauri/src/routes/sources/$mediaSourceId/components/media-list-actions.tsx`: Server の実装と同一に置き換え（Portal 方式、同じボタン群）
- `apps/tauri/src/routes/sources/$mediaSourceId/components/source-media-page.tsx`: `renderActions` を server と同じ形に縮退

### Removed (tauri-specific differences)

- `sourceName` / `sourceDescription` 表示
- `Add Media` ボタン（`SourceMediaScreen` の floating button で代替）
- `Sync Loaded Media` ボタン
- `renderJobProgress` prop

### Verification

- [x] `apps/tauri` type check passes
- [x] `apps/server` type check passes
- [x] `packages/ui` type check passes
- [x] `apps/tauri` tests pass (4/4)