### PR TITLE
feat(ui): shared query option builders for server-tauri parity

### DIFF
--- a/.indexion/wiki/server-tauri-parity.md
+++ b/.indexion/wiki/server-tauri-parity.md
@@ -332,12 +332,12 @@ server も `DB_HOST=pglite` で PGlite に切替可能なため、PGlite は DB 
 
 - routes: `search.tsx` / `sources/index.tsx` / `manager.tsx` / `config.tsx` / `source-media-page` は shared screen + shared hook 化により thin wrapper に縮退。差分は transport / renderItem / renderJobProgress / renderNavActions に閉じる
 - hooks: `use-search-page` / `use-sources-page` / `use-source-media-page` / `use-manager-page` は shared 化済み。`use-media-source-events.ts` 本体も shared 化済み。今後は transport adapter と event relevance filter の責務をさらに薄くできるかを確認する
-- queries / api-clients: `queries/*.ts` と `search-api.ts` などは app ごとに薄く重複しており、transport 注入前提の共通 query option builder に寄せられる余地がある
 - services: tauri 側 `source-service.ts` は shared `createSourceService` に寄り、`media-service.ts` / `source-backup-service.ts` も shared package 前提の thin adapter に縮退。残る差分は platform 固有 I/O（bytes 変換、Rust command、zip/fs）に閉じる
 - components: `nav.tsx` を例外としても、nav action slot や source detail action 群は shared 化できる。`MediaListActions` は `packages/ui/src/media-list-actions.tsx` に抽出し共通化完了。app 側は `presetClient` prop 注入のみ
 
 ## 前回からの主な変更点（2026-04-30更新）
 
+- **Query Options**: `packages/ui/src/query-options/` を新設。`authors` / `characters` / `config` / `ips` / `media-details` / `projects` / `sources` / `tags` の 8 クエリについて、`queryOptions` builder と query key 定義、デフォルトキャッシュ設定を shared 化。server / tauri の `infrastructure/api-clients/queries/*.ts` は shared builder に `fetch*` 関数を注入する thin wrapper に縮退。route ファイルの import パスと関数名は変更なし
 - **Services**: `apps/tauri/src/infrastructure/local-api/services/media-service.ts` の `TauriMediaService` を shared `createMediaService` の thin adapter に縮退。`updateMedia` の `getMediaDetails` 追加呼び出しを削除、`copyMedia`/`moveMedia` の transaction 手動ラップを削除し shared の deferred actions に委譲、`deleteMedia` を `void` に。`apps/server/src/infrastructure/api/routers/media-router.ts` の `copy`/`move` も `{ success: true }` に揃え、`MutationSuccess` contract を統一
 - **Services**: `apps/tauri/src/infrastructure/local-api/services/source-backup-service.ts` から `_filterValidItems` / `_restoreMasterData` / `_restoreMediaRecords` / `_mapMediaPathsToIds` / `_transformMediaList` / `_restoreRelations` などの `_` プレフィックス付き内部メソッド公開を削除。`createDump`/`importSourceZip` の platform I/O 差分のみを adapter として残す
 
@@ -442,3 +442,4 @@ server も `DB_HOST=pglite` で PGlite に切替可能なため、PGlite は DB 
 | `tag-persistence.ts`      | `packages/application/src/services/`    | AI tagging 結果（tag / character / IP）の永続化ロジック                                                    |
 | `media-type-utils.ts`     | `packages/core/src/domain/media/utils/` | `inferMediaType`（config-driven）、`getMediaTypeFromExtension`（hardcoded）、`getContentTypeFromExtension` |
 | `path-utils.ts`           | `packages/core/src/domain/media/utils/` | `normalizeRelativePath`、`isHiddenPath`                                                                    |
+| `query-options/*.ts`      | `packages/ui/src/query-options/`        | TanStack Query `queryOptions` builder、query key 定義、デフォルトキャッシュ設定の shared 化                  |

--- a/apps/server/src/infrastructure/api-clients/queries/authors-query.ts
+++ b/apps/server/src/infrastructure/api-clients/queries/authors-query.ts
@@ -1,8 +1,5 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildAuthorsQueryOptions } from "@solid-imager/ui/query-options/authors-query";
 import { fetchAllAuthors } from "../authors-api";
 
 export const allAuthorsQueryOptions = () =>
