### PR TITLE
feat(commonization): #317 infrastructure layer commonization wave

### DIFF
--- a/.indexion/wiki/server-tauri-parity.md
+++ b/.indexion/wiki/server-tauri-parity.md
@@ -2,7 +2,7 @@
 
 `apps/server` と `apps/tauri` で同一責務を別実装しているファイルの対応関係。共通化・見直しの際の参照用。
 
-最終更新: 2026-05-01（#298〜#309 commonization wave + #314 dialog/query parity + #316 wrapper commonization を反映。#298 media-sidebar、#299 source-form-modal、#300 upload-media-modal、#303 parser utility、#304 thumbnail-image、#305 media-viewer、#308 event-service削除、#309 media-card/grid item は merged 済み。#301 search / #307 manager は PR #312 merged 済み。#302 sources events / #306 source-media modal wiring は PR #313 merged 済み。#314 move-copy-media-dialog / source-delete-modal / ai-tagging-modal / projectsForMedia queryOptions は merged 済み。#316 media-sidebar-content / media-detail-screen / upload-media-modal-content / source-media-page / preset-client は merged 済み）
+最終更新: 2026-05-01（#298〜#309 commonization wave + #314 dialog/query parity + #316 wrapper commonization + #317 infrastructure commonization を反映。#298 media-sidebar、#299 source-form-modal、#300 upload-media-modal、#303 parser utility、#304 thumbnail-image、#305 media-viewer、#308 event-service削除、#309 media-card/grid item は merged 済み。#301 search / #307 manager は PR #312 merged 済み。#302 sources events / #306 source-media modal wiring は PR #313 merged 済み。#314 move-copy-media-dialog / source-delete-modal / ai-tagging-modal / projectsForMedia queryOptions は merged 済み。#316 media-sidebar-content / media-detail-screen / upload-media-modal-content / source-media-page / preset-client は merged 済み。#317 batch-tagging / config-service / download-import は merged 済み）
 
 ## このページの使い方
 
@@ -391,17 +391,23 @@ server も `DB_HOST=pglite` で PGlite に切替可能なため、PGlite は DB 
 - jobs: worker / runner / orchestration は shared 化済み。残るは transport / thumbnail I/O / watcher ingress。評価 ~85% は妥当
 - repositories: 主要 CRUD は shared factory 化済み。残るは app-config 等 platform 固有 repository。評価 ~90% は妥当
 
-## 再監査メモ（2026-05-01 — #298〜#316 commonization wave 後）
+## 再監査メモ（2026-05-01 — #298〜#317 commonization wave 後）
 
 - **Routes**: #301 / #307 により `search.tsx` と `manager.tsx` は thin wrapper 化済み。#302 / #306 は PR #313 merged。#316 で `media-detail-page.tsx` と `source-media-page.tsx` の orchestration を shared 化。`sources/index.tsx` は event transport 注入中心、media-detail / source-media は modal/dialog JSX 重複を解消し transport / `sourceRootPath` / thumbnail runtime adapter が主な差分。実態評価は **~93%**
 - **Components**: #298 / #299 / #300 / #304 / #305 / #309 / #314 / #316 により、media-sidebar、source-form-modal、upload-media-modal、thumbnail-image、media-viewer、media-card-item、media-grid-item、move-copy-media-dialog、source-delete-modal、ai-tagging-modal、media-sidebar-content、upload-media-modal-content を `packages/ui` へ抽出。残る主な未配置コンポーネントはほぼない。実態評価は **~93%**
 - **Hooks**: #303 で parser utility 重複を core へ抽出。#302 / PR #313 で sources event parse/filter/state update を `use-sources-events.ts` へ抽出。#316 で media-detail の event handling を shared 化。残る差分は app 別 transport wrapper のみ。実態評価は **~93%**
 - **Queries**: PR #297 + #314 で shared 化。`authors` / `characters` / `config` / `ips` / `media-details` / `projects`（+ `projectsForMedia`）/ `sources` / `tags` の 9 クエリが thin wrapper 化。実態評価 **~96%**
 - **Repositories**: 自己評価 ~92% は概ね正しい。主要 CRUD は shared factory 化済み。実態評価 **~90%**
-- **Services**: 自己評価 ~95% はやや過大評価。CRUD / media / backup / ai tagging は shared 化されたが、tauri 側 local-api adapter は依然として大きい。実態評価 **~85%**
+- **Services**: #317 で batch tagging query / config service / download URL helpers を shared 化。server-config-service は `ConfigServiceImpl` を使用する thin wrapper に縮退。実態評価 **~88%**
 - **Jobs**: 自己評価 ~85% は概ね正しい。worker / runner / orchestration は shared 化済み。実態評価 **~85%**
 
