### PR TITLE
[codex] Align Tauri import downloads with job queue

### DIFF
--- a/.indexion/wiki/server-tauri-parity.md
+++ b/.indexion/wiki/server-tauri-parity.md
@@ -2,7 +2,7 @@
 
 `apps/server` と `apps/tauri` で同一責務を別実装しているファイルの対応関係。共通化・見直しの際の参照用。
 
-最終更新: 2026-05-01（#298〜#309 commonization wave + #314 dialog/query parity + #316 wrapper commonization + #317 infrastructure commonization を反映。#298 media-sidebar、#299 source-form-modal、#300 upload-media-modal、#303 parser utility、#304 thumbnail-image、#305 media-viewer、#308 event-service削除、#309 media-card/grid item は merged 済み。#301 search / #307 manager は PR #312 merged 済み。#302 sources events / #306 source-media modal wiring は PR #313 merged 済み。#314 move-copy-media-dialog / source-delete-modal / ai-tagging-modal / projectsForMedia queryOptions は merged 済み。#316 media-sidebar-content / media-detail-screen / upload-media-modal-content / source-media-page / preset-client は merged 済み。#317 batch-tagging / config-service / download-import は merged 済み）
+最終更新: 2026-05-01（#298〜#309 commonization wave + #314 dialog/query parity + #316 wrapper commonization + #317 infrastructure commonization + Tauri import/download job adapter parity を反映。#298 media-sidebar、#299 source-form-modal、#300 upload-media-modal、#303 parser utility、#304 thumbnail-image、#305 media-viewer、#308 event-service削除、#309 media-card/grid item は merged 済み。#301 search / #307 manager は PR #312 merged 済み。#302 sources events / #306 source-media modal wiring は PR #313 merged 済み。#314 move-copy-media-dialog / source-delete-modal / ai-tagging-modal / projectsForMedia queryOptions は merged 済み。#316 media-sidebar-content / media-detail-screen / upload-media-modal-content / source-media-page / preset-client は merged 済み。#317 batch-tagging / config-service / download-import は merged 済み）
 
 ## このページの使い方
 
@@ -300,7 +300,7 @@ server も `DB_HOST=pglite` で PGlite に切替可能なため、PGlite は DB 
 | background startup            | `BackgroundJobsCoordinator` + `file-watcher-service.ts` adapter                                                          | `BackgroundJobsCoordinator` + `source-service.ts` / maintenance adapter       |
 | processMedia payload          | `{ mediaId, sourcePath, steps?, type: "processMedia" }`                                                                  | 同左                                                                          |
 | processMedia 実行             | `process-media-runner.ts` + `media-processing-service.ts` adapter                                                        | `process-media-runner.ts` batch runner + `tauri-job-queue.ts` adapter         |
-| download runner               | `packages/application/src/services/download-job-runner.ts` + `download-jobs.ts` adapter                                  | 同左 + `imports-api.ts` adapter                                               |
+| download runner               | `packages/application/src/services/download-job-runner.ts` + `download-jobs.ts` adapter                                  | 同左 + `jobs/download-jobs.ts` adapter                                        |
 | tagging runner                | `packages/application/src/services/tagging-job-runner.ts` + `tagging-jobs.ts` adapter                                    | 同左 + `ai-service.ts` adapter                                                |
 | watcher reconciliation        | `packages/application/src/services/watcher-runtime.ts` + `file-watcher-service.ts` / `directory-sync-service.ts` adapter | 同左 + `source-service.ts` adapter                                            |
 | job / media event contract    | `packages/application/src/services/runtime-events.ts` + `sse-manager.ts` transport                                       | 同左 + Tauri event bus transport                                              |
@@ -335,7 +335,7 @@ server も `DB_HOST=pglite` で PGlite に切替可能なため、PGlite は DB 
 - 片側だけ変更して完了にしない。未対応なら、もう片側への影響か未対応理由を必ず残す
 - PGlite は共通化を諦める理由ではなく、shared repository / executor 注入で吸収する前提で扱う
 - import inbox の pending queue は `localStorage` を廃止し、server / tauri とも `jobs` table の `import_request` を source of truth とする