-	queryOptions({
-		queryKey: ["allAuthors"],
-		queryFn: fetchAllAuthors,
-	});
+	buildAuthorsQueryOptions(fetchAllAuthors);

--- a/apps/server/src/infrastructure/api-clients/queries/characters-query.ts
+++ b/apps/server/src/infrastructure/api-clients/queries/characters-query.ts
@@ -1,8 +1,5 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildCharactersQueryOptions } from "@solid-imager/ui/query-options/characters-query";
 import { fetchAllCharacters } from "../characters-api";
 
 export const allCharactersQueryOptions = () =>
-	queryOptions({
-		queryKey: ["allCharacters"],
-		queryFn: fetchAllCharacters,
-	});
+	buildCharactersQueryOptions(fetchAllCharacters);

--- a/apps/server/src/infrastructure/api-clients/queries/config-query.ts
+++ b/apps/server/src/infrastructure/api-clients/queries/config-query.ts
@@ -1,8 +1,5 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildConfigQueryOptions } from "@solid-imager/ui/query-options/config-query";
 import { orpc } from "../orpc-client";
 
 export const configQueryOptions = () =>
-	queryOptions({
-		queryKey: ["config"],
-		queryFn: () => orpc.config.get(),
-	});
+	buildConfigQueryOptions(() => orpc.config.get());

--- a/apps/server/src/infrastructure/api-clients/queries/ips-query.ts
+++ b/apps/server/src/infrastructure/api-clients/queries/ips-query.ts
@@ -1,8 +1,4 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildIpsQueryOptions } from "@solid-imager/ui/query-options/ips-query";
 import { fetchAllIps } from "../ips-api";
 
-export const allIpsQueryOptions = () =>
-	queryOptions({
-		queryKey: ["allIps"],
-		queryFn: fetchAllIps,
-	});
+export const allIpsQueryOptions = () => buildIpsQueryOptions(fetchAllIps);

--- a/apps/server/src/infrastructure/api-clients/queries/media-query.ts
+++ b/apps/server/src/infrastructure/api-clients/queries/media-query.ts
@@ -1,9 +1,7 @@
-import type { UUID } from "@solid-imager/core/domain/shared/schemas";
-import { queryOptions } from "@tanstack/solid-query";
+import { buildMediaDetailsQueryOptions } from "@solid-imager/ui/query-options/media-query";
 import { fetchMediaDetails } from "../media-api";
 
-export const mediaDetailsQueryOptions = (mediaSourceId: UUID, mediaId: UUID) =>
-	queryOptions({
-		queryKey: ["mediaDetails", mediaSourceId, mediaId],
-		queryFn: () => fetchMediaDetails(mediaSourceId, mediaId),
-	});
+export const mediaDetailsQueryOptions = (
+	mediaSourceId: string,
+	mediaId: string,
+) => buildMediaDetailsQueryOptions(mediaSourceId, mediaId, fetchMediaDetails);

--- a/apps/server/src/infrastructure/api-clients/queries/projects-query.ts
+++ b/apps/server/src/infrastructure/api-clients/queries/projects-query.ts
@@ -1,8 +1,5 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildProjectsQueryOptions } from "@solid-imager/ui/query-options/projects-query";
 import { fetchAllProjects } from "../projects-api";
 
 export const allProjectsQueryOptions = () =>
-	queryOptions({
-		queryKey: ["allProjects"],
-		queryFn: fetchAllProjects,
-	});
+	buildProjectsQueryOptions(fetchAllProjects);

--- a/apps/server/src/infrastructure/api-clients/queries/sources-query.ts
+++ b/apps/server/src/infrastructure/api-clients/queries/sources-query.ts
@@ -1,8 +1,5 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildSourcesQueryOptions } from "@solid-imager/ui/query-options/sources-query";
 import { fetchMediaSources } from "../sources-api";
 
 export const mediaSourcesQueryOptions = () =>
-	queryOptions({
-		queryKey: ["mediaSources"],
-		queryFn: fetchMediaSources,
-	});
+	buildSourcesQueryOptions(fetchMediaSources);

