### PR TITLE
fix(xtracter): remove Save button and auto-persist source/API URL

### DIFF
--- a/apps/xtracter/src/popup/index.tsx
+++ b/apps/xtracter/src/popup/index.tsx
@@ -51,22 +51,6 @@ function Popup() {
 		}
 	};
 
-	const handleSave = async () => {
-		try {
-			await chrome.storage.local.set({
-				selectedSourceId: selectedSourceId(),
-				apiUrl: apiUrl(),
-			});
-			setStatus("Saved!");
-			setStatusType("success");
-			setTimeout(() => setStatus(""), 2000);
-			await fetchSources();
-		} catch (_err) {
-			setStatus("Failed to save settings.");
-			setStatusType("error");
-		}
-	};
-
 	const handleExport = async () => {
 		setExportStatus("Requesting data...");
 		try {
@@ -138,7 +122,12 @@ function Popup() {
 					id="api-url"
 					type="text"
 					value={apiUrl()}
-					onInput={(e) => setApiUrl(e.currentTarget.value)}
+					onInput={async (e) => {
+						const url = e.currentTarget.value;
+						setApiUrl(url);
+						await chrome.storage.local.set({ apiUrl: url });
+						await fetchSources();
+					}}
 					style={{
 						width: "100%",
 						padding: "8px",
@@ -163,7 +152,11 @@ function Popup() {
 				<select
 					id="source-select"
 					value={selectedSourceId()}
-					onChange={(e) => setSelectedSourceId(e.currentTarget.value)}
+					onChange={async (e) => {
+						const id = e.currentTarget.value;
+						setSelectedSourceId(id);
+						await chrome.storage.local.set({ selectedSourceId: id });
+					}}
 					disabled={isLoading() || sources().length === 0}
 					style={{
 						width: "100%",
@@ -184,23 +177,6 @@ function Popup() {
 					</For>
 				</select>
 			</div>
-
-			<button
-				type="button"
-				onClick={handleSave}
-				style={{
-					width: "100%",
-					padding: "8px",
-					"background-color": "#1d9bf0",
-					color: "white",
-					border: "none",
-					"border-radius": "4px",
-					"font-weight": "bold",
-					cursor: "pointer",
-				}}
-			>
-				Save
-			</button>
 
 			<div
 				style={{


### PR DESCRIPTION
## 変更内容

xtracter ポップアップの設定保存フローを改善し、Save ボタン起因のバグを修正しました。

- **Source 選択時に即自動保存**: `chrome.storage.local.set({ selectedSourceId })` を `onChange` で実行
- **API URL 入力時に即自動保存＋再接続**: `chrome.storage.local.set({ apiUrl })` + `fetchSources()` を `onInput` で実行
- **Save ボタンを削除**: `handleSave` 関数と Save ボタンを完全に削除

## バグの原因

Save ボタンの `handleSave` で `await fetchSources()` を呼んでいたため、保存直後にソースを再取得し、`selectedSourceId` がレスポンスに含まれないと先頭の ID に上書きされてしまっていた。表示が元に戻るだけでなく `chrome.storage.local` も上書きされ、ユーザーの選択が失われていた。

## 関連

最近の IP 変更対応コミット (`47ca62f`) で `fetchSources` のバリデーションが強化された際、保存後の再取得でも同じバリデーションが走るようになって再発していた。