-- import request の `bulkAdd / listPending / process / cancel` は `packages/application/src/services/import-request-service.ts` を正とし、server / tauri は restore / execute / event publish の adapter だけを注入する
+- import request の `bulkAdd / listPending / process / cancel` は `packages/application/src/services/import-request-service.ts` を正とし、server / tauri は restore / execute / event publish の adapter だけを注入する。Tauri の `processPendingImports` は direct download / sync を行わず、server と同じく download job enqueue 完了を `processedCount` として返す
 
 ## 再監査メモ（2026-04-29 — SourceMediaGrid 共通化後）
 
@@ -407,7 +407,8 @@ server も `DB_HOST=pglite` で PGlite に切替可能なため、PGlite は DB 
 
 - **Services / Batch Tagging Query (#317, PR #317)**: `packages/application/src/services/batch-tagging.ts` を新設。`scanBatchTaggingTargets`（AI未タグ付けmedia検索Drizzle query）、`createBatchTaggingDispatchJob`、`createBatchTaggingParentJob`（mediaLookup callback注入）を shared 化。server `ai-router.ts` / tauri `ai-service.ts` は thin adapter に縮退。`db` / `tables` / `jobRepo` / `mediaLookup` を app 側で注入
 - **Services / Config Service Alignment (#317, PR #317)**: `apps/server/src/application/services/server-config-store.ts` を新設。`ConfigStore` adapter（file I/O + env override + validation + atomic write）を抽出。server `server-config-service.ts` は `createConfigService(store)` をラップする singleton thin wrapper に縮退。sync `getConfig()` のためメモリキャッシュを保持。tauri は既に shared `ConfigServiceImpl` を使用
-- **Core / Download URL Helpers (#317, PR #317)**: `packages/core/src/utils/download-utils.ts` を新設。`basenameFromUrl` / `guessExtensionFromUrl` を shared 化。tauri `imports-api.ts` は shared helpers を import し、独自の `resolveUniqueTargetPath` を削除して shared `resolveUploadTargetPath` + `MediaPathAdapter` に統一
+- **Core / Download URL Helpers (#317, PR #317)**: `packages/core/src/utils/download-utils.ts` を新設。`basenameFromUrl` / `guessExtensionFromUrl` を shared 化。tauri `jobs/download-jobs.ts` は shared helpers を import し、独自の `resolveUniqueTargetPath` を削除して shared `resolveUploadTargetPath` + `MediaPathAdapter` に統一
+- **Tauri Import/Download Job Adapter**: `apps/tauri/src/infrastructure/jobs/download-jobs.ts` を新設し、server 側 `download-jobs.ts` と同じ責務名へ整理。`imports-api.ts` は `createImportRequestService` adapter に縮退し、pending import 処理は direct download ではなく `enqueueDownloadJobs` + `tauriJobQueue.wake()` に統一
 
 ## 前回からの主な変更点（2026-05-01更新 — #316 commonization wave）
 

--- a/apps/tauri/src/components/upload-media-modal/upload-media-modal-content.tsx
+++ b/apps/tauri/src/components/upload-media-modal/upload-media-modal-content.tsx
@@ -1,7 +1,4 @@
-import {
-	UploadMediaModalContent as SharedUploadMediaModalContent,
-	UploadMediaModal,
-} from "@solid-imager/ui/upload-media-modal-content";
+import { UploadMediaModalContent as SharedUploadMediaModalContent } from "@solid-imager/ui/upload-media-modal-content";
 
 type UploadMediaModalProps = {
 	isOpen: boolean;

--- a/apps/tauri/src/infrastructure/api-clients/imports-api.test.ts
+++ b/apps/tauri/src/infrastructure/api-clients/imports-api.test.ts
@@ -8,8 +8,8 @@ const {
 	mockDeleteImportRequests,
 	mockFindMediaSourceForFile,
 	mockRestoreSource,
-	mockFetchMediaSource,
-	mockSyncMediaSources,
+	mockEnqueueDownloadJobs,
+	mockWake,
 	mockEmit,
 	mockGetTauriAppServices,
 } = vi.hoisted(() => ({
@@ -24,8 +24,8 @@ const {
 		skipped: 0,
 		errors: [],
 	})),
-	mockFetchMediaSource: vi.fn(),
-	mockSyncMediaSources: vi.fn(async () => ({ results: [] })),
+	mockEnqueueDownloadJobs: vi.fn(async () => 0),
+	mockWake: vi.fn(),
 	mockEmit: vi.fn(async () => undefined),
 	mockGetTauriAppServices: vi.fn(),
 }));
@@ -54,9 +54,14 @@ vi.mock("~/infrastructure/local-api/services/source-backup-service", () => ({
 	},
 }));
 
-vi.mock("./sources-api", () => ({
-	fetchMediaSource: mockFetchMediaSource,
-	syncMediaSources: mockSyncMediaSources,
+vi.mock("../jobs/download-jobs", () => ({
+	enqueueDownloadJobs: mockEnqueueDownloadJobs,
+}));
+
+vi.mock("../jobs/tauri-job-queue", () => ({
+	tauriJobQueue: {
+		wake: mockWake,
+	},
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -151,7 +156,7 @@ describe("tauri imports api", () => {
 		]);
 	});
 
-	it("downloads files, syncs sources, and completes jobs during processing", async () => {
+	it("enqueues download jobs and completes import requests during processing", async () => {
 		mockFindImportRequestsByIds.mockResolvedValueOnce([
 			{
 				id: "job-1",
@@ -169,13 +174,6 @@ describe("tauri imports api", () => {
 				parentId: null,
 			},
 		]);
-		mockFetchMediaSource.mockResolvedValueOnce({
-			id: "source-1",
-			name: "Default",
-			description: null,
-			type: "local",
-			connectionInfo: { path: "/library" },
-		});
 		const mkdir = vi.fn(async () => undefined);
 		const invoke = vi.fn(async () => undefined);
 		mockGetTauriAppServices.mockReturnValue({
@@ -192,16 +190,20 @@ describe("tauri imports api", () => {
 			},
 			commandClient: { invoke },
 		});
+		mockEnqueueDownloadJobs.mockResolvedValueOnce(1);
 
 		const result = await importsApi.processPendingImports(["job-1"], "source-1");
 
 		expect(result).toEqual({ success: true, processedCount: 1 });
-		expect(mkdir).toHaveBeenCalled();
-		expect(invoke).toHaveBeenCalledWith("download_file", {
-			url: "https://example.com/image.png",
-			destPath: expect.stringContaining("image.png"),
-		});
-		expect(mockSyncMediaSources).toHaveBeenCalledWith(["source-1"]);
+		expect(mockEnqueueDownloadJobs).toHaveBeenCalledWith("source-1", [
+			expect.objectContaining({
+				targetUrl: "https://example.com/image.png",
+				fileName: "image.png",
+			}),
+		]);
+		expect(mockWake).toHaveBeenCalledOnce();
+		expect(mkdir).not.toHaveBeenCalled();
+		expect(invoke).not.toHaveBeenCalled();
 		expect(mockMarkImportRequestsCompleted).toHaveBeenCalledWith(["job-1"]);
 		expect(mockEmit).toHaveBeenCalledWith("import-request:processed", {
 			processedCount: 1,

--- a/apps/tauri/src/infrastructure/api-clients/imports-api.ts
+++ b/apps/tauri/src/infrastructure/api-clients/imports-api.ts
@@ -1,234 +1,25 @@
-import type { JobRecord } from "@solid-imager/application/ports/job-repository";
-import {
-	type DownloadArtifact,
-	queueDownloadJobs as queueSharedDownloadJobs,
-	runDownloadImageJob,
-} from "@solid-imager/application/services/download-job-runner";
 import {
 	createImportRequestService,
 	type PendingImportJob,
 } from "@solid-imager/application/services/import-request-service";
 import type { DownloadItem } from "@solid-imager/core/domain/media/schemas";
-import { getMediaTypeFromExtension } from "@solid-imager/core/domain/media/utils/media-type-utils";
-import { basenameFromUrl, guessExtensionFromUrl } from "@solid-imager/core/utils/download-utils";
-import { resolveUploadTargetPath } from "@solid-imager/application/services/media-upload-utils";
-import type { MediaPathAdapter } from "@solid-imager/application/services/media-service";
 import { emit } from "@tauri-apps/api/event";
-import { getTauriAppServices } from "~/app-services";
-import { TauriMediaRepository } from "~/infrastructure/local-api/repositories/media-repository";
 import { TauriJobRepository } from "~/infrastructure/local-api/repositories/tauri-job-repository";
 import { TauriSourceBackupService } from "~/infrastructure/local-api/services/source-backup-service";
-import {
-	basename,
-	dirname,
-	extname,
-	joinLocalPath,
-	toRelativePath,
-} from "../path-utils";
-import { fetchMediaSource, syncMediaSources } from "./sources-api";
+import { enqueueDownloadJobs } from "../jobs/download-jobs";
+import { tauriJobQueue } from "../jobs/tauri-job-queue";
 
 async function emitImportEvent(event: string, payload: Record<string, unknown>) {
 	await emit(event, payload);
 }
 
-function resolveDownloadTarget(item: DownloadItem) {
-	if (item.targetUrl) {
-		return item.targetUrl;
-	}
-	return item.sourceUrls?.[0];
-}
-
-const pathAdapter: MediaPathAdapter = {
-	join: joinLocalPath,
-	extname,
-	basename,
-	relative: toRelativePath,
-};
-
-async function downloadItemToSource(targetSourceId: string, item: DownloadItem) {
-	const downloadTarget = resolveDownloadTarget(item);
-	if (!downloadTarget) {
-		throw new Error("targetUrl or sourceUrls[0] is required");
-	}
-
-	const source = await fetchMediaSource(targetSourceId);
-	if (source.type !== "local") {
-		throw new Error("Only local sources are supported in Tauri.");
-	}
-
-	const targetRoot = (source.connectionInfo as { path?: string }).path;
-	if (!targetRoot) {
-		throw new Error("Source path is missing.");
-	}
-
-	const sourceFileName =
-		item.fileName ||
-		basenameFromUrl(downloadTarget) ||
-		`${crypto.randomUUID()}${guessExtensionFromUrl(downloadTarget)}`;
-	const resolved = await resolveUploadTargetPath(
-		targetRoot,
-		sourceFileName,
-		false,
-		true,
-		{
-			pathAdapter,
-			exists: async (p) => await getTauriAppServices().fileSystem.exists(p),
-		},
-	);
-	const targetPath = resolved.fullPath;
-	await getTauriAppServices().fileSystem.mkdir(dirname(targetPath), {
-		recursive: true,
-	});
-	await getTauriAppServices().commandClient.invoke("download_file", {
-		url: downloadTarget,
-		destPath: targetPath,
-	});
-}
-
-function inferMediaTypeFromPath(filePath: string): "image" | "video" | "audio" {
-	const mediaType = getMediaTypeFromExtension(filePath);
-	if (mediaType === "video" || mediaType === "audio") {
-		return mediaType;
-	}
-	return "image";
-}
-
-export async function processImportItemsToSource(targetSourceId: string, items: DownloadItem[]) {
-	for (const item of items) {
-		await downloadItemToSource(targetSourceId, item);
-	}
-	await syncMediaSources([targetSourceId]);
-	return { success: true, processedCount: items.length };
-}
-
-export async function enqueueDownloadJobs(
+async function executeImport(
 	targetSourceId: string,
 	items: DownloadItem[],
-): Promise<number> {
-	return await queueSharedDownloadJobs(TauriJobRepository, targetSourceId, items);
-}
-
-export async function processQueuedDownloadJob(job: JobRecord): Promise<void> {
-	await runDownloadImageJob(job, {
-		resolveBasePath: async (mediaSourceId) => {
-			const source = await fetchMediaSource(mediaSourceId);
-			if (source.type !== "local") {
-				throw new Error("Only local sources are supported in Tauri.");
-			}
-			const rootPath = (source.connectionInfo as { path?: string }).path;
-			if (!rootPath) {
-				throw new Error("Source path is missing.");
-			}
-			return rootPath;
-		},
-		selectMode: () => "direct",
-		download: async (item, context) => {
-			const downloadTarget = resolveDownloadTarget(item);
-			if (!downloadTarget) {
-				throw new Error("targetUrl or sourceUrls[0] is required");
-			}
-			const sourceFileName =
-				item.fileName ||
-				basenameFromUrl(downloadTarget) ||
-				`${crypto.randomUUID()}${guessExtensionFromUrl(downloadTarget)}`;
-			const resolved = await resolveUploadTargetPath(
-				context.basePath,
-				sourceFileName,
-				false,
-				true,
-				{
-					pathAdapter,
-					exists: async (p) =>
-						await getTauriAppServices().fileSystem.exists(p),
-				},
-			);
-			const targetPath = resolved.fullPath;
-			await getTauriAppServices().fileSystem.mkdir(dirname(targetPath), {
-				recursive: true,
-			});
-			await getTauriAppServices().commandClient.invoke("download_file", {
-				url: downloadTarget,
-				destPath: targetPath,
-			});
-
-			const relativePath = toRelativePath(context.basePath, targetPath);
-			const stat = await getTauriAppServices().fileSystem.stat(targetPath);
-			const mediaType = inferMediaTypeFromPath(targetPath);
-
-			let createdAt = item.createdAt ? new Date(item.createdAt) : undefined;
-			if (createdAt && Number.isNaN(createdAt.getTime())) {
-				createdAt = undefined;
-			}
-
-			return [
-				{
-					mediaSourceId: context.mediaSourceId,
-					filePath: relativePath,
-					fileName: sourceFileName,
-					mediaType,
-					width: 0,
-					height: 0,
-					fileSize: stat.size,
-					description: item.description ?? null,
-					createdAt: createdAt ?? new Date(stat.birthtime),
-					modifiedAt: new Date(stat.mtime),
-					sourceUrls: Array.from(
-						new Set(
-							[item.targetUrl, ...(item.sourceUrls ?? [])].filter(
-								(value): value is string => typeof value === "string",
-							),
-						),
-					),
-				} satisfies DownloadArtifact,
-			];
-		},
-		registerMedia: async (artifact, context) => {
-			try {
-				const normalizedPath = artifact.filePath.replaceAll("\\", "/");
-				const [row] = await TauriMediaRepository.batchUpsert([
-					{
-						mediaSourceId: context.mediaSourceId,
-						filePath: normalizedPath,
-						fileName: artifact.fileName,
-						mediaType: artifact.mediaType,
-						width: artifact.width,
-						height: artifact.height,
-						fileSize: artifact.fileSize,
-						description: artifact.description,
-						createdAt: artifact.createdAt,
-						modifiedAt: artifact.modifiedAt,
-					},
-				]);
-				if (!row) {
-					console.error("[registerMedia] batchUpsert returned empty result for", artifact.filePath);
-					return;
-				}
-				const existing = await TauriMediaRepository.findByPath(
-					context.mediaSourceId,
-					normalizedPath,
-				);
-				const eventPayload = {
-					mediaSourceId: context.mediaSourceId,
-					mediaId: row.id,
-					filePath: normalizedPath,
-					timestamp: new Date().toISOString(),
-				};
-				if (existing && existing.id !== row.id) {
-					await emit("media-changed", eventPayload);
-				} else {
-					await emit("media-added", eventPayload);
-				}
-			} catch (error) {
-				console.error("[registerMedia] Failed to upsert media for", artifact.filePath, error);
-			}
-		},
-		events: {
-			downloadError: async (event) => {
-				await emit("download-error", event);
-			},
-		},
-		logger: console,
-	});
+): Promise<{ processedCount: number }> {
+	const processedCount = await enqueueDownloadJobs(targetSourceId, items);
+	tauriJobQueue.wake();
+	return { processedCount };
 }
 
 const importRequestService = createImportRequestService({
@@ -237,8 +28,7 @@ const importRequestService = createImportRequestService({
 		await TauriSourceBackupService.findMediaSourceForFile(filePath),
 	restoreSource: async (sourceId, items) =>
 		await TauriSourceBackupService.restoreSource(sourceId, items),
-	executeImport: async (targetSourceId, items) =>
-		await processImportItemsToSource(targetSourceId, items),
+	executeImport: async (targetSourceId, items) => await executeImport(targetSourceId, items),
 	publishImportEvent: emitImportEvent,
 });
 

--- a/apps/tauri/src/infrastructure/api-clients/local-procedures.ts
+++ b/apps/tauri/src/infrastructure/api-clients/local-procedures.ts
@@ -56,7 +56,7 @@ import { TauriSourceBackupService } from "../local-api/services/source-backup-se
 import { TauriSourceService } from "../local-api/services/source-service";
 import { TauriTagService } from "../local-api/services/tag-service";
 import { TauriUserService } from "../local-api/services/user-service";
-import { enqueueDownloadJobs } from "./imports-api";
+import { enqueueDownloadJobs } from "../jobs/download-jobs";
 
 const authorUpdateSchema = z.object({
 	name: z.string().min(1).optional(),

--- a/apps/tauri/src/infrastructure/api/clients/preset-client.ts
+++ b/apps/tauri/src/infrastructure/api/clients/preset-client.ts
@@ -1,4 +1,4 @@
 import { createPresetClient } from "@solid-imager/ui/preset-client";
-import { orpc } from "./orpc-client";
+import { orpc } from "../../api-clients/orpc-client";
 
 export const PresetClient = createPresetClient(orpc);

--- a/apps/tauri/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/tauri/src/infrastructure/jobs/download-jobs.ts
@@ -130,6 +130,10 @@ export async function processQueuedDownloadJob(job: JobRecord): Promise<void> {
 		registerMedia: async (artifact, context) => {
 			try {
 				const normalizedPath = artifact.filePath.replaceAll("\\", "/");
+				const existing = await TauriMediaRepository.findByPath(
+					context.mediaSourceId,
+					normalizedPath,
+				);
 				const [row] = await TauriMediaRepository.batchUpsert([
 					{
 						mediaSourceId: context.mediaSourceId,
@@ -151,17 +155,13 @@ export async function processQueuedDownloadJob(job: JobRecord): Promise<void> {
 					);
 					return;
 				}
-				const existing = await TauriMediaRepository.findByPath(
-					context.mediaSourceId,
-					normalizedPath,
-				);
 				const eventPayload = {
 					mediaSourceId: context.mediaSourceId,
 					mediaId: row.id,
 					filePath: normalizedPath,
 					timestamp: new Date().toISOString(),
 				};
-				if (existing && existing.id !== row.id) {
+				if (existing) {
 					await emit("media-changed", eventPayload);
 				} else {
 					await emit("media-added", eventPayload);

--- a/apps/tauri/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/tauri/src/infrastructure/jobs/download-jobs.ts
@@ -1,0 +1,184 @@
+import type { JobRecord } from "@solid-imager/application/ports/job-repository";
+import {
+	type DownloadArtifact,
+	queueDownloadJobs as queueSharedDownloadJobs,
+	runDownloadImageJob,
+} from "@solid-imager/application/services/download-job-runner";
+import type { MediaPathAdapter } from "@solid-imager/application/services/media-service";
+import { resolveUploadTargetPath } from "@solid-imager/application/services/media-upload-utils";
+import type { DownloadItem } from "@solid-imager/core/domain/media/schemas";
+import { getMediaTypeFromExtension } from "@solid-imager/core/domain/media/utils/media-type-utils";
+import {
+	basenameFromUrl,
+	guessExtensionFromUrl,
+} from "@solid-imager/core/utils/download-utils";
+import { emit } from "@tauri-apps/api/event";
+import { getTauriAppServices } from "~/app-services";
+import { TauriMediaRepository } from "~/infrastructure/local-api/repositories/media-repository";
+import { TauriJobRepository } from "~/infrastructure/local-api/repositories/tauri-job-repository";
+import {
+	basename,
+	dirname,
+	extname,
+	joinLocalPath,
+	toRelativePath,
+} from "../path-utils";
+import { fetchMediaSource } from "../api-clients/sources-api";
+
+function resolveDownloadTarget(item: DownloadItem) {
+	if (item.targetUrl) {
+		return item.targetUrl;
+	}
+	return item.sourceUrls?.[0];
+}
+
+function inferMediaTypeFromPath(filePath: string): "image" | "video" | "audio" {
+	const mediaType = getMediaTypeFromExtension(filePath);
+	if (mediaType === "video" || mediaType === "audio") {
+		return mediaType;
+	}
+	return "image";
+}
+
+const pathAdapter: MediaPathAdapter = {
+	join: joinLocalPath,
+	extname,
+	basename,
+	relative: toRelativePath,
+};
+
+export async function enqueueDownloadJobs(
+	targetSourceId: string,
+	items: DownloadItem[],
+): Promise<number> {
+	return await queueSharedDownloadJobs(TauriJobRepository, targetSourceId, items);
+}
+
+export async function processQueuedDownloadJob(job: JobRecord): Promise<void> {
+	await runDownloadImageJob(job, {
+		resolveBasePath: async (mediaSourceId) => {
+			const source = await fetchMediaSource(mediaSourceId);
+			if (source.type !== "local") {
+				throw new Error("Only local sources are supported in Tauri.");
+			}
+			const rootPath = (source.connectionInfo as { path?: string }).path;
+			if (!rootPath) {
+				throw new Error("Source path is missing.");
+			}
+			return rootPath;
+		},
+		selectMode: () => "direct",
+		download: async (item, context) => {
+			const downloadTarget = resolveDownloadTarget(item);
+			if (!downloadTarget) {
+				throw new Error("targetUrl or sourceUrls[0] is required");
+			}
+			const sourceFileName =
+				item.fileName ||
+				basenameFromUrl(downloadTarget) ||
+				`${crypto.randomUUID()}${guessExtensionFromUrl(downloadTarget)}`;
+			const resolved = await resolveUploadTargetPath(
+				context.basePath,
+				sourceFileName,
+				false,
+				true,
+				{
+					pathAdapter,
+					exists: async (p) => await getTauriAppServices().fileSystem.exists(p),
+				},
+			);
+			const targetPath = resolved.fullPath;
+			await getTauriAppServices().fileSystem.mkdir(dirname(targetPath), {
+				recursive: true,
+			});
+			await getTauriAppServices().commandClient.invoke("download_file", {
+				url: downloadTarget,
+				destPath: targetPath,
+			});
+
+			const relativePath = toRelativePath(context.basePath, targetPath);
+			const stat = await getTauriAppServices().fileSystem.stat(targetPath);
+			const mediaType = inferMediaTypeFromPath(targetPath);
+
+			let createdAt = item.createdAt ? new Date(item.createdAt) : undefined;
+			if (createdAt && Number.isNaN(createdAt.getTime())) {
+				createdAt = undefined;
+			}
+
+			return [
+				{
+					mediaSourceId: context.mediaSourceId,
+					filePath: relativePath,
+					fileName: sourceFileName,
+					mediaType,
+					width: 0,
+					height: 0,
+					fileSize: stat.size,
+					description: item.description ?? null,
+					createdAt: createdAt ?? new Date(stat.birthtime),
+					modifiedAt: new Date(stat.mtime),
+					sourceUrls: Array.from(
+						new Set(
+							[item.targetUrl, ...(item.sourceUrls ?? [])].filter(
+								(value): value is string => typeof value === "string",
+							),
+						),
+					),
+				} satisfies DownloadArtifact,
+			];
+		},
+		registerMedia: async (artifact, context) => {
+			try {
+				const normalizedPath = artifact.filePath.replaceAll("\\", "/");
+				const [row] = await TauriMediaRepository.batchUpsert([
+					{
+						mediaSourceId: context.mediaSourceId,
+						filePath: normalizedPath,
+						fileName: artifact.fileName,
+						mediaType: artifact.mediaType,
+						width: artifact.width,
+						height: artifact.height,
+						fileSize: artifact.fileSize,
+						description: artifact.description,
+						createdAt: artifact.createdAt,
+						modifiedAt: artifact.modifiedAt,
+					},
+				]);
+				if (!row) {
+					console.error(
+						"[registerMedia] batchUpsert returned empty result for",
+						artifact.filePath,
+					);
+					return;
+				}
+				const existing = await TauriMediaRepository.findByPath(
+					context.mediaSourceId,
+					normalizedPath,
+				);
+				const eventPayload = {
+					mediaSourceId: context.mediaSourceId,
+					mediaId: row.id,
+					filePath: normalizedPath,
+					timestamp: new Date().toISOString(),
+				};
+				if (existing && existing.id !== row.id) {
+					await emit("media-changed", eventPayload);
+				} else {
+					await emit("media-added", eventPayload);
+				}
+			} catch (error) {
+				console.error(
+					"[registerMedia] Failed to upsert media for",
+					artifact.filePath,
+					error,
+				);
+			}
+		},
+		events: {
+			downloadError: async (event) => {
+				await emit("download-error", event);
+			},
+		},
+		logger: console,
+	});
+}

--- a/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
+++ b/apps/tauri/src/infrastructure/jobs/tauri-job-queue.ts
@@ -14,7 +14,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { emit } from "@tauri-apps/api/event";
 import { appDataDir, isAbsolute, join } from "@tauri-apps/api/path";
 import { getTauriAppServices } from "~/app-services";
-import { processQueuedDownloadJob } from "../api-clients/imports-api";
+import { processQueuedDownloadJob } from "./download-jobs";
 import { TauriMediaRepository } from "../local-api/repositories/media-repository";
 import { TauriTagRepository } from "../local-api/repositories/tag-repository";
 import { TauriJobRepository } from "../local-api/repositories/tauri-job-repository";


### PR DESCRIPTION
## Summary

- Move Tauri download job runner/enqueue logic into `apps/tauri/src/infrastructure/jobs/download-jobs.ts`.
- Keep `imports-api.ts` as a thin `createImportRequestService` adapter and enqueue download jobs instead of downloading inline.
- Fix Tauri typecheck/build blockers in upload modal and preset client imports.
- Update parity wiki notes for the new Tauri import/download job adapter split.

## Impact

Pending import processing now matches the server contract: `processedCount` means accepted download jobs, while actual file download, media registration, and events happen in the `downloadImage` job runner.

## Validation

- `rtk bun run --cwd apps/tauri test src/infrastructure/api-clients/imports-api.test.ts`
- `rtk bun run --cwd packages/application test src/tests/import-request-service.test.ts src/tests/download-job-runner.test.ts`
- `rtk bun run --cwd apps/tauri typecheck`
- `rtk bun run --cwd apps/tauri build:web`

Note: `build:web` still emits existing route helper/PGlite/chunk-size warnings, but completed successfully.