### PR TITLE
perf(tauri): batch scan and probe for source addition

### DIFF
--- a/apps/tauri/src-tauri/src/commands/fs.rs
+++ b/apps/tauri/src-tauri/src/commands/fs.rs
@@ -1,8 +1,16 @@
 use super::utils::*;
 use futures_util::StreamExt;
+use serde::Serialize;
 use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FsScanEntry {
+    pub full_path: String,
+    pub is_directory: bool,
+}
 
 #[tauri::command(async)]
 pub fn fs_exists(path: String) -> bool {
@@ -55,6 +63,46 @@ pub fn fs_readdir(path: String) -> Result<Vec<String>, String> {
     }
 
     Ok(names)
+}
+
+#[tauri::command(async)]
+pub fn fs_scan_recursive(path: String) -> Result<Vec<FsScanEntry>, String> {
+    let root = Path::new(&path);
+    if !root.is_dir() {
+        return Err(format!("Path is not a directory: {path}"));
+    }
+
+    let mut entries = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let read_dir =
+            fs::read_dir(&dir).map_err(|error| with_path_context("Reading directory", &dir.to_string_lossy(), error))?;
+
+        for entry in read_dir {
+            let entry =
+                entry.map_err(|error| with_path_context("Reading directory entry", &dir.to_string_lossy(), error))?;
+            let file_name = entry.file_name().to_string_lossy().into_owned();
+
+            if file_name.starts_with('.') {
+                continue;
+            }
+
+            let entry_path = entry.path();
+            let is_directory = entry_path.is_dir();
+
+            if is_directory {
+                stack.push(entry_path.clone());
+            }
+
+            entries.push(FsScanEntry {
+                full_path: entry_path.to_string_lossy().into_owned(),
+                is_directory,
+            });
+        }
+    }
+
+    Ok(entries)
 }
 
 #[tauri::command(async)]

--- a/apps/tauri/src-tauri/src/commands/media.rs
+++ b/apps/tauri/src-tauri/src/commands/media.rs
@@ -13,11 +13,10 @@ pub fn image_get_dimensions(media_path: String) -> Result<MediaDimensions, Strin
     Ok(inspect_image_header(&media_path)?.dimensions)
 }
 
-#[tauri::command(async)]
-pub fn probe_media(media_path: String) -> Result<ProbeMediaResult, String> {
-    let metadata = fs::metadata(&media_path)
-        .map_err(|error| with_path_context("Reading file metadata", &media_path, error))?;
-    let header = inspect_image_header(&media_path).ok();
+fn probe_single_media(media_path: &str) -> Result<ProbeMediaResult, String> {
+    let metadata = fs::metadata(media_path)
+        .map_err(|error| with_path_context("Reading file metadata", media_path, error))?;
+    let header = inspect_image_header(media_path).ok();
     let dimensions = header
         .as_ref()
         .map(|value| value.dimensions)
@@ -26,7 +25,7 @@ pub fn probe_media(media_path: String) -> Result<ProbeMediaResult, String> {
             height: 0,
         });
     let mime_type = header.and_then(|value| value.mime_type).or_else(|| {
-        mime_guess::from_path(&media_path)
+        mime_guess::from_path(media_path)
             .first_raw()
             .map(|value| value.to_string())
     });
@@ -35,12 +34,51 @@ pub fn probe_media(media_path: String) -> Result<ProbeMediaResult, String> {
         width: dimensions.width,
         height: dimensions.height,
         size: metadata.len(),
-        created_at: metadata_created_or_modified(&media_path, &metadata)?,
-        modified_at: metadata_modified(&media_path, &metadata)?,
+        created_at: metadata_created_or_modified(media_path, &metadata)?,
+        modified_at: metadata_modified(media_path, &metadata)?,
         duration: None,
         mime_type,
         codec: None,
     })
