### PR TITLE
feat: accept Rust commands modules from fix/issue-165-tauri (#352)

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +428,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -525,6 +559,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -690,6 +735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +870,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1038,8 +1098,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1049,9 +1111,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1320,6 +1384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,6 +1413,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1578,6 +1664,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +1818,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,6 +1924,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -1895,6 +2027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -1971,6 +2104,33 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "num-conv"
@@ -2566,6 +2726,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +2827,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,6 +2857,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +2882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2672,6 +2916,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -2744,6 +3008,47 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -2772,8 +3077,22 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2792,10 +3111,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3006,6 +3366,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3161,12 +3533,17 @@ name = "solid-imager-tauri"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "futures-util",
  "image",
  "mime_guess",
+ "notify",
+ "rayon",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "zip",
 ]
 
 [[package]]
@@ -3255,6 +3632,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3394,6 +3777,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",
@@ -3407,7 +3791,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3694,6 +4078,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3705,6 +4104,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3995,6 +4404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4203,6 +4618,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -4231,6 +4659,16 @@ name = "web-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4290,6 +4728,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4526,6 +4973,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5017,6 +5473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5050,10 +5512,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.13.1",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -12,6 +12,11 @@ tauri-build = { version = "2", features = [] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
 mime_guess = "2"
+rayon = "1"
+notify = "8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
+zip = { version = "2.2.0", default-features = false, features = ["deflate"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+futures-util = "0.3"

--- a/apps/tauri/src-tauri/src/commands/backup.rs
+++ b/apps/tauri/src-tauri/src/commands/backup.rs
@@ -1,0 +1,154 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fs;
+use std::io::{Cursor, Read, Write};
+use std::path::{Component, Path, PathBuf};
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackupCreateZipInput {
+    pub root_path: String,
+    pub dump_json: String,
+    pub file_paths: Vec<String>,
+    pub file_name: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackupExtractZipInput {
+    pub root_path: String,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BinaryFilePayload {
+    pub file_name: String,
+    pub mime_type: String,
+    pub data: Vec<u8>,
+}
+
+fn is_safe_relative_path(path: &str) -> bool {
+    let candidate = Path::new(path);
+    !candidate.is_absolute()
+        && candidate
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+fn normalize_relative_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(segment) => Some(segment.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+#[tauri::command(async)]
+pub fn backup_create_zip(input: BackupCreateZipInput) -> Result<BinaryFilePayload, String> {
+    let mut writer = ZipWriter::new(Cursor::new(Vec::<u8>::new()));
+    let file_options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    writer
+        .start_file("dump.json", file_options)
+        .map_err(|error| format!("Creating dump.json in ZIP failed: {error}"))?;
+    writer
+        .write_all(input.dump_json.as_bytes())
+        .map_err(|error| format!("Writing dump.json failed: {error}"))?;
+
+    let root = PathBuf::from(&input.root_path);
+    for file_path in input.file_paths {
+        if !is_safe_relative_path(&file_path) {
+            continue;
+        }
+
+        let full_path = root.join(Path::new(&file_path));
+        let mut file = match fs::File::open(&full_path) {
+            Ok(file) => file,
+            Err(_) => continue,
+        };
+
+        writer
+            .start_file(
+                format!("images/{}", file_path.replace('\\', "/")),
+                file_options,
+            )
+            .map_err(|error| format!("Adding {file_path} to ZIP failed: {error}"))?;
+        std::io::copy(&mut file, &mut writer)
+            .map_err(|error| format!("Writing {file_path} to ZIP failed: {error}"))?;
+    }
+
+    let cursor = writer
+        .finish()
+        .map_err(|error| format!("Finalizing ZIP dump failed: {error}"))?;
+
+    Ok(BinaryFilePayload {
+        file_name: input.file_name,
+        mime_type: "application/zip".to_string(),
+        data: cursor.into_inner(),
+    })
+}
+
+#[tauri::command(async)]
+pub fn backup_extract_zip(input: BackupExtractZipInput) -> Result<Value, String> {
+    let cursor = Cursor::new(input.bytes);
+    let mut archive =
+        ZipArchive::new(cursor).map_err(|error| format!("Opening ZIP failed: {error}"))?;
+    let root = PathBuf::from(&input.root_path);
+    let mut dump_data: Option<Value> = None;
+
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|error| format!("Reading ZIP entry failed: {error}"))?;
+
+        if entry.name() == "dump.json" {
+            let mut text = String::new();
+            entry
+                .read_to_string(&mut text)
+                .map_err(|error| format!("Reading dump.json failed: {error}"))?;
+            dump_data = Some(
+                serde_json::from_str::<Value>(&text)
+                    .map_err(|error| format!("Parsing dump.json failed: {error}"))?,
+            );
+            continue;
+        }
+
+        let Some(enclosed_name) = entry.enclosed_name().map(|path| path.to_path_buf()) else {
+            continue;
+        };
+        let Some(relative_path) = enclosed_name
+            .strip_prefix("images")
+            .ok()
+            .map(normalize_relative_path)
+        else {
+            continue;
+        };
+        if relative_path.is_empty() || !is_safe_relative_path(&relative_path) {
+            continue;
+        }
+
+        let destination = root.join(Path::new(&relative_path));
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("Creating ZIP restore directory failed: {error}"))?;
+        }
+
+        let mut output = fs::File::create(&destination)
+            .map_err(|error| format!("Creating restored file failed: {error}"))?;
+        std::io::copy(&mut entry, &mut output)
+            .map_err(|error| format!("Extracting ZIP file failed: {error}"))?;
+    }
+
+    dump_data.ok_or_else(|| "dump.json not found in ZIP".to_string())
+}
+
+#[tauri::command(async)]
+pub fn parse_restore_json(bytes: Vec<u8>) -> Result<Value, String> {
+    serde_json::from_slice::<Value>(&bytes)
+        .map_err(|error| format!("Parsing JSON failed: {error}"))
+}

--- a/apps/tauri/src-tauri/src/commands/backup.rs
+++ b/apps/tauri/src-tauri/src/commands/backup.rs
@@ -99,6 +99,18 @@ pub fn backup_extract_zip(input: BackupExtractZipInput) -> Result<Value, String>
     let mut archive =
         ZipArchive::new(cursor).map_err(|error| format!("Opening ZIP failed: {error}"))?;
     let root = PathBuf::from(&input.root_path);
+
+    // Resolve root_path to guard against traversal attacks
+    let resolved_root = root
+        .canonicalize()
+        .map_err(|error| format!("Resolving restore root path failed: {error}"))?;
+    if !resolved_root.is_dir() {
+        return Err(format!(
+            "Restore root is not a directory: {}",
+            resolved_root.display()
+        ));
+    }
+
     let mut dump_data: Option<Value> = None;
 
     for index in 0..archive.len() {
@@ -133,6 +145,17 @@ pub fn backup_extract_zip(input: BackupExtractZipInput) -> Result<Value, String>
         }
 
         let destination = root.join(Path::new(&relative_path));
+
+        // Guard against symlink/TOCTOU escapes by checking canonical path
+        if let Ok(canonical) = destination.canonicalize() {
+            if !canonical.starts_with(&resolved_root) {
+                return Err(format!(
+                    "ZIP entry escapes restore root: {}",
+                    relative_path
+                ));
+            }
+        }
+
         if let Some(parent) = destination.parent() {
             fs::create_dir_all(parent)
                 .map_err(|error| format!("Creating ZIP restore directory failed: {error}"))?;

--- a/apps/tauri/src-tauri/src/commands/fs.rs
+++ b/apps/tauri/src-tauri/src/commands/fs.rs
@@ -84,6 +84,8 @@ pub fn fs_scan_recursive(path: String) -> Result<Vec<FsScanEntry>, String> {
                 entry.map_err(|error| with_path_context("Reading directory entry", &dir.to_string_lossy(), error))?;
             let file_name = entry.file_name().to_string_lossy().into_owned();
 
+            // Hidden files (dotfiles) are intentionally skipped — most media managers
+            // filter these out to avoid scanning system metadata, cache files, etc.
             if file_name.starts_with('.') {
                 continue;
             }
@@ -213,6 +215,20 @@ pub async fn download_file(
 
     if !response.status().is_success() {
         return Err(format!("HTTP error: {}", response.status()));
+    }
+
+    // Validate dest_path: resolve and ensure parent is reachable
+    let dest = Path::new(&dest_path);
+    if let Some(parent) = dest.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                with_path_context("Creating download parent directory", &dest_path, e)
+            })?;
+        }
+        // Canonicalize parent to detect traversal attacks
+        let _resolved_parent = parent
+            .canonicalize()
+            .map_err(|e| with_path_context("Resolving download path", &dest_path, e))?;
     }
 
     let mut file = std::fs::File::create(&dest_path)

--- a/apps/tauri/src-tauri/src/commands/fs.rs
+++ b/apps/tauri/src-tauri/src/commands/fs.rs
@@ -1,0 +1,230 @@
+use super::utils::*;
+use futures_util::StreamExt;
+use serde::Serialize;
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FsScanEntry {
+    pub full_path: String,
+    pub is_directory: bool,
+}
+
+#[tauri::command(async)]
+pub fn fs_exists(path: String) -> bool {
+    Path::new(&path).exists()
+}
+
+#[tauri::command(async)]
+pub fn fs_read_file(path: String) -> Result<Vec<u8>, String> {
+    fs::read(&path).map_err(|error| with_path_context("Reading file", &path, error))
+}
+
+#[tauri::command(async)]
+pub fn fs_read_text_file(path: String, encoding: Option<String>) -> Result<String, String> {
+    let encoding = encoding.unwrap_or_else(|| "utf-8".to_string());
+    if encoding != "utf-8" {
+        return Err(format!("Unsupported encoding: {encoding}"));
+    }
+
+    fs::read_to_string(&path).map_err(|error| with_path_context("Reading text file", &path, error))
+}
+
+#[tauri::command(async)]
+pub fn fs_write_file(path: String, data: WriteFileData) -> Result<(), String> {
+    fs::write(&path, data.into_bytes())
+        .map_err(|error| with_path_context("Writing file", &path, error))
+}
+
+#[tauri::command(async)]
+pub fn fs_mkdir(path: String, options: Option<MkdirOptions>) -> Result<(), String> {
+    let recursive = options.and_then(|value| value.recursive).unwrap_or(false);
+
+    if recursive {
+        fs::create_dir_all(&path)
+            .map_err(|error| with_path_context("Creating directory tree", &path, error))
+    } else {
+        fs::create_dir(&path).map_err(|error| with_path_context("Creating directory", &path, error))
+    }
+}
+
+#[tauri::command(async)]
+pub fn fs_readdir(path: String) -> Result<Vec<String>, String> {
+    let entries = fs::read_dir(&path)
+        .map_err(|error| with_path_context("Reading directory", &path, error))?;
+
+    let mut names = Vec::new();
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| with_path_context("Reading directory entry", &path, error))?;
+        names.push(entry.file_name().to_string_lossy().into_owned());
+    }
+
+    Ok(names)
+}
+
+#[tauri::command(async)]
+pub fn fs_scan_recursive(path: String) -> Result<Vec<FsScanEntry>, String> {
+    let root = Path::new(&path);
+    if !root.is_dir() {
+        return Err(format!("Path is not a directory: {path}"));
+    }
+
+    let mut entries = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let read_dir =
+            fs::read_dir(&dir).map_err(|error| with_path_context("Reading directory", &dir.to_string_lossy(), error))?;
+
+        for entry in read_dir {
+            let entry =
+                entry.map_err(|error| with_path_context("Reading directory entry", &dir.to_string_lossy(), error))?;
+            let file_name = entry.file_name().to_string_lossy().into_owned();
+
+            if file_name.starts_with('.') {
+                continue;
+            }
+
+            let entry_path = entry.path();
+            let is_directory = entry_path.is_dir();
+
+            if is_directory {
+                stack.push(entry_path.clone());
+            }
+
+            entries.push(FsScanEntry {
+                full_path: entry_path.to_string_lossy().into_owned(),
+                is_directory,
+            });
+        }
+    }
+
+    Ok(entries)
+}
+
+#[tauri::command(async)]
+pub fn fs_stat(path: String) -> Result<TauriFileStat, String> {
+    let metadata = fs::metadata(&path)
+        .map_err(|error| with_path_context("Reading file metadata", &path, error))?;
+
+    Ok(TauriFileStat {
+        size: metadata.len(),
+        mtime: metadata_modified(&path, &metadata)?,
+        birthtime: metadata_created_or_modified(&path, &metadata)?,
+        is_directory: metadata.is_dir(),
+    })
+}
+
+#[tauri::command(async)]
+pub fn fs_unlink(path: String) -> Result<(), String> {
+    fs::remove_file(&path).map_err(|error| with_path_context("Removing file", &path, error))
+}
+
+#[tauri::command(async)]
+pub fn fs_rm(path: String, options: Option<RmOptions>) -> Result<(), String> {
+    let recursive = options
+        .as_ref()
+        .and_then(|value| value.recursive)
+        .unwrap_or(false);
+    let force = options
+        .as_ref()
+        .and_then(|value| value.force)
+        .unwrap_or(false);
+    let target = Path::new(&path);
+
+    if !target.exists() {
+        return if force {
+            Ok(())
+        } else {
+            Err(format!("Path does not exist: {path}"))
+        };
+    }
+
+    let result = if target.is_dir() {
+        if recursive {
+            fs::remove_dir_all(target)
+        } else {
+            fs::remove_dir(target)
+        }
+    } else {
+        fs::remove_file(target)
+    };
+
+    result.map_err(|error| with_path_context("Removing path", &path, error))
+}
+
+#[tauri::command(async)]
+pub fn fs_copy_file(src: String, dest: String) -> Result<(), String> {
+    fs::copy(&src, &dest)
+        .map(|_| ())
+        .map_err(|error| with_path_context("Copying file", &src, error))
+}
+
+#[tauri::command(async)]
+pub fn fs_rename(old_path: String, new_path: String) -> Result<(), String> {
+    fs::rename(&old_path, &new_path)
+        .map_err(|error| with_path_context("Renaming path", &old_path, error))
+}
+
+#[tauri::command(async)]
+pub fn fs_mkdtemp(prefix: String) -> Result<String, String> {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("Creating temp directory timestamp failed: {error}"))?
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("{prefix}{unique}"));
+
+    fs::create_dir_all(&path).map_err(|error| {
+        with_path_context(
+            "Creating temporary directory",
+            &path.to_string_lossy(),
+            error,
+        )
+    })?;
+
+    Ok(path.to_string_lossy().into_owned())
+}
+
+#[tauri::command(async)]
+pub async fn download_file(
+    url: String,
+    dest_path: String,
+    headers: Option<Vec<(String, String)>>,
+) -> Result<(), String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
+
+    let mut request = client.get(&url);
+    if let Some(hdrs) = headers {
+        for (key, value) in hdrs {
+            request = request.header(&key, &value);
+        }
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("HTTP request failed: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("HTTP error: {}", response.status()));
+    }
+
+    let mut file = std::fs::File::create(&dest_path)
+        .map_err(|e| with_path_context("Creating file for download", &dest_path, e))?;
+
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("Download stream error: {e}"))?;
+        use std::io::Write;
+        file.write_all(&chunk)
+            .map_err(|e| with_path_context("Writing download chunk", &dest_path, e))?;
+    }
+
+    Ok(())
+}