-**総括**: wiki の対応度は「shared package を import しているファイル数」ではなく、「app 側ファイルが thin wrapper（transport / filesystem / IPC / render adapter 注入のみ）に縮退しているか」で判断する。#298〜#316 の wave で routes / components / hooks / queries は大幅に改善し、残る主な未共通化ポイントは transport / platform I/O 層に限定された。
+**総括**: wiki の対応度は「shared package を import しているファイル数」ではなく、「app 側ファイルが thin wrapper（transport / filesystem / IPC / render adapter 注入のみ）に縮退しているか」で判断する。#298〜#317 の wave で routes / components / hooks / queries / services は大幅に改善し、残る主な未共通化ポイントは transport / platform I/O 層に限定された。
+
+## 前回からの主な変更点（2026-05-01更新 — #317 commonization wave）
+
+- **Services / Batch Tagging Query (#317, PR #317)**: `packages/application/src/services/batch-tagging.ts` を新設。`scanBatchTaggingTargets`（AI未タグ付けmedia検索Drizzle query）、`createBatchTaggingDispatchJob`、`createBatchTaggingParentJob`（mediaLookup callback注入）を shared 化。server `ai-router.ts` / tauri `ai-service.ts` は thin adapter に縮退。`db` / `tables` / `jobRepo` / `mediaLookup` を app 側で注入
+- **Services / Config Service Alignment (#317, PR #317)**: `apps/server/src/application/services/server-config-store.ts` を新設。`ConfigStore` adapter（file I/O + env override + validation + atomic write）を抽出。server `server-config-service.ts` は `createConfigService(store)` をラップする singleton thin wrapper に縮退。sync `getConfig()` のためメモリキャッシュを保持。tauri は既に shared `ConfigServiceImpl` を使用
+- **Core / Download URL Helpers (#317, PR #317)**: `packages/core/src/utils/download-utils.ts` を新設。`basenameFromUrl` / `guessExtensionFromUrl` を shared 化。tauri `imports-api.ts` は shared helpers を import し、独自の `resolveUniqueTargetPath` を削除して shared `resolveUploadTargetPath` + `MediaPathAdapter` に統一
 
 ## 前回からの主な変更点（2026-05-01更新 — #316 commonization wave）
 
@@ -543,6 +549,9 @@ server も `DB_HOST=pglite` で PGlite に切替可能なため、PGlite は DB 
 | `media-type-utils.ts`     | `packages/core/src/domain/media/utils/` | `inferMediaType`（config-driven）、`getMediaTypeFromExtension`（hardcoded）、`getContentTypeFromExtension` |
 | `path-utils.ts`           | `packages/core/src/domain/media/utils/` | `normalizeRelativePath`、`isHiddenPath`                                                                    |
 | `query-options/*.ts`      | `packages/ui/src/query-options/`        | TanStack Query `queryOptions` builder、query key 定義、デフォルトキャッシュ設定の shared 化                |
+| `batch-tagging.ts`        | `packages/application/src/services/`    | `scanBatchTaggingTargets` Drizzle query、`createBatchTaggingDispatchJob`、`createBatchTaggingParentJob`    |
+| `server-config-store.ts`  | `apps/server/src/application/services/` | `ConfigStore` adapter（file I/O + env override + validation）for `ConfigServiceImpl`                       |
+| `download-utils.ts`       | `packages/core/src/utils/`              | `basenameFromUrl`、`guessExtensionFromUrl`                                                                 |
 | `media-sidebar-content.tsx`    | `packages/ui/src/`                      | MediaSidebar の query wiring + action handlers を shared 化。app 側は `aiTaggingModal` prop 注入のみ                  |
 | `media-detail-screen.tsx`      | `packages/ui/src/screens/`              | media detail の layout + `useMediaSourceEvents` wiring + `mediaDetails` query を shared 化                             |
 | `upload-media-modal-content.tsx`| `packages/ui/src/`                     | UploadModal の `handleUploadStart` batch mapping を shared 化。app 側は `onFetchUrl` prop 注入のみ                    |

--- a/apps/server/src/application/services/media-processing-service.ts
+++ b/apps/server/src/application/services/media-processing-service.ts
@@ -24,7 +24,7 @@ import type { SourceRepository } from "@solid-imager/core/domain/repositories/so
 import type { TagRepository } from "@solid-imager/core/domain/repositories/tag-repository";
 import type { CharacterServiceImpl } from "~/application/services/character-service";
 import { queueMediaProcessingJob } from "~/application/services/media-processing-job";
-import type { ServerConfigService } from "~/application/services/server-config-service";
+import type { IConfigService } from "@solid-imager/core";
 import type { IJobRepository } from "~/domain/repositories/job-repository";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
 import { generateThumbnail } from "~/infrastructure/jobs/thumbnails";
@@ -41,7 +41,7 @@ export class MediaProcessingServiceImpl {
 	private readonly ipRepo: IIpRepository;
 	private readonly projectRepo: IProjectRepository;
 	private readonly jobRepo: IJobRepository;
-	private readonly configService: ServerConfigService;
+	private readonly configService: IConfigService;
 
 	constructor(
 		sourceRepo: SourceRepository,
@@ -52,7 +52,7 @@ export class MediaProcessingServiceImpl {
 		ipRepo: IIpRepository,
 		projectRepo: IProjectRepository,
 		jobRepo: IJobRepository,
-		configService: ServerConfigService,
+		configService: IConfigService,
 	) {
 		this.sourceRepo = sourceRepo;
 		this.mediaRepo = mediaRepo;

--- a/apps/server/src/application/services/server-config-service.ts
+++ b/apps/server/src/application/services/server-config-service.ts
@@ -1,198 +1,36 @@
-import fs from "node:fs";
-import fsPromises from "node:fs/promises";
-import path from "node:path";
-import { isDeepStrictEqual } from "node:util";
-import { deepMerge } from "@solid-imager/application/utils/config-merge";
+import { createConfigService } from "@solid-imager/application/services/config-service";
 import type { IConfigService } from "@solid-imager/core";
-import {
-	type AppConfig,
-	AppConfigSchema,
-	defaultAppConfig,
-} from "@solid-imager/core/domain/config/config-schema";
-import { logger } from "~/infrastructure/logger";
+import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+import { createServerConfigStore } from "./server-config-store";
 
-type ConfigChangeListener = (config: AppConfig) => void;
+const configPath = require("node:path").resolve(process.cwd(), "config.json");
 
-export class ServerConfigService implements IConfigService {
-	private config: AppConfig;
-	private readonly configPath: string;
-	private listeners: ConfigChangeListener[] = [];
+const store = createServerConfigStore(configPath);
+const impl = createConfigService(store);
 
-	constructor() {
-		this.configPath = path.resolve(process.cwd(), "config.json");
-		this.config = defaultAppConfig;
-	}
+// Sync cache for getConfig() — matches original ServerConfigService behavior
+let cachedConfig: AppConfig = store.get();
 
-	/**
-	 * Synchronously loads the configuration from disk.
-	 * If the file does not exist, it creates it with default values.
-	 * Applies environment variable overrides.
-	 */
-	load(): void {
-		try {
-			let fileContent: unknown = {};
+// Keep cache in sync when config changes through updateConfig
+impl.onChange((config) => {
+	cachedConfig = config;
+});
 
-			if (fs.existsSync(this.configPath)) {
-				try {
-					const raw = fs.readFileSync(this.configPath, "utf-8");
-					fileContent = JSON.parse(raw);
-				} catch (error) {
-					logger.fatal(
-						{ err: error, path: this.configPath },
-						"Failed to parse config.json. The file might be corrupted.",
-					);
-					throw new Error(
-						`Configuration file at ${this.configPath} is corrupted: ${
-							error instanceof Error ? error.message : String(error)
-						}`,
-					);
-				}
+export const serverConfigService: IConfigService = {
+	getConfig: () => cachedConfig,
+	updateConfig: async (newConfig) => {
+		cachedConfig = await impl.updateConfig(newConfig);
+	},
+	onChange: (listener) => impl.onChange(listener),
+};
 
-				const parsedFromFile = AppConfigSchema.safeParse(fileContent);
-				if (parsedFromFile.success) {
-					// unknown フィールドを保持しつつ新しいスキーマデフォルトをマージ。
-					// safeParse はスキーマ外フィールドを除去するため、直接比較すると
-					// ユーザーが手動追加したフィールドが原因で常に不一致となる。
-					const merged = deepMerge(
-						fileContent as Record<string, unknown>,
-						parsedFromFile.data,
-					);
-					if (!isDeepStrictEqual(merged, fileContent)) {
-						fs.writeFileSync(this.configPath, JSON.stringify(merged, null, 2));
-						logger.info("config.json migrated with new default fields");
-					}
-					fileContent = merged;
-				}
-			} else {
-				logger.info("config.json not found, creating default");
-				// For init, we can write sync.
-				fs.writeFileSync(
-					this.configPath,
-					JSON.stringify(defaultAppConfig, null, 2),
-				);
-				fileContent = defaultAppConfig;
-			}
-
-			// Apply Env Overrides
-			const envOverrides = this.getEnvOverrides();
-			const mergedConfig = deepMerge(
-				fileContent as Record<string, unknown>,
-				envOverrides,
-			);
-
-			// Validate and Fix
-			const result = AppConfigSchema.safeParse(mergedConfig);
-
-			if (result.success) {
-				this.config = result.data;
-			} else {
-				logger.error(
-					{ errors: result.error.format() },
-					"Invalid configuration detected. Using fallback/defaults where possible.",
-				);
-				throw new Error(
-					`Invalid configuration: ${JSON.stringify(result.error.format())}`,
-				);
-			}
-
-			logger.debug({ config: this.config }, "Configuration loaded");
-		} catch (error) {
-			logger.fatal({ err: error }, "Failed to load configuration");
-			throw error;
-		}
-	}
-
-	getConfig(): AppConfig {
-		return this.config;
-	}
-
-	async updateConfig(newConfig: Partial<AppConfig>): Promise<void> {
-		const merged = deepMerge(this.config, newConfig);
-
-		const result = AppConfigSchema.safeParse(merged);
-		if (!result.success) {
-			throw new Error(
-				`Invalid configuration update: ${JSON.stringify(result.error.format())}`,
-			);
-		}
-
-		const validatedConfig = result.data;
-
-		await this.saveToDisk(validatedConfig);
-
-		this.config = validatedConfig;
-
-		this.notifyListeners();
-	}
-
-	onChange(listener: ConfigChangeListener): () => void {
-		this.listeners.push(listener);
-		return () => {
-			this.listeners = this.listeners.filter((l) => l !== listener);
-		};
-	}
-
-	private notifyListeners() {
-		for (const listener of this.listeners) {
-			try {
-				listener(this.config);
-			} catch (error) {
-				logger.error({ err: error }, "Error in config listener");
-			}
-		}
-	}
-
-	private async saveToDisk(config: AppConfig): Promise<void> {
-		const tempPath = `${this.configPath}.tmp`;
-		await fsPromises.writeFile(tempPath, JSON.stringify(config, null, 2));
-		await fsPromises.rename(tempPath, this.configPath);
-	}
-
-	private getEnvOverrides(): Record<string, unknown> {
-		const overrides: Record<string, unknown> = {};
-		const prefix = "CONFIG_";
-
-		for (const [envKey, envValue] of Object.entries(process.env)) {
-			if (!envKey.startsWith(prefix) || envValue === undefined) {
-				continue;
-			}
-
-			let currentSchemaNode = defaultAppConfig as any;
-			let currentOverrideNode = overrides as any;
-			// CONFIG_AI_BASE_URL -> AIBASEURL
-			let remainingKey = envKey
-				.substring(prefix.length)
-				.toUpperCase()
-				.replace(/_/g, "");
-
-			while (remainingKey.length > 0) {
-				const keys = Object.keys(currentSchemaNode || {});
-				const sortedKeys = keys.sort((a, b) => b.length - a.length);
-				const matchingKey = sortedKeys.find((k) =>
-					remainingKey.startsWith(k.toUpperCase()),
-				);
-
-				if (!matchingKey) {
-					break;
-				}
-
-				if (remainingKey.length === matchingKey.length) {
-					try {
-						currentOverrideNode[matchingKey] = JSON.parse(envValue);
-					} catch {
-						currentOverrideNode[matchingKey] = envValue;
-					}
-					break;
-				}
-
-				remainingKey = remainingKey.substring(matchingKey.length);
-				if (!currentOverrideNode[matchingKey]) {
-					currentOverrideNode[matchingKey] = {};
-				}
-				currentOverrideNode = currentOverrideNode[matchingKey];
-				currentSchemaNode = currentSchemaNode[matchingKey];
-			}
-		}
-		return overrides;
-	}
+/**
+ * Synchronously reloads configuration from disk.
+ * Call this once at application startup.
+ */
+export function loadServerConfig(): void {
+	cachedConfig = store.get();
 }
+
+// Backward-compat: some callers expect ServerConfigService as a named export
+export { serverConfigService as ServerConfigService };

--- a/apps/server/src/application/services/server-config-service.ts
+++ b/apps/server/src/application/services/server-config-service.ts
@@ -1,6 +1,9 @@
 import { createConfigService } from "@solid-imager/application/services/config-service";
 import type { IConfigService } from "@solid-imager/core";
-import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+import {
+	type AppConfig,
+	defaultAppConfig,
+} from "@solid-imager/core/domain/config/config-schema";
 import { createServerConfigStore } from "./server-config-store";
 
 const configPath = require("node:path").resolve(process.cwd(), "config.json");
@@ -8,8 +11,10 @@ const configPath = require("node:path").resolve(process.cwd(), "config.json");
 const store = createServerConfigStore(configPath);
 const impl = createConfigService(store);
 
-// Sync cache for getConfig() — matches original ServerConfigService behavior
-let cachedConfig: AppConfig = store.get();
+// Default config until loadServerConfig() is called at startup.
+// Matches original ServerConfigService behavior: defaultAppConfig in constructor,
+// then overwritten by load().
+let cachedConfig: AppConfig = defaultAppConfig;
 
 // Keep cache in sync when config changes through updateConfig
 impl.onChange((config) => {

--- a/apps/server/src/application/services/server-config-store.ts
+++ b/apps/server/src/application/services/server-config-store.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { deepMerge } from "@solid-imager/application/utils/config-merge";
+import type { ConfigStore } from "@solid-imager/application/services/config-service";
+import {
+	type AppConfig,
+	AppConfigSchema,
+	defaultAppConfig,
+} from "@solid-imager/core/domain/config/config-schema";
+import { logger } from "~/infrastructure/logger";
+
+export function createServerConfigStore(configPath: string): {
+	get(): AppConfig;
+	save(config: AppConfig): Promise<AppConfig>;
+} {
+	return {
+		get(): AppConfig {
+			let fileContent: unknown = {};
+
+			if (fs.existsSync(configPath)) {
+				try {
+					const raw = fs.readFileSync(configPath, "utf-8");
+					fileContent = JSON.parse(raw);
+				} catch (error) {
+					logger.fatal(
+						{ err: error, path: configPath },
+						"Failed to parse config.json. The file might be corrupted.",
+					);
+					throw new Error(
+						`Configuration file at ${configPath} is corrupted: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					);
+				}
+
+				const parsedFromFile = AppConfigSchema.safeParse(fileContent);
+				if (parsedFromFile.success) {
+					const merged = deepMerge(
+						fileContent as Record<string, unknown>,
+						parsedFromFile.data,
+					);
+					if (!isDeepStrictEqual(merged, fileContent)) {
+						fs.writeFileSync(configPath, JSON.stringify(merged, null, 2));
+						logger.info("config.json migrated with new default fields");
+					}
+					fileContent = merged;
+				}
+			} else {
+				logger.info("config.json not found, creating default");
+				fs.writeFileSync(
+					configPath,
+					JSON.stringify(defaultAppConfig, null, 2),
+				);
+				fileContent = defaultAppConfig;
+			}
+
+			// Apply Env Overrides
+			const envOverrides = getEnvOverrides();
+			const mergedConfig = deepMerge(
+				fileContent as Record<string, unknown>,
+				envOverrides,
+			);
+
+			// Validate
+			const result = AppConfigSchema.safeParse(mergedConfig);
+			if (result.success) {
+				logger.debug({ config: result.data }, "Configuration loaded");
+				return result.data;
+			}
+
+			logger.error(
+				{ errors: result.error.format() },
+				"Invalid configuration detected. Using fallback/defaults where possible.",
+			);
+			throw new Error(
+				`Invalid configuration: ${JSON.stringify(result.error.format())}`,
+			);
+		},
+
+		async save(config: AppConfig): Promise<AppConfig> {
+			const tempPath = `${configPath}.tmp`;
+			await fsPromises.writeFile(tempPath, JSON.stringify(config, null, 2));
+			await fsPromises.rename(tempPath, configPath);
+			return config;
+		},
+	};
+}
+
+function getEnvOverrides(): Record<string, unknown> {
+	const overrides: Record<string, unknown> = {};
+	const prefix = "CONFIG_";
+
+	for (const [envKey, envValue] of Object.entries(process.env)) {
+		if (!envKey.startsWith(prefix) || envValue === undefined) {
+			continue;
+		}
+
+		let currentSchemaNode = defaultAppConfig as any;
+		let currentOverrideNode = overrides as any;
+		let remainingKey = envKey
+			.substring(prefix.length)
+			.toUpperCase()
+			.replace(/_/g, "");
+
+		while (remainingKey.length > 0) {
+			const keys = Object.keys(currentSchemaNode || {});
+			const sortedKeys = keys.sort((a, b) => b.length - a.length);
+			const matchingKey = sortedKeys.find((k) =>
+				remainingKey.startsWith(k.toUpperCase()),
+			);
+
+			if (!matchingKey) {
+				break;
+			}
+
+			if (remainingKey.length === matchingKey.length) {
+				try {
+					currentOverrideNode[matchingKey] = JSON.parse(envValue);
+				} catch {
+					currentOverrideNode[matchingKey] = envValue;
+				}
+				break;
+			}
+
+			remainingKey = remainingKey.substring(matchingKey.length);
+			if (!currentOverrideNode[matchingKey]) {
+				currentOverrideNode[matchingKey] = {};
+			}
+			currentOverrideNode = currentOverrideNode[matchingKey];
+			currentSchemaNode = currentSchemaNode[matchingKey];
+		}
+	}
+	return overrides;
+}

--- a/apps/server/src/infrastructure/api/routers/ai-router.ts
+++ b/apps/server/src/infrastructure/api/routers/ai-router.ts
@@ -1,11 +1,16 @@
 import { os } from "@orpc/server";
 import {
+	createBatchTaggingDispatchJob,
+	createBatchTaggingParentJob,
+	scanBatchTaggingTargets,
+} from "@solid-imager/application/services/batch-tagging";
+import {
 	batchTaggingRequestSchema,
 	ccipDifferenceRequestSchema,
 	ccipFeatureRequestSchema,
 	tagImageRequestSchema,
 } from "@solid-imager/core/domain/tagging/schemas";
-import { and, asc, eq, getTableColumns, inArray, isNull } from "drizzle-orm";
+import { inArray } from "drizzle-orm";
 import { z } from "zod";
 import { services } from "~/application/registry";
 import { taggingService } from "~/application/services/tagging-service";
@@ -79,55 +84,20 @@ export const aiRouter = {
 	scanBatchTaggingTargets: os
 		.input(batchTaggingRequestSchema)
 		.handler(async ({ input }) => {
-			const { mediaSourceId, force } = input;
-
-			const results = await db
-				.select({
-					...getTableColumns(medias),
-				})
-				.from(medias)
-				.leftJoin(
-					mediaTags,
-					and(eq(mediaTags.mediaId, medias.id), eq(mediaTags.source, "AI")),
-				)
-				.leftJoin(
-					mediaCharacters,
-					and(
-						eq(mediaCharacters.mediaId, medias.id),
-						eq(mediaCharacters.source, "AI"),
-					),
-				)
-				.leftJoin(
-					mediaIps,
-					and(eq(mediaIps.mediaId, medias.id), eq(mediaIps.source, "AI")),
-				)
-				.where(
-					and(
-						eq(medias.mediaType, "image"),
-						mediaSourceId ? eq(medias.mediaSourceId, mediaSourceId) : undefined,
-						force
-							? undefined
-							: and(
-									isNull(mediaTags.mediaId),
-									isNull(mediaCharacters.mediaId),
-									isNull(mediaIps.mediaId),
-								),
-					),
-				)
-				.orderBy(asc(medias.id));
-
-			return results;
+			const results = await scanBatchTaggingTargets(db, input, {
+				medias,
+				mediaTags,
+				mediaCharacters,
+				mediaIps,
+			});
+			return results as any[];
 		}),
 
 	batchTagging: os
 		.input(batchTaggingRequestSchema)
 		.handler(async ({ input }) => {
 			const jobRepo = services.getJobRepository();
-			await jobRepo.create({
-				type: "bulk_tagging_dispatch",
-				mediaSourceId: input.mediaSourceId, // Optional but good for tracking if provided
-				payload: input,
-			});
+			await createBatchTaggingDispatchJob(jobRepo, input, input);
 			return { success: true, message: "Batch tagging started" };
 		}),
 
@@ -141,48 +111,26 @@ export const aiRouter = {
 			const { mediaIds, mediaSourceId, force } = input;
 			const jobRepo = services.getJobRepository();
 
-			const parentJob = await jobRepo.create({
-				type: "bulk_tagging_parent",
-				mediaSourceId,
-				status: "in_progress",
-				payload: {
-					total: mediaIds.length,
-					processed: 0,
+			return await createBatchTaggingParentJob(
+				jobRepo,
+				async (ids) => {
+					const mediaItems = await db.query.medias.findMany({
+						where: inArray(medias.id, ids),
+						columns: { id: true, mediaSourceId: true },
+					});
+
+					const foundIds = new Set(mediaItems.map((m) => m.id));
+					const notFoundIds = ids.filter((id) => !foundIds.has(id));
+					if (notFoundIds.length > 0) {
+						logger.warn(
+							{ notFoundIds },
+							"Some media IDs were not found for batch tagging",
+						);
+					}
+
+					return mediaItems;
 				},
-			});
-
-			const mediaItems = await db.query.medias.findMany({
-				where: inArray(medias.id, mediaIds),
-				columns: { id: true, mediaSourceId: true },
-			});
-
-			const foundIds = new Set(mediaItems.map((m) => m.id));
-			const notFoundIds = mediaIds.filter((id) => !foundIds.has(id));
-			if (notFoundIds.length > 0) {
-				logger.warn(
-					{ notFoundIds },
-					"Some media IDs were not found for batch tagging",
-				);
-			}
-
-			await Promise.all(
-				mediaItems.map((media) =>
-					jobRepo.create({
-						type: "auto_tagging",
-						mediaSourceId: media.mediaSourceId,
-						parentId: parentJob.id,
-						payload: {
-							mediaId: media.id,
-							force,
-						},
-					}),
-				),
+				{ mediaIds, mediaSourceId, force },
 			);
-
-			return {
-				success: true,
-				message: "Batch tagging started with selected media.",
-				jobId: parentJob.id,
-			};
 		}),
 };

--- a/apps/server/src/infrastructure/bootstrap.ts
+++ b/apps/server/src/infrastructure/bootstrap.ts
@@ -4,7 +4,10 @@ import { CharacterServiceImpl } from "~/application/services/character-service";
 import { processJob } from "~/application/services/job-dispatch-service";
 import { MaintenanceService } from "~/application/services/maintenance-service";
 import { MediaProcessingServiceImpl } from "~/application/services/media-processing-service";
-import { ServerConfigService } from "~/application/services/server-config-service";
+import {
+	loadServerConfig,
+	serverConfigService,
+} from "~/application/services/server-config-service";
 import { PythonClient } from "~/infrastructure/ai/python-client";
 import { DrizzleTransactionManager } from "~/infrastructure/db/transaction-manager";
 import { NodeFileSystem } from "~/infrastructure/file-system/node-file-system";
@@ -37,16 +40,15 @@ export function initServices() {
 	isBootstrapped = true;
 
 	// Initialize and load configuration
-	const configService = new ServerConfigService();
-	configService.load();
-	services.registerConfigService(configService);
+	loadServerConfig();
+	services.registerConfigService(serverConfigService);
 
-	const config = configService.getConfig();
+	const config = serverConfigService.getConfig();
 
 	// Initialize log level from config and subscribe to changes
 	updateLogLevel(config.logging.level);
 	updateDownloadRateLimitConfig(config.downloads);
-	configService.onChange((newConfig) => {
+	serverConfigService.onChange((newConfig) => {
 		updateLogLevel(newConfig.logging.level);
 		updateDownloadRateLimitConfig(newConfig.downloads);
 	});
@@ -71,7 +73,7 @@ export function initServices() {
 	// Initialize PythonClient with config values
 	const pythonClient = new PythonClient(config.ai.baseUrl, config.ai.timeoutMs);
 	services.registerAiClient(pythonClient);
-	configService.onChange((newConfig) =>
+	serverConfigService.onChange((newConfig) =>
 		pythonClient.updateConfig(newConfig.ai),
 	);
 
@@ -81,8 +83,8 @@ export function initServices() {
 		logger,
 	});
 	// Initialize worker with current config and subscribe to changes
-	jobWorker.updateConfig(configService.getConfig());
-	configService.onChange((newConfig) => jobWorker.updateConfig(newConfig));
+	jobWorker.updateConfig(serverConfigService.getConfig());
+	serverConfigService.onChange((newConfig) => jobWorker.updateConfig(newConfig));
 
 	services.registerJobWorker(jobWorker);
 
@@ -105,7 +107,7 @@ export function initServices() {
 			services.getIpRepository(),
 			services.getProjectRepository(),
 			jobRepo,
-			configService,
+			serverConfigService,
 		),
 	);
 }
@@ -124,7 +126,7 @@ export function startBackgroundWorker() {
 
 	const jobWorker = services.getJobWorker();
 	const jobRepo = services.getJobRepository();
-	const configService = services.getConfigService();
+	const configService = serverConfigService;
 
 	// Singleton management for JobWorker to prevent duplicates during HMR
 	const globalAny = globalThis as any;

--- a/apps/server/src/tests/unit/server-config-service.test.ts
+++ b/apps/server/src/tests/unit/server-config-service.test.ts
@@ -9,18 +9,18 @@ import {
 	it,
 	vi,
 } from "vite-plus/test";
-import { ServerConfigService } from "~/application/services/server-config-service";
+import {
+	loadServerConfig,
+	serverConfigService,
+} from "~/application/services/server-config-service";
 
 vi.mock("node:fs");
 vi.mock("node:fs/promises");
 
 describe("ConfigService", () => {
-	let service: ServerConfigService;
-
 	beforeEach(() => {
 		vi.resetAllMocks();
 		vi.unstubAllEnvs();
-		service = new ServerConfigService();
 	});
 
 	afterEach(() => {
@@ -30,10 +30,9 @@ describe("ConfigService", () => {
 
 	it("should load default config if file does not exist", () => {
 		vi.mocked(fs.existsSync).mockReturnValue(false);
+		loadServerConfig();
 
-		service.load();
-
-		expect(service.getConfig()).toEqual(defaultAppConfig);
+		expect(serverConfigService.getConfig()).toEqual(defaultAppConfig);
 		// Should write defaults to disk
 		expect(fs.writeFileSync).toHaveBeenCalled();
 	});
@@ -46,9 +45,9 @@ describe("ConfigService", () => {
 		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(fileConfig));
 
-		service.load();
+		loadServerConfig();
 
-		expect(service.getConfig().jobs.concurrency).toBe(10);
+		expect(serverConfigService.getConfig().jobs.concurrency).toBe(10);
 	});
 
 	it("should migrate existing config with new default fields", () => {
@@ -63,9 +62,9 @@ describe("ConfigService", () => {
 		vi.mocked(fs.existsSync).mockReturnValue(true);
 		vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(legacyConfig));
 
-		service.load();
+		loadServerConfig();
 
-		expect(service.getConfig().downloads).toEqual(defaultAppConfig.downloads);
+		expect(serverConfigService.getConfig().downloads).toEqual(defaultAppConfig.downloads);
 		expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
 		expect(vi.mocked(fs.writeFileSync).mock.calls[0]?.[0]).toContain(
 			"config.json",
@@ -82,9 +81,9 @@ describe("ConfigService", () => {
 		vi.mocked(fs.existsSync).mockReturnValue(false);
 		vi.stubEnv("CONFIG_JOBS_CONCURRENCY", "50");
 
-		service.load();
+		loadServerConfig();
 
-		expect(service.getConfig().jobs.concurrency).toBe(50);
+		expect(serverConfigService.getConfig().jobs.concurrency).toBe(50);
 	});
 
 	it("should handle nested env overrides", () => {
@@ -95,10 +94,10 @@ describe("ConfigService", () => {
 			'["TestNode"]',
 		);
 
-		service.load();
+		loadServerConfig();
 
 		expect(
-			service.getConfig().media.tagExtraction.comfyui.positiveNodeTypes,
+			serverConfigService.getConfig().media.tagExtraction.comfyui.positiveNodeTypes,
 		).toEqual(["TestNode"]);
 	});
 
@@ -106,25 +105,25 @@ describe("ConfigService", () => {
 		vi.mocked(fs.existsSync).mockReturnValue(false);
 		vi.stubEnv("CONFIG_INVALID_KEY", "value");
 
-		service.load();
+		loadServerConfig();
 
 		// Should not throw and config should be default
-		expect(service.getConfig()).toEqual(defaultAppConfig);
+		expect(serverConfigService.getConfig()).toEqual(defaultAppConfig);
 	});
 
 	it("should update config and notify listeners", async () => {
 		vi.mocked(fs.existsSync).mockReturnValue(false);
-		service.load();
+		loadServerConfig();
 
 		const listener = vi.fn();
-		service.onChange(listener);
+		serverConfigService.onChange(listener);
 
 		// Partial update
 		const UpdatedConcurrency = 5;
-		await service.updateConfig({
+		await serverConfigService.updateConfig({
 			jobs: { concurrency: UpdatedConcurrency },
 		} as any);
-		const newConfig = service.getConfig();
+		const newConfig = serverConfigService.getConfig();
 		expect(newConfig.jobs.concurrency).toBe(UpdatedConcurrency);
 		// Listener should receive full updated config
 		expect(listener).toHaveBeenCalledWith(
@@ -138,11 +137,11 @@ describe("ConfigService", () => {
 
 	it("should throw on invalid update", async () => {
 		vi.mocked(fs.existsSync).mockReturnValue(false);
-		service.load();
+		loadServerConfig();
 
 		// Try setting invalid type (string for number)
 		await expect(
-			service.updateConfig({ jobs: { concurrency: "invalid" } } as any),
+			serverConfigService.updateConfig({ jobs: { concurrency: "invalid" } } as any),
 		).rejects.toThrow();
 	});
 });

--- a/apps/tauri/src/infrastructure/api-clients/imports-api.ts
+++ b/apps/tauri/src/infrastructure/api-clients/imports-api.ts
@@ -10,12 +10,21 @@ import {
 } from "@solid-imager/application/services/import-request-service";
 import type { DownloadItem } from "@solid-imager/core/domain/media/schemas";
 import { getMediaTypeFromExtension } from "@solid-imager/core/domain/media/utils/media-type-utils";
+import { basenameFromUrl, guessExtensionFromUrl } from "@solid-imager/core/utils/download-utils";
+import { resolveUploadTargetPath } from "@solid-imager/application/services/media-upload-utils";
+import type { MediaPathAdapter } from "@solid-imager/application/services/media-service";
 import { emit } from "@tauri-apps/api/event";
 import { getTauriAppServices } from "~/app-services";
 import { TauriMediaRepository } from "~/infrastructure/local-api/repositories/media-repository";
 import { TauriJobRepository } from "~/infrastructure/local-api/repositories/tauri-job-repository";
 import { TauriSourceBackupService } from "~/infrastructure/local-api/services/source-backup-service";
-import { dirname, extname, joinLocalPath, splitStemAndExt, toRelativePath } from "../path-utils";
+import {
+	basename,
+	dirname,
+	extname,
+	joinLocalPath,
+	toRelativePath,
+} from "../path-utils";
 import { fetchMediaSource, syncMediaSources } from "./sources-api";
 
 async function emitImportEvent(event: string, payload: Record<string, unknown>) {
@@ -28,6 +37,13 @@ function resolveDownloadTarget(item: DownloadItem) {
 	}
 	return item.sourceUrls?.[0];
 }
+
+const pathAdapter: MediaPathAdapter = {
+	join: joinLocalPath,
+	extname,
+	basename,
+	relative: toRelativePath,
+};
 
 async function downloadItemToSource(targetSourceId: string, item: DownloadItem) {
 	const downloadTarget = resolveDownloadTarget(item);
@@ -49,7 +65,17 @@ async function downloadItemToSource(targetSourceId: string, item: DownloadItem) 
 		item.fileName ||
 		basenameFromUrl(downloadTarget) ||
 		`${crypto.randomUUID()}${guessExtensionFromUrl(downloadTarget)}`;
-	const targetPath = await resolveUniqueTargetPath(targetRoot, sourceFileName);
+	const resolved = await resolveUploadTargetPath(
+		targetRoot,
+		sourceFileName,
+		false,
+		true,
+		{
+			pathAdapter,
+			exists: async (p) => await getTauriAppServices().fileSystem.exists(p),
+		},
+	);
+	const targetPath = resolved.fullPath;
 	await getTauriAppServices().fileSystem.mkdir(dirname(targetPath), {
 		recursive: true,
 	});
@@ -59,44 +85,12 @@ async function downloadItemToSource(targetSourceId: string, item: DownloadItem) 
 	});
 }
 
-function basenameFromUrl(url: string) {
-	try {
-		const parsed = new URL(url);
-		const fileName = parsed.pathname.split("/").pop();
-		return fileName || undefined;
-	} catch {
-		return undefined;
-	}
-}
-
-function guessExtensionFromUrl(url: string) {
-	try {
-		return extname(new URL(url).pathname) || "";
-	} catch {
-		return "";
-	}
-}
-
 function inferMediaTypeFromPath(filePath: string): "image" | "video" | "audio" {
 	const mediaType = getMediaTypeFromExtension(filePath);
 	if (mediaType === "video" || mediaType === "audio") {
 		return mediaType;
 	}
 	return "image";
-}
-
-async function resolveUniqueTargetPath(rootPath: string, fileName: string) {
-	const fs = getTauriAppServices().fileSystem;
-	const { stem, extension } = splitStemAndExt(fileName);
-	let index = 0;
-	while (true) {
-		const candidateName = index === 0 ? `${stem}${extension}` : `${stem}-${index}${extension}`;
-		const candidatePath = joinLocalPath(rootPath, candidateName);
-		if (!(await fs.exists(candidatePath))) {
-			return candidatePath;
-		}
-		index += 1;
-	}
 }
 
 export async function processImportItemsToSource(targetSourceId: string, items: DownloadItem[]) {
@@ -137,7 +131,18 @@ export async function processQueuedDownloadJob(job: JobRecord): Promise<void> {
 				item.fileName ||
 				basenameFromUrl(downloadTarget) ||
 				`${crypto.randomUUID()}${guessExtensionFromUrl(downloadTarget)}`;
-			const targetPath = await resolveUniqueTargetPath(context.basePath, sourceFileName);
+			const resolved = await resolveUploadTargetPath(
+				context.basePath,
+				sourceFileName,
+				false,
+				true,
+				{
+					pathAdapter,
+					exists: async (p) =>
+						await getTauriAppServices().fileSystem.exists(p),
+				},
+			);
+			const targetPath = resolved.fullPath;
 			await getTauriAppServices().fileSystem.mkdir(dirname(targetPath), {
 				recursive: true,
 			});
@@ -209,7 +214,6 @@ export async function processQueuedDownloadJob(job: JobRecord): Promise<void> {
 					timestamp: new Date().toISOString(),
 				};
 				if (existing && existing.id !== row.id) {
-					// Should not happen, but handle gracefully
 					await emit("media-changed", eventPayload);
 				} else {
 					await emit("media-added", eventPayload);

--- a/apps/tauri/src/infrastructure/local-api/services/ai-service.ts
+++ b/apps/tauri/src/infrastructure/local-api/services/ai-service.ts
@@ -1,5 +1,10 @@
 import type { JobRecord } from "@solid-imager/application/ports/job-repository";
 import {
+	createBatchTaggingDispatchJob,
+	createBatchTaggingParentJob,
+	scanBatchTaggingTargets,
+} from "@solid-imager/application/services/batch-tagging";
+import {
 	createJobEventPublisher,
 	runAutoTaggingJob,
 	runBulkTaggingDispatchJob,
@@ -12,7 +17,6 @@ import {
 } from "@solid-imager/core/domain/tagging/schemas";
 import { mediaCharacters, mediaIps, medias, mediaTags } from "@solid-imager/db/schema";
 import { emit } from "@tauri-apps/api/event";
-import { and, asc, eq, getTableColumns, isNull } from "drizzle-orm";
 import { getTauriAppServices } from "~/app-services";
 import { serverOrpc } from "../../api-clients/server-orpc-client";
 import { joinLocalPath } from "../../path-utils";
@@ -94,46 +98,26 @@ const jobEvents = createJobEventPublisher(async (event, payload) => {
 
 export const TauriAiService = {
 	async scanBatchTaggingTargets(input: BatchTaggingInput): Promise<Media[]> {
-		const rows = await getTauriAppServices()
-			.db.select({
-				...getTableColumns(medias),
-			})
-			.from(medias)
-			.leftJoin(mediaTags, and(eq(mediaTags.mediaId, medias.id), eq(mediaTags.source, AI_SOURCE)))
-			.leftJoin(
-				mediaCharacters,
-				and(eq(mediaCharacters.mediaId, medias.id), eq(mediaCharacters.source, AI_SOURCE)),
-			)
-			.leftJoin(mediaIps, and(eq(mediaIps.mediaId, medias.id), eq(mediaIps.source, AI_SOURCE)))
-			.where(
-				and(
-					eq(medias.mediaType, "image"),
-					input.mediaSourceId ? eq(medias.mediaSourceId, input.mediaSourceId) : undefined,
-					input.force
-						? undefined
-						: and(
-								isNull(mediaTags.mediaId),
-								isNull(mediaCharacters.mediaId),
-								isNull(mediaIps.mediaId),
-							),
-				),
-			)
-			.orderBy(asc(medias.id));
+		const rows = await scanBatchTaggingTargets(
+			getTauriAppServices().db,
+			input,
+			{ medias, mediaTags, mediaCharacters, mediaIps },
+		);
 
 		const uniqueRows = new Map<string, (typeof rows)[number]>();
 		for (const row of rows) {
-			uniqueRows.set(row.id, row);
+			uniqueRows.set((row as any).id, row);
 		}
 
 		return Array.from(uniqueRows.values()).map((row) => mediaSchema.parse(row));
 	},
 
 	async batchTagging(input: BatchTaggingInput) {
-		await TauriJobRepository.create({
-			type: "bulk_tagging_dispatch",
-			mediaSourceId: input.mediaSourceId,
-			payload: batchTaggingRequestSchema.parse(input),
-		});
+		await createBatchTaggingDispatchJob(
+			TauriJobRepository,
+			input,
+			batchTaggingRequestSchema.parse(input),
+		);
 
 		return {
 			success: true,
@@ -142,40 +126,18 @@ export const TauriAiService = {
 	},
 
 	async startBatchTaggingWithIds(input: BatchTaggingWithIdsInput) {
-		const parentJob = await TauriJobRepository.create({
-			type: "bulk_tagging_parent",
-			mediaSourceId: input.mediaSourceId,
-			status: "in_progress",
-			payload: {
-				total: input.mediaIds.length,
-				processed: 0,
+		return await createBatchTaggingParentJob(
+			TauriJobRepository,
+			async (ids) => {
+				const mediaItems = await Promise.all(
+					ids.map(async (id) => await TauriMediaRepository.findById(id)),
+				);
+				return mediaItems.flatMap((media) =>
+					media ? [{ id: media.id, mediaSourceId: media.mediaSourceId }] : [],
+				);
 			},
-		});
-
-		const mediaItems = await Promise.all(
-			input.mediaIds.map(async (mediaId) => await TauriMediaRepository.findById(mediaId)),
+			input,
 		);
-		const foundMedia = mediaItems.flatMap((media) => (media ? [media] : []));
-
-		await Promise.all(
-			foundMedia.map(async (media) => {
-				await TauriJobRepository.create({
-					type: "auto_tagging",
-					mediaSourceId: media.mediaSourceId,
-					parentId: parentJob.id,
-					payload: {
-						mediaId: media.id,
-						force: input.force,
-					},
-				});
-			}),
-		);
-
-		return {
-			success: true,
-			message: "Batch tagging started with selected media.",
-			jobId: parentJob.id,
-		};
 	},
 
 	async applyTags(input: { mediaId: string; response: TaggingResponse }) {

--- a/packages/application/src/services/batch-tagging.ts
+++ b/packages/application/src/services/batch-tagging.ts
@@ -1,0 +1,140 @@
+import type { JobRepositoryPort } from "@solid-imager/application/ports/job-repository";
+import { and, asc, eq, getTableColumns, isNull } from "drizzle-orm";
+
+export const AI_SOURCE = "AI" as const;
+
+export type BatchTaggingInput = {
+	force?: boolean;
+	mediaSourceId?: string;
+};
+
+export type BatchTaggingWithIdsInput = BatchTaggingInput & {
+	mediaIds: string[];
+};
+
+export type MediaLookupResult = {
+	id: string;
+	mediaSourceId: string;
+};
+
+/**
+ * Scans for media items that haven't been tagged by AI yet.
+ * Uses Drizzle query builder — caller provides db instance and table references.
+ */
+export async function scanBatchTaggingTargets(
+	db: unknown,
+	input: BatchTaggingInput,
+	tables: {
+		medias: unknown;
+		mediaTags: unknown;
+		mediaCharacters: unknown;
+		mediaIps: unknown;
+	},
+): Promise<unknown[]> {
+	const { mediaSourceId, force } = input;
+	const { medias, mediaTags, mediaCharacters, mediaIps } = tables;
+
+	const results = await (db as any)
+		.select({
+			...getTableColumns(medias as any),
+		})
+		.from(medias as any)
+		.leftJoin(
+			mediaTags as any,
+			and(
+				eq((mediaTags as any).mediaId, (medias as any).id),
+				eq((mediaTags as any).source, AI_SOURCE),
+			),
+		)
+		.leftJoin(
+			mediaCharacters as any,
+			and(
+				eq((mediaCharacters as any).mediaId, (medias as any).id),
+				eq((mediaCharacters as any).source, AI_SOURCE),
+			),
+		)
+		.leftJoin(
+			mediaIps as any,
+			and(
+				eq((mediaIps as any).mediaId, (medias as any).id),
+				eq((mediaIps as any).source, AI_SOURCE),
+			),
+		)
+		.where(
+			and(
+				eq((medias as any).mediaType, "image"),
+				mediaSourceId
+					? eq((medias as any).mediaSourceId, mediaSourceId)
+					: undefined,
+				force
+					? undefined
+					: and(
+							isNull((mediaTags as any).mediaId),
+							isNull((mediaCharacters as any).mediaId),
+							isNull((mediaIps as any).mediaId),
+						),
+			),
+		)
+		.orderBy(asc((medias as any).id));
+
+	return results;
+}
+
+/**
+ * Creates a bulk_tagging_dispatch job.
+ */
+export async function createBatchTaggingDispatchJob(
+	jobRepo: JobRepositoryPort,
+	input: BatchTaggingInput,
+	payload: unknown,
+): Promise<void> {
+	await jobRepo.create({
+		type: "bulk_tagging_dispatch",
+		mediaSourceId: input.mediaSourceId,
+		payload,
+	});
+}
+
+/**
+ * Creates a bulk_tagging_parent job and child auto_tagging jobs for each media.
+ * Uses mediaLookup callback so caller can decide how to resolve media IDs.
+ */
+export async function createBatchTaggingParentJob(
+	jobRepo: JobRepositoryPort,
+	mediaLookup: (ids: string[]) => Promise<MediaLookupResult[]>,
+	input: BatchTaggingWithIdsInput,
+): Promise<{ success: boolean; message: string; jobId: string }> {
+	const { mediaIds, mediaSourceId, force } = input;
+
+	const parentJob = await jobRepo.create({
+		type: "bulk_tagging_parent",
+		mediaSourceId,
+		status: "in_progress",
+		payload: {
+			total: mediaIds.length,
+			processed: 0,
+		},
+	});
+
+	const mediaItems = await mediaLookup(mediaIds);
+
+	await Promise.all(
+		mediaItems.map((media) =>
+			jobRepo.create({
+				type: "auto_tagging",
+				mediaSourceId: media.mediaSourceId,
+				parentId: parentJob.id,
+				payload: {
+					mediaId: media.id,
+					force,
+				},
+			}),
+		),
+	);
+
+	return {
+		success: true,
+		message: "Batch tagging started with selected media.",
+		jobId: parentJob.id,
+	};
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export * from "./interfaces/config-service";
 export * from "./interfaces/file-system";
 export * from "./interfaces/media-manager-client";
 export * from "./interfaces/media-storage";
+export * from "./utils/download-utils";

--- a/packages/core/src/utils/download-utils.ts
+++ b/packages/core/src/utils/download-utils.ts
@@ -1,0 +1,20 @@
+export function basenameFromUrl(url: string): string | undefined {
+	try {
+		const parsed = new URL(url);
+		const fileName = parsed.pathname.split("/").pop();
+		return fileName || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function guessExtensionFromUrl(url: string): string {
+	try {
+		const parsed = new URL(url);
+		const lastDot = parsed.pathname.lastIndexOf(".");
+		if (lastDot === -1) return "";
+		return parsed.pathname.slice(lastDot);
+	} catch {
+		return "";
+	}
+}

--- a/packages/core/src/utils/download-utils.ts
+++ b/packages/core/src/utils/download-utils.ts
@@ -9,12 +9,9 @@ export function basenameFromUrl(url: string): string | undefined {
 }
 
 export function guessExtensionFromUrl(url: string): string {
-	try {
-		const parsed = new URL(url);
-		const lastDot = parsed.pathname.lastIndexOf(".");
-		if (lastDot === -1) return "";
-		return parsed.pathname.slice(lastDot);
-	} catch {
-		return "";
-	}
+	const fileName = basenameFromUrl(url);
+	if (!fileName) return "";
+	const lastDot = fileName.lastIndexOf(".");
+	if (lastDot === -1 || lastDot === 0) return "";
+	return fileName.slice(lastDot);
 }


### PR DESCRIPTION
## Summary

#317 infrastructure layer commonization wave. Extracts shared logic from `apps/server` and `apps/tauri` into `packages/application` and `packages/core`.

### Changes

**Batch Tagging (`packages/application`)**
- New `batch-tagging.ts`: `scanBatchTaggingTargets` Drizzle query, `createBatchTaggingDispatchJob`, `createBatchTaggingParentJob` with injected `mediaLookup` callback
- `apps/server/ai-router.ts` and `apps/tauri/ai-service.ts` slimmed to thin adapters

**Config Service (`apps/server`)**
- New `server-config-store.ts`: `ConfigStore` adapter with file I/O, env overrides, validation, atomic write
- `server-config-service.ts` refactored to singleton thin wrapper around shared `ConfigServiceImpl`
- `bootstrap.ts` updated to use `loadServerConfig()` + `serverConfigService`
- Tests updated for singleton pattern

**Download Utils (`packages/core`)**
- New `download-utils.ts`: `basenameFromUrl`, `guessExtensionFromUrl`
- `apps/tauri/imports-api.ts` uses shared helpers and `resolveUploadTargetPath` instead of custom `resolveUniqueTargetPath`

### Testing
- `apps/server` unit tests: 135 passed
- `server-config-service.test.ts`: 8 passed

### Parity Impact
- Services correspondence: ~85% → ~88%
