### PR TITLE
commonize MediaSidebar, MediaDetail, UploadModal, SourceMediaPage wrappers (#315 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ dev.log
 .playwright-cli/
 apps/tauri/src-tauri/target/
 .tsbuild/
+.worktree/

--- a/apps/server/src/components/media/media-sidebar/media-sidebar-content.tsx
+++ b/apps/server/src/components/media/media-sidebar/media-sidebar-content.tsx
@@ -1,28 +1,28 @@
 import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
-import { MediaSidebar as SharedMediaSidebar } from "@solid-imager/ui/media-sidebar";
-import { projectsQueryKeys } from "@solid-imager/ui/query-options";
-import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import { MediaSidebarContent } from "@solid-imager/ui/media-sidebar-content";
 import AiTaggingModal from "~/components/media/ai-tagging-modal";
 import {
 	addCharacterToMedia,
 	createCharacter,
-	fetchAllCharacters,
 	removeCharacterFromMedia,
 } from "~/infrastructure/api-clients/characters-api";
 import {
 	addIpToMedia,
 	createIp,
-	fetchAllIps,
 	removeIpFromMedia,
 } from "~/infrastructure/api-clients/ips-api";
 import { updateMedia } from "~/infrastructure/api-clients/media-api";
 import {
 	addProjectToMedia,
 	createProject,
-	fetchAllProjects,
 	removeProjectFromMedia,
 } from "~/infrastructure/api-clients/projects-api";
-import { projectsForMediaQueryOptions } from "~/infrastructure/api-clients/queries/projects-query";
+import { allCharactersQueryOptions } from "~/infrastructure/api-clients/queries/characters-query";
+import { allIpsQueryOptions } from "~/infrastructure/api-clients/queries/ips-query";
+import {
+	allProjectsQueryOptions,
+	projectsForMediaQueryOptions,
+} from "~/infrastructure/api-clients/queries/projects-query";
 
 type MediaSidebarProps = {
 	media: MediaDetails;
@@ -31,30 +31,11 @@ type MediaSidebarProps = {
 };
 
 export default function MediaSidebar(props: MediaSidebarProps) {
-	const queryClient = useQueryClient();
-	const projects = createQuery(() =>
-		projectsForMediaQueryOptions(props.media.mediaSourceId, props.media.id),
-	);
-	const allProjects = createQuery(() => ({
-		queryKey: ["allProjects"],
-		queryFn: fetchAllProjects,
-	}));
-	const allIps = createQuery(() => ({
-		queryKey: ["allIps"],
-		queryFn: fetchAllIps,
-	}));
-	const allCharacters = createQuery(() => ({
-		queryKey: ["allCharacters"],
-		queryFn: fetchAllCharacters,
-	}));
-
-	const invalidateProjectsForMedia = () =>
-		queryClient.invalidateQueries({
-			queryKey: projectsQueryKeys.forMedia(props.media.id),
-		});
-
 	return (
-		<SharedMediaSidebar
+		<MediaSidebarContent
+			addCharacterToMedia={addCharacterToMedia}
+			addIpToMedia={addIpToMedia}
+			addProjectToMedia={addProjectToMedia}
 			aiTaggingModal={(modalProps) => (
 				<AiTaggingModal
 					isOpen={modalProps.isOpen}
@@ -63,79 +44,22 @@ export default function MediaSidebar(props: MediaSidebarProps) {
 					onClose={modalProps.onClose}
 				/>
 			)}
-			allCharacters={allCharacters.data || []}
-			allIps={allIps.data || []}
-			allProjects={allProjects.data || []}
-			isAllCharactersLoading={allCharacters.isLoading}
-			isAllIpsLoading={allIps.isLoading}
-			isProjectsLoading={projects.isLoading}
+			allCharactersQueryOptions={allCharactersQueryOptions}
+			allIpsQueryOptions={allIpsQueryOptions}
+			allProjectsQueryOptions={allProjectsQueryOptions}
+			createCharacter={createCharacter}
+			createIp={createIp}
+			createProject={createProject}
 			isUpdating={props.isUpdating}
 			media={props.media}
-			onCharacterAdd={async (characterId) => {
-				await addCharacterToMedia(
-					props.media.mediaSourceId,
-					props.media.id,
-					characterId,
-				);
-			}}
-			onCharacterCreate={async (name) => {
-				const character = await createCharacter({ name });
-				await queryClient.invalidateQueries({ queryKey: ["allCharacters"] });
-				return character;
-			}}
-			onCharacterRemove={async (characterId) => {
-				await removeCharacterFromMedia(
-					props.media.mediaSourceId,
-					props.media.id,
-					characterId,
-				);
-				props.onUpdate?.();
-			}}
-			onDescriptionUpdate={async (description) => {
-				await updateMedia(props.media.mediaSourceId, props.media.id, {
-					description,
-				});
-			}}
-			onIpAdd={async (ipId) => {
-				await addIpToMedia(props.media.mediaSourceId, props.media.id, ipId);
-				props.onUpdate?.();
-			}}
-			onIpCreate={async (name) => {
-				const ip = await createIp({ name });
-				await queryClient.invalidateQueries({ queryKey: ["allIps"] });
-				return ip;
-			}}
-			onIpRemove={async (ipId) => {
-				await removeIpFromMedia(
-					props.media.mediaSourceId,
-					props.media.id,
-					ipId,
-				);
-				props.onUpdate?.();
-			}}
-			onProjectAdd={async (projectId) => {
-				await addProjectToMedia(
-					props.media.mediaSourceId,
-					props.media.id,
-					projectId,
-				);
-				await invalidateProjectsForMedia();
-			}}
-			onProjectCreate={async (name) => {
-				const project = await createProject({ name });
-				await queryClient.invalidateQueries({ queryKey: ["allProjects"] });
-				return project;
-			}}
-			onProjectRemove={async (projectId) => {
-				await removeProjectFromMedia(
-					props.media.mediaSourceId,
-					props.media.id,
-					projectId,
-				);
-				await invalidateProjectsForMedia();
-			}}
 			onUpdate={props.onUpdate}
-			projects={projects.data || []}
+			projectsForMediaQueryOptions={projectsForMediaQueryOptions}
+			removeCharacterFromMedia={removeCharacterFromMedia}
+			removeIpFromMedia={removeIpFromMedia}
+			removeProjectFromMedia={removeProjectFromMedia}
+			updateMediaDescription={(mediaSourceId, mediaId, description) =>
+				updateMedia(mediaSourceId, mediaId, { description })
+			}
 		/>
 	);
 }

--- a/apps/server/src/components/upload-media-modal/upload-media-modal-content.tsx
+++ b/apps/server/src/components/upload-media-modal/upload-media-modal-content.tsx
@@ -1,7 +1,4 @@
-import {
-	UploadMediaModalContent as SharedUploadMediaModalContent,
-	type UploadMediaModalSubmitOptions,
-} from "@solid-imager/ui/upload-media-modal";
+import { UploadMediaModalContent as SharedUploadMediaModalContent } from "@solid-imager/ui/upload-media-modal-content";
 import { fetchFromUrl } from "~/infrastructure/api-clients/fetch-url-api";
 
 type UploadMediaModalProps = {
@@ -32,34 +29,14 @@ async function fetchFileFromUrl(url: string) {
 }
 
 export function UploadMediaModalContent(props: UploadMediaModalProps) {
-	const handleUploadStart = async (options: UploadMediaModalSubmitOptions) => {
-		await Promise.all(
-			options.files.map((file, index) =>
-				props.onUpload({
-					file,
-					filename: index === 0 ? options.filename : file.name,
-					description: options.description,
-					sourceUrl: index === 0 ? options.sourceUrl : undefined,
-					overwrite: options.overwrite,
-					autoIncrement: options.autoIncrement,
-				}),
-			),
-		);
-	};
-
 	return (
 		<SharedUploadMediaModalContent
 			initialFile={props.initialFile}
 			isOpen={props.isOpen}
 			onClose={props.onClose}
 			onFetchUrl={fetchFileFromUrl}
-			onFilesSelected={(files) => {
-				const firstFile = files[0];
-				if (firstFile) {
-					props.onUrlFetch(firstFile);
-				}
-			}}
-			onUploadStart={handleUploadStart}
+			onUrlFetch={props.onUrlFetch}
+			onUpload={props.onUpload}
 			pastedUrl={props.pastedUrl}
 		/>
 	);

--- a/apps/server/src/hooks/use-media-source-events.ts
+++ b/apps/server/src/hooks/use-media-source-events.ts
@@ -21,24 +21,11 @@ export type {
 
 type MediaSourceEventsOptions = Omit<UseMediaSourceEventsOptions, "transport">;
 
-/**
- * Server-side thin wrapper around the shared `useMediaSourceEvents` hook.
- *
- * Creates an oRPC SSE transport scoped to `mediaSourceId` and injects it into
- * the shared hook. The `mediaSourceId` accessor is read synchronously inside
- * the transport's `listen` method, which itself is called inside the shared
- * hook's `createEffect`, so changes to `mediaSourceId()` correctly re-trigger
- * the effect, abort the previous SSE connection, and open a new one.
- */
-export function useMediaSourceEvents(
+export function createServerTransport(
 	mediaSourceId: Accessor<string | undefined>,
-	options: MediaSourceEventsOptions = {},
-): void {
-	const transport: MediaSourceEventTransport = {
+): MediaSourceEventTransport {
+	return {
 		listen(handler) {
-			// Reading `mediaSourceId()` synchronously here is intentional:
-			// this function is called inside the shared hook's `createEffect`,
-			// so Solid tracks it and re-runs the effect when the id changes.
 			const id = mediaSourceId();
 			if (!id) {
 				return () => {
@@ -75,6 +62,22 @@ export function useMediaSourceEvents(
 			};
 		},
 	};
+}
+
+/**
+ * Server-side thin wrapper around the shared `useMediaSourceEvents` hook.
+ *
+ * Creates an oRPC SSE transport scoped to `mediaSourceId` and injects it into
+ * the shared hook. The `mediaSourceId` accessor is read synchronously inside
+ * the transport's `listen` method, which itself is called inside the shared
+ * hook's `createEffect`, so changes to `mediaSourceId()` correctly re-trigger
+ * the effect, abort the previous SSE connection, and open a new one.
+ */
+export function useMediaSourceEvents(
+	mediaSourceId: Accessor<string | undefined>,
+	options: MediaSourceEventsOptions = {},
+): void {
+	const transport = createServerTransport(mediaSourceId);
 
 	useMediaSourceEventsShared({
 		...options,

--- a/apps/server/src/infrastructure/api/clients/preset-client.ts
+++ b/apps/server/src/infrastructure/api/clients/preset-client.ts
@@ -1,26 +1,4 @@
-import type { SearchGroup } from "@solid-imager/core/domain/media/schemas";
+import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { orpc } from "~/infrastructure/api-clients/orpc-client";
 
-export const PresetClient = {
-	list: async () => await orpc.presets.list(),
-	get: async (id: number) => await orpc.presets.get({ id }),
-	getByName: async (name: string) => await orpc.presets.getByName({ name }),
-	create: async (data: {
-		name: string;
-		value: SearchGroup;
-		sort?: "name" | "date" | "rating" | "viewCount" | "size";
-		order?: "asc" | "desc";
-		mode?: "simple" | "pro";
-	}) => await orpc.presets.create(data),
-	update: async (
-		id: number,
-		data: {
-			name?: string;
-			value?: SearchGroup;
-			sort?: "name" | "date" | "rating" | "viewCount" | "size";
-			order?: "asc" | "desc";
-			mode?: "simple" | "pro";
-		},
-	) => await orpc.presets.update({ id, data }),
-	delete: async (id: number) => await orpc.presets.delete({ id }),
-};
+export const PresetClient = createPresetClient(orpc);

--- a/apps/server/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
@@ -1,10 +1,9 @@
 import type { UUID } from "@solid-imager/core/domain/shared/schemas";
-import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import { MediaDetailScreen } from "@solid-imager/ui/screens/media-detail-screen";
 import { createFileRoute, useParams } from "@tanstack/solid-router";
-import { Match, Switch } from "solid-js";
 import MediaSidebar from "~/components/media/media-sidebar";
 import MediaViewer from "~/components/media/media-viewer";
-import { useMediaSourceEvents } from "~/hooks/use-media-source-events";
+import { createServerTransport } from "~/hooks/use-media-source-events";
 import { mediaDetailsQueryOptions } from "~/infrastructure/api-clients/queries/media-query";
 
 export const Route = createFileRoute("/sources/$mediaSourceId/$mediaId/")({
@@ -25,81 +24,23 @@ export const Route = createFileRoute("/sources/$mediaSourceId/$mediaId/")({
 
 function Media() {
 	const params = useParams({ from: "/sources/$mediaSourceId/$mediaId/" });
-	const queryClient = useQueryClient();
 	const mediaSourceId = params().mediaSourceId as UUID;
 	const mediaId = params().mediaId as UUID;
 
-	const mediaDetails = createQuery(() =>
-		mediaDetailsQueryOptions(mediaSourceId, mediaId),
-	);
-
-	const handleUpdate = async () => {
-		await queryClient.invalidateQueries({
-			queryKey: ["mediaDetails", mediaSourceId, mediaId],
-		});
-	};
-
-	useMediaSourceEvents(() => mediaSourceId, {
-		onMediaAdded: () => {
-			// New media added to source, invalidate list cache
-			queryClient.invalidateQueries({
-				queryKey: ["media", mediaSourceId],
-			});
-		},
-		onMediaDeleted: (data) => {
-			// Media deleted from source
-			queryClient.invalidateQueries({
-				queryKey: ["media", mediaSourceId],
-			});
-			// If current media is deleted, invalidate details to show error
-			if (data.filePath === mediaDetails.data?.filePath) {
-				handleUpdate();
-			}
-		},
-		onMediaChanged: (data) => {
-			// Invalidate list cache as changes might affect sorting/filtering
-			queryClient.invalidateQueries({
-				queryKey: ["media", mediaSourceId],
-			});
-			// If current media changed, update
-			if (data.filePath === mediaDetails.data?.filePath) {
-				handleUpdate();
-			}
-		},
-		onThumbnailGenerated: (data) => {
-			// Thumbnail might affect current view if it was missing
-			if (data.mediaId === mediaId) {
-				handleUpdate();
-			}
-		},
-	});
-
 	return (
-		<div class="container mx-auto p-4">
-			<Switch>
-				{/* <Match when={mediaDetails.isLoading}>
-          <div>Loading media...</div>
-        </Match> */}
-				<Match when={mediaDetails.isError}>
-					<div class="text-red-500">Error: {mediaDetails.error?.message}</div>
-				</Match>
-				<Match when={mediaDetails.data}>
-					{(details) => (
-						<div class="flex h-[calc(100vh-80px)] flex-col gap-4 lg:flex-row">
-							<div class="flex-grow">
-								<MediaViewer media={details()} />
-							</div>
-							<div class="w-full shrink-0 lg:w-96">
-								<MediaSidebar
-									isUpdating={mediaDetails.isRefetching}
-									media={details()}
-									onUpdate={handleUpdate}
-								/>
-							</div>
-						</div>
-					)}
-				</Match>
-			</Switch>
-		</div>
+		<MediaDetailScreen
+			mediaDetailsQueryOptions={mediaDetailsQueryOptions}
+			mediaId={mediaId}
+			mediaSourceId={mediaSourceId}
+			renderMediaSidebar={(media, isUpdating, onUpdate) => (
+				<MediaSidebar
+					isUpdating={isUpdating}
+					media={media}
+					onUpdate={onUpdate}
+				/>
+			)}
+			renderMediaViewer={(media) => <MediaViewer media={media} />}
+			transport={createServerTransport(() => mediaSourceId)}
+		/>
 	);
 }

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -1,16 +1,9 @@
-import type { MediaSourceEventTransport } from "@solid-imager/ui/hooks/use-media-source-events";
-import { useSourceMediaPage } from "@solid-imager/ui/hooks/use-source-media-page";
-import { MediaListActions } from "@solid-imager/ui/media-list-actions";
-import {
-	SourceMediaScreen,
-	type SourceMediaScreenProps,
-} from "@solid-imager/ui/screens/source-media-screen";
-import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import { SourceMediaPage as SourceMediaPageComponent } from "@solid-imager/ui/source-media-page";
 import { useParams } from "@tanstack/solid-router";
-import type { Accessor } from "solid-js";
 import { MediaGridItem } from "~/components/media/media-grid-item";
 import { MoveCopyMediaDialog } from "~/components/media/move-copy-media-dialog";
 import { UploadMediaModal } from "~/components/upload-media-modal";
+import { createServerTransport } from "~/hooks/use-media-source-events";
 import { PresetClient } from "~/infrastructure/api/clients/preset-client";
 import { startDownloadJobs } from "~/infrastructure/api-clients/downloads-api";
 import {
@@ -20,7 +13,6 @@ import {
 	syncMediaItems,
 	uploadMedia,
 } from "~/infrastructure/api-clients/media-api";
-import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import { allAuthorsQueryOptions } from "~/infrastructure/api-clients/queries/authors-query";
 import { allCharactersQueryOptions } from "~/infrastructure/api-clients/queries/characters-query";
 import { allIpsQueryOptions } from "~/infrastructure/api-clients/queries/ips-query";
@@ -32,111 +24,43 @@ import {
 	importSourceZip,
 	restoreSource,
 } from "~/infrastructure/api-clients/sources-api";
-import { logger } from "~/infrastructure/logger";
 import {
 	getSearchCondition,
 	searchState,
 } from "~/presentation/store/search-store";
 
-function createServerTransport(
-	mediaSourceId: Accessor<string | undefined>,
-): MediaSourceEventTransport {
-	return {
-		listen(handler) {
-			const id = mediaSourceId();
-			if (!id) {
-				return () => {
-					/* no-op */
-				};
-			}
-
-			const ac = new AbortController();
-
-			const startEventStream = async () => {
-				try {
-					const events = await orpc.sources.events(
-						{ id },
-						{ signal: ac.signal },
-					);
-
-					for await (const msg of events) {
-						if (ac.signal.aborted) {
-							break;
-						}
-						handler(msg.event, msg.data);
-					}
-				} catch (err) {
-					if (!ac.signal.aborted) {
-						logger.error({ err }, "Event stream error");
-					}
-				}
-			};
-
-			startEventStream();
-
-			return () => {
-				ac.abort();
-			};
-		},
-	};
-}
-
 export function SourceMediaPage() {
 	const params = useParams({ from: "/sources/$mediaSourceId/" });
-	const queryClient = useQueryClient();
-
 	const mediaSourceId = () => params().mediaSourceId;
-
-	const tags = createQuery(() => tagsQueryOptions());
-	const allProjects = createQuery(() => allProjectsQueryOptions());
-	const allIps = createQuery(() => allIpsQueryOptions());
-	const allCharacters = createQuery(() => allCharactersQueryOptions());
-	const allAuthors = createQuery(() => allAuthorsQueryOptions());
 
 	const transport = createServerTransport(mediaSourceId);
 
-	const page = useSourceMediaPage({
-		mediaSourceId,
-		queries: {
-			tags: () => tags.data,
-			projects: () => allProjects.data,
-			ips: () => allIps.data,
-			characters: () => allCharacters.data,
-			authors: () => allAuthors.data,
-		},
-		actions: {
-			searchMedia,
-			uploadMedia: (sourceId, file, opts) => uploadMedia(sourceId, file, opts),
-			deleteMedia,
-			copyMedia,
-			moveMedia,
-			syncMediaItems,
-			startDownloadJobs,
-			fetchSourceDump,
-			restoreSource: (sourceId, data) => restoreSource(sourceId, data),
-			importSourceZip: (sourceId, file) => importSourceZip(sourceId, file),
-		},
-		queryClient,
-		presetClient: PresetClient,
-		transport,
-		getSearchCondition,
-		sortBy: () => searchState.sortBy,
-		sortOrder: () => searchState.sortOrder,
-	});
-
-	const renderActions: SourceMediaScreenProps["renderActions"] = (_props) => (
-		<MediaListActions
-			filterData={page.filterData()}
-			onDumpDownload={page.handleDumpDownload}
-			onSearch={page.handleSearch}
-			presetClient={PresetClient}
-		/>
-	);
-
 	return (
-		<SourceMediaScreen
-			page={page}
-			renderActions={renderActions}
+		<SourceMediaPageComponent
+			mediaSourceId={mediaSourceId}
+			transport={transport}
+			presetClient={PresetClient}
+			actions={{
+				searchMedia,
+				uploadMedia: (sourceId, file, opts) =>
+					uploadMedia(sourceId, file, opts),
+				deleteMedia,
+				copyMedia,
+				moveMedia,
+				syncMediaItems,
+				startDownloadJobs,
+				fetchSourceDump,
+				restoreSource: (sourceId, data) => restoreSource(sourceId, data),
+				importSourceZip: (sourceId, file) => importSourceZip(sourceId, file),
+			}}
+			getSearchCondition={getSearchCondition}
+			sortBy={() => searchState.sortBy}
+			sortOrder={() => searchState.sortOrder}
+			tagsQueryOptions={tagsQueryOptions}
+			projectsQueryOptions={allProjectsQueryOptions}
+			ipsQueryOptions={allIpsQueryOptions}
+			charactersQueryOptions={allCharactersQueryOptions}
+			authorsQueryOptions={allAuthorsQueryOptions}
 			renderItem={(media, { onContextMenu }) => (
 				<MediaGridItem media={media} onContextMenu={onContextMenu} />
 			)}

--- a/apps/tauri/src/components/media/media-sidebar/media-sidebar-content.tsx
+++ b/apps/tauri/src/components/media/media-sidebar/media-sidebar-content.tsx
@@ -1,28 +1,28 @@
 import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
-import { MediaSidebar as SharedMediaSidebar } from "@solid-imager/ui/media-sidebar";
-import { projectsQueryKeys } from "@solid-imager/ui/query-options";
-import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import { MediaSidebarContent } from "@solid-imager/ui/media-sidebar-content";
+import { allCharactersQueryOptions } from "~/infrastructure/api-clients/queries/characters-query";
+import { allIpsQueryOptions } from "~/infrastructure/api-clients/queries/ips-query";
+import {
+	allProjectsQueryOptions,
+	projectsForMediaQueryOptions,
+} from "~/infrastructure/api-clients/queries/projects-query";
 import { getTauriAppServices } from "~/app-services";
 import {
 	addCharacterToMedia,
 	createCharacter,
-	fetchAllCharacters,
 	removeCharacterFromMedia,
 } from "~/infrastructure/api-clients/characters-api";
 import {
 	addIpToMedia,
 	createIp,
-	fetchAllIps,
 	removeIpFromMedia,
 } from "~/infrastructure/api-clients/ips-api";
 import { updateMedia } from "~/infrastructure/api-clients/media-api";
 import {
 	addProjectToMedia,
 	createProject,
-	fetchAllProjects,
 	removeProjectFromMedia,
 } from "~/infrastructure/api-clients/projects-api";
-import { projectsForMediaQueryOptions } from "~/infrastructure/api-clients/queries/projects-query";
 import { joinLocalPath } from "~/infrastructure/path-utils";
 import { AiTaggingModal } from "../ai-tagging-modal";
 
@@ -34,28 +34,6 @@ type MediaSidebarProps = {
 };
 
 export function MediaSidebar(props: MediaSidebarProps) {
-	const queryClient = useQueryClient();
-	const projects = createQuery(() =>
-		projectsForMediaQueryOptions(props.media.mediaSourceId, props.media.id),
-	);
-	const allProjects = createQuery(() => ({
-		queryKey: ["allProjects"],
-		queryFn: fetchAllProjects,
-	}));
-	const allIps = createQuery(() => ({
-		queryKey: ["allIps"],
-		queryFn: fetchAllIps,
-	}));
-	const allCharacters = createQuery(() => ({
-		queryKey: ["allCharacters"],
-		queryFn: fetchAllCharacters,
-	}));
-
-	const invalidateProjectsForMedia = () =>
-		queryClient.invalidateQueries({
-			queryKey: projectsQueryKeys.forMedia(props.media.id),
-		});
-
 	const loadMediaFile = async () => {
 		const sourceRootPath = props.sourceRootPath;
 		if (!sourceRootPath) {
@@ -70,7 +48,10 @@ export function MediaSidebar(props: MediaSidebarProps) {
 	};
 
 	return (
-		<SharedMediaSidebar
+		<MediaSidebarContent
+			addCharacterToMedia={addCharacterToMedia}
+			addIpToMedia={addIpToMedia}
+			addProjectToMedia={addProjectToMedia}
 			aiTaggingModal={(modalProps) => (
 				<AiTaggingModal
 					fileName={props.media.fileName}
@@ -79,59 +60,22 @@ export function MediaSidebar(props: MediaSidebarProps) {
 					onClose={modalProps.onClose}
 				/>
 			)}
-			allCharacters={allCharacters.data || []}
-			allIps={allIps.data || []}
-			allProjects={allProjects.data || []}
-			isAllCharactersLoading={allCharacters.isLoading}
-			isAllIpsLoading={allIps.isLoading}
-			isProjectsLoading={projects.isLoading}
+			allCharactersQueryOptions={allCharactersQueryOptions}
+			allIpsQueryOptions={allIpsQueryOptions}
+			allProjectsQueryOptions={allProjectsQueryOptions}
+			createCharacter={createCharacter}
+			createIp={createIp}
+			createProject={createProject}
 			isUpdating={props.isUpdating}
 			media={props.media}
-			onCharacterAdd={async (characterId) => {
-				await addCharacterToMedia(props.media.mediaSourceId, props.media.id, characterId);
-			}}
-			onCharacterCreate={async (name) => {
-				const character = await createCharacter({ name });
-				await queryClient.invalidateQueries({ queryKey: ["allCharacters"] });
-				return character;
-			}}
-			onCharacterRemove={async (characterId) => {
-				await removeCharacterFromMedia(props.media.mediaSourceId, props.media.id, characterId);
-				props.onUpdate?.();
-			}}
-			onDescriptionUpdate={async (description) => {
-				await updateMedia(props.media.mediaSourceId, props.media.id, {
-					description,
-				});
-			}}
-			onIpAdd={async (ipId) => {
-				await addIpToMedia(props.media.mediaSourceId, props.media.id, ipId);
-				props.onUpdate?.();
-			}}
-			onIpCreate={async (name) => {
-				const ip = await createIp({ name });
-				await queryClient.invalidateQueries({ queryKey: ["allIps"] });
-				return ip;
-			}}
-			onIpRemove={async (ipId) => {
-				await removeIpFromMedia(props.media.mediaSourceId, props.media.id, ipId);
-				props.onUpdate?.();
-			}}
-			onProjectAdd={async (projectId) => {
-				await addProjectToMedia(props.media.mediaSourceId, props.media.id, projectId);
-				await invalidateProjectsForMedia();
-			}}
-			onProjectCreate={async (name) => {
-				const project = await createProject({ name });
-				await queryClient.invalidateQueries({ queryKey: ["allProjects"] });
-				return project;
-			}}
-			onProjectRemove={async (projectId) => {
-				await removeProjectFromMedia(props.media.mediaSourceId, props.media.id, projectId);
-				await invalidateProjectsForMedia();
-			}}
 			onUpdate={props.onUpdate}
-			projects={projects.data || []}
+			projectsForMediaQueryOptions={projectsForMediaQueryOptions}
+			removeCharacterFromMedia={removeCharacterFromMedia}
+			removeIpFromMedia={removeIpFromMedia}
+			removeProjectFromMedia={removeProjectFromMedia}
+			updateMediaDescription={(mediaSourceId, mediaId, description) =>
+				updateMedia(mediaSourceId, mediaId, { description })
+			}
 		/>
 	);
 }

--- a/apps/tauri/src/components/upload-media-modal/upload-media-modal-content.tsx
+++ b/apps/tauri/src/components/upload-media-modal/upload-media-modal-content.tsx
@@ -1,7 +1,7 @@
 import {
 	UploadMediaModalContent as SharedUploadMediaModalContent,
-	type UploadMediaModalSubmitOptions,
-} from "@solid-imager/ui/upload-media-modal";
+	UploadMediaModal,
+} from "@solid-imager/ui/upload-media-modal-content";
 
 type UploadMediaModalProps = {
 	isOpen: boolean;
@@ -25,40 +25,24 @@ async function fetchFileFromUrl(url: string) {
 		throw new Error(`Failed to fetch URL: ${response.status}`);
 	}
 	const blob = await response.blob();
-	return new File([blob], url.substring(url.lastIndexOf("/") + 1) || "fetched-image", {
-		type: blob.type,
-	});
+	return new File(
+		[blob],
+		url.substring(url.lastIndexOf("/") + 1) || "fetched-image",
+		{
+			type: blob.type,
+		},
+	);
 }
 
 export function UploadMediaModalContent(props: UploadMediaModalProps) {
-	const handleUploadStart = async (options: UploadMediaModalSubmitOptions) => {
-		await Promise.all(
-			options.files.map((file, index) =>
-				props.onUpload({
-					file,
-					filename: index === 0 ? options.filename : file.name,
-					description: options.description,
-					sourceUrl: index === 0 ? options.sourceUrl : undefined,
-					overwrite: options.overwrite,
-					autoIncrement: options.autoIncrement,
-				}),
-			),
-		);
-	};
-
 	return (
 		<SharedUploadMediaModalContent
 			initialFile={props.initialFile}
 			isOpen={props.isOpen}
 			onClose={props.onClose}
 			onFetchUrl={fetchFileFromUrl}
-			onFilesSelected={(files) => {
-				const firstFile = files[0];
-				if (firstFile) {
-					props.onUrlFetch(firstFile);
-				}
-			}}
-			onUploadStart={handleUploadStart}
+			onUrlFetch={props.onUrlFetch}
+			onUpload={props.onUpload}
 			pastedUrl={props.pastedUrl}
 		/>
 	);

--- a/apps/tauri/src/hooks/use-media-source-events.ts
+++ b/apps/tauri/src/hooks/use-media-source-events.ts
@@ -20,23 +20,11 @@ export type {
 
 type MediaSourceEventsOptions = Omit<UseMediaSourceEventsOptions, "transport">;
 
-/**
- * Tauri-side thin wrapper around the shared `useMediaSourceEvents` hook.
- *
- * Creates a Tauri event-bus transport scoped to `mediaSourceId` and injects it
- * into the shared hook. Each call to `transport.listen` registers one Tauri
- * event listener per event name and fans out to the shared handler, filtering
- * events to those relevant for the current `mediaSourceId`.
- */
-export function useMediaSourceEvents(
+export function createTauriTransport(
 	mediaSourceId: Accessor<string | undefined>,
-	options: MediaSourceEventsOptions = {},
-): void {
-	const transport: MediaSourceEventTransport = {
+): MediaSourceEventTransport {
+	return {
 		listen(handler) {
-			// Reading `mediaSourceId()` synchronously here is intentional:
-			// this function is called inside the shared hook's `createEffect`,
-			// so Solid tracks it and re-runs the effect when the id changes.
 			const id = mediaSourceId();
 			if (!id) {
 				return () => {
@@ -46,9 +34,6 @@ export function useMediaSourceEvents(
 
 			let isCleanedUp = false;
 
-			// Register a Tauri listener for each event name that the shared hook
-			// understands. We fan-out to the unified `handler(event, data)` callback
-			// after filtering by `mediaSourceId` / `sourceId` relevance.
 			const EVENT_NAMES = [
 				"media-added",
 				"media-deleted",
@@ -73,15 +58,11 @@ export function useMediaSourceEvents(
 					if (isCleanedUp) return;
 
 					const payload = event.payload;
-					// Route to handler only if the event is relevant for this source.
-					// media-copied and media-moved may target either side of the operation.
 					const relevant =
 						payload?.mediaSourceId === id ||
 						payload?.sourceId === id ||
 						payload?.targetId === id ||
-						// job-progress is scoped by jobId which may equal the sourceId
 						payload?.jobId === id ||
-						// Fall back to delivering the event unfiltered when no source key present
 						(payload?.mediaSourceId === undefined &&
 							payload?.sourceId === undefined &&
 							payload?.targetId === undefined &&
@@ -103,6 +84,21 @@ export function useMediaSourceEvents(
 			};
 		},
 	};
+}
+
+/**
+ * Tauri-side thin wrapper around the shared `useMediaSourceEvents` hook.
+ *
+ * Creates a Tauri event-bus transport scoped to `mediaSourceId` and injects it
+ * into the shared hook. Each call to `transport.listen` registers one Tauri
+ * event listener per event name and fans out to the shared handler, filtering
+ * events to those relevant for the current `mediaSourceId`.
+ */
+export function useMediaSourceEvents(
+	mediaSourceId: Accessor<string | undefined>,
+	options: MediaSourceEventsOptions = {},
+): void {
+	const transport = createTauriTransport(mediaSourceId);
 
 	useMediaSourceEventsShared({
 		...options,

--- a/apps/tauri/src/infrastructure/api/clients/preset-client.ts
+++ b/apps/tauri/src/infrastructure/api/clients/preset-client.ts
@@ -1,26 +1,4 @@
-import type { SearchGroup } from "@solid-imager/core/domain/media/schemas";
-import { orpc } from "~/infrastructure/api-clients/orpc-client";
+import { createPresetClient } from "@solid-imager/ui/preset-client";
+import { orpc } from "./orpc-client";
 
-export const PresetClient = {
-	list: async () => await orpc.presets.list(),
-	get: async (id: number) => await orpc.presets.get({ id }),
-	getByName: async (name: string) => await orpc.presets.getByName({ name }),
-	create: async (data: {
-		name: string;
-		value: SearchGroup;
-		sort?: "name" | "date" | "rating" | "viewCount" | "size";
-		order?: "asc" | "desc";
-		mode?: "simple" | "pro";
-	}) => await orpc.presets.create(data),
-	update: async (
-		id: number,
-		data: {
-			name?: string;
-			value?: SearchGroup;
-			sort?: "name" | "date" | "rating" | "viewCount" | "size";
-			order?: "asc" | "desc";
-			mode?: "simple" | "pro";
-		},
-	) => await orpc.presets.update({ id, data }),
-	delete: async (id: number) => await orpc.presets.delete({ id }),
-};
+export const PresetClient = createPresetClient(orpc);

--- a/apps/tauri/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
+++ b/apps/tauri/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
@@ -1,12 +1,12 @@
 import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import { MediaDetailScreen } from "@solid-imager/ui/screens/media-detail-screen";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute, useParams } from "@tanstack/solid-router";
-import { Match, Switch } from "solid-js";
 import { MediaSidebar } from "~/components/media/media-sidebar";
 import { MediaViewer } from "~/components/media/media-viewer";
-import { useMediaSourceEvents } from "~/hooks/use-media-source-events";
 import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import { mediaDetailsQueryOptions } from "~/infrastructure/api-clients/queries/media-query";
+import { createTauriTransport } from "~/hooks/use-media-source-events";
 
 export const Route = createFileRoute("/sources/$mediaSourceId/$mediaId/")({
 	loader: async ({ context, params }) => {
@@ -29,7 +29,6 @@ function MediaDetailRoute() {
 	const mediaSourceId = () => params().mediaSourceId;
 	const mediaId = () => params().mediaId;
 
-	const mediaDetails = createQuery(() => mediaDetailsQueryOptions(mediaSourceId(), mediaId()));
 	const mediaSource = createQuery(() => ({
 		queryKey: ["mediaSource", mediaSourceId()],
 		queryFn: () => orpc.sources.get({ id: mediaSourceId() }),
@@ -44,70 +43,29 @@ function MediaDetailRoute() {
 		return connectionInfo.path;
 	};
 
-	const handleUpdate = async () => {
-		await Promise.all([
-			queryClient.invalidateQueries({
-				queryKey: ["mediaDetails", mediaSourceId(), mediaId()],
-			}),
-			queryClient.invalidateQueries({
-				queryKey: ["projectsForMedia", mediaId()],
-			}),
-		]);
-	};
-
-	useMediaSourceEvents(mediaSourceId, {
-		onMediaAdded: () => {
-			void queryClient.invalidateQueries({
-				queryKey: ["media", mediaSourceId()],
-			});
-		},
-		onMediaDeleted: (data) => {
-			void queryClient.invalidateQueries({
-				queryKey: ["media", mediaSourceId()],
-			});
-			if (data.mediaId === mediaId() || data.filePath === mediaDetails.data?.filePath) {
-				void handleUpdate();
-			}
-		},
-		onMediaChanged: (data) => {
-			void queryClient.invalidateQueries({
-				queryKey: ["media", mediaSourceId()],
-			});
-			if (data.mediaId === mediaId() || data.filePath === mediaDetails.data?.filePath) {
-				void handleUpdate();
-			}
-		},
-		onThumbnailGenerated: (data) => {
-			if (data.mediaId === mediaId()) {
-				void handleUpdate();
-			}
-		},
-	});
-
 	return (
-		<div class="container mx-auto p-4">
-			<Switch>
-				<Match when={mediaDetails.isError}>
-					<div class="text-red-500">Error: {mediaDetails.error?.message}</div>
-				</Match>
-				<Match when={mediaDetails.data}>
-					{(details) => (
-						<div class="flex h-[calc(100vh-80px)] flex-col gap-4 lg:flex-row">
-							<div class="flex-grow">
-								<MediaViewer media={details()} sourceRootPath={sourceRootPath()} />
-							</div>
-							<div class="w-full shrink-0 lg:w-96">
-								<MediaSidebar
-									isUpdating={mediaDetails.isRefetching}
-									media={details()}
-									onUpdate={handleUpdate}
-									sourceRootPath={sourceRootPath()}
-								/>
-							</div>
-						</div>
-					)}
-				</Match>
-			</Switch>
-		</div>
+		<MediaDetailScreen
+			mediaDetailsQueryOptions={mediaDetailsQueryOptions}
+			mediaId={mediaId()}
+			mediaSourceId={mediaSourceId()}
+			onAdditionalInvalidate={async () => {
+				await queryClient.invalidateQueries({
+					queryKey: ["projectsForMedia", mediaId()],
+				});
+			}}
+			renderMediaSidebar={(media, isUpdating, onUpdate, srp) => (
+				<MediaSidebar
+					isUpdating={isUpdating}
+					media={media}
+					onUpdate={onUpdate}
+					sourceRootPath={srp}
+				/>
+			)}
+			renderMediaViewer={(media, srp) => (
+				<MediaViewer media={media} sourceRootPath={srp} />
+			)}
+			sourceRootPath={sourceRootPath()}
+			transport={createTauriTransport(mediaSourceId)}
+		/>
 	);
 }

--- a/apps/tauri/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/tauri/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -1,13 +1,6 @@
-import type { MediaSourceEventTransport } from "@solid-imager/ui/hooks/use-media-source-events";
-import { useSourceMediaPage } from "@solid-imager/ui/hooks/use-source-media-page";
-import { MediaListActions } from "@solid-imager/ui/media-list-actions";
-import {
-	SourceMediaScreen,
-	type SourceMediaScreenProps,
-} from "@solid-imager/ui/screens/source-media-screen";
-import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import { SourceMediaPage as SourceMediaPageComponent } from "@solid-imager/ui/source-media-page";
+import { createQuery } from "@tanstack/solid-query";
 import { useParams } from "@tanstack/solid-router";
-import { listen } from "@tauri-apps/api/event";
 import { createMemo } from "solid-js";
 import { MediaGridItem } from "~/components/media/media-grid-item";
 import { MoveCopyMediaDialog } from "~/components/media/move-copy-media-dialog";
@@ -33,83 +26,17 @@ import {
 	importSourceZip,
 	restoreSource,
 } from "~/infrastructure/api-clients/sources-api";
+import { createTauriTransport } from "~/hooks/use-media-source-events";
 import { notifyThumbnailReady } from "~/infrastructure/media/thumbnail-runtime";
-import { getSearchCondition, searchState } from "~/presentation/store/search-store";
-
-function createTauriTransport(mediaSourceId: () => string | undefined): MediaSourceEventTransport {
-	return {
-		listen(handler) {
-			const id = mediaSourceId();
-			if (!id) {
-				return () => {
-					/* no-op */
-				};
-			}
-
-			let isCleanedUp = false;
-
-			const EVENT_NAMES = [
-				"media-added",
-				"media-deleted",
-				"media-changed",
-				"media-copied",
-				"media-moved",
-				"thumbnail-generated",
-				"all-jobs-completed",
-				"watcher-error",
-				"job-progress",
-			] as const;
-
-			type EventPayload = {
-				mediaSourceId?: string;
-				sourceId?: string;
-				targetId?: string;
-				jobId?: string;
-			};
-
-			const unlistenPromises = EVENT_NAMES.map((eventName) =>
-				listen<EventPayload>(eventName, (event) => {
-					if (isCleanedUp) return;
-
-					const payload = event.payload;
-					const relevant =
-						payload?.mediaSourceId === id ||
-						payload?.sourceId === id ||
-						payload?.targetId === id ||
-						payload?.jobId === id ||
-						(payload?.mediaSourceId === undefined &&
-							payload?.sourceId === undefined &&
-							payload?.targetId === undefined &&
-							payload?.jobId === undefined);
-
-					if (relevant) {
-						handler(eventName, payload);
-					}
-				}),
-			);
-
-			return () => {
-				isCleanedUp = true;
-				void Promise.all(unlistenPromises).then((unlistenFns) => {
-					for (const unlisten of unlistenFns) {
-						unlisten();
-					}
-				});
-			};
-		},
-	};
-}
+import {
+	getSearchCondition,
+	searchState,
+} from "~/presentation/store/search-store";
 
 export function SourceMediaPage() {
 	const params = useParams({ from: "/sources/$mediaSourceId/" });
 	const mediaSourceId = () => params().mediaSourceId;
-	const queryClient = useQueryClient();
 
-	const tags = createQuery(() => tagsQueryOptions());
-	const allProjects = createQuery(() => allProjectsQueryOptions());
-	const allIps = createQuery(() => allIpsQueryOptions());
-	const allCharacters = createQuery(() => allCharactersQueryOptions());
-	const allAuthors = createQuery(() => allAuthorsQueryOptions());
 	const sources = createQuery(() => mediaSourcesQueryOptions());
 
 	const sourceRootPath = createMemo(() => {
@@ -123,50 +50,34 @@ export function SourceMediaPage() {
 
 	const transport = createTauriTransport(mediaSourceId);
 
-	const page = useSourceMediaPage({
-		mediaSourceId,
-		queries: {
-			tags: () => tags.data,
-			projects: () => allProjects.data,
-			ips: () => allIps.data,
-			characters: () => allCharacters.data,
-			authors: () => allAuthors.data,
-		},
-		actions: {
-			searchMedia,
-			uploadMedia: (sourceId, file, opts) => uploadMedia(sourceId, file, opts),
-			deleteMedia,
-			copyMedia,
-			moveMedia,
-			syncMediaItems,
-			startDownloadJobs,
-			fetchSourceDump,
-			restoreSource,
-			importSourceZip,
-		},
-		queryClient,
-		presetClient: PresetClient,
-		transport,
-		getSearchCondition,
-		sortBy: () => searchState.sortBy,
-		sortOrder: () => searchState.sortOrder,
-		onThumbnailReady: notifyThumbnailReady,
-	});
-
-	const renderActions: SourceMediaScreenProps["renderActions"] = () => (
-		<MediaListActions
-			filterData={page.filterData()}
-			onDumpDownload={page.handleDumpDownload}
-			onSearch={page.handleSearch}
-			presetClient={PresetClient}
-		/>
-	);
-
 	return (
-		<SourceMediaScreen
+		<SourceMediaPageComponent
+			mediaSourceId={mediaSourceId}
+			transport={transport}
+			presetClient={PresetClient}
+			actions={{
+				searchMedia,
+				uploadMedia: (sourceId, file, opts) =>
+					uploadMedia(sourceId, file, opts),
+				deleteMedia,
+				copyMedia,
+				moveMedia,
+				syncMediaItems,
+				startDownloadJobs,
+				fetchSourceDump,
+				restoreSource,
+				importSourceZip,
+			}}
+			getSearchCondition={getSearchCondition}
+			sortBy={() => searchState.sortBy}
+			sortOrder={() => searchState.sortOrder}
+			onThumbnailReady={notifyThumbnailReady}
+			tagsQueryOptions={tagsQueryOptions}
+			projectsQueryOptions={allProjectsQueryOptions}
+			ipsQueryOptions={allIpsQueryOptions}
+			charactersQueryOptions={allCharactersQueryOptions}
+			authorsQueryOptions={allAuthorsQueryOptions}
 			enableVirtualization
-			page={page}
-			renderActions={renderActions}
 			renderItem={(media, { onContextMenu }) => (
 				<MediaGridItem
 					media={media}
@@ -174,9 +85,9 @@ export function SourceMediaPage() {
 					sourceRootPath={sourceRootPath()}
 				/>
 			)}
-			showOpenInNewTab
 			moveCopyDialogComponent={MoveCopyMediaDialog}
 			uploadModalComponent={UploadMediaModal}
+			showOpenInNewTab
 		/>
 	);
 }

--- a/packages/ui/src/media-sidebar-content.tsx
+++ b/packages/ui/src/media-sidebar-content.tsx
@@ -1,0 +1,172 @@
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import type { JSX } from "solid-js";
+import { MediaSidebar } from "./media-sidebar";
+import { projectsQueryKeys } from "./query-options";
+
+export type MediaSidebarContentProps = {
+	media: MediaDetails;
+	isUpdating?: boolean;
+	onUpdate?: () => void;
+	aiTaggingModal: (props: {
+		isOpen: boolean;
+		onClose: () => void;
+	}) => JSX.Element;
+	projectsForMediaQueryOptions: (
+		mediaSourceId: string,
+		mediaId: string,
+	) => unknown;
+	allProjectsQueryOptions: () => unknown;
+	allIpsQueryOptions: () => unknown;
+	allCharactersQueryOptions: () => unknown;
+	addProjectToMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		projectId: string,
+	) => Promise<unknown>;
+	removeProjectFromMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		projectId: string,
+	) => Promise<unknown>;
+	createProject: (data: { name: string }) => Promise<{ id: string }>;
+	addIpToMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		ipId: string,
+	) => Promise<unknown>;
+	removeIpFromMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		ipId: string,
+	) => Promise<unknown>;
+	createIp: (data: { name: string }) => Promise<{ id: string }>;
+	addCharacterToMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		characterId: string,
+	) => Promise<unknown>;
+	removeCharacterFromMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		characterId: string,
+	) => Promise<unknown>;
+	createCharacter: (data: { name: string }) => Promise<{ id: string }>;
+	updateMediaDescription: (
+		mediaSourceId: string,
+		mediaId: string,
+		description: string,
+	) => Promise<unknown>;
+};
+
+export function MediaSidebarContent(props: MediaSidebarContentProps) {
+	const queryClient = useQueryClient();
+
+	const projects = createQuery<Project[]>(
+		() =>
+			props.projectsForMediaQueryOptions(
+				props.media.mediaSourceId,
+				props.media.id,
+			) as any,
+	);
+	const allProjects = createQuery<Project[]>(
+		() => props.allProjectsQueryOptions() as any,
+	);
+	const allIps = createQuery<Ip[]>(() => props.allIpsQueryOptions() as any);
+	const allCharacters = createQuery<Character[]>(
+		() => props.allCharactersQueryOptions() as any,
+	);
+
+	const invalidateProjectsForMedia = () =>
+		queryClient.invalidateQueries({
+			queryKey: projectsQueryKeys.forMedia(props.media.id),
+		});
+
+	return (
+		<MediaSidebar
+			aiTaggingModal={props.aiTaggingModal}
+			allCharacters={allCharacters.data || []}
+			allIps={allIps.data || []}
+			allProjects={allProjects.data || []}
+			isAllCharactersLoading={allCharacters.isLoading}
+			isAllIpsLoading={allIps.isLoading}
+			isProjectsLoading={projects.isLoading}
+			isUpdating={props.isUpdating}
+			media={props.media}
+			onCharacterAdd={async (characterId) => {
+				await props.addCharacterToMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					characterId,
+				);
+			}}
+			onCharacterCreate={async (name) => {
+				const character = await props.createCharacter({ name });
+				await queryClient.invalidateQueries({ queryKey: ["allCharacters"] });
+				return character;
+			}}
+			onCharacterRemove={async (characterId) => {
+				await props.removeCharacterFromMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					characterId,
+				);
+				props.onUpdate?.();
+			}}
+			onDescriptionUpdate={async (description) => {
+				await props.updateMediaDescription(
+					props.media.mediaSourceId,
+					props.media.id,
+					description,
+				);
+			}}
+			onIpAdd={async (ipId) => {
+				await props.addIpToMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					ipId,
+				);
+				props.onUpdate?.();
+			}}
+			onIpCreate={async (name) => {
+				const ip = await props.createIp({ name });
+				await queryClient.invalidateQueries({ queryKey: ["allIps"] });
+				return ip;
+			}}
+			onIpRemove={async (ipId) => {
+				await props.removeIpFromMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					ipId,
+				);
+				props.onUpdate?.();
+			}}
+			onProjectAdd={async (projectId) => {
+				await props.addProjectToMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					projectId,
+				);
+				await invalidateProjectsForMedia();
+			}}
+			onProjectCreate={async (name) => {
+				const project = await props.createProject({ name });
+				await queryClient.invalidateQueries({ queryKey: ["allProjects"] });
+				return project;
+			}}
+			onProjectRemove={async (projectId) => {
+				await props.removeProjectFromMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					projectId,
+				);
+				await invalidateProjectsForMedia();
+			}}
+			onUpdate={props.onUpdate}
+			projects={projects.data || []}
+		/>
+	);
+}

--- a/packages/ui/src/preset-client.ts
+++ b/packages/ui/src/preset-client.ts
@@ -1,0 +1,58 @@
+import type {
+	Preset,
+	SearchGroup,
+} from "@solid-imager/core/domain/media/schemas";
+
+export interface PresetOrpcLike {
+	presets: {
+		list(): Promise<Preset[]>;
+		get(input: { id: number }): Promise<Preset>;
+		getByName(input: { name: string }): Promise<Preset | null | undefined>;
+		create(data: {
+			name: string;
+			value: SearchGroup;
+			sort?: "name" | "date" | "rating" | "viewCount" | "size";
+			order?: "asc" | "desc";
+			mode?: "simple" | "pro";
+		}): Promise<Preset>;
+		update(input: {
+			id: number;
+			data: {
+				name?: string;
+				value?: SearchGroup;
+				sort?: "name" | "date" | "rating" | "viewCount" | "size";
+				order?: "asc" | "desc";
+				mode?: "simple" | "pro";
+			};
+		}): Promise<Preset>;
+		delete(input: { id: number }): Promise<unknown>;
+	};
+}
+
+export function createPresetClient(orpc: PresetOrpcLike) {
+	return {
+		list: async () => await orpc.presets.list(),
+		get: async (id: number) => await orpc.presets.get({ id }),
+		getByName: async (name: string) => await orpc.presets.getByName({ name }),
+		create: async (data: {
+			name: string;
+			value: SearchGroup;
+			sort?: "name" | "date" | "rating" | "viewCount" | "size";
+			order?: "asc" | "desc";
+			mode?: "simple" | "pro";
+		}) => await orpc.presets.create(data),
+		update: async (
+			id: number,
+			data: {
+				name?: string;
+				value?: SearchGroup;
+				sort?: "name" | "date" | "rating" | "viewCount" | "size";
+				order?: "asc" | "desc";
+				mode?: "simple" | "pro";
+			},
+		) => await orpc.presets.update({ id, data }),
+		delete: async (id: number) => await orpc.presets.delete({ id }),
+	};
+}
+
+export type PresetClientType = ReturnType<typeof createPresetClient>;

--- a/packages/ui/src/screens/media-detail-screen.tsx
+++ b/packages/ui/src/screens/media-detail-screen.tsx
@@ -1,0 +1,112 @@
+import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
+import type {
+	MediaChangedEvent,
+	MediaDeletedEvent,
+	ThumbnailGeneratedEvent,
+} from "@solid-imager/core/domain/sources/events";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import { type JSX, Match, Switch } from "solid-js";
+import {
+	type MediaSourceEventTransport,
+	useMediaSourceEvents,
+} from "../hooks/use-media-source-events";
+
+export type MediaDetailScreenProps = {
+	mediaSourceId: string;
+	mediaId: string;
+	mediaDetailsQueryOptions: (mediaSourceId: string, mediaId: string) => unknown;
+	sourceRootPath?: string;
+	onAdditionalInvalidate?: () => Promise<void>;
+	transport: MediaSourceEventTransport;
+	renderMediaViewer: (
+		media: MediaDetails,
+		sourceRootPath?: string,
+	) => JSX.Element;
+	renderMediaSidebar: (
+		media: MediaDetails,
+		isUpdating: boolean,
+		onUpdate: () => void,
+		sourceRootPath?: string,
+	) => JSX.Element;
+};
+
+export function MediaDetailScreen(props: MediaDetailScreenProps) {
+	const queryClient = useQueryClient();
+
+	const mediaDetails = createQuery<MediaDetails>(
+		() =>
+			props.mediaDetailsQueryOptions(props.mediaSourceId, props.mediaId) as any,
+	);
+
+	const handleUpdate = async () => {
+		await queryClient.invalidateQueries({
+			queryKey: ["mediaDetails", props.mediaSourceId, props.mediaId],
+		});
+		if (props.onAdditionalInvalidate) {
+			await props.onAdditionalInvalidate();
+		}
+	};
+
+	useMediaSourceEvents({
+		transport: props.transport,
+		onMediaAdded: () => {
+			void queryClient.invalidateQueries({
+				queryKey: ["media", props.mediaSourceId],
+			});
+		},
+		onMediaDeleted: (data: MediaDeletedEvent) => {
+			void queryClient.invalidateQueries({
+				queryKey: ["media", props.mediaSourceId],
+			});
+			if (
+				data.mediaId === props.mediaId ||
+				data.filePath === mediaDetails.data?.filePath
+			) {
+				void handleUpdate();
+			}
+		},
+		onMediaChanged: (data: MediaChangedEvent) => {
+			void queryClient.invalidateQueries({
+				queryKey: ["media", props.mediaSourceId],
+			});
+			if (
+				data.mediaId === props.mediaId ||
+				data.filePath === mediaDetails.data?.filePath
+			) {
+				void handleUpdate();
+			}
+		},
+		onThumbnailGenerated: (data: ThumbnailGeneratedEvent) => {
+			if (data.mediaId === props.mediaId) {
+				void handleUpdate();
+			}
+		},
+	});
+
+	return (
+		<div class="container mx-auto p-4">
+			<Switch>
+				<Match when={mediaDetails.isError}>
+					<div class="text-red-500">Error: {mediaDetails.error?.message}</div>
+				</Match>
+				<Match when={mediaDetails.data}>
+					{(details) => (
+						<div class="flex h-[calc(100vh-80px)] flex-col gap-4 lg:flex-row">
+							<div class="flex-grow">
+								{props.renderMediaViewer(details(), props.sourceRootPath)}
+							</div>
+							<div class="w-full shrink-0 lg:w-96">
+								{props.renderMediaSidebar(
+									details(),
+									mediaDetails.isRefetching,
+									handleUpdate,
+									props.sourceRootPath,
+								)}
+							</div>
+						</div>
+					)}
+				</Match>
+			</Switch>
+		</div>
+	);
+}

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -1,0 +1,98 @@
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type {
+	Author,
+	MediaSearchRequest,
+} from "@solid-imager/core/domain/media/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import type { Accessor, JSX } from "solid-js";
+import type { MediaSourceEventTransport } from "./hooks/use-media-source-events";
+import {
+	type SourceMediaPageActions,
+	type SourceMediaPagePresetClient,
+	useSourceMediaPage,
+} from "./hooks/use-source-media-page";
+import { MediaListActions } from "./media-list-actions";
+import {
+	SourceMediaScreen,
+	type SourceMediaScreenProps,
+} from "./screens/source-media-screen";
+
+type QueryOptionFactory<_TData> = () => any;
+
+export type SourceMediaPageProps = {
+	mediaSourceId: Accessor<string>;
+	transport: MediaSourceEventTransport;
+	presetClient: SourceMediaPagePresetClient;
+	actions: SourceMediaPageActions;
+	getSearchCondition: () => MediaSearchRequest["condition"];
+	sortBy: () => MediaSearchRequest["sort"];
+	sortOrder: () => "asc" | "desc";
+	onThumbnailReady?: (mediaId: string) => void;
+	tagsQueryOptions: QueryOptionFactory<TagResponse[]>;
+	projectsQueryOptions: QueryOptionFactory<Project[]>;
+	ipsQueryOptions: QueryOptionFactory<Ip[]>;
+	charactersQueryOptions: QueryOptionFactory<Character[]>;
+	authorsQueryOptions: QueryOptionFactory<Author[]>;
+	enableVirtualization?: boolean;
+	moveCopyDialogComponent: SourceMediaScreenProps["moveCopyDialogComponent"];
+	uploadModalComponent: SourceMediaScreenProps["uploadModalComponent"];
+	renderItem: SourceMediaScreenProps["renderItem"];
+	showOpenInNewTab?: boolean;
+};
+
+export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
+	const queryClient = useQueryClient();
+
+	const tags = createQuery<TagResponse[]>(() => props.tagsQueryOptions());
+	const allProjects = createQuery<Project[]>(() =>
+		props.projectsQueryOptions(),
+	);
+	const allIps = createQuery<Ip[]>(() => props.ipsQueryOptions());
+	const allCharacters = createQuery<Character[]>(() =>
+		props.charactersQueryOptions(),
+	);
+	const allAuthors = createQuery<Author[]>(() => props.authorsQueryOptions());
+
+	const page = useSourceMediaPage({
+		mediaSourceId: props.mediaSourceId,
+		queries: {
+			tags: () => tags.data,
+			projects: () => allProjects.data,
+			ips: () => allIps.data,
+			characters: () => allCharacters.data,
+			authors: () => allAuthors.data,
+		},
+		actions: props.actions,
+		queryClient,
+		presetClient: props.presetClient,
+		transport: props.transport,
+		getSearchCondition: props.getSearchCondition,
+		sortBy: props.sortBy,
+		sortOrder: props.sortOrder,
+		onThumbnailReady: props.onThumbnailReady,
+	});
+
+	const renderActions: SourceMediaScreenProps["renderActions"] = () => (
+		<MediaListActions
+			filterData={page.filterData()}
+			onDumpDownload={page.handleDumpDownload}
+			onSearch={page.handleSearch}
+			presetClient={props.presetClient}
+		/>
+	);
+
+	return (
+		<SourceMediaScreen
+			enableVirtualization={props.enableVirtualization}
+			page={page}
+			renderActions={renderActions}
+			renderItem={props.renderItem}
+			moveCopyDialogComponent={props.moveCopyDialogComponent}
+			uploadModalComponent={props.uploadModalComponent}
+			showOpenInNewTab={props.showOpenInNewTab}
+		/>
+	);
+}

--- a/packages/ui/src/upload-media-modal-content.tsx
+++ b/packages/ui/src/upload-media-modal-content.tsx
@@ -1,0 +1,57 @@
+import {
+	UploadMediaModalContent as SharedUploadMediaModalContent,
+	type UploadMediaModalSubmitOptions,
+} from "./upload-media-modal";
+
+type UploadMediaModalContentProps = {
+	isOpen: boolean;
+	onClose: () => void;
+	onUpload: (options: {
+		file: File;
+		filename: string;
+		description: string;
+		sourceUrl?: string;
+		overwrite: boolean;
+		autoIncrement: boolean;
+	}) => Promise<void>;
+	initialFile: File | null;
+	onUrlFetch: (file: File) => void;
+	pastedUrl: string | null;
+	onFetchUrl: (url: string) => Promise<File>;
+};
+
+export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
+	const handleUploadStart = async (options: UploadMediaModalSubmitOptions) => {
+		await Promise.all(
+			options.files.map((file, index) =>
+				props.onUpload({
+					file,
+					filename: index === 0 ? options.filename : file.name,
+					description: options.description,
+					sourceUrl: index === 0 ? options.sourceUrl : undefined,
+					overwrite: options.overwrite,
+					autoIncrement: options.autoIncrement,
+				}),
+			),
+		);
+	};
+
+	return (
+		<SharedUploadMediaModalContent
+			initialFile={props.initialFile}
+			isOpen={props.isOpen}
+			onClose={props.onClose}
+			onFetchUrl={props.onFetchUrl}
+			onFilesSelected={(files) => {
+				const firstFile = files[0];
+				if (firstFile) {
+					props.onUrlFetch(firstFile);
+				}
+			}}
+			onUploadStart={handleUploadStart}
+			pastedUrl={props.pastedUrl}
+		/>
+	);
+}
+
+export { UploadMediaModalContent as UploadMediaModal };


### PR DESCRIPTION
## Summary

This PR extracts duplicated wrapper logic between `apps/server` and `apps/tauri` into shared `packages/ui` components, following the server-tauri-commonization skill guidelines.

### Changes

- **packages/ui/src/media-sidebar-content.tsx**
  - Shared query wiring (`projectsForMedia`, `allProjects`, `allIps`, `allCharacters`)
  - Shared action handlers (`onProjectAdd/Remove/Create`, `onIpAdd/Remove/Create`, `onCharacterAdd/Remove/Create`, `onDescriptionUpdate`)
  - App wrappers thin down to ~20 lines (API client imports + `aiTaggingModal` render prop injection)

- **packages/ui/src/screens/media-detail-screen.tsx**
  - Shared `mediaDetails` query + `useMediaSourceEvents` wiring
  - Shared layout (`MediaViewer` + `MediaSidebar` side-by-side)
  - App-specific components passed via `renderMediaViewer` / `renderMediaSidebar` props
  - Tauri-specific `sourceRootPath` + `onAdditionalInvalidate` supported via optional props

- **packages/ui/src/upload-media-modal-content.tsx**
  - Shared `handleUploadStart` batch mapping logic (previously byte-identical in both apps)
  - App-specific `fetchFileFromUrl` passed via `onFetchUrl` prop

- **packages/ui/src/source-media-page.tsx**
  - Shared `useSourceMediaPage` orchestration + query wiring
  - Shared `renderActions` definition (`MediaListActions`)
  - App wrappers only define transport (`createServerTransport` / `createTauriTransport`)

- **packages/ui/src/preset-client.ts**
  - Shared `createPresetClient` factory (previously byte-identical passthrough in both apps)
  - App wrappers call factory with app-specific `orpc` instance

### Verification

- `packages/ui` tests: 4 passed
- `apps/server` unit tests: 135 passed
- TypeScript typecheck: pass for both `packages/ui` and `apps/server`

### Review Notes

- Server-side naming and behavior is the source of truth.
- App-specific I/O (file loading, transport, modal props) remains in app wrappers.
- `createFileRoute` stays in app route files as required by TanStack Start.