### PR TITLE
refactor: extract AI tagging orchestration into shared service (#324)

### DIFF
--- a/apps/server/src/application/services/tagging-service.ts
+++ b/apps/server/src/application/services/tagging-service.ts
@@ -47,6 +47,13 @@ export class TaggingService {
 		return await this.aiClient.tagImage(imageBuffer);
 	}
 
+	private getAiBaseUrl(): string | undefined {
+		const client = this.aiClient as unknown as {
+			getBaseUrl?: () => string;
+		};
+		return client.getBaseUrl?.();
+	}
+
 	async getTagsForMedia(
 		mediaSourceId: string,
 		mediaId: string,
@@ -67,13 +74,6 @@ export class TaggingService {
 			throw new Error("Media source not found");
 		}
 
-		const getAiBaseUrl = () => {
-			const client = this.aiClient as unknown as {
-				getBaseUrl?: () => string;
-			};
-			return client.getBaseUrl?.();
-		};
-
 		return await orchestrateTagging(mediaId, options, {
 			aiClient: this.aiClient,
 			reconstructDeps: {
@@ -81,7 +81,7 @@ export class TaggingService {
 				characterRepository: this.characterRepo,
 				ipRepository: this.ipRepo,
 			},
-			getAiBaseUrl,
+			getAiBaseUrl: () => this.getAiBaseUrl(),
 			mediaSourceType: mediaSource.type,
 			mediaSourceConnectionInfo: mediaSource.connectionInfo,
 			mediaFilePath: media.filePath,
@@ -131,16 +131,9 @@ export class TaggingService {
 			throw new Error("Media source not found");
 		}
 
-		const getAiBaseUrl = () => {
-			const client = this.aiClient as unknown as {
-				getBaseUrl?: () => string;
-			};
-			return client.getBaseUrl?.();
-		};
-
 		return await orchestrateCcipExtraction({
 			aiClient: this.aiClient,
-			getAiBaseUrl,
+			getAiBaseUrl: () => this.getAiBaseUrl(),
 			mediaSourceType: mediaSource.type,
 			mediaSourceConnectionInfo: mediaSource.connectionInfo,
 			mediaFilePath: media.filePath,

--- a/apps/server/src/application/services/tagging-service.ts
+++ b/apps/server/src/application/services/tagging-service.ts
@@ -1,10 +1,13 @@
 import path from "node:path";
+import {
+	orchestrateCcipExtraction,
+	orchestrateTagging,
+} from "@solid-imager/application/services/ai-tagging-service";
 import type { IAiClient } from "@solid-imager/core/domain/interfaces/ai-client";
 import type { CharacterRepository } from "@solid-imager/core/domain/repositories/character-repository";
 import type { IIpRepository } from "@solid-imager/core/domain/repositories/ip-repository";
 import type { SourceRepository } from "@solid-imager/core/domain/repositories/source-repository";
 import type { TagRepository as TagRepositoryDef } from "@solid-imager/core/domain/repositories/tag-repository";
-import { DEFAULT_MANUAL_CONFIDENCE } from "@solid-imager/core/domain/tagging/constants";
 import type {
 	CcipFeatureResponse,
 	TaggingResponse,
@@ -55,122 +58,59 @@ export class TaggingService {
 				general: {},
 				character: {},
 				ips: [],
-
 				ips_mapping: {},
 			};
 		}
 
-		// 1. Check Cache (DB)
-		if (!options?.skipCache) {
-			const existingTags = await this.tagRepo.findByMediaId(mediaId);
-			const aiTags = existingTags.filter((t) => t.source === "AI");
-
-			if (aiTags.length > 0) {
-				const aiCharacters = (
-					await this.characterRepo.getMediaCharacters(mediaId)
-				).filter((c) => c.associationSource === "AI");
-				const aiIps = (await this.ipRepo.getMediaIps(mediaId)).filter(
-					(i) => i.associationSource === "AI",
-				);
-
-				// Reconstruct response
-				const response: TaggingResponse = {
-					general: {},
-					character: {},
-					ips: aiIps.map((i) => i.name),
-
-					ips_mapping: {},
-				};
-
-				for (const tag of aiTags) {
-					response.general[tag.name] =
-						tag.confidence ?? DEFAULT_MANUAL_CONFIDENCE;
-				}
-				for (const char of aiCharacters) {
-					response.character[char.name] =
-						char.confidence ?? DEFAULT_MANUAL_CONFIDENCE;
-				}
-
-				// ips_mapping: We need to know which IP a character belongs to.
-				const ipMap = new Map<string, string>(); // id -> name
-				for (const ip of aiIps) {
-					ipMap.set(ip.id, ip.name);
-				}
-
-				for (const char of aiCharacters) {
-					const matchedIpNames: string[] = [];
-					for (const charIp of char.ips) {
-						if (ipMap.has(charIp.id)) {
-							const ipName = ipMap.get(charIp.id);
-							if (ipName) {
-								matchedIpNames.push(ipName);
-							}
-						}
-					}
-					if (matchedIpNames.length > 0) {
-						response.ips_mapping[char.name] = matchedIpNames;
-					}
-				}
-
-				return response;
-			}
-		}
-
 		const mediaSource = await this.sourceRepo.findById(mediaSourceId);
-
 		if (!mediaSource) {
 			throw new Error("Media source not found");
 		}
 
-		let response: TaggingResponse;
+		const getAiBaseUrl = () => {
+			const client = this.aiClient as unknown as {
+				getBaseUrl?: () => string;
+			};
+			return client.getBaseUrl?.();
+		};
 
-		// Check if AI service is accessible locally (can use path-based API)
-		// If AI service is on remote host, we must send the file buffer
-		const canUsePathApi = this.isAiServiceLocal();
+		return await orchestrateTagging(mediaId, options, {
+			aiClient: this.aiClient,
+			reconstructDeps: {
+				tagRepository: this.tagRepo,
+				characterRepository: this.characterRepo,
+				ipRepository: this.ipRepo,
+			},
+			getAiBaseUrl,
+			mediaSourceType: mediaSource.type,
+			mediaSourceConnectionInfo: mediaSource.connectionInfo,
+			mediaFilePath: media.filePath,
+			getBuffer: async () => {
+				const { buffer } = await MediaService.getMediaContent(
+					mediaSourceId,
+					mediaId,
+				);
+				return buffer.buffer as ArrayBuffer;
+			},
+			joinPath: path.join,
+			persistResponse: async (response) => {
+				const { persistTaggingResponse } = await import(
+					"@solid-imager/application/services/tag-persistence"
+				);
+				await persistTaggingResponse(mediaId, response, {
+					tagRepository: this.tagRepo,
+					ipRepository: this.ipRepo,
+					characterRepository: this.characterRepo,
+					source: "AI",
+				});
 
-		if (mediaSource.type === "local" && canUsePathApi) {
-			const connectionInfo = mediaSource.connectionInfo as { path: string };
-			const fullPath = path.join(connectionInfo.path, media.filePath);
-			response = await this.aiClient.tagImageByPath(fullPath);
-		} else {
-			// Send file buffer when:
-			// - AI service is remote (can't access local paths)
-			// - Media source is not local
-			const { buffer } = await MediaService.getMediaContent(
-				mediaSourceId,
-				mediaId,
-			);
-			response = await this.aiClient.tagImage(buffer.buffer as ArrayBuffer);
-		}
-
-		// Save to DB
-		await this.saveTags(mediaSourceId, mediaId, media.filePath, response);
-
-		return response;
-	}
-
-	private async saveTags(
-		mediaSourceId: string,
-		mediaId: string,
-		filePath: string,
-		response: TaggingResponse,
-	): Promise<void> {
-		const { persistTaggingResponse } = await import(
-			"@solid-imager/application/services/tag-persistence"
-		);
-		await persistTaggingResponse(mediaId, response, {
-			tagRepository: this.tagRepo,
-			ipRepository: this.ipRepo,
-			characterRepository: this.characterRepo,
-			source: "AI",
-		});
-
-		// Notify clients of the update
-		// Ensure all consumers (like use-media-source-events.ts) are updated to "media-changed"
-		SseManager.sendEvent(mediaSourceId, "media-changed", {
-			filePath,
-			mediaId,
-			timestamp: new Date().toISOString(),
+				// Notify clients of the update
+				SseManager.sendEvent(mediaSourceId, "media-changed", {
+					filePath: media.filePath,
+					mediaId,
+					timestamp: new Date().toISOString(),
+				});
+			},
 		});
 	}
 
@@ -187,24 +127,32 @@ export class TaggingService {
 			throw new Error("CCIP feature extraction is only supported for images");
 		}
 		const mediaSource = await this.sourceRepo.findById(mediaSourceId);
-
 		if (!mediaSource) {
 			throw new Error("Media source not found");
 		}
 
-		// Check if AI service is accessible locally (can use path-based API)
-		const canUsePathApi = this.isAiServiceLocal();
+		const getAiBaseUrl = () => {
+			const client = this.aiClient as unknown as {
+				getBaseUrl?: () => string;
+			};
+			return client.getBaseUrl?.();
+		};
 
-		if (mediaSource.type === "local" && canUsePathApi) {
-			const connectionInfo = mediaSource.connectionInfo as { path: string };
-			const fullPath = path.join(connectionInfo.path, media.filePath);
-			return await this.aiClient.extractCcipFeatureByPath(fullPath);
-		}
-		const { buffer } = await MediaService.getMediaContent(
-			mediaSourceId,
-			mediaId,
-		);
-		return await this.aiClient.extractCcipFeature(buffer.buffer as ArrayBuffer);
+		return await orchestrateCcipExtraction({
+			aiClient: this.aiClient,
+			getAiBaseUrl,
+			mediaSourceType: mediaSource.type,
+			mediaSourceConnectionInfo: mediaSource.connectionInfo,
+			mediaFilePath: media.filePath,
+			getBuffer: async () => {
+				const { buffer } = await MediaService.getMediaContent(
+					mediaSourceId,
+					mediaId,
+				);
+				return buffer.buffer as ArrayBuffer;
+			},
+			joinPath: path.join,
+		});
 	}
 
 	async getCcipDifference(
@@ -216,31 +164,6 @@ export class TaggingService {
 			feature2,
 		);
 		return result.difference;
-	}
-
-	/**
-	 * Check if AI service is running on localhost
-	 * Path-based API only works when AI service can access the file system
-	 */
-	private isAiServiceLocal(): boolean {
-		const client = this.aiClient as unknown as { getBaseUrl?: () => string };
-		const baseUrl = client.getBaseUrl?.();
-		if (!baseUrl) {
-			return true; // Fallback: assume local
-		}
-
-		try {
-			const url = new URL(baseUrl);
-			const host = url.hostname.toLowerCase();
-			return (
-				host === "localhost" ||
-				host === "127.0.0.1" ||
-				host === "::1" ||
-				host === "0.0.0.0"
-			);
-		} catch {
-			return true; // Fallback: assume local if URL parsing fails
-		}
 	}
 }
 

--- a/apps/tauri/src/infrastructure/local-api/services/ai-service.ts
+++ b/apps/tauri/src/infrastructure/local-api/services/ai-service.ts
@@ -188,7 +188,7 @@ export const TauriAiService = {
 							characterRepository: TauriCharacterRepository,
 							ipRepository: TauriIpRepository,
 						},
-						getAiBaseUrl: () => undefined,
+						getAiBaseUrl: () => "http://tauri-client-proxy",
 						mediaSourceType: source.type,
 						mediaSourceConnectionInfo: source.connectionInfo,
 						mediaFilePath: media.filePath,

--- a/apps/tauri/src/infrastructure/local-api/services/ai-service.ts
+++ b/apps/tauri/src/infrastructure/local-api/services/ai-service.ts
@@ -1,4 +1,5 @@
 import type { JobRecord } from "@solid-imager/application/ports/job-repository";
+import { orchestrateTagging } from "@solid-imager/application/services/ai-tagging-service";
 import {
 	createBatchTaggingDispatchJob,
 	createBatchTaggingParentJob,
@@ -9,6 +10,7 @@ import {
 	runAutoTaggingJob,
 	runBulkTaggingDispatchJob,
 } from "@solid-imager/application/services/tagging-job-runner";
+import type { IAiClient } from "@solid-imager/core/domain/interfaces/ai-client";
 import {
 	type Media,
 	mediaSchema,
@@ -46,33 +48,32 @@ type BatchTaggingWithIdsInput = BatchTaggingInput & {
 	mediaIds: string[];
 };
 
-async function resolveLocalMediaFile(
-	mediaId: string,
-): Promise<{ media: Media; fullPath: string }> {
-	const media = await TauriMediaRepository.findById(mediaId);
-	if (!media) {
-		throw new Error(`Media not found: ${mediaId}`);
-	}
-
-	const source = await TauriSourceRepository.findById(media.mediaSourceId);
-	if (!source) {
-		throw new Error(`Media source not found: ${media.mediaSourceId}`);
-	}
-	if (source.type !== "local" || !("path" in source.connectionInfo)) {
-		throw new Error("AI tagging currently supports only local Tauri sources.");
-	}
-
+function createTauriAiClient(media: Media): IAiClient {
 	return {
-		media,
-		fullPath: joinLocalPath(source.connectionInfo.path, media.filePath),
+		healthCheck: async () => true,
+		tagImage: async (buffer) => {
+			const file = new File([buffer], media.fileName);
+			return taggingResponseSchema.parse(await serverOrpc.ai.tag({ file }));
+		},
+		tagImageByPath: async (_path) => {
+			throw new Error("Path-based AI tagging is not supported in Tauri client");
+		},
+		extractCcipFeature: async (_buffer) => {
+			throw new Error(
+				"CCIP feature extraction is not supported in Tauri client",
+			);
+		},
+		extractCcipFeatureByPath: async (_path) => {
+			throw new Error(
+				"Path-based CCIP extraction is not supported in Tauri client",
+			);
+		},
+		calculateCcipDifference: async (_f1, _f2) => {
+			throw new Error(
+				"CCIP difference calculation is not supported in Tauri client",
+			);
+		},
 	};
-}
-
-async function tagMediaFromServer(mediaId: string): Promise<TaggingResponse> {
-	const { media, fullPath } = await resolveLocalMediaFile(mediaId);
-	const bytes = await getTauriAppServices().fileSystem.readFile(fullPath);
-	const file = new File([bytes.buffer as ArrayBuffer], media.fileName);
-	return taggingResponseSchema.parse(await serverOrpc.ai.tag({ file }));
 }
 
 async function persistAiTags(mediaId: string, response: TaggingResponse) {
@@ -160,10 +161,53 @@ export const TauriAiService = {
 	async processAutoTaggingJob(job: JobRecord): Promise<void> {
 		await runAutoTaggingJob(job, {
 			jobRepository: TauriJobRepository,
-			executeAutoTagging: async ({ mediaId }) => {
-				const response = await tagMediaFromServer(mediaId);
-				await persistAiTags(mediaId, response);
-				await emitMediaChanged(mediaId);
+			executeAutoTagging: async ({ mediaId, force }) => {
+				const media = await TauriMediaRepository.findById(mediaId);
+				if (!media) {
+					throw new Error(`Media not found: ${mediaId}`);
+				}
+				const source = await TauriSourceRepository.findById(
+					media.mediaSourceId,
+				);
+				if (!source) {
+					throw new Error(`Media source not found: ${media.mediaSourceId}`);
+				}
+				if (source.type !== "local" || !("path" in source.connectionInfo)) {
+					throw new Error(
+						"AI tagging currently supports only local Tauri sources.",
+					);
+				}
+
+				await orchestrateTagging(
+					mediaId,
+					{ skipCache: force },
+					{
+						aiClient: createTauriAiClient(media),
+						reconstructDeps: {
+							tagRepository: TauriTagRepository,
+							characterRepository: TauriCharacterRepository,
+							ipRepository: TauriIpRepository,
+						},
+						getAiBaseUrl: () => undefined,
+						mediaSourceType: source.type,
+						mediaSourceConnectionInfo: source.connectionInfo,
+						mediaFilePath: media.filePath,
+						getBuffer: async () => {
+							const fullPath = joinLocalPath(
+								(source.connectionInfo as { path: string }).path,
+								media.filePath,
+							);
+							const bytes =
+								await getTauriAppServices().fileSystem.readFile(fullPath);
+							return bytes.buffer as ArrayBuffer;
+						},
+						joinPath: joinLocalPath,
+						persistResponse: async (response) => {
+							await persistAiTags(mediaId, response);
+							await emitMediaChanged(mediaId);
+						},
+					},
+				);
 			},
 			jobEvents,
 			logger: console,

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./ports/job-repository";
+export * from "./services/ai-tagging-service";
 export * from "./services/author-service";
 export * from "./services/background-jobs-coordinator";
 export * from "./services/category-service";

--- a/packages/application/src/services/ai-tagging-service.ts
+++ b/packages/application/src/services/ai-tagging-service.ts
@@ -1,0 +1,190 @@
+import type { IAiClient } from "@solid-imager/core/domain/interfaces/ai-client";
+import type { CharacterRepository } from "@solid-imager/core/domain/repositories/character-repository";
+import type { IIpRepository } from "@solid-imager/core/domain/repositories/ip-repository";
+import type { TagRepository } from "@solid-imager/core/domain/repositories/tag-repository";
+import { DEFAULT_MANUAL_CONFIDENCE } from "@solid-imager/core/domain/tagging/constants";
+import type {
+	CcipFeatureResponse,
+	TaggingResponse,
+} from "@solid-imager/core/domain/tagging/schemas";
+
+export type AiInput =
+	| { type: "path"; fullPath: string }
+	| { type: "buffer"; buffer: ArrayBuffer };
+
+export type ReconstructTaggingResponseDeps = {
+	tagRepository: Pick<TagRepository, "findByMediaId">;
+	characterRepository: Pick<CharacterRepository, "getMediaCharacters">;
+	ipRepository: Pick<IIpRepository, "getMediaIps">;
+};
+
+export async function reconstructTaggingResponseFromCache(
+	mediaId: string,
+	deps: ReconstructTaggingResponseDeps,
+): Promise<TaggingResponse | null> {
+	const existingTags = await deps.tagRepository.findByMediaId(mediaId);
+	const aiTags = existingTags.filter((t) => t.source === "AI");
+
+	if (aiTags.length === 0) {
+		return null;
+	}
+
+	const aiCharacters = (
+		await deps.characterRepository.getMediaCharacters(mediaId)
+	).filter((c) => c.associationSource === "AI");
+	const aiIps = (await deps.ipRepository.getMediaIps(mediaId)).filter(
+		(i) => i.associationSource === "AI",
+	);
+
+	const response: TaggingResponse = {
+		general: {},
+		character: {},
+		ips: aiIps.map((i) => i.name),
+		ips_mapping: {},
+	};
+
+	for (const tag of aiTags) {
+		response.general[tag.name] = tag.confidence ?? DEFAULT_MANUAL_CONFIDENCE;
+	}
+	for (const char of aiCharacters) {
+		response.character[char.name] =
+			char.confidence ?? DEFAULT_MANUAL_CONFIDENCE;
+	}
+
+	const ipMap = new Map<string, string>();
+	for (const ip of aiIps) {
+		ipMap.set(ip.id, ip.name);
+	}
+
+	for (const char of aiCharacters) {
+		const matchedIpNames: string[] = [];
+		for (const charIp of char.ips) {
+			const ipName = ipMap.get(charIp.id);
+			if (ipName) {
+				matchedIpNames.push(ipName);
+			}
+		}
+		if (matchedIpNames.length > 0) {
+			response.ips_mapping[char.name] = matchedIpNames;
+		}
+	}
+
+	return response;
+}
+
+export function isAiServiceLocal(baseUrl?: string): boolean {
+	if (!baseUrl) {
+		return true; // Fallback: assume local
+	}
+
+	try {
+		const url = new URL(baseUrl);
+		const host = url.hostname.toLowerCase();
+		return (
+			host === "localhost" ||
+			host === "127.0.0.1" ||
+			host === "::1" ||
+			host === "[::1]" ||
+			host === "0.0.0.0"
+		);
+	} catch {
+		return true; // Fallback: assume local if URL parsing fails
+	}
+}
+
+export type ResolveAiInputDeps = {
+	mediaSourceType: string;
+	mediaSourceConnectionInfo: unknown;
+	mediaFilePath: string;
+	isAiServiceLocal: boolean;
+	getBuffer: () => Promise<ArrayBuffer>;
+	joinPath: (base: string, filePath: string) => string;
+};
+
+export async function resolveAiInput(
+	deps: ResolveAiInputDeps,
+): Promise<AiInput> {
+	if (deps.mediaSourceType === "local" && deps.isAiServiceLocal) {
+		const info = deps.mediaSourceConnectionInfo as { path: string };
+		return {
+			type: "path",
+			fullPath: deps.joinPath(info.path, deps.mediaFilePath),
+		};
+	}
+	return { type: "buffer", buffer: await deps.getBuffer() };
+}
+
+export type OrchestrateTaggingDeps = {
+	aiClient: IAiClient;
+	reconstructDeps: ReconstructTaggingResponseDeps;
+	getAiBaseUrl: () => string | undefined;
+	mediaSourceType: string;
+	mediaSourceConnectionInfo: unknown;
+	mediaFilePath: string;
+	getBuffer: () => Promise<ArrayBuffer>;
+	joinPath: (base: string, filePath: string) => string;
+	persistResponse: (response: TaggingResponse) => Promise<void>;
+};
+
+export async function orchestrateTagging(
+	mediaId: string,
+	options: { skipCache?: boolean } | undefined,
+	deps: OrchestrateTaggingDeps,
+): Promise<TaggingResponse> {
+	if (!options?.skipCache) {
+		const cached = await reconstructTaggingResponseFromCache(
+			mediaId,
+			deps.reconstructDeps,
+		);
+		if (cached) {
+			return cached;
+		}
+	}
+
+	const input = await resolveAiInput({
+		mediaSourceType: deps.mediaSourceType,
+		mediaSourceConnectionInfo: deps.mediaSourceConnectionInfo,
+		mediaFilePath: deps.mediaFilePath,
+		isAiServiceLocal: isAiServiceLocal(deps.getAiBaseUrl()),
+		getBuffer: deps.getBuffer,
+		joinPath: deps.joinPath,
+	});
+
+	let response: TaggingResponse;
+	if (input.type === "path") {
+		response = await deps.aiClient.tagImageByPath(input.fullPath);
+	} else {
+		response = await deps.aiClient.tagImage(input.buffer);
+	}
+
+	await deps.persistResponse(response);
+	return response;
+}
+
+export type OrchestrateCcipDeps = {
+	aiClient: IAiClient;
+	getAiBaseUrl: () => string | undefined;
+	mediaSourceType: string;
+	mediaSourceConnectionInfo: unknown;
+	mediaFilePath: string;
+	getBuffer: () => Promise<ArrayBuffer>;
+	joinPath: (base: string, filePath: string) => string;
+};
+
+export async function orchestrateCcipExtraction(
+	deps: OrchestrateCcipDeps,
+): Promise<CcipFeatureResponse> {
+	const input = await resolveAiInput({
+		mediaSourceType: deps.mediaSourceType,
+		mediaSourceConnectionInfo: deps.mediaSourceConnectionInfo,
+		mediaFilePath: deps.mediaFilePath,
+		isAiServiceLocal: isAiServiceLocal(deps.getAiBaseUrl()),
+		getBuffer: deps.getBuffer,
+		joinPath: deps.joinPath,
+	});
+
+	if (input.type === "path") {
+		return await deps.aiClient.extractCcipFeatureByPath(input.fullPath);
+	}
+	return await deps.aiClient.extractCcipFeature(input.buffer);
+}

--- a/packages/application/src/services/ai-tagging-service.ts
+++ b/packages/application/src/services/ai-tagging-service.ts
@@ -57,13 +57,10 @@ export async function reconstructTaggingResponseFromCache(
 	}
 
 	for (const char of aiCharacters) {
-		const matchedIpNames: string[] = [];
-		for (const charIp of char.ips) {
+		const matchedIpNames = char.ips.flatMap((charIp) => {
 			const ipName = ipMap.get(charIp.id);
-			if (ipName) {
-				matchedIpNames.push(ipName);
-			}
-		}
+			return ipName ? [ipName] : [];
+		});
 		if (matchedIpNames.length > 0) {
 			response.ips_mapping[char.name] = matchedIpNames;
 		}

--- a/packages/application/src/tests/ai-tagging-service.test.ts
+++ b/packages/application/src/tests/ai-tagging-service.test.ts
@@ -1,0 +1,350 @@
+import type { IAiClient } from "@solid-imager/core/domain/interfaces/ai-client";
+import type { CharacterRepository } from "@solid-imager/core/domain/repositories/character-repository";
+import type { IIpRepository } from "@solid-imager/core/domain/repositories/ip-repository";
+import type { TagRepository } from "@solid-imager/core/domain/repositories/tag-repository";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+	isAiServiceLocal,
+	orchestrateCcipExtraction,
+	orchestrateTagging,
+	reconstructTaggingResponseFromCache,
+	resolveAiInput,
+} from "../services/ai-tagging-service";
+
+describe("ai-tagging-service", () => {
+	describe("isAiServiceLocal", () => {
+		it("returns true for localhost", () => {
+			expect(isAiServiceLocal("http://localhost:8000")).toBe(true);
+		});
+
+		it("returns true for 127.0.0.1", () => {
+			expect(isAiServiceLocal("http://127.0.0.1:8000")).toBe(true);
+		});
+
+		it("returns true for [::1]", () => {
+			expect(isAiServiceLocal("http://[::1]:8000")).toBe(true);
+		});
+
+		it("returns false for remote host", () => {
+			expect(isAiServiceLocal("http://example.com:8000")).toBe(false);
+		});
+
+		it("returns true when baseUrl is undefined", () => {
+			expect(isAiServiceLocal(undefined)).toBe(true);
+		});
+
+		it("returns true for invalid URL", () => {
+			expect(isAiServiceLocal("not-a-url")).toBe(true);
+		});
+	});
+
+	describe("reconstructTaggingResponseFromCache", () => {
+		const mockTagRepo = {
+			findByMediaId: vi.fn(),
+		} as unknown as Pick<TagRepository, "findByMediaId">;
+		const mockCharacterRepo = {
+			getMediaCharacters: vi.fn(),
+		} as unknown as Pick<CharacterRepository, "getMediaCharacters">;
+		const mockIpRepo = {
+			getMediaIps: vi.fn(),
+		} as unknown as Pick<IIpRepository, "getMediaIps">;
+
+		beforeEach(() => {
+			mockTagRepo.findByMediaId.mockReset();
+			mockCharacterRepo.getMediaCharacters.mockReset();
+			mockIpRepo.getMediaIps.mockReset();
+		});
+
+		it("returns null when no AI tags exist", async () => {
+			mockTagRepo.findByMediaId.mockResolvedValue([
+				{ name: "manual-tag", source: "manual", confidence: 1.0 },
+			]);
+			const result = await reconstructTaggingResponseFromCache("media-1", {
+				tagRepository: mockTagRepo,
+				characterRepository: mockCharacterRepo,
+				ipRepository: mockIpRepo,
+			});
+			expect(result).toBeNull();
+		});
+
+		it("reconstructs response from cached AI data", async () => {
+			mockTagRepo.findByMediaId.mockResolvedValue([
+				{ name: "1girl", source: "AI", confidence: 0.9 },
+			]);
+			mockCharacterRepo.getMediaCharacters.mockResolvedValue([
+				{
+					id: "char-1",
+					name: "HatsuneMiku",
+					associationSource: "AI",
+					confidence: 0.95,
+					ips: [{ id: "ip-1", name: "Vocaloid" }],
+					description: null,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			]);
+			mockIpRepo.getMediaIps.mockResolvedValue([
+				{
+					id: "ip-1",
+					name: "Vocaloid",
+					associationSource: "AI",
+					confidence: null,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			]);
+
+			const result = await reconstructTaggingResponseFromCache("media-1", {
+				tagRepository: mockTagRepo,
+				characterRepository: mockCharacterRepo,
+				ipRepository: mockIpRepo,
+			});
+
+			expect(result).toEqual({
+				general: { "1girl": 0.9 },
+				character: { HatsuneMiku: 0.95 },
+				ips: ["Vocaloid"],
+				ips_mapping: { HatsuneMiku: ["Vocaloid"] },
+			});
+		});
+	});
+
+	describe("resolveAiInput", () => {
+		it("returns path when local source and local AI", async () => {
+			const result = await resolveAiInput({
+				mediaSourceType: "local",
+				mediaSourceConnectionInfo: { path: "/data" },
+				mediaFilePath: "img.jpg",
+				isAiServiceLocal: true,
+				getBuffer: vi.fn(),
+				joinPath: (a, b) => `${a}/${b}`,
+			});
+			expect(result).toEqual({ type: "path", fullPath: "/data/img.jpg" });
+		});
+
+		it("returns buffer when remote AI", async () => {
+			const getBuffer = vi.fn(async () => new ArrayBuffer(8));
+			const result = await resolveAiInput({
+				mediaSourceType: "local",
+				mediaSourceConnectionInfo: { path: "/data" },
+				mediaFilePath: "img.jpg",
+				isAiServiceLocal: false,
+				getBuffer,
+				joinPath: (a, b) => `${a}/${b}`,
+			});
+			expect(result).toEqual({ type: "buffer", buffer: new ArrayBuffer(8) });
+			expect(getBuffer).toHaveBeenCalled();
+		});
+
+		it("returns buffer when non-local source", async () => {
+			const getBuffer = vi.fn(async () => new ArrayBuffer(8));
+			const result = await resolveAiInput({
+				mediaSourceType: "s3",
+				mediaSourceConnectionInfo: {},
+				mediaFilePath: "img.jpg",
+				isAiServiceLocal: true,
+				getBuffer,
+				joinPath: (a, b) => `${a}/${b}`,
+			});
+			expect(result).toEqual({ type: "buffer", buffer: new ArrayBuffer(8) });
+		});
+	});
+
+	describe("orchestrateTagging", () => {
+		const mockAiClient = {
+			tagImage: vi.fn(),
+			tagImageByPath: vi.fn(),
+		} as unknown as IAiClient;
+
+		beforeEach(() => {
+			mockAiClient.tagImage.mockReset();
+			mockAiClient.tagImageByPath.mockReset();
+		});
+
+		it("uses cache when available", async () => {
+			const mockTagRepo = {
+				findByMediaId: vi.fn(async () => [
+					{ name: "cached", source: "AI", confidence: 0.8 },
+				]),
+			} as unknown as Pick<TagRepository, "findByMediaId">;
+			const mockCharacterRepo = {
+				getMediaCharacters: vi.fn(async () => []),
+			} as unknown as Pick<CharacterRepository, "getMediaCharacters">;
+			const mockIpRepo = {
+				getMediaIps: vi.fn(async () => []),
+			} as unknown as Pick<IIpRepository, "getMediaIps">;
+
+			const persistResponse = vi.fn();
+
+			const result = await orchestrateTagging("media-1", undefined, {
+				aiClient: mockAiClient,
+				reconstructDeps: {
+					tagRepository: mockTagRepo,
+					characterRepository: mockCharacterRepo,
+					ipRepository: mockIpRepo,
+				},
+				getAiBaseUrl: () => "http://localhost",
+				mediaSourceType: "local",
+				mediaSourceConnectionInfo: { path: "/data" },
+				mediaFilePath: "img.jpg",
+				getBuffer: vi.fn(),
+				joinPath: (a, b) => `${a}/${b}`,
+				persistResponse,
+			});
+
+			expect(result).toEqual({
+				general: { cached: 0.8 },
+				character: {},
+				ips: [],
+				ips_mapping: {},
+			});
+			expect(mockAiClient.tagImage).not.toHaveBeenCalled();
+			expect(mockAiClient.tagImageByPath).not.toHaveBeenCalled();
+			expect(persistResponse).not.toHaveBeenCalled();
+		});
+
+		it("calls tagImageByPath for local source + local AI", async () => {
+			const mockTagRepo = {
+				findByMediaId: vi.fn(async () => []),
+			} as unknown as Pick<TagRepository, "findByMediaId">;
+			const mockCharacterRepo = {
+				getMediaCharacters: vi.fn(async () => []),
+			} as unknown as Pick<CharacterRepository, "getMediaCharacters">;
+			const mockIpRepo = {
+				getMediaIps: vi.fn(async () => []),
+			} as unknown as Pick<IIpRepository, "getMediaIps">;
+
+			mockAiClient.tagImageByPath.mockResolvedValue({
+				general: { tag: 0.5 },
+				character: {},
+				ips: [],
+				ips_mapping: {},
+			});
+
+			const persistResponse = vi.fn();
+
+			await orchestrateTagging(
+				"media-1",
+				{ skipCache: true },
+				{
+					aiClient: mockAiClient,
+					reconstructDeps: {
+						tagRepository: mockTagRepo,
+						characterRepository: mockCharacterRepo,
+						ipRepository: mockIpRepo,
+					},
+					getAiBaseUrl: () => "http://localhost",
+					mediaSourceType: "local",
+					mediaSourceConnectionInfo: { path: "/data" },
+					mediaFilePath: "img.jpg",
+					getBuffer: vi.fn(),
+					joinPath: (a, b) => `${a}/${b}`,
+					persistResponse,
+				},
+			);
+
+			expect(mockAiClient.tagImageByPath).toHaveBeenCalledWith("/data/img.jpg");
+			expect(mockAiClient.tagImage).not.toHaveBeenCalled();
+			expect(persistResponse).toHaveBeenCalled();
+		});
+
+		it("calls tagImage for remote AI", async () => {
+			const mockTagRepo = {
+				findByMediaId: vi.fn(async () => []),
+			} as unknown as Pick<TagRepository, "findByMediaId">;
+			const mockCharacterRepo = {
+				getMediaCharacters: vi.fn(async () => []),
+			} as unknown as Pick<CharacterRepository, "getMediaCharacters">;
+			const mockIpRepo = {
+				getMediaIps: vi.fn(async () => []),
+			} as unknown as Pick<IIpRepository, "getMediaIps">;
+
+			const buffer = new ArrayBuffer(8);
+			mockAiClient.tagImage.mockResolvedValue({
+				general: { tag: 0.5 },
+				character: {},
+				ips: [],
+				ips_mapping: {},
+			});
+
+			const persistResponse = vi.fn();
+
+			await orchestrateTagging(
+				"media-1",
+				{ skipCache: true },
+				{
+					aiClient: mockAiClient,
+					reconstructDeps: {
+						tagRepository: mockTagRepo,
+						characterRepository: mockCharacterRepo,
+						ipRepository: mockIpRepo,
+					},
+					getAiBaseUrl: () => "http://remote.example.com",
+					mediaSourceType: "local",
+					mediaSourceConnectionInfo: { path: "/data" },
+					mediaFilePath: "img.jpg",
+					getBuffer: async () => buffer,
+					joinPath: (a, b) => `${a}/${b}`,
+					persistResponse,
+				},
+			);
+
+			expect(mockAiClient.tagImage).toHaveBeenCalledWith(buffer);
+			expect(mockAiClient.tagImageByPath).not.toHaveBeenCalled();
+			expect(persistResponse).toHaveBeenCalled();
+		});
+	});
+
+	describe("orchestrateCcipExtraction", () => {
+		const mockAiClient = {
+			extractCcipFeature: vi.fn(),
+			extractCcipFeatureByPath: vi.fn(),
+		} as unknown as IAiClient;
+
+		beforeEach(() => {
+			mockAiClient.extractCcipFeature.mockReset();
+			mockAiClient.extractCcipFeatureByPath.mockReset();
+		});
+
+		it("calls extractCcipFeatureByPath for local source + local AI", async () => {
+			mockAiClient.extractCcipFeatureByPath.mockResolvedValue({
+				feature: [1, 2, 3],
+			});
+
+			const result = await orchestrateCcipExtraction({
+				aiClient: mockAiClient,
+				getAiBaseUrl: () => "http://localhost",
+				mediaSourceType: "local",
+				mediaSourceConnectionInfo: { path: "/data" },
+				mediaFilePath: "img.jpg",
+				getBuffer: vi.fn(),
+				joinPath: (a, b) => `${a}/${b}`,
+			});
+
+			expect(mockAiClient.extractCcipFeatureByPath).toHaveBeenCalledWith(
+				"/data/img.jpg",
+			);
+			expect(result).toEqual({ feature: [1, 2, 3] });
+		});
+
+		it("calls extractCcipFeature for remote AI", async () => {
+			const buffer = new ArrayBuffer(8);
+			mockAiClient.extractCcipFeature.mockResolvedValue({
+				feature: [4, 5, 6],
+			});
+
+			const result = await orchestrateCcipExtraction({
+				aiClient: mockAiClient,
+				getAiBaseUrl: () => "http://remote.example.com",
+				mediaSourceType: "local",
+				mediaSourceConnectionInfo: { path: "/data" },
+				mediaFilePath: "img.jpg",
+				getBuffer: async () => buffer,
+				joinPath: (a, b) => `${a}/${b}`,
+			});
+
+			expect(mockAiClient.extractCcipFeature).toHaveBeenCalledWith(buffer);
+			expect(result).toEqual({ feature: [4, 5, 6] });
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Closes #324

`apps/server/src/application/services/tagging-service.ts` の orchestration logic を `packages/application/src/services/ai-tagging-service.ts` として shared service contract に切り出しました。

## Changes
- `packages/application/src/services/ai-tagging-service.ts` を新規作成
  - `reconstructTaggingResponseFromCache`
  - `isAiServiceLocal`
  - `resolveAiInput`
  - `orchestrateTagging`
  - `orchestrateCcipExtraction`
- `apps/server/src/application/services/tagging-service.ts` をリファクタリングし、platform 固有の adapter 部分だけを残す
- `apps/tauri/src/infrastructure/local-api/services/ai-service.ts` をリファクタリングし、shared orchestration を使用
- unit tests を追加