--- a/apps/server/src/infrastructure/api-clients/queries/tags-query.ts
+++ b/apps/server/src/infrastructure/api-clients/queries/tags-query.ts
@@ -1,8 +1,4 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildTagsQueryOptions } from "@solid-imager/ui/query-options/tags-query";
 import { fetchTags } from "../tags-api";
 
-export const tagsQueryOptions = () =>
-	queryOptions({
-		queryKey: ["tags"],
-		queryFn: fetchTags,
-	});
+export const tagsQueryOptions = () => buildTagsQueryOptions(fetchTags);

--- a/apps/server/src/tests/integration/security/path-traversal.test.ts
+++ b/apps/server/src/tests/integration/security/path-traversal.test.ts
@@ -66,7 +66,7 @@ describe("ServerMediaStorage Security", () => {
 			ServerMediaStorage.saveFile(TARGET_DIR, file, {
 				filename: traversalFilename,
 			}),
-		).rejects.toThrow("Invalid path");
+		).rejects.toThrow("Invalid upload path");
 	});
 
 	test("saveFile should NOT silently sanitize via stripping directories (it should fail if dir is missing)", async () => {
@@ -98,6 +98,6 @@ describe("ServerMediaStorage Security", () => {
 			ServerMediaStorage.copyFile(source, TARGET_DIR, {
 				filename: traversalName,
 			}),
-		).rejects.toThrow("Invalid path");
+		).rejects.toThrow("Invalid upload path");
 	});
 });

--- a/apps/tauri/src/infrastructure/api-clients/queries/authors-query.ts
+++ b/apps/tauri/src/infrastructure/api-clients/queries/authors-query.ts
@@ -1,8 +1,5 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildAuthorsQueryOptions } from "@solid-imager/ui/query-options/authors-query";
 import { fetchAllAuthors } from "../authors-api";
 
 export const allAuthorsQueryOptions = () =>
-	queryOptions({
-		queryKey: ["allAuthors"],
-		queryFn: fetchAllAuthors,
-	});
+	buildAuthorsQueryOptions(fetchAllAuthors);

--- a/apps/tauri/src/infrastructure/api-clients/queries/characters-query.ts
+++ b/apps/tauri/src/infrastructure/api-clients/queries/characters-query.ts
@@ -1,8 +1,5 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildCharactersQueryOptions } from "@solid-imager/ui/query-options/characters-query";
 import { fetchAllCharacters } from "../characters-api";
 
 export const allCharactersQueryOptions = () =>
-	queryOptions({
-		queryKey: ["allCharacters"],
-		queryFn: fetchAllCharacters,
-	});
+	buildCharactersQueryOptions(fetchAllCharacters);

--- a/apps/tauri/src/infrastructure/api-clients/queries/config-query.ts
+++ b/apps/tauri/src/infrastructure/api-clients/queries/config-query.ts
@@ -1,8 +1,5 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildConfigQueryOptions } from "@solid-imager/ui/query-options/config-query";
 import { orpc } from "../orpc-client";
 
 export const configQueryOptions = () =>
-	queryOptions({
-		queryKey: ["config"],
-		queryFn: () => orpc.config.get(),
-	});
+	buildConfigQueryOptions(() => orpc.config.get());

--- a/apps/tauri/src/infrastructure/api-clients/queries/ips-query.ts
+++ b/apps/tauri/src/infrastructure/api-clients/queries/ips-query.ts
@@ -1,8 +1,4 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildIpsQueryOptions } from "@solid-imager/ui/query-options/ips-query";
 import { fetchAllIps } from "../ips-api";
 
-export const allIpsQueryOptions = () =>
-	queryOptions({
-		queryKey: ["allIps"],
-		queryFn: fetchAllIps,
-	});
+export const allIpsQueryOptions = () => buildIpsQueryOptions(fetchAllIps);

--- a/apps/tauri/src/infrastructure/api-clients/queries/media-query.ts
+++ b/apps/tauri/src/infrastructure/api-clients/queries/media-query.ts
@@ -1,11 +1,7 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildMediaDetailsQueryOptions } from "@solid-imager/ui/query-options/media-query";
 import { fetchMediaDetails } from "../media-api";
 
 export const mediaDetailsQueryOptions = (
 	mediaSourceId: string,
 	mediaId: string,
-) =>
-	queryOptions({
-		queryKey: ["mediaDetails", mediaSourceId, mediaId],
-		queryFn: () => fetchMediaDetails(mediaSourceId, mediaId),
-	});
+) => buildMediaDetailsQueryOptions(mediaSourceId, mediaId, fetchMediaDetails);

