### PR TITLE
perf(tauri): batch restore transactions, parallel pathExists, Rust JSON parse

### DIFF
--- a/apps/tauri/src-tauri/src/commands/backup.rs
+++ b/apps/tauri/src-tauri/src/commands/backup.rs
@@ -146,3 +146,9 @@ pub fn backup_extract_zip(input: BackupExtractZipInput) -> Result<Value, String>
 
     dump_data.ok_or_else(|| "dump.json not found in ZIP".to_string())
 }
+
+#[tauri::command(async)]
+pub fn parse_restore_json(bytes: Vec<u8>) -> Result<Value, String> {
+    serde_json::from_slice::<Value>(&bytes)
+        .map_err(|error| format!("Parsing JSON failed: {error}"))
+}

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -23,6 +23,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::backup::backup_create_zip,
             commands::backup::backup_extract_zip,
+            commands::backup::parse_restore_json,
             commands::fs::fs_exists,
             commands::fs::fs_read_file,
             commands::fs::fs_read_text_file,

--- a/apps/tauri/src/infrastructure/api-clients/app-client.ts
+++ b/apps/tauri/src/infrastructure/api-clients/app-client.ts
@@ -96,7 +96,7 @@ export const tauriSourcesApiContract: SourcesApiContract = {
 		return orpc.sources.importZip({ id, bytes: Array.from(bytes) });
 	},
 	parseRestoreFile: async (file: File) => {
-		const bytes = Array.from(new Uint8Array(await file.arrayBuffer()));
+		const bytes = new Uint8Array(await file.arrayBuffer());
 		return await getTauriAppServices().commandClient.invoke<unknown>(
 			"parse_restore_json",
 			{ bytes },

--- a/apps/tauri/src/infrastructure/api-clients/app-client.ts
+++ b/apps/tauri/src/infrastructure/api-clients/app-client.ts
@@ -4,6 +4,8 @@ import type {
 	SyncMediaItemsResponse,
 	UploadMediaRequest,
 } from "@solid-imager/core/interfaces/media-manager-client";
+import { getTauriAppServices } from "~/app-services";
+import { TauriSourceBackupService } from "~/infrastructure/local-api/services/source-backup-service";
 import { orpc } from "./orpc-client";
 
 function toBooleanString(value: boolean | undefined) {
@@ -76,7 +78,7 @@ export const tauriSourcesApiContract: SourcesApiContract = {
 			type: "application/json",
 		});
 	},
-	restoreSource: (id, data) => {
+	restoreSource: (id, data, opts) => {
 		const payload = data as
 			| {
 					media?: unknown[];
@@ -87,10 +89,17 @@ export const tauriSourcesApiContract: SourcesApiContract = {
 			: Array.isArray(payload.media)
 				? payload.media
 				: [];
-		return orpc.sources.restore({ id, data: items });
+		return TauriSourceBackupService.restoreSource(id, items, opts);
 	},
 	async importSourceZip(id, file) {
 		const bytes = new Uint8Array(await file.arrayBuffer());
 		return orpc.sources.importZip({ id, bytes: Array.from(bytes) });
+	},
+	parseRestoreFile: async (file: File) => {
+		const bytes = Array.from(new Uint8Array(await file.arrayBuffer()));
+		return await getTauriAppServices().commandClient.invoke<unknown>(
+			"parse_restore_json",
+			{ bytes },
+		);
 	},
 };

--- a/apps/tauri/src/infrastructure/api-clients/local-procedures.ts
+++ b/apps/tauri/src/infrastructure/api-clients/local-procedures.ts
@@ -267,7 +267,6 @@ const localProcedureHandlers = {
 				data: z.array(z.unknown()),
 			})
 			.parse(input);
-		await TauriSourceService.sync([id]);
 		return await TauriSourceBackupService.restoreSource(id, data);
 	},
 	"sources.importZip": async (input: unknown) => {

--- a/apps/tauri/src/infrastructure/api-clients/orpc-client.ts
+++ b/apps/tauri/src/infrastructure/api-clients/orpc-client.ts
@@ -49,6 +49,7 @@ const restoreSourceResultSchema = z.object({
 	processed: z.number(),
 	skipped: z.number(),
 	errors: z.array(z.string()),
+	cancelled: z.boolean().optional(),
 });
 const importSourceZipResultSchema = z.object({
 	success: z.boolean(),

--- a/apps/tauri/src/infrastructure/api-clients/sources-api.ts
+++ b/apps/tauri/src/infrastructure/api-clients/sources-api.ts
@@ -10,5 +10,6 @@ export const updateMediaSource = sourcesApi.updateMediaSource;
 export const deleteMediaSource = sourcesApi.deleteMediaSource;
 export const syncMediaSources = sourcesApi.syncMediaSources;
 export const fetchSourceDump = sourcesApi.fetchSourceDump;
-export const restoreSource = sourcesApi.restoreSource;
+export const restoreSource = tauriSourcesApiContract.restoreSource;
 export const importSourceZip = sourcesApi.importSourceZip;
+export const parseRestoreFile = tauriSourcesApiContract.parseRestoreFile;

--- a/apps/tauri/src/infrastructure/local-api/services/source-backup-service.ts
+++ b/apps/tauri/src/infrastructure/local-api/services/source-backup-service.ts
@@ -9,7 +9,6 @@ import type { TauriDbExecutor } from "~/infrastructure/db/client";
 import { joinLocalPath } from "../../path-utils";
 import { TauriSourceRepository } from "../repositories/source-repository";
 import { TauriJobRepository } from "../repositories/tauri-job-repository";
-import { TauriSourceService } from "./source-service";
 
 type BinaryFilePayload = {
 	fileName: string;
@@ -17,10 +16,16 @@ type BinaryFilePayload = {
 	data: number[];
 };
 
+type RestoreSourceOpts = {
+	signal?: AbortSignal;
+	onProgress?: (done: number, total: number) => void;
+};
+
 type RestoreSourceResult = {
 	processed: number;
 	skipped: number;
 	errors: string[];
+	cancelled?: boolean;
 };
 
 function toLocalSourcePath(
@@ -98,8 +103,9 @@ export const TauriSourceBackupService = {
 	async restoreSource(
 		mediaSourceId: string,
 		items: unknown[],
+		opts?: RestoreSourceOpts,
 	): Promise<RestoreSourceResult> {
-		return await backupService.restoreSource(mediaSourceId, items);
+		return await backupService.restoreSource(mediaSourceId, items, opts);
 	},
 
 	async importSourceZip(
@@ -120,7 +126,6 @@ export const TauriSourceBackupService = {
 			bytes,
 		});
 
-		await TauriSourceService.sync([mediaSourceId]);
 		const restoreResult = await backupService.restoreSource(
 			mediaSourceId,
 			dumpData,

--- a/apps/tauri/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/tauri/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -25,6 +25,7 @@ import { searchMedia } from "~/infrastructure/api-clients/search-api";
 import {
 	fetchSourceDump,
 	importSourceZip,
+	parseRestoreFile,
 	restoreSource,
 } from "~/infrastructure/api-clients/sources-api";
 import { notifyThumbnailReady } from "~/infrastructure/media/thumbnail-runtime";
@@ -67,6 +68,7 @@ export function SourceMediaPage() {
 				fetchSourceDump,
 				restoreSource,
 				importSourceZip,
+				parseRestoreFile,
 			}}
 			getSearchCondition={getSearchCondition}
 			sortBy={() => searchState.sortBy}

--- a/packages/core/src/interfaces/media-manager-client.ts
+++ b/packages/core/src/interfaces/media-manager-client.ts
@@ -112,7 +112,16 @@ export type SourcesApiContract = {
 	restoreSource: (
 		id: string,
 		data: unknown,
-	) => Promise<{ processed: number; skipped: number; errors: string[] }>;
+		opts?: {
+			signal?: AbortSignal;
+			onProgress?: (done: number, total: number) => void;
+		},
+	) => Promise<{
+		processed: number;
+		skipped: number;
+		errors: string[];
+		cancelled?: boolean;
+	}>;
 	importSourceZip: (
 		id: string,
 		file: File,
@@ -123,6 +132,7 @@ export type SourcesApiContract = {
 		errors: string[];
 		message: string;
 	}>;
+	parseRestoreFile?: (file: File) => Promise<unknown>;
 };
 
 export function createMediaApi(contract: MediaApiContract) {
@@ -198,11 +208,21 @@ export function createSourcesApi(contract: SourcesApiContract) {
 		fetchSourceDump(id: string, mode: "json" | "zip" = "json") {
 			return contract.fetchSourceDump(id, mode);
 		},
-		restoreSource(id: string, data: unknown) {
-			return contract.restoreSource(id, data);
+		restoreSource(
+			id: string,
+			data: unknown,
+			opts?: {
+				signal?: AbortSignal;
+				onProgress?: (done: number, total: number) => void;
+			},
+		) {
+			return contract.restoreSource(id, data, opts);
 		},
 		importSourceZip(id: string, file: File) {
 			return contract.importSourceZip(id, file);
+		},
+		parseRestoreFile(file: File) {
+			return contract.parseRestoreFile?.(file);
 		},
 	};
 }

--- a/packages/db/src/backup.ts
+++ b/packages/db/src/backup.ts
@@ -868,48 +868,46 @@ export function createBackupService(deps: BackupServiceDeps) {
 			totalSkipped += skippedCount;
 			allErrors.push(...errorMessages);
 
-			if (validItems.length === 0) {
-				continue;
-			}
+			if (validItems.length > 0) {
+				const { mediaPathToId } = await runTransaction(async (executor) => {
+					const { tagMap, authorMap, projectMap, ipMap, charMap } =
+						await restoreMasterData(executor, validItems);
 
-			const { mediaPathToId } = await runTransaction(async (executor) => {
-				const { tagMap, authorMap, projectMap, ipMap, charMap } =
-					await restoreMasterData(executor, validItems);
+					await restoreMediaRecords(executor, mediaSourceId, validItems);
+					const nextMediaPathToId = await mapMediaPathsToIds(
+						() => executor,
+						mediaSourceId,
+						validItems,
+					);
 
-				await restoreMediaRecords(executor, mediaSourceId, validItems);
-				const nextMediaPathToId = await mapMediaPathsToIds(
-					() => executor,
-					mediaSourceId,
-					validItems,
-				);
+					await restoreRelations(executor, {
+						items: validItems,
+						mediaPathToId: nextMediaPathToId,
+						tagMap,
+						authorMap,
+						projectMap,
+						ipMap,
+						charMap,
+					});
 
-				await restoreRelations(executor, {
-					items: validItems,
-					mediaPathToId: nextMediaPathToId,
-					tagMap,
-					authorMap,
-					projectMap,
-					ipMap,
-					charMap,
+					return {
+						mediaPathToId: nextMediaPathToId,
+					};
 				});
 
-				return {
-					mediaPathToId: nextMediaPathToId,
-				};
-			});
+				totalProcessed += validItems.length;
 
-			totalProcessed += validItems.length;
-
-			const mediaIds = Array.from(mediaPathToId.values());
-			if (deps.onRestoreComplete && mediaIds.length > 0) {
-				await deps.onRestoreComplete({
-					source,
-					mediaIds,
-					rootPath,
-				});
+				const mediaIds = Array.from(mediaPathToId.values());
+				if (deps.onRestoreComplete && mediaIds.length > 0) {
+					await deps.onRestoreComplete({
+						source,
+						mediaIds,
+						rootPath,
+					});
+				}
 			}
 
-			opts?.onProgress?.(totalProcessed, totalItems);
+			opts?.onProgress?.(totalProcessed + totalSkipped, totalItems);
 		}
 
 		return {

--- a/packages/db/src/backup.ts
+++ b/packages/db/src/backup.ts
@@ -74,6 +74,8 @@ type SimpleMasterDataNameColumn =
 const MASTER_DATA_CHUNK_SIZE = 1000;
 const AUTHOR_UPDATE_CHUNK_SIZE = 500;
 const MEDIA_QUERY_CHUNK_SIZE = 1000;
+const RESTORE_BATCH_SIZE = 500;
+const PATH_EXISTS_CONCURRENCY = 50;
 
 function isMediaSourcePath(pathValue: string): boolean {
 	return /^(?:[A-Za-z]:[\\/]|\/)/.test(pathValue);
@@ -678,6 +680,34 @@ async function restoreRelations(
 	}
 }
 
+async function pathExistsParallel(
+	checks: Array<{ item: MediaDumpItem; fullPath: string }>,
+	pathExists: (fullPath: string) => Promise<boolean>,
+): Promise<{ existing: MediaDumpItem[]; skipped: number }> {
+	const existing: MediaDumpItem[] = [];
+	let skipped = 0;
+
+	for (let index = 0; index < checks.length; index += PATH_EXISTS_CONCURRENCY) {
+		const chunk = checks.slice(index, index + PATH_EXISTS_CONCURRENCY);
+		const results = await Promise.allSettled(
+			chunk.map(async ({ item, fullPath }) => {
+				const exists = await pathExists(fullPath);
+				return { item, exists };
+			}),
+		);
+
+		for (const result of results) {
+			if (result.status === "fulfilled" && result.value.exists) {
+				existing.push(result.value.item);
+			} else {
+				skipped += 1;
+			}
+		}
+	}
+
+	return { existing, skipped };
+}
+
 export async function filterValidItems(
 	items: unknown[],
 	mediaSource: BackupSource,
@@ -688,7 +718,8 @@ export async function filterValidItems(
 	const basePath = connectionInfo.path ?? "";
 	const isLocal = mediaSource.type === "local";
 
-	const validItems: MediaDumpItem[] = [];
+	const preValidated: MediaDumpItem[] = [];
+	const pathChecks: Array<{ item: MediaDumpItem; fullPath: string }> = [];
 	const errorMessages: string[] = [];
 	let skippedCount = 0;
 
@@ -716,22 +747,22 @@ export async function filterValidItems(
 
 		if (isLocal) {
 			const fullPath = resolvePath(basePath, validItem.filePath);
-			try {
-				const exists = await pathExists(fullPath);
-				if (!exists) {
-					skippedCount += 1;
-					continue;
-				}
-			} catch {
-				skippedCount += 1;
-				continue;
-			}
+			pathChecks.push({ item: validItem, fullPath });
+		} else {
+			preValidated.push(validItem);
 		}
-
-		validItems.push(validItem);
 	}
 
-	return { validItems, skippedCount, errorMessages };
+	if (pathChecks.length > 0) {
+		const { existing, skipped } = await pathExistsParallel(
+			pathChecks,
+			pathExists,
+		);
+		preValidated.push(...existing);
+		skippedCount += skipped;
+	}
+
+	return { validItems: preValidated, skippedCount, errorMessages };
 }
 
 export function createBackupService(deps: BackupServiceDeps) {
@@ -789,71 +820,102 @@ export function createBackupService(deps: BackupServiceDeps) {
 	async function restoreSource(
 		mediaSourceId: string,
 		items: unknown[],
-	): Promise<{ processed: number; skipped: number; errors: string[] }> {
+		opts?: {
+			signal?: AbortSignal;
+			onProgress?: (done: number, total: number) => void;
+		},
+	): Promise<{
+		processed: number;
+		skipped: number;
+		errors: string[];
+		cancelled?: boolean;
+	}> {
 		const source = await deps.sourceRepository.findById(mediaSourceId);
 		if (!source) {
 			throw new Error("Media source not found");
 		}
 
-		const { validItems, skippedCount, errorMessages } = await filterValidItems(
-			items,
-			source,
-			deps.pathExists,
-			deps.resolvePath,
-		);
-
-		if (validItems.length === 0) {
-			return {
-				processed: 0,
-				skipped: skippedCount,
-				errors: errorMessages,
-			};
-		}
+		const totalItems = items.length;
+		let totalProcessed = 0;
+		let totalSkipped = 0;
+		const allErrors: string[] = [];
 
 		const runTransaction =
 			deps.runTransaction ??
 			(async <T>(callback: (executor: DrizzleExecutor) => Promise<T>) =>
 				await callback(deps.getExecutor()));
 
-		const { mediaPathToId } = await runTransaction(async (executor) => {
-			const { tagMap, authorMap, projectMap, ipMap, charMap } =
-				await restoreMasterData(executor, validItems);
+		const rootPath = (source.connectionInfo as { path?: string }).path ?? "";
 
-			await restoreMediaRecords(executor, mediaSourceId, validItems);
-			const nextMediaPathToId = await mapMediaPathsToIds(
-				() => executor,
-				mediaSourceId,
-				validItems,
-			);
+		for (let offset = 0; offset < items.length; offset += RESTORE_BATCH_SIZE) {
+			if (opts?.signal?.aborted) {
+				return {
+					processed: totalProcessed,
+					skipped: totalSkipped,
+					errors: allErrors,
+					cancelled: true,
+				};
+			}
 
-			await restoreRelations(executor, {
-				items: validItems,
-				mediaPathToId: nextMediaPathToId,
-				tagMap,
-				authorMap,
-				projectMap,
-				ipMap,
-				charMap,
+			const batch = items.slice(offset, offset + RESTORE_BATCH_SIZE);
+			const { validItems, skippedCount, errorMessages } =
+				await filterValidItems(
+					batch,
+					source,
+					deps.pathExists,
+					deps.resolvePath,
+				);
+			totalSkipped += skippedCount;
+			allErrors.push(...errorMessages);
+
+			if (validItems.length === 0) {
+				continue;
+			}
+
+			const { mediaPathToId } = await runTransaction(async (executor) => {
+				const { tagMap, authorMap, projectMap, ipMap, charMap } =
+					await restoreMasterData(executor, validItems);
+
+				await restoreMediaRecords(executor, mediaSourceId, validItems);
+				const nextMediaPathToId = await mapMediaPathsToIds(
+					() => executor,
+					mediaSourceId,
+					validItems,
+				);
+
+				await restoreRelations(executor, {
+					items: validItems,
+					mediaPathToId: nextMediaPathToId,
+					tagMap,
+					authorMap,
+					projectMap,
+					ipMap,
+					charMap,
+				});
+
+				return {
+					mediaPathToId: nextMediaPathToId,
+				};
 			});
 
-			return {
-				mediaPathToId: nextMediaPathToId,
-			};
-		});
+			totalProcessed += validItems.length;
 
-		const mediaIds = Array.from(mediaPathToId.values());
-		if (deps.onRestoreComplete && mediaIds.length > 0) {
-			await deps.onRestoreComplete({
-				source,
-				mediaIds,
-				rootPath: (source.connectionInfo as { path?: string }).path ?? "",
-			});
+			const mediaIds = Array.from(mediaPathToId.values());
+			if (deps.onRestoreComplete && mediaIds.length > 0) {
+				await deps.onRestoreComplete({
+					source,
+					mediaIds,
+					rootPath,
+				});
+			}
+
+			opts?.onProgress?.(totalProcessed, totalItems);
 		}
 
 		return {
-			processed: validItems.length,
-			skipped: skippedCount,
-			errors: errorMessages,
+			processed: totalProcessed,
+			skipped: totalSkipped,
+			errors: allErrors,
 		};
 	}
 

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -91,7 +91,16 @@ export type SourceMediaPageActions = {
 	restoreSource: (
 		sourceId: string,
 		data: unknown,
-	) => Promise<{ processed: number; skipped: number; errors: string[] }>;
+		opts?: {
+			signal?: AbortSignal;
+			onProgress?: (done: number, total: number) => void;
+		},
+	) => Promise<{
+		processed: number;
+		skipped: number;
+		errors: string[];
+		cancelled?: boolean;
+	}>;
 	importSourceZip: (
 		sourceId: string,
 		file: File,
@@ -102,6 +111,7 @@ export type SourceMediaPageActions = {
 		errors: string[];
 		message: string;
 	}>;
+	parseRestoreFile?: (file: File) => Promise<unknown>;
 };
 
 export type SourceMediaPagePresetClient = PresetManagerClient &
@@ -396,6 +406,13 @@ export function useSourceMediaPage(
 		}
 	});
 
+	onCleanup(() => {
+		if (restoreAbortController) {
+			restoreAbortController.abort();
+			restoreAbortController = null;
+		}
+	});
+
 	// --- Media source events ---
 	useMediaSourceEvents({
 		transport,
@@ -581,6 +598,8 @@ export function useSourceMediaPage(
 		}
 	};
 
+	let restoreAbortController: AbortController | null = null;
+
 	const handleRestoreSelect = async (e: Event) => {
 		const target = e.target as HTMLInputElement;
 		if (!target.files || target.files.length === 0) {
@@ -592,6 +611,8 @@ export function useSourceMediaPage(
 		if (!sourceId) {
 			return;
 		}
+
+		restoreAbortController = new AbortController();
 
 		try {
 			if (
@@ -608,25 +629,57 @@ export function useSourceMediaPage(
 					},
 				);
 				refreshMediaQuery();
-				target.value = "";
 				return;
 			}
 
-			const data = JSON.parse(await file.text());
-			toast.loading("Restoring metadata...", { id: "restore-toast" });
-			const result = await actions.restoreSource(sourceId, data);
-			toast.success(
-				`Restore complete: ${result.processed} processed, ${result.skipped} skipped`,
-				{
-					id: "restore-toast",
+			const data = actions.parseRestoreFile
+				? await actions.parseRestoreFile(file)
+				: JSON.parse(await file.text());
+
+			const showCancel = typeof actions.parseRestoreFile === "function";
+			const cancelAction = showCancel
+				? {
+						label: "Cancel",
+						onClick: () => restoreAbortController?.abort(),
+					}
+				: undefined;
+
+			toast.loading("Restoring metadata...", {
+				id: "restore-toast",
+				cancel: cancelAction,
+			});
+
+			const total = Array.isArray(data) ? data.length : 0;
+
+			const result = await actions.restoreSource(sourceId, data, {
+				signal: restoreAbortController.signal,
+				onProgress: (done) => {
+					toast.loading(`Restoring metadata... ${done}/${total} items`, {
+						id: "restore-toast",
+						cancel: cancelAction,
+					});
 				},
-			);
+			});
+
+			if (result.cancelled) {
+				toast.info(`Restore cancelled: ${result.processed} items restored.`, {
+					id: "restore-toast",
+				});
+			} else {
+				toast.success(
+					`Restore complete: ${result.processed} processed, ${result.skipped} skipped`,
+					{
+						id: "restore-toast",
+					},
+				);
+			}
 			refreshMediaQuery();
 		} catch (error) {
 			toast.error(`Restore failed: ${(error as Error).message}`, {
 				id: "restore-toast",
 			});
 		} finally {
+			restoreAbortController = null;
 			target.value = "";
 		}
 	};

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -649,7 +649,9 @@ export function useSourceMediaPage(
 				cancel: cancelAction,
 			});
 
-			const total = Array.isArray(data) ? data.length : 0;
+			const total = Array.isArray(data)
+				? data.length
+				: ((data as { media?: unknown[] })?.media?.length ?? 0);
 
 			const result = await actions.restoreSource(sourceId, data, {
 				signal: restoreAbortController.signal,


### PR DESCRIPTION
## Summary

TauriでのJSON restoreが遅く、メモリ使用量が多く、ディスク書き込み量も多く、途中で中断するとデータが消える問題を修正。

### Changes

- **500件バッチトランザクション**: `restoreSource()` を1つの巨大トランザクションから500件刻みに分割。各バッチは独立してコミットされるため、中断してもコミット済み分は残る
- **`pathExists` 50並列化**: ローカルソースでのファイル存在チェックを逐次実行から50件並列に変更
- **Rust側JSONパース**: `parse_restore_json` Tauriコマンドを追加。JSON.parseをUIスレッドからRustワーカースレッドにオフロード
- **不要な `sync()` 削除**: リストア前の全ディレクトリスキャン（`TauriSourceService.sync([id])`）を削除
- **AbortSignal対応**: 進捗トーストにCancelボタン追加。ページ離脱時も自動中断
- **進捗表示**: `onProgress` コールバックで UIにリアルタイム進捗を表示

### Files Changed

| Layer | Files |
|---|---|
| Core engine | `packages/db/src/backup.ts` |
| Contract | `packages/core/src/interfaces/media-manager-client.ts` |
| UI hook | `packages/ui/src/hooks/use-source-media-page.ts` |
| Rust | `apps/tauri/src-tauri/src/commands/backup.rs`, `main.rs` |
| Tauri infra | `app-client.ts`, `source-backup-service.ts`, `local-procedures.ts`, `orpc-client.ts`, `sources-api.ts` |
| Tauri page | `source-media-page.tsx` |

### サーバー互換性

共有パッケージ（`backup.ts`, `media-manager-client.ts`, `use-source-media-page.ts`）の変更はすべて後方互換。サーバー側は一切修正不要で、バッチ化とpathExists並列化の恩恵を自動的に受ける。