### PR TITLE
fix(server): validate downloaded image integrity and fix yt-dlp binary resolution

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,7 +4,8 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vp dev",
-		"build": "vp build",
+		"build": "vp build && bun run build:post",
+		"build:post": "cp ../node_modules/youtube-dl-exec/bin/yt-dlp .output/server/yt-dlp 2>/dev/null || cp node_modules/youtube-dl-exec/bin/yt-dlp .output/server/yt-dlp 2>/dev/null; chmod +x .output/server/yt-dlp 2>/dev/null || true",
 		"preview": "vp preview",
 		"start": "bun run db:migrate:pglite && bun .output/server/index.mjs",
 		"db:generate": "drizzle-kit generate",

--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -18,7 +18,7 @@ import type {
 } from "@solid-imager/core/domain/media/schemas";
 import { generateMediaFilename } from "@solid-imager/core/domain/media/utils/filename-utils";
 import { getMediaTypeFromExtension } from "@solid-imager/core/domain/media/utils/media-type-utils";
-import youtubedl from "youtube-dl-exec";
+import { create as createYtDlp } from "youtube-dl-exec";
 import { services } from "~/application/registry";
 import type { Job } from "~/infrastructure/db/schema";
 import { waitForDownloadRateLimit } from "~/infrastructure/jobs/download-rate-limiter";
@@ -31,6 +31,54 @@ import { resolveFfmpegPath } from "~/infrastructure/utils/ffmpeg";
 
 const DATE_REGEX = /(\d{4})(\d{2})(\d{2})/;
 const TWITTER_URL_REGEX = /(twitter|x)\.com\/\w+\/status\/\d+/;