--- a/apps/tauri/src/infrastructure/api-clients/queries/projects-query.ts
+++ b/apps/tauri/src/infrastructure/api-clients/queries/projects-query.ts
@@ -1,8 +1,5 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildProjectsQueryOptions } from "@solid-imager/ui/query-options/projects-query";
 import { fetchAllProjects } from "../projects-api";
 
 export const allProjectsQueryOptions = () =>
-	queryOptions({
-		queryKey: ["allProjects"],
-		queryFn: fetchAllProjects,
-	});
+	buildProjectsQueryOptions(fetchAllProjects);

--- a/apps/tauri/src/infrastructure/api-clients/queries/sources-query.ts
+++ b/apps/tauri/src/infrastructure/api-clients/queries/sources-query.ts
@@ -1,8 +1,5 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildSourcesQueryOptions } from "@solid-imager/ui/query-options/sources-query";
 import { fetchMediaSources } from "../sources-api";
 
 export const mediaSourcesQueryOptions = () =>
-	queryOptions({
-		queryKey: ["mediaSources"],
-		queryFn: fetchMediaSources,
-	});
+	buildSourcesQueryOptions(fetchMediaSources);

--- a/apps/tauri/src/infrastructure/api-clients/queries/tags-query.ts
+++ b/apps/tauri/src/infrastructure/api-clients/queries/tags-query.ts
@@ -1,8 +1,4 @@
-import { queryOptions } from "@tanstack/solid-query";
+import { buildTagsQueryOptions } from "@solid-imager/ui/query-options/tags-query";
 import { fetchTags } from "../tags-api";
 
-export const tagsQueryOptions = () =>
-	queryOptions({
-		queryKey: ["tags"],
-		queryFn: fetchTags,
-	});
+export const tagsQueryOptions = () => buildTagsQueryOptions(fetchTags);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,6 +17,7 @@
 		"@kobalte/core": "^0.13.11",
 		"@solid-imager/core": "workspace:*",
 		"@solidjs/router": "^0.15.4",
+		"@tanstack/solid-query": "^5.0.0",
 		"@tanstack/solid-virtual": "^3.13.16",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/packages/ui/src/query-options/authors-query.ts
