### PR TITLE
refactor: audit and extract shared pure logic from media storage adapters (#325)

### DIFF
--- a/apps/server/src/infrastructure/storage/server-media-storage.ts
+++ b/apps/server/src/infrastructure/storage/server-media-storage.ts
@@ -1,38 +1,24 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { MediaPathAdapter } from "@solid-imager/application/services/media-service";
+import {
+	buildMediaStorageResult,
+	resolveSafePath,
+	withCleanup,
+} from "@solid-imager/application/services/media-storage-utils";
 import { resolveUploadTargetPath } from "@solid-imager/application/services/media-upload-utils";
 import type {
 	IMediaStorage,
 	MediaMetadata,
 	MediaStorageResult,
 } from "@solid-imager/core";
-import type { conflictSchema } from "@solid-imager/core/domain/media/upload-schemas";
 import sharp from "sharp";
-import type { z } from "zod";
 
 const pathAdapter: MediaPathAdapter = {
 	join: path.join,
 	extname: path.extname,
 	basename: path.basename,
 	relative: path.relative,
-};
-
-/**
- * Resolves a path safely, ensuring it remains within the base path.
- * Prevents path traversal attacks.
- */
-const resolveSafePath = (basePath: string, targetPath: string): string => {
-	const resolvedPath = path.resolve(basePath, targetPath);
-	const absoluteBase = path.resolve(basePath);
-
-	if (
-		resolvedPath !== absoluteBase &&
-		!resolvedPath.startsWith(absoluteBase + path.sep)
-	) {
-		throw new Error(`Invalid path: ${targetPath}`);
-	}
-	return resolvedPath;
 };
 
 export const ServerMediaStorage: IMediaStorage = {
@@ -67,35 +53,28 @@ export const ServerMediaStorage: IMediaStorage = {
 		const targetFilePath = resolved.fullPath;
 		const relativeFilePath = resolved.relativePath;
 		const targetFileName = path.basename(targetFilePath);
-		const conflict: z.infer<typeof conflictSchema> | undefined =
-			resolved.conflict;
+		const conflict = resolved.conflict;
 
 		// Save the file
 		const arrayBuffer = await file.arrayBuffer();
 		await fs.writeFile(targetFilePath, new Uint8Array(arrayBuffer));
 
 		// Extract valid metadata using getFileMetadata to support both images and videos
-		try {
-			const metadata = await ServerMediaStorage.getFileMetadata(targetFilePath);
-
-			return {
-				filePath: relativeFilePath,
-				fileName: targetFileName,
-				width: metadata.width,
-				height: metadata.height,
-				size: metadata.size,
-				createdAt: metadata.createdAt,
-				modifiedAt: metadata.modifiedAt,
-				conflict,
-			};
-		} catch (e) {
-			try {
+		return await withCleanup(
+			async () => {
+				const metadata =
+					await ServerMediaStorage.getFileMetadata(targetFilePath);
+				return buildMediaStorageResult(
+					metadata,
+					relativeFilePath,
+					targetFileName,
+					conflict,
+				);
+			},
+			async () => {
 				await fs.unlink(targetFilePath);
-			} catch (_) {
-				/* ignore unlink error */
-			}
-			throw e;
-		}
+			},
+		);
 	},
 
 	async deleteFile(basePath: string, filePath: string): Promise<void> {
@@ -252,34 +231,27 @@ export const ServerMediaStorage: IMediaStorage = {
 		const targetFilePath = resolved.fullPath;
 		const relativeFilePath = resolved.relativePath;
 		const targetFileName = path.basename(targetFilePath);
-		const conflict: z.infer<typeof conflictSchema> | undefined =
-			resolved.conflict;
+		const conflict = resolved.conflict;
 
 		// Copy the file
 		await fs.copyFile(sourcePath, targetFilePath);
 
 		// Extract metadata using getFileMetadata
-		try {
-			// Use ServerMediaStorage.getFileMetadata to support video files as well
-			const metadata = await ServerMediaStorage.getFileMetadata(targetFilePath);
-
-			return {
-				filePath: relativeFilePath,
-				fileName: targetFileName,
-				width: metadata.width,
-				height: metadata.height,
-				size: metadata.size,
-				createdAt: metadata.createdAt,
-				modifiedAt: metadata.modifiedAt,
-				conflict,
-			};
-		} catch (e) {
-			try {
+		return await withCleanup(
+			async () => {
+				// Use ServerMediaStorage.getFileMetadata to support video files as well
+				const metadata =
+					await ServerMediaStorage.getFileMetadata(targetFilePath);
+				return buildMediaStorageResult(
+					metadata,
+					relativeFilePath,
+					targetFileName,
+					conflict,
+				);
+			},
+			async () => {
 				await fs.unlink(targetFilePath);
-			} catch (_) {
-				// Ignore error if temporary file cleanup fails
-			}
-			throw e;
-		}
+			},
+		);
 	},
 };

--- a/apps/tauri/src/infrastructure/local-api/services/media-service.ts
+++ b/apps/tauri/src/infrastructure/local-api/services/media-service.ts
@@ -5,6 +5,11 @@ import {
 	type MediaPathAdapter,
 } from "@solid-imager/application/services/media-service";
 import {
+	buildMediaStorageResult,
+	resolveSafePath,
+	withCleanup,
+} from "@solid-imager/application/services/media-storage-utils";
+import {
 	normalizeRelativePath,
 	resolveUploadTargetPath,
 } from "@solid-imager/application/services/media-upload-utils";
@@ -115,39 +120,34 @@ const tauriMediaStorage: IMediaStorage = {
 			new Uint8Array(buffer),
 		);
 
-		try {
-			const metadata = await this.getFileMetadata(target.fullPath);
-			return {
-				filePath: target.relativePath,
-				fileName: basename(target.relativePath),
-				width: metadata.width,
-				height: metadata.height,
-				size: metadata.size,
-				createdAt: metadata.createdAt,
-				modifiedAt: metadata.modifiedAt,
-				conflict: target.conflict,
-			};
-		} catch (error) {
-			await getTauriAppServices().fileSystem.rm(target.fullPath, {
-				force: true,
-			});
-			throw error;
-		}
-	},
-
-	async deleteFile(basePath: string, filePath: string): Promise<void> {
-		await getTauriAppServices().fileSystem.rm(
-			joinLocalPath(basePath, filePath),
-			{
-				force: true,
+		return await withCleanup(
+			async () => {
+				const metadata = await this.getFileMetadata(target.fullPath);
+				return buildMediaStorageResult(
+					metadata,
+					target.relativePath,
+					basename(target.relativePath),
+					target.conflict,
+				);
+			},
+			async () => {
+				await getTauriAppServices().fileSystem.rm(target.fullPath, {
+					force: true,
+				});
 			},
 		);
 	},
 
+	async deleteFile(basePath: string, filePath: string): Promise<void> {
+		const safePath = resolveSafePath(basePath, filePath);
+		await getTauriAppServices().fileSystem.rm(safePath, {
+			force: true,
+		});
+	},
+
 	async getFile(basePath: string, filePath: string): Promise<Uint8Array> {
-		return await getTauriAppServices().fileSystem.readFile(
-			joinLocalPath(basePath, filePath),
-		);
+		const safePath = resolveSafePath(basePath, filePath);
+		return await getTauriAppServices().fileSystem.readFile(safePath);
 	},
 
 	async scanDirectory(basePath: string): Promise<string[]> {
@@ -210,24 +210,22 @@ const tauriMediaStorage: IMediaStorage = {
 			target.fullPath,
 		);
 
-		try {
-			const metadata = await this.getFileMetadata(target.fullPath);
-			return {
-				filePath: target.relativePath,
-				fileName: basename(target.relativePath),
-				width: metadata.width,
-				height: metadata.height,
-				size: metadata.size,
-				createdAt: metadata.createdAt,
-				modifiedAt: metadata.modifiedAt,
-				conflict: target.conflict,
-			};
-		} catch (error) {
-			await getTauriAppServices().fileSystem.rm(target.fullPath, {
-				force: true,
-			});
-			throw error;
-		}
+		return await withCleanup(
+			async () => {
+				const metadata = await this.getFileMetadata(target.fullPath);
+				return buildMediaStorageResult(
+					metadata,
+					target.relativePath,
+					basename(target.relativePath),
+					target.conflict,
+				);
+			},
+			async () => {
+				await getTauriAppServices().fileSystem.rm(target.fullPath, {
+					force: true,
+				});
+			},
+		);
 	},
 };
 

--- a/packages/application/src/services/media-storage-utils.ts
+++ b/packages/application/src/services/media-storage-utils.ts
@@ -1,0 +1,116 @@
+import type {
+	MediaMetadata,
+	MediaStorageResult,
+} from "@solid-imager/core/interfaces/media-storage";
+
+/**
+ * Resolves a path safely, ensuring it remains within the base path.
+ * Prevents path traversal attacks. Works cross-platform (Unix/Windows).
+ */
+export function resolveSafePath(basePath: string, targetPath: string): string {
+	const pathSeparator = basePath.includes("\\") ? "\\" : "/";
+	const normalizedBase = basePath
+		.replace(/[\\/]+$/, "")
+		.replace(/[\\/]/g, pathSeparator);
+	const normalizedTarget = targetPath
+		.replace(/[\\/]+$/, "")
+		.replace(/[\\/]/g, pathSeparator);
+
+	// If target is absolute, it must be within base
+	const isAbsolute = /^(?:[A-Za-z]:)?[\\/]/.test(normalizedTarget);
+	if (isAbsolute) {
+		const lowerBase = normalizedBase.toLowerCase();
+		const lowerTarget = normalizedTarget.toLowerCase();
+		if (lowerTarget === lowerBase) {
+			return normalizedTarget;
+		}
+		const baseWithSep = lowerBase + pathSeparator;
+		if (lowerTarget.startsWith(baseWithSep)) {
+			return normalizedTarget;
+		}
+		throw new Error(`Invalid path: ${targetPath}`);
+	}
+
+	// Resolve relative path manually
+	const baseParts = normalizedBase.split(pathSeparator);
+	const targetParts = normalizedTarget
+		.split(pathSeparator)
+		.filter((s) => s.length > 0);
+
+	const resolvedParts = [...baseParts];
+	for (const part of targetParts) {
+		if (part === "..") {
+			if (resolvedParts.length === 0) {
+				throw new Error(`Invalid path: ${targetPath}`);
+			}
+			const last = resolvedParts[resolvedParts.length - 1];
+			// Don't pop root or drive letter
+			if (last === "") {
+				throw new Error(`Invalid path: ${targetPath}`);
+			}
+			if (/^[A-Za-z]:$/.test(last) && resolvedParts.length === 1) {
+				throw new Error(`Invalid path: ${targetPath}`);
+			}
+			resolvedParts.pop();
+		} else if (part !== "." && part !== "") {
+			resolvedParts.push(part);
+		}
+	}
+
+	const resolvedPath = resolvedParts.join(pathSeparator);
+
+	const lowerResolved = resolvedPath.toLowerCase();
+	const lowerBase = normalizedBase.toLowerCase();
+
+	if (
+		lowerResolved !== lowerBase &&
+		!lowerResolved.startsWith(lowerBase + pathSeparator.toLowerCase())
+	) {
+		throw new Error(`Invalid path: ${targetPath}`);
+	}
+
+	return resolvedPath;
+}
+
+/**
+ * Builds a MediaStorageResult from extracted metadata and path information.
+ * Pure logic shared between platform adapters.
+ */
+export function buildMediaStorageResult(
+	metadata: MediaMetadata,
+	relativePath: string,
+	fileName: string,
+	conflict?: { existingFile: string; suggestedName: string },
+): MediaStorageResult {
+	return {
+		filePath: relativePath,
+		fileName,
+		width: metadata.width,
+		height: metadata.height,
+		size: metadata.size,
+		createdAt: metadata.createdAt,
+		modifiedAt: metadata.modifiedAt,
+		conflict,
+	};
+}
+
+/**
+ * Executes an operation and runs cleanup if it throws.
+ * Used for the "save/copy file → extract metadata → return result" pattern
+ * where the file must be removed if metadata extraction fails.
+ */
+export async function withCleanup<T>(
+	operation: () => Promise<T>,
+	cleanup: () => Promise<void> | void,
+): Promise<T> {
+	try {
+		return await operation();
+	} catch (error) {
+		try {
+			await cleanup();
+		} catch (_) {
+			// Ignore cleanup errors; preserve original error
+		}
+		throw error;
+	}
+}

--- a/packages/application/src/services/media-storage-utils.ts
+++ b/packages/application/src/services/media-storage-utils.ts
@@ -6,9 +6,18 @@ import type {
 /**
  * Resolves a path safely, ensuring it remains within the base path.
  * Prevents path traversal attacks. Works cross-platform (Unix/Windows).
+ *
+ * @param separator - Optional path separator. If not provided, it is inferred from the base path.
  */
-export function resolveSafePath(basePath: string, targetPath: string): string {
-	const pathSeparator = basePath.includes("\\") ? "\\" : "/";
+export function resolveSafePath(
+	basePath: string,
+	targetPath: string,
+	separator?: string,
+): string {
+	const pathSeparator =
+		(separator ?? (basePath.includes("\\") && !basePath.includes("/")))
+			? "\\"
+			: "/";
 	const normalizedBase = basePath
 		.replace(/[\\/]+$/, "")
 		.replace(/[\\/]/g, pathSeparator);
@@ -80,7 +89,7 @@ export function buildMediaStorageResult(
 	metadata: MediaMetadata,
 	relativePath: string,
 	fileName: string,
-	conflict?: { existingFile: string; suggestedName: string },
+	conflict?: MediaStorageResult["conflict"],
 ): MediaStorageResult {
 	return {
 		filePath: relativePath,


### PR DESCRIPTION
## Summary
Closes #325

media storage adapter の重複境界を監査し、shared 化できる pure logic を `packages/application/src/services/media-storage-utils.ts` に切り出しました。

## Changes
- `packages/application/src/services/media-storage-utils.ts` を新規作成
  - `resolveSafePath` — パストラバーサル防止の純粋関数
  - `buildMediaStorageResult` — `MediaMetadata` から `MediaStorageResult` を構築
  - `withCleanup` — 失敗時クリーンアップパターンの共通化
- `apps/server/src/infrastructure/storage/server-media-storage.ts` をリファクタリング
- `apps/tauri/src/infrastructure/local-api/services/media-service.ts` をリファクタリング
  - `deleteFile` / `getFile` に `resolveSafePath` を適用