+
+const JPEG_EOI = Buffer.from([0xff, 0xd9]);
+const PNG_SIGNATURE = Buffer.from([
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const PNG_IEND = Buffer.from([0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82]);
+
+function validateImageIntegrity(filePath: string): void {
+	const content = require("node:fs").readFileSync(filePath);
+	if (content.length === 0) {
+		throw new Error(`Downloaded file is empty: ${filePath}`);
+	}
+
+	const isJpeg = content[0] === 0xff && content[1] === 0xd8;
+	const isPng =
+		content.length >= 8 && content.subarray(0, 8).equals(PNG_SIGNATURE);
+
+	if (isJpeg) {
+		if (content.length < 2 || !content.subarray(-2).equals(JPEG_EOI)) {
+			throw new Error(
+				`Truncated JPEG file (missing end marker FFD9): ${filePath} (${content.length} bytes)`,
+			);
+		}
+	} else if (isPng) {
+		if (content.length < 8 || !content.subarray(-8).equals(PNG_IEND)) {
+			throw new Error(
+				`Truncated PNG file (missing IEND chunk): ${filePath} (${content.length} bytes)`,
+			);
+		}
+	}
+}
+
+const CONTENT_TYPE_TO_EXT: Record<string, string> = {
+	"image/jpeg": ".jpg",
+	"image/png": ".png",
+	"image/webp": ".webp",
+	"image/gif": ".gif",
+	"image/avif": ".avif",
+};
+
+function resolveExtensionFromContentType(
+	contentType: string | null,
+	fallback: string,
+): string {
+	if (!contentType) return fallback;
+	const mime = contentType.split(";")[0].trim().toLowerCase();
+	return CONTENT_TYPE_TO_EXT[mime] ?? fallback;
+}
 
 type YtDlpOutput = {
 	id: string;
@@ -92,6 +140,49 @@ async function createNetscapeCookieFile(
 	}
 }
 
+let ytDlpPathCache: string | null = null;
+
+async function resolveYtDlpPath(): Promise<string> {
+	if (ytDlpPathCache) return ytDlpPathCache;
+
+	const { existsSync } = await import("node:fs");
+
+	// 1. Check built output location first (for production builds)
+	const outputBin = path.join(process.cwd(), "yt-dlp");
+	if (existsSync(outputBin)) {
+		ytDlpPathCache = outputBin;
+		return ytDlpPathCache;
+	}
+
+	// 2. Check node_modules in current working directory
+	const nodeModulesBin = path.join(
+		process.cwd(),
+		"node_modules/youtube-dl-exec/bin/yt-dlp",
+	);
+	if (existsSync(nodeModulesBin)) {
+		ytDlpPathCache = nodeModulesBin;
+		return ytDlpPathCache;
+	}
+
+	// 3. Walk up from current file to find workspace root
+	const { dirname } = await import("node:path");
+	let dir = dirname(new URL(import.meta.url).pathname);
+	for (let i = 0; i < 10; i++) {
+		const candidate = path.join(dir, "node_modules/youtube-dl-exec/bin/yt-dlp");
+		if (existsSync(candidate)) {
+			ytDlpPathCache = candidate;
+			return ytDlpPathCache;
+		}
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+
+	// 4. Fallback to PATH
+	ytDlpPathCache = "yt-dlp";
+	return ytDlpPathCache;
+}
+
 /**
  * Downloads video/media using yt-dlp via youtube-dl-exec
  */
@@ -108,7 +199,9 @@ async function downloadWithYtDlp(
 
 	try {
 		const ffmpegLocation = await resolveFfmpegPath();
-		const result = await youtubedl(url, {
+		const ytDlpPath = await resolveYtDlpPath();
+		const ytdlp = createYtDlp(ytDlpPath);
+		const result = await ytdlp(url, {
 			noSimulate: true,
 			printJson: true,
 			paths: outputDir,
@@ -140,7 +233,8 @@ async function downloadWithYtDlp(
 		} else {
 			logger.error({ err: error }, "yt-dlp execution failed");
 		}
-		throw new Error(`yt-dlp failed: ${error}`);
+		const msg = error instanceof Error ? error.message : String(error);
+		throw new Error(`yt-dlp failed: ${msg}`);
 	} finally {
 		if (cookieFilePath) {
 			fs.unlink(cookieFilePath).catch((err) =>
@@ -191,7 +285,9 @@ async function fetchMetadataWithYtDlp(
 
 	try {
 		const ffmpegLocation = await resolveFfmpegPath();
-		const result = await youtubedl(url, {
+		const ytDlpPath = await resolveYtDlpPath();
+		const ytdlp = createYtDlp(ytDlpPath);
+		const result = await ytdlp(url, {
 			dumpSingleJson: true,
 			noDownload: true,
 			...(ffmpegLocation && { ffmpegLocation }),
@@ -367,11 +463,18 @@ export async function processDownloadJob(job: Job): Promise<void> {
 			}
 
 			const urlPath = new URL(item.targetUrl).pathname;
-			const extension = path.extname(urlPath) || ".png";
-			const filename = generateMediaFilename(item, extension);
+			const fallbackExt = path.extname(urlPath) || ".png";
 			const headers = buildFetchHeaders(item);
+
+			let response: Response;
+			let extension: string;
+			let filename: string;
+			let arrayBuffer: ArrayBuffer;
+			let fileInfo: Awaited<ReturnType<typeof ServerMediaStorage.saveFile>>;
+
+			// First attempt
 			await waitForDownloadRateLimit();
-			const response = await fetch(item.targetUrl, {
+			response = await fetch(item.targetUrl, {
 				headers,
 				signal: AbortSignal.timeout(30000),
 			});
@@ -380,8 +483,13 @@ export async function processDownloadJob(job: Job): Promise<void> {
 					`Failed to download image: ${response.status} ${response.statusText}`,
 				);
 			}
-			const arrayBuffer = await response.arrayBuffer();
-			const fileInfo = await ServerMediaStorage.saveFile(
+			extension = resolveExtensionFromContentType(
+				response.headers.get("content-type"),
+				fallbackExt,
+			);
+			filename = generateMediaFilename(item, extension);
+			arrayBuffer = await response.arrayBuffer();
+			fileInfo = await ServerMediaStorage.saveFile(
 				context.basePath,
 				{
 					name: filename,
@@ -393,6 +501,52 @@ export async function processDownloadJob(job: Job): Promise<void> {
 					autoIncrement: true,
 				},
 			);
+
+			// Validate integrity, retry once on failure
+			try {
+				const fullPath = path.join(context.basePath, fileInfo.filePath);
+				validateImageIntegrity(fullPath);
+			} catch (validationError) {
+				logger.warn(
+					{ err: validationError, url: item.targetUrl },
+					"Image validation failed, retrying download",
+				);
+				await fs
+					.unlink(path.join(context.basePath, fileInfo.filePath))
+					.catch(() => {});
+
+				await waitForDownloadRateLimit();
+				response = await fetch(item.targetUrl, {
+					headers,
+					signal: AbortSignal.timeout(30000),
+				});
+				if (!response.ok) {
+					throw new Error(
+						`Retry download failed: ${response.status} ${response.statusText}`,
+					);
+				}
+				extension = resolveExtensionFromContentType(
+					response.headers.get("content-type"),
+					fallbackExt,
+				);
+				filename = generateMediaFilename(item, extension);
+				arrayBuffer = await response.arrayBuffer();
+				fileInfo = await ServerMediaStorage.saveFile(
+					context.basePath,
+					{
+						name: filename,
+						arrayBuffer: async () => arrayBuffer,
+					},
+					{
+						filename,
+						overwrite: false,
+						autoIncrement: true,
+					},
+				);
+
+				const retryFullPath = path.join(context.basePath, fileInfo.filePath);
+				validateImageIntegrity(retryFullPath);
+			}
 			let createdAt = item.createdAt ? new Date(item.createdAt) : undefined;
 			if (createdAt && Number.isNaN(createdAt.getTime())) {
 				createdAt = undefined;

--- a/apps/server/src/infrastructure/processing/image-processor.ts
+++ b/apps/server/src/infrastructure/processing/image-processor.ts
@@ -110,6 +110,21 @@ export class LocalImageProcessor implements IImageProcessor {
 
 		// Default image processing
 		try {
+			// Validate JPEG integrity before processing
+			const { readFileSync } = await import("node:fs");
+			const content = readFileSync(mediaPath);
+			if (content.length >= 2 && content[0] === 0xff && content[1] === 0xd8) {
+				if (
+					content.length < 2 ||
+					content[content.length - 2] !== 0xff ||
+					content[content.length - 1] !== 0xd9
+				) {
+					throw new Error(
+						`Cannot generate thumbnail: truncated JPEG file (missing FFD9 end marker): ${mediaPath}`,
+					);
+				}
+			}
+
 			await sharp(mediaPath)
 				.resize(size, size, { fit: "inside", withoutEnlargement: true })
 				.webp({ quality })


### PR DESCRIPTION
## 変更概要

Twitter ダウンロードにおける 2 つの問題を修正:

1. **画像の切断ダウンロード**: `VipsJpeg: premature end of JPEG image` エラーが発生していた
2. **yt-dlp バイナリが見つからない**: ビルド出力で yt-dlp が実行できず動画ダウンロードが失敗していた

## 修正内容

### 画像ダウンロードの検証強化 (`download-jobs.ts`)
- Content-Type ヘッダーから正しい拡張子を推定（Twitter CDN の `.png` フォールバック問題に対応）
- ダウンロード後のファイル整合性検証（JPEG: `FFD9` 終端、PNG: `IEND` チャンク）
- 検証失敗時に 1 回リトライ
- リトライでも失敗した場合はジョブ失敗（メディア登録されない）

### yt-dlp バイナリ解決 (`download-jobs.ts`)
- `resolveYtDlpPath()` 関数を追加: `.output/` → `node_modules/` → ワークスペースルートの順で探索
- `youtube-dl-exec` の `create()` を使用して解決済みパスを明示指定
- エラーメッセージの改善: `${error}` → 実際のメッセージを抽出

### サムネイル生成の堅牢化 (`image-processor.ts`)
- `sharp()` 呼び出し前に JPEG 切断チェック（バックアップとして）

### ビルド設定 (`package.json`)
- `build:post` スクリプトを追加し、yt-dlp バイナリを `.output/server/` にコピー

## 動作確認

- 切断 JPEG の検出が明確なエラーメッセージに変化（ cryptic `VipsJpeg` → `Cannot generate thumbnail: truncated JPEG file (missing FFD9 end marker)` ）
- 新規動画ダウンロードが正常に動作（yt-dlp パス解決確認）