### PR TITLE
fix(xtracter): remove Save button and auto-persist source/API URL

### DIFF
--- a/apps/xtracter/src/popup/index.tsx
+++ b/apps/xtracter/src/popup/index.tsx
@@ -40,7 +40,9 @@ function Popup() {
 			});
 			setSources(resp || []);
 			if (resp && resp.length > 0 && !selectedSourceId()) {
-				setSelectedSourceId(resp[0].id);
+				const firstId = resp[0].id;
+				setSelectedSourceId(firstId);
+				await chrome.storage.local.set({ selectedSourceId: firstId });
 			}
 			setStatus("");
 		} catch (_err) {
@@ -122,7 +124,7 @@ function Popup() {
 					id="api-url"
 					type="text"
 					value={apiUrl()}
-					onInput={async (e) => {
+					onChange={async (e) => {
 						const url = e.currentTarget.value;
 						setApiUrl(url);
 						await chrome.storage.local.set({ apiUrl: url });

--- a/apps/xtracter/src/popup/index.tsx
+++ b/apps/xtracter/src/popup/index.tsx
@@ -39,41 +39,15 @@ function Popup() {
 				type: "GET_SOURCES",
 			});
 			setSources(resp || []);
-
-			const currentId = selectedSourceId();
-			const isValid = resp?.some((s) => s.id === currentId);
-
-			if (!isValid && resp && resp.length > 0) {
-				const firstId = resp[0].id;
-				setSelectedSourceId(firstId);
-				await chrome.storage.local.set({ selectedSourceId: firstId });
-			} else if (!isValid) {
-				setSelectedSourceId("");
-				await chrome.storage.local.set({ selectedSourceId: "" });
+			if (resp && resp.length > 0 && !selectedSourceId()) {
+				setSelectedSourceId(resp[0].id);
 			}
-
 			setStatus("");
 		} catch (_err) {
 			setStatus("Failed to load sources. Check API URL.");
 			setStatusType("error");
 		} finally {
 			setIsLoading(false);
-		}
-	};
-
-	const handleSave = async () => {
-		try {
-			await chrome.storage.local.set({
-				selectedSourceId: selectedSourceId(),
-				apiUrl: apiUrl(),
-			});
-			setStatus("Saved!");
-			setStatusType("success");
-			setTimeout(() => setStatus(""), 2000);
-			await fetchSources();
-		} catch (_err) {
-			setStatus("Failed to save settings.");
-			setStatusType("error");
 		}
 	};
 
@@ -148,7 +122,12 @@ function Popup() {
 					id="api-url"
 					type="text"
 					value={apiUrl()}
-					onInput={(e) => setApiUrl(e.currentTarget.value)}
+					onInput={async (e) => {
+						const url = e.currentTarget.value;
+						setApiUrl(url);
+						await chrome.storage.local.set({ apiUrl: url });
+						await fetchSources();
+					}}
 					style={{
 						width: "100%",
 						padding: "8px",
@@ -173,7 +152,11 @@ function Popup() {
 				<select
 					id="source-select"
 					value={selectedSourceId()}
-					onChange={(e) => setSelectedSourceId(e.currentTarget.value)}
+					onChange={async (e) => {
+						const id = e.currentTarget.value;
+						setSelectedSourceId(id);
+						await chrome.storage.local.set({ selectedSourceId: id });
+					}}
 					disabled={isLoading() || sources().length === 0}
 					style={{
 						width: "100%",
@@ -194,23 +177,6 @@ function Popup() {
 					</For>
 				</select>
 			</div>
-
-			<button
-				type="button"
-				onClick={handleSave}
-				style={{
-					width: "100%",
-					padding: "8px",
-					"background-color": "#1d9bf0",
-					color: "white",
-					border: "none",
-					"border-radius": "4px",
-					"font-weight": "bold",
-					cursor: "pointer",
-				}}
-			>
-				Save
-			</button>
 
 			<div
 				style={{


### PR DESCRIPTION
## 変更内容

xtracter ポップアップの設定保存フローを改善し、Save ボタン起因のバグを修正しました。

- **Source 選択時に即自動保存**: `chrome.storage.local.set({ selectedSourceId })` を `onChange` で実行
- **API URL 入力時に即自動保存＋再接続**: `chrome.storage.local.set({ apiUrl })` + `fetchSources()` を `onInput` で実行
- **Save ボタンを削除**: `handleSave` 関数と Save ボタンを完全に削除

## バグの原因

Save ボタンの `handleSave` で `await fetchSources()` を呼んでいたため、保存直後にソースを再取得し、`selectedSourceId` がレスポンスに含まれないと先頭の ID に上書きされてしまっていた。表示が元に戻るだけでなく `chrome.storage.local` も上書きされ、ユーザーの選択が失われていた。

## 関連

最近の IP 変更対応コミット (`47ca62f`) で `fetchSources` のバリデーションが強化された際、保存後の再取得でも同じバリデーションが走るようになって再発していた。