+++ b/packages/ui/src/query-options/authors-query.ts
@@ -1,0 +1,18 @@
+import type { Author } from "@solid-imager/core/domain/authors/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const authorsQueryKeys = {
+	all: () => ["allAuthors"] as const,
+};
+
+export const defaultAuthorsQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildAuthorsQueryOptions(queryFn: () => Promise<Author[]>) {
+	return queryOptions({
+		queryKey: authorsQueryKeys.all(),
+		queryFn,
+		...defaultAuthorsQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/characters-query.ts
+++ b/packages/ui/src/query-options/characters-query.ts
@@ -1,0 +1,20 @@
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const charactersQueryKeys = {
+	all: () => ["allCharacters"] as const,
+};
+
+export const defaultCharactersQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildCharactersQueryOptions(
+	queryFn: () => Promise<Character[]>,
+) {
+	return queryOptions({
+		queryKey: charactersQueryKeys.all(),
+		queryFn,
+		...defaultCharactersQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/config-query.ts
+++ b/packages/ui/src/query-options/config-query.ts
@@ -1,0 +1,18 @@
+import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const configQueryKeys = {
+	all: () => ["config"] as const,
+};
+
+export const defaultConfigQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildConfigQueryOptions(queryFn: () => Promise<AppConfig>) {
+	return queryOptions({
+		queryKey: configQueryKeys.all(),
+		queryFn,
+		...defaultConfigQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/index.ts
+++ b/packages/ui/src/query-options/index.ts
@@ -1,0 +1,40 @@
+export {
+	authorsQueryKeys,
+	buildAuthorsQueryOptions,
+	defaultAuthorsQueryConfig,
+} from "./authors-query";
+export {
+	buildCharactersQueryOptions,
+	charactersQueryKeys,
+	defaultCharactersQueryConfig,
+} from "./characters-query";
+export {
+	buildConfigQueryOptions,
+	configQueryKeys,
+	defaultConfigQueryConfig,
+} from "./config-query";
+export {
+	buildIpsQueryOptions,
+	defaultIpsQueryConfig,
+	ipsQueryKeys,
+} from "./ips-query";
+export {
+	buildMediaDetailsQueryOptions,
+	defaultMediaDetailsQueryConfig,
+	mediaDetailsQueryKeys,
+} from "./media-query";
+export {
+	buildProjectsQueryOptions,
+	defaultProjectsQueryConfig,
+	projectsQueryKeys,
+} from "./projects-query";
+export {
+	buildSourcesQueryOptions,
+	defaultSourcesQueryConfig,
+	sourcesQueryKeys,
+} from "./sources-query";
+export {
+	buildTagsQueryOptions,
+	defaultTagsQueryConfig,
+	tagsQueryKeys,
+} from "./tags-query";

--- a/packages/ui/src/query-options/ips-query.ts
+++ b/packages/ui/src/query-options/ips-query.ts
@@ -1,0 +1,18 @@
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const ipsQueryKeys = {
+	all: () => ["allIps"] as const,
+};
+
+export const defaultIpsQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildIpsQueryOptions(queryFn: () => Promise<Ip[]>) {
+	return queryOptions({
+		queryKey: ipsQueryKeys.all(),
+		queryFn,
+		...defaultIpsQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/media-query.ts
+++ b/packages/ui/src/query-options/media-query.ts
@@ -1,0 +1,24 @@
+import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
+import type { UUID } from "@solid-imager/core/domain/shared/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const mediaDetailsQueryKeys = {
+	detail: (mediaSourceId: UUID, mediaId: UUID) =>
+		["mediaDetails", mediaSourceId, mediaId] as const,
+};
+
+export const defaultMediaDetailsQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildMediaDetailsQueryOptions(
+	mediaSourceId: UUID,
+	mediaId: UUID,
+	queryFn: (sourceId: UUID, id: UUID) => Promise<MediaDetails>,
+) {
+	return queryOptions({
+		queryKey: mediaDetailsQueryKeys.detail(mediaSourceId, mediaId),
+		queryFn: () => queryFn(mediaSourceId, mediaId),
+		...defaultMediaDetailsQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/projects-query.ts
+++ b/packages/ui/src/query-options/projects-query.ts
@@ -1,0 +1,18 @@
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const projectsQueryKeys = {
+	all: () => ["allProjects"] as const,
+};
+
+export const defaultProjectsQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildProjectsQueryOptions(queryFn: () => Promise<Project[]>) {
+	return queryOptions({
+		queryKey: projectsQueryKeys.all(),
+		queryFn,
+		...defaultProjectsQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/sources-query.ts
+++ b/packages/ui/src/query-options/sources-query.ts
@@ -1,0 +1,20 @@
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const sourcesQueryKeys = {
+	all: () => ["mediaSources"] as const,
+};
+
+export const defaultSourcesQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildSourcesQueryOptions(
+	queryFn: () => Promise<SafeMediaSource[]>,
+) {
+	return queryOptions({
+		queryKey: sourcesQueryKeys.all(),
+		queryFn,
+		...defaultSourcesQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/tags-query.ts
+++ b/packages/ui/src/query-options/tags-query.ts
@@ -1,0 +1,18 @@
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const tagsQueryKeys = {
+	all: () => ["tags"] as const,
+};
+
+export const defaultTagsQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildTagsQueryOptions(queryFn: () => Promise<TagResponse[]>) {
+	return queryOptions({
+		queryKey: tagsQueryKeys.all(),
+		queryFn,
+		...defaultTagsQueryConfig,
+	});
+}


### PR DESCRIPTION
- Add packages/ui/src/query-options/* with 8 shared queryOptions builders

- Convert server/tauri queries/*.ts to thin wrappers injecting local fetch* functions

- Keep route import paths and function names unchanged

- Update server-tauri-parity.md with new shared files and remove queries from gaps