--- a/apps/tauri/src-tauri/src/commands/media.rs
+++ b/apps/tauri/src-tauri/src/commands/media.rs
@@ -1,0 +1,181 @@
+use super::utils::*;
+use crate::media_config::ComfyUiTagExtractionConfig;
+use crate::media_metadata::extract_metadata_from_path;
+use image::codecs::jpeg::JpegEncoder;
+use image::ImageFormat;
+use serde::Deserialize;
+use std::fs::{self, File};
+use std::io::BufWriter;
+use std::path::Path;
+
+#[tauri::command(async)]
+pub fn image_get_dimensions(media_path: String) -> Result<MediaDimensions, String> {
+    Ok(inspect_image_header(&media_path)?.dimensions)
+}
+
+fn probe_single_media(media_path: &str) -> Result<ProbeMediaResult, String> {
+    let metadata = fs::metadata(media_path)
+        .map_err(|error| with_path_context("Reading file metadata", media_path, error))?;
+    let header = inspect_image_header(media_path).ok();
+    let dimensions = header
+        .as_ref()
+        .map(|value| value.dimensions)
+        .unwrap_or(MediaDimensions {
+            width: 0,
+            height: 0,
+        });
+    let mime_type = header.and_then(|value| value.mime_type).or_else(|| {
+        mime_guess::from_path(media_path)
+            .first_raw()
+            .map(|value| value.to_string())
+    });
+
+    Ok(ProbeMediaResult {
+        width: dimensions.width,
+        height: dimensions.height,
+        size: metadata.len(),
+        created_at: metadata_created_or_modified(media_path, &metadata)?,
+        modified_at: metadata_modified(media_path, &metadata)?,
+        duration: None,
+        mime_type,
+        codec: None,
+    })
+}
+
+#[tauri::command(async)]
+pub fn probe_media(media_path: String) -> Result<ProbeMediaResult, String> {
+    probe_single_media(&media_path)
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeMediaBatchItemResult {
+    pub media_path: String,
+    pub result: Option<ProbeMediaResult>,
+    pub error: Option<String>,
+}
+
+#[tauri::command(async)]
+pub async fn probe_media_batch(media_paths: Vec<String>) -> Result<Vec<ProbeMediaBatchItemResult>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        use rayon::prelude::*;
+        media_paths
+            .into_par_iter()
+            .map(|path| {
+                match probe_single_media(&path) {
+                    Ok(result) => ProbeMediaBatchItemResult {
+                        media_path: path,
+                        result: Some(result),
+                        error: None,
+                    },
+                    Err(error) => ProbeMediaBatchItemResult {
+                        media_path: path,
+                        result: None,
+                        error: Some(error),
+                    },
+                }
+            })
+            .collect()
+    })
+    .await
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command(async)]
+pub fn image_extract_metadata(media_path: String) -> Result<ExtractMetadataResult, String> {
+    extract_metadata_from_path(&media_path, &ComfyUiTagExtractionConfig::default())
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThumbnailRequest {
+    pub media_path: String,
+    pub output_path: String,
+    pub size: u32,
+    pub quality: u8,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThumbnailItemResult {
+    pub media_path: String,
+    pub error: Option<String>,
+}
+
+fn generate_single_thumbnail(req: &ThumbnailRequest) -> ThumbnailItemResult {
+    let result = (|| -> Result<(), String> {
+        let image = load_image(&req.media_path)?;
+        let thumbnail = image.thumbnail(req.size, req.size);
+        let output = Path::new(&req.output_path);
+
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                with_path_context("Creating thumbnail directory", &req.output_path, error)
+            })?;
+        }
+
+        let extension = output
+            .extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or("jpg")
+            .to_ascii_lowercase();
+
+        match extension.as_str() {
+            "jpg" | "jpeg" => {
+                let file = File::create(output).map_err(|error| {
+                    with_path_context("Creating thumbnail file", &req.output_path, error)
+                })?;
+                let mut encoder = JpegEncoder::new_with_quality(BufWriter::new(file), req.quality);
+                encoder.encode_image(&thumbnail).map_err(|error| {
+                    with_path_context("Encoding JPEG thumbnail", &req.output_path, error)
+                })
+            }
+            "png" => thumbnail
+                .save_with_format(output, ImageFormat::Png)
+                .map_err(|error| with_path_context("Saving PNG thumbnail", &req.output_path, error)),
+            "webp" => thumbnail
+                .save_with_format(output, ImageFormat::WebP)
+                .map_err(|error| with_path_context("Saving WebP thumbnail", &req.output_path, error)),
+            _ => thumbnail
+                .save(output)
+                .map_err(|error| with_path_context("Saving thumbnail", &req.output_path, error)),
+        }
+    })();
+
+    ThumbnailItemResult {
+        media_path: req.media_path.clone(),
+        error: result.err(),
+    }
+}
+
+#[tauri::command(async)]
+pub fn image_generate_thumbnail(
+    media_path: String,
+    output_path: String,
+    size: u32,
+    quality: u8,
+) -> Result<(), String> {
+    generate_single_thumbnail(&ThumbnailRequest {
+        media_path,
+        output_path,
+        size,
+        quality,
+    })
+    .error
+    .map_or(Ok(()), Err)
+}
+
+#[tauri::command(async)]
+pub async fn image_generate_thumbnails_batch(
+    items: Vec<ThumbnailRequest>,
+) -> Result<Vec<ThumbnailItemResult>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        use rayon::prelude::*;
+        items
+            .into_par_iter()
+            .map(|req| generate_single_thumbnail(&req))
+            .collect()
+    })
+    .await
+    .map_err(|e| e.to_string())
+}

