### PR TITLE
fix(ui): restore manual error handling in AiTaggingModal

### DIFF
--- a/packages/ui/src/ai-tagging-modal.tsx
+++ b/packages/ui/src/ai-tagging-modal.tsx
@@ -1,5 +1,5 @@
 import type { TaggingResponse } from "@solid-imager/core/domain/tagging/schemas";
-import { createEffect, createSignal, For, Show } from "solid-js";
+import { createEffect, createSignal, For, onCleanup, Show } from "solid-js";
 import { Badge } from "./badge";
 import {
 	Dialog,
@@ -27,26 +27,41 @@ export function AiTaggingModal(props: AiTaggingModalProps) {
 
 	createEffect(() => {
 		if (props.isOpen) {
+			let isCancelled = false;
+
+			const fetchTags = async () => {
+				setIsLoading(true);
+				setResult(null);
+				setError(null);
+				try {
+					const data = await props.fetchTags();
+					if (!isCancelled) {
+						setResult(data);
+					}
+				} catch (err) {
+					if (!isCancelled) {
+						setError(
+							err instanceof Error ? err.message : "Unknown error occurred",
+						);
+					}
+				} finally {
+					if (!isCancelled) {
+						setIsLoading(false);
+					}
+				}
+			};
+
 			fetchTags();
+
+			onCleanup(() => {
+				isCancelled = true;
+			});
 		} else {
 			setResult(null);
 			setError(null);
 			setIsLoading(false);
 		}
 	});
-
-	const fetchTags = async () => {
-		setIsLoading(true);
-		setError(null);
-		try {
-			const data = await props.fetchTags();
-			setResult(data);
-		} catch (err) {
-			setError(err instanceof Error ? err.message : "Unknown error occurred");
-		} finally {
-			setIsLoading(false);
-		}
-	};
 
 	return (
 		<Dialog

--- a/packages/ui/src/ai-tagging-modal.tsx
+++ b/packages/ui/src/ai-tagging-modal.tsx
@@ -1,5 +1,5 @@
 import type { TaggingResponse } from "@solid-imager/core/domain/tagging/schemas";
-import { createResource, For, Show } from "solid-js";
+import { createEffect, createSignal, For, Show } from "solid-js";
 import { Badge } from "./badge";
 import {
 	Dialog,
@@ -21,13 +21,32 @@ const DEFAULT_DESCRIPTION =
 	"Tags extracted from the image using the AI service.";
 
 export function AiTaggingModal(props: AiTaggingModalProps) {
-	const [result] = createResource(
-		() => (props.isOpen ? props.fetchTags : null),
-		async (fetcher) => await fetcher(),
-	);
+	const [isLoading, setIsLoading] = createSignal(false);
+	const [result, setResult] = createSignal<TaggingResponse | null>(null);
+	const [error, setError] = createSignal<string | null>(null);
 
-	const isLoading = () => result.loading;
-	const error = () => result.error?.message ?? null;
+	createEffect(() => {
+		if (props.isOpen) {
+			fetchTags();
+		} else {
+			setResult(null);
+			setError(null);
+			setIsLoading(false);
+		}
+	});
+
+	const fetchTags = async () => {
+		setIsLoading(true);
+		setError(null);
+		try {
+			const data = await props.fetchTags();
+			setResult(data);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Unknown error occurred");
+		} finally {
+			setIsLoading(false);
+		}
+	};
 
 	return (
 		<Dialog


### PR DESCRIPTION
## Summary

Fixes AI tagging modal closing unexpectedly and breaking page navigation when the AI service is unreachable.

## Problem

PR#314 extracted `AiTaggingModal` to `packages/ui` and replaced the manual `createEffect` + `createSignal` + `try/catch` pattern with `createResource`. This caused a regression:

- When the AI tagging API is unreachable, `createResource` did not reliably keep the modal open to display the error
- The modal would close unexpectedly
- Page navigation would break

## Solution

Restore the original error handling pattern:
- Use `createEffect` to watch `props.isOpen`
- Use `createSignal` for `isLoading`, `result`, `error`
- Wrap `fetchTags` in `try/catch` to capture errors and store them in the `error` signal
- Explicitly reset state when the modal closes

## Verification

- [x] `bun run typecheck` — all packages pass
- [x] `bun run test` — all 75 test files pass
- [x] `bun run lint` — clean (only pre-existing generated file warning)