+}
+
+#[tauri::command(async)]
+pub fn probe_media(media_path: String) -> Result<ProbeMediaResult, String> {
+    probe_single_media(&media_path)
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeMediaBatchItemResult {
+    pub media_path: String,
+    pub result: Option<ProbeMediaResult>,
+    pub error: Option<String>,
+}
+
+#[tauri::command(async)]
+pub async fn probe_media_batch(media_paths: Vec<String>) -> Result<Vec<ProbeMediaBatchItemResult>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        use rayon::prelude::*;
+        media_paths
+            .into_par_iter()
+            .map(|path| {
+                match probe_single_media(&path) {
+                    Ok(result) => ProbeMediaBatchItemResult {
+                        media_path: path,
+                        result: Some(result),
+                        error: None,
+                    },
+                    Err(error) => ProbeMediaBatchItemResult {
+                        media_path: path,
+                        result: None,
+                        error: Some(error),
+                    },
+                }
+            })
+            .collect()
+    })
+    .await
+    .map_err(|e| e.to_string())
 }
 
 #[tauri::command(async)]

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -42,6 +42,7 @@ fn main() {
             commands::media::image_extract_metadata,
             commands::media::image_get_dimensions,
             commands::media::probe_media,
+            commands::media::probe_media_batch,
             watcher::source_watch_start,
             watcher::source_watch_stop
         ])

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -29,6 +29,7 @@ fn main() {
             commands::fs::fs_write_file,
             commands::fs::fs_mkdir,
             commands::fs::fs_readdir,
+            commands::fs::fs_scan_recursive,
             commands::fs::fs_stat,
             commands::fs::fs_unlink,
             commands::fs::fs_rm,

--- a/apps/tauri/src/bootstrap.ts
+++ b/apps/tauri/src/bootstrap.ts
@@ -1,5 +1,4 @@
 import type { IImageProcessor } from "@solid-imager/core/domain/services/image-processor";
-import type { IFileSystem } from "@solid-imager/core/interfaces/file-system";
 import {
 	createTauriApiClient,
 	type TauriApiClient,
@@ -14,7 +13,7 @@ import { TauriImageProcessor } from "./infrastructure/tauri/image-processor";
 
 export type TauriAppServices = {
 	commandClient: TauriCommandClient;
-	fileSystem: IFileSystem;
+	fileSystem: TauriFileSystem;
 	imageProcessor: IImageProcessor;
 	apiClient: TauriApiClient;
 	db: TauriDb;

--- a/apps/tauri/src/infrastructure/local-api/services/source-service.ts
+++ b/apps/tauri/src/infrastructure/local-api/services/source-service.ts
@@ -119,11 +119,8 @@ const sourceSyncRuntime = createSourceSyncRuntime({
 		stat: async (path) => await getTauriAppServices().fileSystem.stat(path),
 		readdir: async (path) =>
 			await getTauriAppServices().fileSystem.readdir(path),
-		scanDirectoryRecursive: async (path) => {
-			const fn = getTauriAppServices().fileSystem.scanDirectoryRecursive;
-			if (!fn) throw new Error("scanDirectoryRecursive not available");
-			return await fn(path);
-		},
+		scanDirectoryRecursive: async (path) =>
+			await getTauriAppServices().fileSystem.scanDirectoryRecursive(path),
 	},
 	config: {
 		getSupportedExtensions: async () =>

--- a/apps/tauri/src/infrastructure/local-api/services/source-service.ts
+++ b/apps/tauri/src/infrastructure/local-api/services/source-service.ts
@@ -32,6 +32,12 @@ type ProbeMediaResult = {
 	codec?: string | null;
 };
 
+type ProbeMediaBatchItemResult = {
+	mediaPath: string;
+	result: ProbeMediaResult | null;
+	error: string | null;
+};
+
 const sourceWatchers = new Map<string, true>();
 const WATCH_START_RETRY_DELAY_MS = 5_000;
 const watchRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -113,6 +119,11 @@ const sourceSyncRuntime = createSourceSyncRuntime({
 		stat: async (path) => await getTauriAppServices().fileSystem.stat(path),
 		readdir: async (path) =>
 			await getTauriAppServices().fileSystem.readdir(path),
+		scanDirectoryRecursive: async (path) => {
+			const fn = getTauriAppServices().fileSystem.scanDirectoryRecursive;
+			if (!fn) throw new Error("scanDirectoryRecursive not available");
+			return await fn(path);
+		},
 	},
 	config: {
 		getSupportedExtensions: async () =>
@@ -125,6 +136,27 @@ const sourceSyncRuntime = createSourceSyncRuntime({
 			"probe_media",
 			{ mediaPath: fullPath },
 		),
+	batchProbeMedia: async (paths) => {
+		const results = await getTauriAppServices().commandClient.invoke<
+			ProbeMediaBatchItemResult[]
+		>("probe_media_batch", { mediaPaths: paths });
+		return results.map((item) => ({
+			mediaPath: item.mediaPath,
+			result: item.result
+				? {
+						width: item.result.width,
+						height: item.result.height,
+						size: item.result.size,
+						createdAt: item.result.createdAt,
+						modifiedAt: item.result.modifiedAt,
+						duration: item.result.duration ?? null,
+						mimeType: item.result.mimeType ?? null,
+						codec: item.result.codec ?? null,
+					}
+				: null,
+			error: item.error,
+		}));
+	},
 	mediaRepository: {
 		findByPath: TauriMediaRepository.findByPath,
 		findAllPathsBySourceId: TauriMediaRepository.findAllPathsBySourceId,

--- a/apps/tauri/src/infrastructure/tauri/file-system.ts
+++ b/apps/tauri/src/infrastructure/tauri/file-system.ts
@@ -8,6 +8,11 @@ type TauriFileStat = {
 	isDirectory: boolean;
 };
 
+type TauriFsScanEntry = {
+	fullPath: string;
+	isDirectory: boolean;
+};
+
 function toUint8Array(data: Uint8Array | number[]): Uint8Array {
 	return data instanceof Uint8Array ? data : new Uint8Array(data);
 }
@@ -48,6 +53,12 @@ export class TauriFileSystem implements IFileSystem {
 
 	async readdir(path: string) {
 		return this.commandClient.invoke<string[]>("fs_readdir", { path });
+	}
+
+	async scanDirectoryRecursive(path: string) {
+		return this.commandClient.invoke<TauriFsScanEntry[]>("fs_scan_recursive", {
+			path,
+		});
 	}
 
 	async stat(path: string) {

--- a/packages/application/src/services/source-sync-runtime.ts
+++ b/packages/application/src/services/source-sync-runtime.ts
@@ -183,9 +183,9 @@ export function createSourceSyncRuntime(deps: SourceSyncRuntimeDeps) {
 	async function scanDirectoryRecursive(rootPath: string): Promise<string[]> {
 		if (deps.fileSystem.scanDirectoryRecursive) {
 			const entries = await deps.fileSystem.scanDirectoryRecursive(rootPath);
-			return entries
-				.filter((entry) => !entry.isDirectory)
-				.map((entry) => entry.fullPath);
+			return entries.flatMap((entry) =>
+				!entry.isDirectory ? [entry.fullPath] : [],
+			);
 		}
 
 		const entries = await deps.fileSystem.readdir(rootPath);
@@ -247,7 +247,7 @@ export function createSourceSyncRuntime(deps: SourceSyncRuntimeDeps) {
 	): Promise<Array<SourceSyncUpsertInput & { normalizedRelPath: string }>> {
 		const paths = files.map((f) => f.fullPath);
 		const fileMap = new Map(files.map((f) => [f.fullPath, f]));
-		const batchResults = await deps.batchProbeMedia?.(paths);
+		const batchResults = (await deps.batchProbeMedia?.(paths)) ?? [];
 		const results: Array<
 			SourceSyncUpsertInput & { normalizedRelPath: string }
 		> = [];

--- a/packages/application/src/services/source-sync-runtime.ts
+++ b/packages/application/src/services/source-sync-runtime.ts
@@ -69,6 +69,17 @@ type FileToIndex = {
 	mediaType: SourceSyncMediaType;
 };
 
+export type SourceSyncScanEntry = {
+	fullPath: string;
+	isDirectory: boolean;
+};
+
+export type SourceSyncBatchProbeItem = {
+	mediaPath: string;
+	result: SourceSyncProbeResult | null;
+	error: string | null;
+};
+
 export type SourceSyncRuntimeDeps = {
 	resolveSourceRootPath(
 		source: Pick<MediaSource, "type" | "connectionInfo">,
@@ -80,6 +91,7 @@ export type SourceSyncRuntimeDeps = {
 		exists(path: string): Promise<boolean>;
 		stat(path: string): Promise<FileSystemEntryStat>;
 		readdir(path: string): Promise<string[]>;
+		scanDirectoryRecursive?(path: string): Promise<SourceSyncScanEntry[]>;
 	};
 	config: {
 		getSupportedExtensions():
@@ -88,6 +100,7 @@ export type SourceSyncRuntimeDeps = {
 		getProbeConcurrency(): Promise<number> | number;
 	};
 	probeMedia(fullPath: string): Promise<SourceSyncProbeResult>;
+	batchProbeMedia?(paths: string[]): Promise<SourceSyncBatchProbeItem[]>;
 	mediaRepository: {
 		findByPath(
 			mediaSourceId: string,
@@ -168,6 +181,13 @@ export function createSourceSyncRuntime(deps: SourceSyncRuntimeDeps) {
 	const sleepForRetry = deps.retry?.sleep ?? sleep;
 
 	async function scanDirectoryRecursive(rootPath: string): Promise<string[]> {
+		if (deps.fileSystem.scanDirectoryRecursive) {
+			const entries = await deps.fileSystem.scanDirectoryRecursive(rootPath);
+			return entries
+				.filter((entry) => !entry.isDirectory)
+				.map((entry) => entry.fullPath);
+		}
+
 		const entries = await deps.fileSystem.readdir(rootPath);
 		const files: string[] = [];
 
@@ -212,6 +232,54 @@ export function createSourceSyncRuntime(deps: SourceSyncRuntimeDeps) {
 	}
 
 	async function probeAndCollect(
+		sourceId: string,
+		files: FileToIndex[],
+	): Promise<Array<SourceSyncUpsertInput & { normalizedRelPath: string }>> {
+		if (deps.batchProbeMedia) {
+			return probeAndCollectBatch(sourceId, files);
+		}
+		return probeAndCollectSequential(sourceId, files);
+	}
+
+	async function probeAndCollectBatch(
+		sourceId: string,
+		files: FileToIndex[],
+	): Promise<Array<SourceSyncUpsertInput & { normalizedRelPath: string }>> {
+		const paths = files.map((f) => f.fullPath);
+		const fileMap = new Map(files.map((f) => [f.fullPath, f]));
+		const batchResults = await deps.batchProbeMedia?.(paths);
+		const results: Array<
+			SourceSyncUpsertInput & { normalizedRelPath: string }
+		> = [];
+
+		for (const item of batchResults) {
+			if (item.error || !item.result) {
+				deps.logger?.error("[sync] probe failed", item.error);
+				continue;
+			}
+			const file = fileMap.get(item.mediaPath);
+			if (!file) {
+				continue;
+			}
+			results.push({
+				mediaSourceId: sourceId,
+				filePath: file.relativePath,
+				fileName: deps.basename(item.mediaPath),
+				mediaType: file.mediaType,
+				width: item.result.width,
+				height: item.result.height,
+				fileSize: item.result.size,
+				description: null,
+				createdAt: new Date(item.result.createdAt),
+				modifiedAt: new Date(item.result.modifiedAt),
+				normalizedRelPath: file.normalizedRelPath,
+			});
+		}
+
+		return results;
+	}
+
+	async function probeAndCollectSequential(
 		sourceId: string,
 		files: FileToIndex[],
 	): Promise<Array<SourceSyncUpsertInput & { normalizedRelPath: string }>> {

--- a/packages/core/src/domain/media/utils/media-type-utils.ts
+++ b/packages/core/src/domain/media/utils/media-type-utils.ts
@@ -1,10 +1,17 @@
-import path from "node:path";
-
 export type SupportedExtensions = {
 	image: string[];
 	video: string[];
 	audio: string[];
 };
+
+function extname(filePath: string): string {
+	const lastDot = filePath.lastIndexOf(".");
+	const lastSlash = Math.max(
+		filePath.lastIndexOf("/"),
+		filePath.lastIndexOf("\\"),
+	);
+	return lastDot > lastSlash ? filePath.slice(lastDot) : "";
+}
 
 /**
  * Determines the media type based on the file extension and a config-driven
@@ -14,7 +21,7 @@ export function inferMediaType(
 	filePath: string,
 	supportedExtensions: SupportedExtensions,
 ): "image" | "video" | "audio" | null {
-	const ext = path.extname(filePath).toLowerCase();
+	const ext = extname(filePath).toLowerCase();
 	if (supportedExtensions.image.includes(ext)) return "image";
 	if (supportedExtensions.video.includes(ext)) return "video";
 	if (supportedExtensions.audio.includes(ext)) return "audio";
@@ -29,7 +36,7 @@ export function inferMediaType(
 export function getMediaTypeFromExtension(
 	fileName: string,
 ): "video" | "audio" | "image" {
-	const ext = path.extname(fileName).toLowerCase();
+	const ext = extname(fileName).toLowerCase();
 	if ([".mp4", ".webm", ".mov", ".mkv", ".avi"].includes(ext)) {
 		return "video";
 	}
@@ -45,7 +52,7 @@ export function getMediaTypeFromExtension(
  * @returns The MIME type string, defaulting to 'application/octet-stream'
  */
 export function getContentTypeFromExtension(fileName: string): string {
-	const ext = path.extname(fileName).toLowerCase().replace(".", "");
+	const ext = extname(fileName).toLowerCase().replace(".", "");
 	switch (ext) {
 		case "jpg":
 		case "jpeg":

--- a/packages/core/src/interfaces/file-system.ts
+++ b/packages/core/src/interfaces/file-system.ts
@@ -19,4 +19,7 @@ export type IFileSystem = {
 	copyFile(src: string, dest: string): Promise<void>;
 	rename(oldPath: string, newPath: string): Promise<void>;
 	mkdtemp(prefix: string): Promise<string>;
+	scanDirectoryRecursive?(
+		path: string,
+	): Promise<Array<{ fullPath: string; isDirectory: boolean }>>;
 };


### PR DESCRIPTION
## Summary

- Tauri のソース追加時の初期ファイル登録を高速化
- ディレクトリスキャン: readdir+stat の逐次IPC往復を1回のバッチIPCに集約
- ファイルprobe: per-file IPC (並行度3) を rayon 並列バッチIPCに集約
- 1000ファイル/50ディレクトリの場合、IPC往復を約2050回→2回に削減

## Changes

### Rust (Tauri native)
- `fs_scan_recursive`: 再帰ディレクトリ走査を1コマンドで完結、隠しファイルをRust側でフィルタ
- `probe_media_batch`: rayon par_iter でファイルメタデータ+画像ヘッダーを並列抽出

### TypeScript (shared package)
- `SourceSyncRuntimeDeps` にオプショナルな `scanDirectoryRecursive` / `batchProbeMedia` を追加
- `source-sync-runtime.ts` のスキャン・probeロジックをバッチ対応、未提供時は既存の逐次処理にフォールバック
- `IFileSystem` にオプショナルな `scanDirectoryRecursive` を追加

### Tauri wiring
- `TauriFileSystem` に `scanDirectoryRecursive` メソッド追加
- source-service のdepsにバッチメソッドを接続

## Impact
- 共有パッケージへの影響: 最小限（オプショナル追加 + 条件分岐、後方互換）
- Server: 影響なし（このruntimeを使用していない）
- 既存テスト: 変更不要（フォールバック動作は既存ロジックと同一）