--- a/apps/tauri/src-tauri/src/commands/mod.rs
+++ b/apps/tauri/src-tauri/src/commands/mod.rs
@@ -1,0 +1,4 @@
+pub mod backup;
+pub mod fs;
+pub mod media;
+pub mod utils;

--- a/apps/tauri/src-tauri/src/commands/utils.rs
+++ b/apps/tauri/src-tauri/src/commands/utils.rs
@@ -1,0 +1,142 @@
+use chrono::{DateTime, Utc};
+use image::{DynamicImage, ImageFormat, ImageReader};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fs::{self};
+use std::time::SystemTime;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeMediaResult {
+    pub width: u32,
+    pub height: u32,
+    pub size: u64,
+    pub created_at: String,
+    pub modified_at: String,
+    pub duration: Option<f64>,
+    pub mime_type: Option<String>,
+    pub codec: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TauriFileStat {
+    pub size: u64,
+    pub mtime: String,
+    pub birthtime: String,
+    pub is_directory: bool,
+}
+
+#[derive(Serialize)]
+pub struct ExtractedTag {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub tag_type: &'static str,
+}
+
+#[derive(Serialize)]
+pub struct ExtractMetadataResult {
+    pub tags: Vec<ExtractedTag>,
+    pub prompt: Option<Value>,
+    pub workflow: Option<Value>,
+}
+
+#[derive(Serialize, Clone, Copy)]
+pub struct MediaDimensions {
+    pub width: u32,
+    pub height: u32,
+}
+
+pub struct ImageHeaderInfo {
+    pub dimensions: MediaDimensions,
+    pub mime_type: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct MkdirOptions {
+    pub recursive: Option<bool>,
+}
+
+#[derive(Deserialize)]
+pub struct RmOptions {
+    pub recursive: Option<bool>,
+    pub force: Option<bool>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum WriteFileData {
+    Text(String),
+    Bytes(Vec<u8>),
+}
+
+impl WriteFileData {
+    pub fn into_bytes(self) -> Vec<u8> {
+        match self {
+            Self::Text(value) => value.into_bytes(),
+            Self::Bytes(value) => value,
+        }
+    }
+}
+
+pub fn format_system_time(value: SystemTime) -> String {
+    DateTime::<Utc>::from(value).to_rfc3339()
+}
+
+pub fn with_path_context(action: &str, path: &str, error: impl std::fmt::Display) -> String {
+    format!("{action} failed for {path}: {error}")
+}
+
+pub fn metadata_created_or_modified(path: &str, metadata: &fs::Metadata) -> Result<String, String> {
+    metadata
+        .created()
+        .or_else(|_| metadata.modified())
+        .map(format_system_time)
+        .map_err(|error| with_path_context("Reading file creation time", path, error))
+}
+
+pub fn metadata_modified(path: &str, metadata: &fs::Metadata) -> Result<String, String> {
+    metadata
+        .modified()
+        .map(format_system_time)
+        .map_err(|error| with_path_context("Reading file modified time", path, error))
+}
+
+pub fn load_image(path: &str) -> Result<DynamicImage, String> {
+    ImageReader::open(path)
+        .map_err(|error| with_path_context("Opening image", path, error))?
+        .with_guessed_format()
+        .map_err(|error| with_path_context("Guessing image format", path, error))?
+        .decode()
+        .map_err(|error| with_path_context("Decoding image", path, error))
+}
+
+pub fn inspect_image_header(path: &str) -> Result<ImageHeaderInfo, String> {
+    let reader = ImageReader::open(path)
+        .map_err(|error| with_path_context("Opening image", path, error))?
+        .with_guessed_format()
+        .map_err(|error| with_path_context("Guessing image format", path, error))?;
+    let mime_type = mime_type_from_format(reader.format());
+
+    let (width, height) = reader
+        .into_dimensions()
+        .map_err(|error| with_path_context("Reading image dimensions", path, error))?;
+
+    Ok(ImageHeaderInfo {
+        dimensions: MediaDimensions { width, height },
+        mime_type,
+    })
+}
+
+pub fn mime_type_from_format(format: Option<ImageFormat>) -> Option<String> {
+    match format {
+        Some(ImageFormat::Jpeg) => Some("image/jpeg".to_string()),
+        Some(ImageFormat::Png) => Some("image/png".to_string()),
+        Some(ImageFormat::Gif) => Some("image/gif".to_string()),
+        Some(ImageFormat::WebP) => Some("image/webp".to_string()),
+        Some(ImageFormat::Bmp) => Some("image/bmp".to_string()),
+        Some(ImageFormat::Tiff) => Some("image/tiff".to_string()),
+        Some(ImageFormat::Avif) => Some("image/avif".to_string()),
+        _ => None,
+    }
+}

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -1,412 +1,52 @@
-use std::fs::{self, File};
-use std::io::BufWriter;
-use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use chrono::{DateTime, Utc};
-use image::codecs::jpeg::JpegEncoder;
-use image::{DynamicImage, ImageFormat, ImageReader};
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ProbeMediaResult {
-	width: u32,
-	height: u32,
-	size: u64,
-	created_at: String,
-	modified_at: String,
-	duration: Option<f64>,
-	mime_type: Option<String>,
-	codec: Option<String>,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TauriFileStat {
-	size: u64,
-	mtime: String,
-	birthtime: String,
-	is_directory: bool,
-}
-
-#[derive(Serialize)]
-struct ExtractedTag {
-	name: String,
-	#[serde(rename = "type")]
-	tag_type: &'static str,
-}
-
-#[derive(Serialize)]
-struct ExtractMetadataResult {
-	tags: Vec<ExtractedTag>,
-	prompt: Option<Value>,
-	workflow: Option<Value>,
-}
-
-#[derive(Serialize, Clone, Copy)]
-struct MediaDimensions {
-	width: u32,
-	height: u32,
-}
-
-struct ImageHeaderInfo {
-	dimensions: MediaDimensions,
-	mime_type: Option<String>,
-}
-
-#[derive(Deserialize)]
-struct MkdirOptions {
-	recursive: Option<bool>,
-}
-
-#[derive(Deserialize)]
-struct RmOptions {
-	recursive: Option<bool>,
-	force: Option<bool>,
-}
-
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum WriteFileData {
-	Text(String),
-	Bytes(Vec<u8>),
-}
-
-impl WriteFileData {
-	fn into_bytes(self) -> Vec<u8> {
-		match self {
-			Self::Text(value) => value.into_bytes(),
-			Self::Bytes(value) => value,
-		}
-	}
-}
-
-fn format_system_time(value: SystemTime) -> String {
-	DateTime::<Utc>::from(value).to_rfc3339()
-}
-
-fn with_path_context(action: &str, path: &str, error: impl std::fmt::Display) -> String {
-	format!("{action} failed for {path}: {error}")
-}
-
-fn metadata_created_or_modified(path: &str, metadata: &fs::Metadata) -> Result<String, String> {
-	metadata
-		.created()
-		.or_else(|_| metadata.modified())
-		.map(format_system_time)
-		.map_err(|error| with_path_context("Reading file creation time", path, error))
-}
-
-fn metadata_modified(path: &str, metadata: &fs::Metadata) -> Result<String, String> {
-	metadata
-		.modified()
-		.map(format_system_time)
-		.map_err(|error| with_path_context("Reading file modified time", path, error))
-}
-
-fn load_image(path: &str) -> Result<DynamicImage, String> {
-	ImageReader::open(path)
-		.map_err(|error| with_path_context("Opening image", path, error))?
-		.with_guessed_format()
-		.map_err(|error| with_path_context("Guessing image format", path, error))?
-		.decode()
-		.map_err(|error| with_path_context("Decoding image", path, error))
-}
-
-fn inspect_image_header(path: &str) -> Result<ImageHeaderInfo, String> {
-	let reader = ImageReader::open(path)
-		.map_err(|error| with_path_context("Opening image", path, error))?
-		.with_guessed_format()
-		.map_err(|error| with_path_context("Guessing image format", path, error))?;
-	let mime_type = mime_type_from_format(reader.format());
-
-	let (width, height) = reader
-		.into_dimensions()
-		.map_err(|error| with_path_context("Reading image dimensions", path, error))?;
-
-	Ok(ImageHeaderInfo {
-		dimensions: MediaDimensions { width, height },
-		mime_type,
-	})
-}
-
-fn get_dimensions_from_header(path: &str) -> Result<MediaDimensions, String> {
-	Ok(inspect_image_header(path)?.dimensions)
-}
-
-fn mime_type_from_format(format: Option<ImageFormat>) -> Option<String> {
-	match format {
-		Some(ImageFormat::Jpeg) => Some("image/jpeg".to_string()),
-		Some(ImageFormat::Png) => Some("image/png".to_string()),
-		Some(ImageFormat::Gif) => Some("image/gif".to_string()),
-		Some(ImageFormat::WebP) => Some("image/webp".to_string()),
-		Some(ImageFormat::Bmp) => Some("image/bmp".to_string()),
-		Some(ImageFormat::Tiff) => Some("image/tiff".to_string()),
-		Some(ImageFormat::Avif) => Some("image/avif".to_string()),
-		_ => None,
-	}
-}
-
-#[tauri::command]
-fn fs_exists(path: String) -> bool {
-	Path::new(&path).exists()
-}
-
-#[tauri::command]
-fn fs_read_file(path: String) -> Result<Vec<u8>, String> {
-	fs::read(&path).map_err(|error| with_path_context("Reading file", &path, error))
-}
-
-#[tauri::command]
-fn fs_read_text_file(path: String, encoding: Option<String>) -> Result<String, String> {
-	let encoding = encoding.unwrap_or_else(|| "utf-8".to_string());
-	if encoding != "utf-8" {
-		return Err(format!("Unsupported encoding: {encoding}"));
-	}
-
-	fs::read_to_string(&path)
-		.map_err(|error| with_path_context("Reading text file", &path, error))
-}
-
-#[tauri::command]
-fn fs_write_file(path: String, data: WriteFileData) -> Result<(), String> {
-	fs::write(&path, data.into_bytes())
-		.map_err(|error| with_path_context("Writing file", &path, error))
-}
-
-#[tauri::command]
-fn fs_mkdir(path: String, options: Option<MkdirOptions>) -> Result<(), String> {
-	let recursive = options.and_then(|value| value.recursive).unwrap_or(false);
-
-	if recursive {
-		fs::create_dir_all(&path)
-			.map_err(|error| with_path_context("Creating directory tree", &path, error))
-	} else {
-		fs::create_dir(&path).map_err(|error| with_path_context("Creating directory", &path, error))
-	}
-}
-
-#[tauri::command]
-fn fs_readdir(path: String) -> Result<Vec<String>, String> {
-	let entries = fs::read_dir(&path)
-		.map_err(|error| with_path_context("Reading directory", &path, error))?;
-
-	let mut names = Vec::new();
-	for entry in entries {
-		let entry = entry.map_err(|error| with_path_context("Reading directory entry", &path, error))?;
-		names.push(entry.file_name().to_string_lossy().into_owned());
-	}
-
-	Ok(names)
-}
-
-#[tauri::command]
-fn fs_stat(path: String) -> Result<TauriFileStat, String> {
-	let metadata = fs::metadata(&path)
-		.map_err(|error| with_path_context("Reading file metadata", &path, error))?;
-
-	Ok(TauriFileStat {
-		size: metadata.len(),
-		mtime: metadata_modified(&path, &metadata)?,
-		birthtime: metadata_created_or_modified(&path, &metadata)?,
-		is_directory: metadata.is_dir(),
-	})
-}
-
-#[tauri::command]
-fn fs_unlink(path: String) -> Result<(), String> {
-	fs::remove_file(&path).map_err(|error| with_path_context("Removing file", &path, error))
-}
-
-#[tauri::command]
-fn fs_rm(path: String, options: Option<RmOptions>) -> Result<(), String> {
-	let recursive = options
-		.as_ref()
-		.and_then(|value| value.recursive)
-		.unwrap_or(false);
-	let force = options
-		.as_ref()
-		.and_then(|value| value.force)
-		.unwrap_or(false);
-	let target = Path::new(&path);
-
-	if !target.exists() {
-		return if force {
-			Ok(())
-		} else {
-			Err(format!("Path does not exist: {path}"))
-		};
-	}
-
-	let result = if target.is_dir() {
-		if recursive {
-			fs::remove_dir_all(target)
-		} else {
-			fs::remove_dir(target)
-		}
-	} else {
-		fs::remove_file(target)
-	};
-
-	result.map_err(|error| with_path_context("Removing path", &path, error))
-}
-
-#[tauri::command]
-fn fs_copy_file(src: String, dest: String) -> Result<(), String> {
-	fs::copy(&src, &dest)
-		.map(|_| ())
-		.map_err(|error| with_path_context("Copying file", &src, error))
-}
-
-#[tauri::command]
-fn fs_rename(old_path: String, new_path: String) -> Result<(), String> {
-	fs::rename(&old_path, &new_path)
-		.map_err(|error| with_path_context("Renaming path", &old_path, error))
-}
-
-#[tauri::command]
-fn fs_mkdtemp(prefix: String) -> Result<String, String> {
-	let unique = SystemTime::now()
-		.duration_since(UNIX_EPOCH)
-		.map_err(|error| format!("Creating temp directory timestamp failed: {error}"))?
-		.as_nanos();
-	let path = std::env::temp_dir().join(format!("{prefix}{unique}"));
-
-	fs::create_dir_all(&path).map_err(|error| {
-		with_path_context("Creating temporary directory", &path.to_string_lossy(), error)
-	})?;
-
-	Ok(path.to_string_lossy().into_owned())
-}
-
-#[tauri::command]
-fn image_get_dimensions(media_path: String) -> Result<MediaDimensions, String> {
-	get_dimensions_from_header(&media_path)
-}
-
-#[tauri::command]
-fn probe_media(media_path: String) -> Result<ProbeMediaResult, String> {
-	let metadata = fs::metadata(&media_path)
-		.map_err(|error| with_path_context("Reading file metadata", &media_path, error))?;
-	let header = inspect_image_header(&media_path).ok();
-	let dimensions = header
-		.as_ref()
-		.map(|value| value.dimensions)
-		.unwrap_or(MediaDimensions {
-		width: 0,
-		height: 0,
-	});
-	let mime_type = header
-		.and_then(|value| value.mime_type)
-		.or_else(|| mime_guess::from_path(&media_path).first_raw().map(|value| value.to_string()));
-
-	Ok(ProbeMediaResult {
-		width: dimensions.width,
-		height: dimensions.height,
-		size: metadata.len(),
-		created_at: metadata_created_or_modified(&media_path, &metadata)?,
-		modified_at: metadata_modified(&media_path, &metadata)?,
-		duration: None,
-		mime_type,
-		codec: None,
-	})
-}
-
-#[tauri::command]
-fn image_extract_metadata(_media_path: String) -> ExtractMetadataResult {
-	ExtractMetadataResult {
-		tags: Vec::new(),
-		prompt: None,
-		workflow: None,
-	}
-}
-
-#[tauri::command]
-fn image_generate_thumbnail(
-	media_path: String,
-	output_path: String,
-	size: u32,
-	quality: u8,
-) -> Result<(), String> {
-	let image = load_image(&media_path)?;
-	let thumbnail = image.thumbnail(size, size);
-	let output = Path::new(&output_path);
-
-	if let Some(parent) = output.parent() {
-		fs::create_dir_all(parent).map_err(|error| {
-			with_path_context("Creating thumbnail directory", &output_path, error)
-		})?;
-	}
-
-	let extension = output
-		.extension()
-		.and_then(|value| value.to_str())
-		.unwrap_or("jpg")
-		.to_ascii_lowercase();
-
-	match extension.as_str() {
-		"jpg" | "jpeg" => {
-			let file = File::create(output)
-				.map_err(|error| with_path_context("Creating thumbnail file", &output_path, error))?;
-			let mut encoder = JpegEncoder::new_with_quality(BufWriter::new(file), quality);
-			encoder
-				.encode_image(&thumbnail)
-				.map_err(|error| with_path_context("Encoding JPEG thumbnail", &output_path, error))
-		}
-		"png" => thumbnail
-			.save_with_format(output, ImageFormat::Png)
-			.map_err(|error| with_path_context("Saving PNG thumbnail", &output_path, error)),
-		"webp" => thumbnail
-			.save_with_format(output, ImageFormat::WebP)
-			.map_err(|error| with_path_context("Saving WebP thumbnail", &output_path, error)),
-		_ => thumbnail
-			.save(output)
-			.map_err(|error| with_path_context("Saving thumbnail", &output_path, error)),
-	}
-}
-
-#[tauri::command]
-fn api_call(procedure: String, _input: Option<Value>) -> Result<Value, String> {
-	Err(format!("Unsupported Tauri API procedure: {procedure}"))
-}
+mod commands;
+mod media_config;
+mod media_metadata;
+mod watcher;
 
 #[cfg(target_os = "linux")]
 fn configure_linux_webview_environment() {
-	if std::env::var_os("WAYLAND_DISPLAY").is_some()
-		&& std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none()
-	{
-		std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-	}
+    if std::env::var_os("WAYLAND_DISPLAY").is_some()
+        && std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none()
+    {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
 fn configure_linux_webview_environment() {}
 
 fn main() {
-	configure_linux_webview_environment();
+    configure_linux_webview_environment();
 
-	tauri::Builder::default()
-		.invoke_handler(tauri::generate_handler![
-			api_call,
-			fs_exists,
-			fs_read_file,
-			fs_read_text_file,
-			fs_write_file,
-			fs_mkdir,
-			fs_readdir,
-			fs_stat,
-			fs_unlink,
-			fs_rm,
-			fs_copy_file,
-			fs_rename,
-			fs_mkdtemp,
-			image_generate_thumbnail,
-			image_extract_metadata,
-			image_get_dimensions,
-			probe_media
-		])
-		.run(tauri::generate_context!())
-		.expect("failed to run tauri application")
+    tauri::Builder::default()
+        .manage(watcher::WatcherRegistry::default())
+        .invoke_handler(tauri::generate_handler![
+            commands::backup::backup_create_zip,
+            commands::backup::backup_extract_zip,
+            commands::backup::parse_restore_json,
+            commands::fs::fs_exists,
+            commands::fs::fs_read_file,
+            commands::fs::fs_read_text_file,
+            commands::fs::fs_write_file,
+            commands::fs::fs_mkdir,
+            commands::fs::fs_readdir,
+            commands::fs::fs_scan_recursive,
+            commands::fs::fs_stat,
+            commands::fs::fs_unlink,
+            commands::fs::fs_rm,
+            commands::fs::fs_copy_file,
+            commands::fs::fs_rename,
+            commands::fs::fs_mkdtemp,
+            commands::fs::download_file,
+            commands::media::image_generate_thumbnail,
+            commands::media::image_generate_thumbnails_batch,
+            commands::media::image_extract_metadata,
+            commands::media::image_get_dimensions,
+            commands::media::probe_media,
+            commands::media::probe_media_batch,
+            watcher::source_watch_start,
+            watcher::source_watch_stop
+        ])
+        .run(tauri::generate_context!())
+        .expect("failed to run tauri application")
 }

--- a/apps/tauri/src-tauri/src/media_config.rs
+++ b/apps/tauri/src-tauri/src/media_config.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ComfyUiTagExtractionConfig {
+    pub positive_node_types: Vec<String>,
+    pub negative_keywords: Vec<String>,
+    pub negative_tags: Vec<String>,
+}
+
+impl Default for ComfyUiTagExtractionConfig {
+    fn default() -> Self {
+        Self {
+            positive_node_types: vec![
+                "CLIPTextEncode".to_string(),
+                "CR Combine Prompt".to_string(),
+            ],
+            negative_keywords: vec!["negative".to_string()],
+            negative_tags: vec!["lowres".to_string()],
+        }
+    }
+}

--- a/apps/tauri/src-tauri/src/media_metadata.rs
+++ b/apps/tauri/src-tauri/src/media_metadata.rs
@@ -1,0 +1,423 @@
+use crate::commands::utils::{ExtractMetadataResult, ExtractedTag};
+use crate::media_config::ComfyUiTagExtractionConfig;
+use serde_json::Value;
+use std::fs;
+use std::io::{Cursor, Read};
+
+const PNG_SIGNATURE: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
+
+struct MetadataComment {
+    keyword: String,
+    text: String,
+}
+
+pub fn extract_metadata_from_path(
+    media_path: &str,
+    config: &ComfyUiTagExtractionConfig,
+) -> Result<ExtractMetadataResult, String> {
+    let comments = extract_comments_from_path(media_path)?;
+    Ok(extract_data_from_comments(&comments, config))
+}
+
+fn extract_comments_from_path(media_path: &str) -> Result<Vec<MetadataComment>, String> {
+    let bytes = fs::read(media_path)
+        .map_err(|error| format!("Reading image metadata failed for {media_path}: {error}"))?;
+    if bytes.starts_with(&PNG_SIGNATURE) {
+        return extract_png_comments(&bytes);
+    }
+
+    Ok(Vec::new())
+}
+
+fn extract_png_comments(bytes: &[u8]) -> Result<Vec<MetadataComment>, String> {
+    let mut cursor = Cursor::new(bytes);
+    let mut signature = [0_u8; 8];
+    cursor
+        .read_exact(&mut signature)
+        .map_err(|error| format!("Reading PNG signature failed: {error}"))?;
+
+    let mut comments = Vec::new();
+    while (cursor.position() as usize) + 8 <= bytes.len() {
+        let length = read_u32_be(&mut cursor)? as usize;
+        let chunk_type = read_chunk_type(&mut cursor)?;
+        if (cursor.position() as usize) + length + 4 > bytes.len() {
+            break;
+        }
+
+        let mut data = vec![0_u8; length];
+        cursor
+            .read_exact(&mut data)
+            .map_err(|error| format!("Reading PNG chunk data failed: {error}"))?;
+        let mut crc = [0_u8; 4];
+        cursor
+            .read_exact(&mut crc)
+            .map_err(|error| format!("Reading PNG CRC failed: {error}"))?;
+
+        match chunk_type.as_str() {
+            "tEXt" => {
+                if let Some(comment) = parse_png_text_chunk(&data) {
+                    comments.push(comment);
+                }
+            }
+            "iTXt" => {
+                if let Some(comment) = parse_png_itxt_chunk(&data) {
+                    comments.push(comment);
+                }
+            }
+            "IEND" => break,
+            _ => {}
+        }
+    }
+
+    Ok(comments)
+}
+
+fn read_u32_be(cursor: &mut Cursor<&[u8]>) -> Result<u32, String> {
+    let mut buf = [0_u8; 4];
+    cursor
+        .read_exact(&mut buf)
+        .map_err(|error| format!("Reading PNG integer failed: {error}"))?;
+    Ok(u32::from_be_bytes(buf))
+}
+
+fn read_chunk_type(cursor: &mut Cursor<&[u8]>) -> Result<String, String> {
+    let mut buf = [0_u8; 4];
+    cursor
+        .read_exact(&mut buf)
+        .map_err(|error| format!("Reading PNG chunk type failed: {error}"))?;
+    String::from_utf8(buf.to_vec()).map_err(|error| format!("Invalid PNG chunk type: {error}"))
+}
+
+fn parse_png_text_chunk(data: &[u8]) -> Option<MetadataComment> {
+    let separator = data.iter().position(|value| *value == 0)?;
+    let keyword = String::from_utf8(data[..separator].to_vec()).ok()?;
+    let text = String::from_utf8(data[separator + 1..].to_vec()).ok()?;
+    Some(MetadataComment { keyword, text })
+}
+
+fn parse_png_itxt_chunk(data: &[u8]) -> Option<MetadataComment> {
+    let mut sections = data.splitn(6, |value| *value == 0);
+    let keyword = String::from_utf8(sections.next()?.to_vec()).ok()?;
+    let compression_flag = *sections.next()?.first()?;
+    if compression_flag != 0 {
+        return None;
+    }
+    let _compression_method = sections.next()?;
+    let _language_tag = sections.next()?;
+    let _translated_keyword = sections.next()?;
+    let text = String::from_utf8(sections.next()?.to_vec()).ok()?;
+    Some(MetadataComment { keyword, text })
+}
+
+fn extract_data_from_comments(
+    comments: &[MetadataComment],
+    config: &ComfyUiTagExtractionConfig,
+) -> ExtractMetadataResult {
+    let mut tags = Vec::new();
+    let mut prompt = None;
+    let mut workflow = None;
+
+    for chunk in comments {
+        let processed = process_comment_chunk(chunk, config);
+        tags.extend(processed.tags);
+        if let Some(value) = processed.prompt {
+            prompt = Some(value);
+        }
+        if let Some(value) = processed.workflow {
+            workflow = Some(value);
+        }
+    }
+
+    tags.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then(left.tag_type.cmp(right.tag_type))
+    });
+    tags.dedup_by(|left, right| left.name == right.name && left.tag_type == right.tag_type);
+
+    ExtractMetadataResult {
+        tags,
+        prompt,
+        workflow,
+    }
+}
+
+struct ProcessedChunk {
+    tags: Vec<ExtractedTag>,
+    prompt: Option<Value>,
+    workflow: Option<Value>,
+}
+
+fn process_comment_chunk(
+    chunk: &MetadataComment,
+    config: &ComfyUiTagExtractionConfig,
+) -> ProcessedChunk {
+    if chunk.keyword == "prompt" {
+        if let Ok(parsed_json) = serde_json::from_str::<Value>(&chunk.text) {
+            if looks_like_workflow(&parsed_json) {
+                let tags = extract_tags_from_workflow(&parsed_json, config);
+                return ProcessedChunk {
+                    tags,
+                    prompt: Some(Value::String(chunk.text.clone())),
+                    workflow: Some(parsed_json),
+                };
+            }
+        }
+
+        return ProcessedChunk {
+            tags: Vec::new(),
+            prompt: Some(Value::String(chunk.text.clone())),
+            workflow: None,
+        };
+    }
+
+    if chunk.keyword == "workflow" {
+        if let Ok(parsed_json) = serde_json::from_str::<Value>(&chunk.text) {
+            let tags = extract_tags_from_workflow(&parsed_json, config);
+            return ProcessedChunk {
+                tags,
+                prompt: None,
+                workflow: Some(parsed_json),
+            };
+        }
+    }
+
+    ProcessedChunk {
+        tags: Vec::new(),
+        prompt: None,
+        workflow: None,
+    }
+}
+
+fn looks_like_workflow(value: &Value) -> bool {
+    if let Some(object) = value.as_object() {
+        if object.contains_key("nodes") {
+            return true;
+        }
+
+        return object.values().take(5).any(|item| {
+            item.as_object()
+                .is_some_and(|node| node.contains_key("class_type"))
+        });
+    }
+
+    false
+}
+
+fn extract_tags_from_workflow(
+    workflow: &Value,
+    config: &ComfyUiTagExtractionConfig,
+) -> Vec<ExtractedTag> {
+    let mut positive_tags = Vec::new();
+    let mut negative_tags = Vec::new();
+
+    let nodes = if let Some(nodes) = workflow.get("nodes").and_then(Value::as_array) {
+        nodes.clone()
+    } else if let Some(object) = workflow.as_object() {
+        object.values().cloned().collect()
+    } else {
+        Vec::new()
+    };
+
+    for node in nodes {
+        process_workflow_node(&node, config, &mut positive_tags, &mut negative_tags);
+    }
+
+    positive_tags.extend(negative_tags);
+    positive_tags
+}
+
+fn process_workflow_node(
+    node: &Value,
+    config: &ComfyUiTagExtractionConfig,
+    positive_tags: &mut Vec<ExtractedTag>,
+    negative_tags: &mut Vec<ExtractedTag>,
+) {
+    let Some(node_object) = node.as_object() else {
+        return;
+    };
+
+    let node_type = node_object
+        .get("type")
+        .and_then(Value::as_str)
+        .or_else(|| node_object.get("class_type").and_then(Value::as_str));
+
+    let is_positive_node = node_type.is_some_and(|node_type| {
+        config
+            .positive_node_types
+            .iter()
+            .any(|allowed| allowed == node_type)
+    });
+    if !is_positive_node {
+        return;
+    }
+
+    let node_title = node_object
+        .get("title")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            node_object
+                .get("_meta")
+                .and_then(Value::as_object)
+                .and_then(|meta| meta.get("title"))
+                .and_then(Value::as_str)
+        });
+
+    let mut values_to_process = Vec::new();
+    if let Some(values) = node_object.get("widgets_values").and_then(Value::as_array) {
+        values_to_process.extend(values.iter().cloned());
+    }
+    if let Some(inputs) = node_object.get("inputs").and_then(Value::as_object) {
+        values_to_process.extend(inputs.values().cloned());
+    }
+
+    for widget_value in values_to_process {
+        let (new_positive_tags, new_negative_tags) =
+            process_widget_value_tags(&widget_value, node_title, config);
+        positive_tags.extend(new_positive_tags);
+        negative_tags.extend(new_negative_tags);
+    }
+}
+
+fn process_widget_value_tags(
+    widget_value: &Value,
+    node_title: Option<&str>,
+    config: &ComfyUiTagExtractionConfig,
+) -> (Vec<ExtractedTag>, Vec<ExtractedTag>) {
+    let Some(text) = widget_value.as_str() else {
+        return (Vec::new(), Vec::new());
+    };
+
+    let tags = text
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.replace(' ', "_").replace('"', ""))
+        .collect::<Vec<_>>();
+    if tags.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+
+    let is_negative_by_title = node_title.is_some_and(|title| {
+        let title = title.to_ascii_lowercase();
+        config
+            .negative_keywords
+            .iter()
+            .any(|keyword| title.contains(&keyword.to_ascii_lowercase()))
+    });
+    let is_negative_by_tag = tags
+        .iter()
+        .any(|tag| config.negative_tags.iter().any(|value| value == tag));
+
+    if is_negative_by_title || is_negative_by_tag {
+        return (
+            Vec::new(),
+            tags.into_iter()
+                .map(|name| ExtractedTag {
+                    name,
+                    tag_type: "negative",
+                })
+                .collect(),
+        );
+    }
+
+    (
+        tags.into_iter()
+            .map(|name| ExtractedTag {
+                name,
+                tag_type: "positive",
+            })
+            .collect(),
+        Vec::new(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> ComfyUiTagExtractionConfig {
+        ComfyUiTagExtractionConfig {
+            positive_node_types: vec![
+                "CLIPTextEncode".to_string(),
+                "CR Combine Prompt".to_string(),
+            ],
+            negative_keywords: vec!["negative".to_string()],
+            negative_tags: vec!["lowres".to_string()],
+        }
+    }
+
+    #[test]
+    fn extracts_prompt_workflow_and_tags_from_comments() {
+        let comments = vec![
+            MetadataComment {
+                keyword: "prompt".to_string(),
+                text: serde_json::json!({
+                    "nodes": [
+                        {
+                            "type": "CR Combine Prompt",
+                            "widgets_values": ["1girl, solo, smile"],
+                            "title": "Positive Prompt"
+                        }
+                    ]
+                })
+                .to_string(),
+            },
+            MetadataComment {
+                keyword: "workflow".to_string(),
+                text: serde_json::json!({
+                    "nodes": [
+                        {
+                            "type": "CR Combine Prompt",
+                            "widgets_values": ["bad anatomy, ugly, disfigured"],
+                            "title": "Negative Prompt"
+                        }
+                    ]
+                })
+                .to_string(),
+            },
+        ];
+
+        let result = extract_data_from_comments(&comments, &config());
+
+        assert_eq!(result.tags.len(), 6);
+        assert!(result.prompt.is_some());
+        assert!(result.workflow.is_some());
+    }
+
+    #[test]
+    fn parses_png_text_chunks() {
+        let data = build_png_with_text_chunks(&[
+            ("prompt", "{\"nodes\":[]}"),
+            ("workflow", "{\"nodes\":[]}"),
+        ]);
+
+        let comments = extract_png_comments(&data).expect("png comments");
+
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].keyword, "prompt");
+        assert_eq!(comments[1].keyword, "workflow");
+    }
+
+    fn build_png_with_text_chunks(entries: &[(&str, &str)]) -> Vec<u8> {
+        let mut bytes = PNG_SIGNATURE.to_vec();
+        bytes.extend(make_chunk("IHDR", &[0, 0, 0, 1, 0, 0, 0, 1, 8, 2, 0, 0, 0]));
+        for (keyword, text) in entries {
+            let mut payload = keyword.as_bytes().to_vec();
+            payload.push(0);
+            payload.extend(text.as_bytes());
+            bytes.extend(make_chunk("tEXt", &payload));
+        }
+        bytes.extend(make_chunk("IEND", &[]));
+        bytes
+    }
+
+    fn make_chunk(chunk_type: &str, payload: &[u8]) -> Vec<u8> {
+        let mut chunk = Vec::new();
+        chunk.extend((payload.len() as u32).to_be_bytes());
+        chunk.extend(chunk_type.as_bytes());
+        chunk.extend(payload);
+        chunk.extend([0, 0, 0, 0]);
+        chunk
+    }
+}

--- a/apps/tauri/src-tauri/src/media_metadata.rs
+++ b/apps/tauri/src-tauri/src/media_metadata.rs
@@ -1,8 +1,8 @@
 use crate::commands::utils::{ExtractMetadataResult, ExtractedTag};
 use crate::media_config::ComfyUiTagExtractionConfig;
 use serde_json::Value;
-use std::fs;
-use std::io::{Cursor, Read};
+use std::fs::File;
+use std::io::{BufReader, Cursor, Read};
 
 const PNG_SIGNATURE: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
 
@@ -20,38 +20,48 @@ pub fn extract_metadata_from_path(
 }
 
 fn extract_comments_from_path(media_path: &str) -> Result<Vec<MetadataComment>, String> {
-    let bytes = fs::read(media_path)
-        .map_err(|error| format!("Reading image metadata failed for {media_path}: {error}"))?;
-    if bytes.starts_with(&PNG_SIGNATURE) {
-        return extract_png_comments(&bytes);
+    let file = File::open(media_path)
+        .map_err(|error| format!("Opening image file failed for {media_path}: {error}"))?;
+    let mut reader = BufReader::new(file);
+
+    // Read only the PNG signature to avoid loading the entire file into memory
+    let mut signature = [0_u8; 8];
+    reader
+        .read_exact(&mut signature)
+        .map_err(|error| format!("Reading PNG signature failed for {media_path}: {error}"))?;
+
+    if signature == PNG_SIGNATURE {
+        // Prepend the signature we already read so the PNG parser sees the full stream
+        let chained = Cursor::new(signature.to_vec()).chain(reader);
+        return extract_png_comments(chained);
     }
 
     Ok(Vec::new())
 }
 
-fn extract_png_comments(bytes: &[u8]) -> Result<Vec<MetadataComment>, String> {
-    let mut cursor = Cursor::new(bytes);
-    let mut signature = [0_u8; 8];
-    cursor
-        .read_exact(&mut signature)
-        .map_err(|error| format!("Reading PNG signature failed: {error}"))?;
-
+fn extract_png_comments<R: Read>(mut reader: R) -> Result<Vec<MetadataComment>, String> {
+    // Signature already consumed by the caller; start parsing chunks directly
     let mut comments = Vec::new();
-    while (cursor.position() as usize) + 8 <= bytes.len() {
-        let length = read_u32_be(&mut cursor)? as usize;
-        let chunk_type = read_chunk_type(&mut cursor)?;
-        if (cursor.position() as usize) + length + 4 > bytes.len() {
-            break;
-        }
+    loop {
+        let length = match read_u32_be(&mut reader) {
+            Ok(v) => v as usize,
+            Err(_) => break,
+        };
+        let chunk_type = read_chunk_type(&mut reader).map_err(|error| {
+            if error.contains("failed to fill whole buffer") {
+                return "Unexpected EOF".to_string();
+            }
+            error
+        })?;
 
         let mut data = vec![0_u8; length];
-        cursor
-            .read_exact(&mut data)
-            .map_err(|error| format!("Reading PNG chunk data failed: {error}"))?;
+        if reader.read_exact(&mut data).is_err() {
+            break;
+        }
         let mut crc = [0_u8; 4];
-        cursor
-            .read_exact(&mut crc)
-            .map_err(|error| format!("Reading PNG CRC failed: {error}"))?;
+        if reader.read_exact(&mut crc).is_err() {
+            break;
+        }
 
         match chunk_type.as_str() {
             "tEXt" => {
@@ -72,17 +82,17 @@ fn extract_png_comments(bytes: &[u8]) -> Result<Vec<MetadataComment>, String> {
     Ok(comments)
 }
 
-fn read_u32_be(cursor: &mut Cursor<&[u8]>) -> Result<u32, String> {
+fn read_u32_be<R: Read>(reader: &mut R) -> Result<u32, String> {
     let mut buf = [0_u8; 4];
-    cursor
+    reader
         .read_exact(&mut buf)
         .map_err(|error| format!("Reading PNG integer failed: {error}"))?;
     Ok(u32::from_be_bytes(buf))
 }
 
-fn read_chunk_type(cursor: &mut Cursor<&[u8]>) -> Result<String, String> {
+fn read_chunk_type<R: Read>(reader: &mut R) -> Result<String, String> {
     let mut buf = [0_u8; 4];
-    cursor
+    reader
         .read_exact(&mut buf)
         .map_err(|error| format!("Reading PNG chunk type failed: {error}"))?;
     String::from_utf8(buf.to_vec()).map_err(|error| format!("Invalid PNG chunk type: {error}"))
@@ -392,7 +402,7 @@ mod tests {
             ("workflow", "{\"nodes\":[]}"),
         ]);
 
-        let comments = extract_png_comments(&data).expect("png comments");
+        let comments = extract_png_comments(data.as_slice()).expect("png comments");
 
         assert_eq!(comments.len(), 2);
         assert_eq!(comments[0].keyword, "prompt");

--- a/apps/tauri/src-tauri/src/watcher.rs
+++ b/apps/tauri/src-tauri/src/watcher.rs
@@ -1,0 +1,150 @@
+use chrono::Utc;
+use notify::event::{CreateKind, ModifyKind, RemoveKind};
+use notify::{recommended_watcher, Event, EventKind, RecursiveMode, Watcher};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter, State};
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SourceWatchEventPayload {
+    media_source_id: String,
+    paths: Vec<String>,
+    timestamp: String,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WatcherErrorPayload {
+    media_source_id: String,
+    error: String,
+    timestamp: String,
+}
+
+struct SourceWatcher {
+    #[allow(dead_code)]
+    watcher: notify::RecommendedWatcher,
+}
+
+#[derive(Default)]
+pub struct WatcherRegistry {
+    watchers: Mutex<HashMap<String, SourceWatcher>>,
+}
+
+fn should_forward_event(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Any
+            | EventKind::Other
+            | EventKind::Create(CreateKind::Any)
+            | EventKind::Create(CreateKind::File)
+            | EventKind::Create(CreateKind::Folder)
+            | EventKind::Create(CreateKind::Other)
+            | EventKind::Modify(ModifyKind::Any)
+            | EventKind::Modify(ModifyKind::Data(_))
+            | EventKind::Modify(ModifyKind::Metadata(_))
+            | EventKind::Modify(ModifyKind::Name(_))
+            | EventKind::Modify(ModifyKind::Other)
+            | EventKind::Remove(RemoveKind::Any)
+            | EventKind::Remove(RemoveKind::File)
+            | EventKind::Remove(RemoveKind::Folder)
+            | EventKind::Remove(RemoveKind::Other)
+    )
+}
+
+fn emit_watch_event(app: &AppHandle, media_source_id: &str, event: Event) {
+    if !should_forward_event(&event.kind) {
+        return;
+    }
+
+    let paths = event
+        .paths
+        .into_iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+
+    if paths.is_empty() {
+        return;
+    }
+
+    let _ = app.emit(
+        "source-watch-event",
+        SourceWatchEventPayload {
+            media_source_id: media_source_id.to_string(),
+            paths,
+            timestamp: Utc::now().to_rfc3339(),
+        },
+    );
+}
+
+fn emit_watch_error(app: &AppHandle, media_source_id: &str, error: impl std::fmt::Display) {
+    let _ = app.emit(
+        "watcher-error",
+        WatcherErrorPayload {
+            media_source_id: media_source_id.to_string(),
+            error: error.to_string(),
+            timestamp: Utc::now().to_rfc3339(),
+        },
+    );
+}
+
+impl WatcherRegistry {
+    fn stop_locked(&self, media_source_id: &str) {
+        let watcher = self.watchers.lock().unwrap().remove(media_source_id);
+        drop(watcher);
+    }
+
+    fn start(
+        &self,
+        app: AppHandle,
+        media_source_id: String,
+        watch_path: String,
+    ) -> Result<(), String> {
+        let path = Path::new(&watch_path);
+        if !path.exists() {
+            return Err(format!("Source path does not exist: {watch_path}"));
+        }
+
+        self.stop_locked(&media_source_id);
+
+        let callback_media_source_id = media_source_id.clone();
+        let callback_app = app.clone();
+        let mut watcher = recommended_watcher(move |result| match result {
+            Ok(event) => emit_watch_event(&callback_app, &callback_media_source_id, event),
+            Err(error) => emit_watch_error(&callback_app, &callback_media_source_id, error),
+        })
+        .map_err(|error| format!("Creating file watcher failed for {watch_path}: {error}"))?;
+
+        watcher
+            .watch(path, RecursiveMode::Recursive)
+            .map_err(|error| format!("Watching source failed for {watch_path}: {error}"))?;
+
+        self.watchers
+            .lock()
+            .unwrap()
+            .insert(media_source_id, SourceWatcher { watcher });
+
+        Ok(())
+    }
+
+    fn stop(&self, media_source_id: &str) {
+        self.stop_locked(media_source_id);
+    }
+}
+
+#[tauri::command]
+pub fn source_watch_start(
+    state: State<WatcherRegistry>,
+    app: AppHandle,
+    media_source_id: String,
+    watch_path: String,
+) -> Result<(), String> {
+    state.start(app, media_source_id, watch_path)
+}
+
+#[tauri::command]
+pub fn source_watch_stop(state: State<WatcherRegistry>, media_source_id: String) {
+    state.stop(&media_source_id);
+}

--- a/apps/tauri/src/infrastructure/tauri/file-system.ts
+++ b/apps/tauri/src/infrastructure/tauri/file-system.ts
@@ -8,6 +8,11 @@ type TauriFileStat = {
 	isDirectory: boolean;
 };
 
+type TauriFsScanEntry = {
+	fullPath: string;
+	isDirectory: boolean;
+};
+
 function toUint8Array(data: Uint8Array | number[]): Uint8Array {
 	return data instanceof Uint8Array ? data : new Uint8Array(data);
 }
@@ -48,6 +53,12 @@ export class TauriFileSystem implements IFileSystem {
 
 	async readdir(path: string) {
 		return this.commandClient.invoke<string[]>("fs_readdir", { path });
+	}
+
+	async scanDirectoryRecursive(path: string) {
+		return this.commandClient.invoke<TauriFsScanEntry[]>("fs_scan_recursive", {
+			path,
+		});
 	}
 
 	async stat(path: string) {


### PR DESCRIPTION
## Summary

Cherry-picked Rust source files and Cargo.toml changes from `fix/issue-165-tauri` branch to modularize Tauri commands.

### Changes
- **New files**: `apps/tauri/src-tauri/src/commands/` directory with `backup.rs`, `fs.rs`, `media.rs`, `utils.rs`, `mod.rs`
- **New files**: `media_metadata.rs`, `watcher.rs`, `media_config.rs`
- **Updated**: `main.rs` refactored to use modular command structure
- **Updated**: `Cargo.toml` with new dependencies (rayon, notify, zip, reqwest, futures-util, protocol-asset)
- **Updated**: `apps/tauri/src/infrastructure/tauri/file-system.ts` (TypeScript command client alignment)

fixes #352