### PR TITLE
feat: accept packages/ui shared screens and hooks (#353)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -164,7 +164,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@kobalte/core": "^0.13.11",
+        "@solid-imager/core": "workspace:*",
         "@solidjs/router": "^0.15.4",
+        "@tanstack/solid-query": "^5.0.0",
         "@tanstack/solid-virtual": "^3.13.16",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -174,10 +176,10 @@
         "solid-sonner": "^0.3.1",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
+        "zod": "^4.3.5",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.4",
-        "@solid-imager/core": "workspace:*",
         "typescript": "^5.9.3",
         "vite-plus": "latest",
         "vite-tsconfig-paths": "^5.1.4",
@@ -1907,9 +1909,19 @@
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
+    "@solid-imager/core/vite-plus": ["vite-plus@0.1.21", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@voidzero-dev/vite-plus-core": "0.1.21", "@voidzero-dev/vite-plus-test": "0.1.21", "oxfmt": "=0.48.0", "oxlint": "=1.63.0", "oxlint-tsgolint": "=0.22.1" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.21", "@voidzero-dev/vite-plus-darwin-x64": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.21", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.21", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.21" }, "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-7MLc9abMelE8g5/vj/xEY8joWT9PLnN/XjX3FhwOliB75WOX3YADcMEFrufmvnl+D4UhrMNZQa2k3A5CSuFJhw=="],
+
+    "@solid-imager/core/vitest": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
+
     "@solid-imager/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@solid-imager/server/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@solid-imager/ui/vite-plus": ["vite-plus@0.1.21", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@voidzero-dev/vite-plus-core": "0.1.21", "@voidzero-dev/vite-plus-test": "0.1.21", "oxfmt": "=0.48.0", "oxlint": "=1.63.0", "oxlint-tsgolint": "=0.22.1" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.21", "@voidzero-dev/vite-plus-darwin-x64": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.21", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.21", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.21" }, "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-7MLc9abMelE8g5/vj/xEY8joWT9PLnN/XjX3FhwOliB75WOX3YADcMEFrufmvnl+D4UhrMNZQa2k3A5CSuFJhw=="],
+
+    "@solid-imager/ui/vitest": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
+
+    "@solid-imager/ui/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
 
@@ -2121,6 +2133,70 @@
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util/@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="],
 
+    "@solid-imager/core/vite-plus/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-T7mPiDbE7VtjpegtJJ/e/uQOjOA/ufMo7npAaP9WVHxUEWLaR/OjVXXL9ALiW+CfKEQ0Qk/iWDB0mI6YMndzNQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-DqS0ZJ0sRtXu55loEIz/mkX99fl1HQ0b9UUj+Qm13NoMfh6JC8d0g6J+Dbu/EJy0TEU7QLjCXoALLQ7ZrsW34g=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-PoW375e3pSayRuN43agoe8LdItEa82bPhcaW7elPxoiO8puynB+4x5Xy5ozU5XgjEuCB3nYKE6R/b9peWsaFEQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5c6i1TyRuMELDcGozuI5Y0JhIZsSbAJ067Okty6XmoJ5tSmUnMzEO5HKRmgjfGryjJpn5dpUKXzj2eWsdx+6g=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-DquiIAvGIUIJBfqOnqAtBPoyhNIGLM1DzswzDPddO5kjg6NCE4hPbFr5ncjhSKqyp88Kd1YWYD93yg3FAdr/EA=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-/nVT+eFySYwf3uEv+n9FrdJ0bg3SbfqUkAnIxH7XMQ/hhmU4lAE2dH4SiUqk6h70gESaFHfJmhWtp5Qzt/W7Vw=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-KhEqfRKlfuuVJb2eY8ZCmmXcxUqy8/ZBZPWPipxcB1QDWIykyN5F4zbewLxXw18JL/Q0ISP0p7V8RIldAh4Gyw=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.21", "", { "os": "win32", "cpu": "x64" }, "sha512-lH8d2qElBfUUpejZhYvK3CrP6kHTz0z2jff/ZowlY6jkr1pQkYj3EVhRi5r81DXcbXZs9yAbXbBPw8mVZtG9FA=="],
+
+    "@solid-imager/core/vite-plus/oxfmt": ["oxfmt@0.48.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.48.0", "@oxfmt/binding-android-arm64": "0.48.0", "@oxfmt/binding-darwin-arm64": "0.48.0", "@oxfmt/binding-darwin-x64": "0.48.0", "@oxfmt/binding-freebsd-x64": "0.48.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.48.0", "@oxfmt/binding-linux-arm-musleabihf": "0.48.0", "@oxfmt/binding-linux-arm64-gnu": "0.48.0", "@oxfmt/binding-linux-arm64-musl": "0.48.0", "@oxfmt/binding-linux-ppc64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-musl": "0.48.0", "@oxfmt/binding-linux-s390x-gnu": "0.48.0", "@oxfmt/binding-linux-x64-gnu": "0.48.0", "@oxfmt/binding-linux-x64-musl": "0.48.0", "@oxfmt/binding-openharmony-arm64": "0.48.0", "@oxfmt/binding-win32-arm64-msvc": "0.48.0", "@oxfmt/binding-win32-ia32-msvc": "0.48.0", "@oxfmt/binding-win32-x64-msvc": "0.48.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g=="],
+
+    "@solid-imager/core/vite-plus/oxlint": ["oxlint@1.63.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.63.0", "@oxlint/binding-android-arm64": "1.63.0", "@oxlint/binding-darwin-arm64": "1.63.0", "@oxlint/binding-darwin-x64": "1.63.0", "@oxlint/binding-freebsd-x64": "1.63.0", "@oxlint/binding-linux-arm-gnueabihf": "1.63.0", "@oxlint/binding-linux-arm-musleabihf": "1.63.0", "@oxlint/binding-linux-arm64-gnu": "1.63.0", "@oxlint/binding-linux-arm64-musl": "1.63.0", "@oxlint/binding-linux-ppc64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-musl": "1.63.0", "@oxlint/binding-linux-s390x-gnu": "1.63.0", "@oxlint/binding-linux-x64-gnu": "1.63.0", "@oxlint/binding-linux-x64-musl": "1.63.0", "@oxlint/binding-openharmony-arm64": "1.63.0", "@oxlint/binding-win32-arm64-msvc": "1.63.0", "@oxlint/binding-win32-ia32-msvc": "1.63.0", "@oxlint/binding-win32-x64-msvc": "1.63.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint": ["oxlint-tsgolint@0.22.1", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.22.1", "@oxlint-tsgolint/darwin-x64": "0.22.1", "@oxlint-tsgolint/linux-arm64": "0.22.1", "@oxlint-tsgolint/linux-x64": "0.22.1", "@oxlint-tsgolint/win32-arm64": "0.22.1", "@oxlint-tsgolint/win32-x64": "0.22.1" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg=="],
+
+    "@solid-imager/core/vitest/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/core/vitest/vite": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/ui/vite-plus/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-T7mPiDbE7VtjpegtJJ/e/uQOjOA/ufMo7npAaP9WVHxUEWLaR/OjVXXL9ALiW+CfKEQ0Qk/iWDB0mI6YMndzNQ=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-DqS0ZJ0sRtXu55loEIz/mkX99fl1HQ0b9UUj+Qm13NoMfh6JC8d0g6J+Dbu/EJy0TEU7QLjCXoALLQ7ZrsW34g=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-PoW375e3pSayRuN43agoe8LdItEa82bPhcaW7elPxoiO8puynB+4x5Xy5ozU5XgjEuCB3nYKE6R/b9peWsaFEQ=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5c6i1TyRuMELDcGozuI5Y0JhIZsSbAJ067Okty6XmoJ5tSmUnMzEO5HKRmgjfGryjJpn5dpUKXzj2eWsdx+6g=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-DquiIAvGIUIJBfqOnqAtBPoyhNIGLM1DzswzDPddO5kjg6NCE4hPbFr5ncjhSKqyp88Kd1YWYD93yg3FAdr/EA=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-/nVT+eFySYwf3uEv+n9FrdJ0bg3SbfqUkAnIxH7XMQ/hhmU4lAE2dH4SiUqk6h70gESaFHfJmhWtp5Qzt/W7Vw=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-KhEqfRKlfuuVJb2eY8ZCmmXcxUqy8/ZBZPWPipxcB1QDWIykyN5F4zbewLxXw18JL/Q0ISP0p7V8RIldAh4Gyw=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.21", "", { "os": "win32", "cpu": "x64" }, "sha512-lH8d2qElBfUUpejZhYvK3CrP6kHTz0z2jff/ZowlY6jkr1pQkYj3EVhRi5r81DXcbXZs9yAbXbBPw8mVZtG9FA=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt": ["oxfmt@0.48.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.48.0", "@oxfmt/binding-android-arm64": "0.48.0", "@oxfmt/binding-darwin-arm64": "0.48.0", "@oxfmt/binding-darwin-x64": "0.48.0", "@oxfmt/binding-freebsd-x64": "0.48.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.48.0", "@oxfmt/binding-linux-arm-musleabihf": "0.48.0", "@oxfmt/binding-linux-arm64-gnu": "0.48.0", "@oxfmt/binding-linux-arm64-musl": "0.48.0", "@oxfmt/binding-linux-ppc64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-musl": "0.48.0", "@oxfmt/binding-linux-s390x-gnu": "0.48.0", "@oxfmt/binding-linux-x64-gnu": "0.48.0", "@oxfmt/binding-linux-x64-musl": "0.48.0", "@oxfmt/binding-openharmony-arm64": "0.48.0", "@oxfmt/binding-win32-arm64-msvc": "0.48.0", "@oxfmt/binding-win32-ia32-msvc": "0.48.0", "@oxfmt/binding-win32-x64-msvc": "0.48.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g=="],
+
+    "@solid-imager/ui/vite-plus/oxlint": ["oxlint@1.63.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.63.0", "@oxlint/binding-android-arm64": "1.63.0", "@oxlint/binding-darwin-arm64": "1.63.0", "@oxlint/binding-darwin-x64": "1.63.0", "@oxlint/binding-freebsd-x64": "1.63.0", "@oxlint/binding-linux-arm-gnueabihf": "1.63.0", "@oxlint/binding-linux-arm-musleabihf": "1.63.0", "@oxlint/binding-linux-arm64-gnu": "1.63.0", "@oxlint/binding-linux-arm64-musl": "1.63.0", "@oxlint/binding-linux-ppc64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-musl": "1.63.0", "@oxlint/binding-linux-s390x-gnu": "1.63.0", "@oxlint/binding-linux-x64-gnu": "1.63.0", "@oxlint/binding-linux-x64-musl": "1.63.0", "@oxlint/binding-openharmony-arm64": "1.63.0", "@oxlint/binding-win32-arm64-msvc": "1.63.0", "@oxlint/binding-win32-ia32-msvc": "1.63.0", "@oxlint/binding-win32-x64-msvc": "1.63.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint": ["oxlint-tsgolint@0.22.1", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.22.1", "@oxlint-tsgolint/darwin-x64": "0.22.1", "@oxlint-tsgolint/linux-arm64": "0.22.1", "@oxlint-tsgolint/linux-x64": "0.22.1", "@oxlint-tsgolint/win32-arm64": "0.22.1", "@oxlint-tsgolint/win32-x64": "0.22.1" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg=="],
+
+    "@solid-imager/ui/vitest/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/ui/vitest/vite": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
     "@tailwindcss/vite/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.121.0", "", {}, "sha512-p0bQukD8OEHxzY4T9OlANBbEFGnOnjo1CYi50HES7OD36UO2yPh6T+uOJKLtlg06eclxroipRCpQGMpeH8EJ/g=="],
 
     "@tailwindcss/vite/vite/@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
@@ -2255,6 +2331,218 @@
 
     "xtracter/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-core/@oxc-project/runtime": ["@oxc-project/runtime@0.129.0", "", {}, "sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-test/vite": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.48.0", "", { "os": "android", "cpu": "arm" }, "sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.48.0", "", { "os": "android", "cpu": "arm64" }, "sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.48.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.48.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.48.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.48.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.48.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.48.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.48.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.48.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.48.0", "", { "os": "win32", "cpu": "x64" }, "sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.63.0", "", { "os": "android", "cpu": "arm" }, "sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.63.0", "", { "os": "android", "cpu": "arm64" }, "sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.63.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.63.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.63.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.63.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.63.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.63.0", "", { "os": "none", "cpu": "arm64" }, "sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.63.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.63.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.63.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.22.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.22.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.22.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.22.1", "", { "os": "linux", "cpu": "x64" }, "sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.22.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.22.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg=="],
+
+    "@solid-imager/core/vitest/@voidzero-dev/vite-plus-core/@oxc-project/runtime": ["@oxc-project/runtime@0.129.0", "", {}, "sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ=="],
+
+    "@solid-imager/core/vitest/@voidzero-dev/vite-plus-core/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/core/vitest/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/core/vitest/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.129.0", "", {}, "sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ=="],
+
+    "@solid-imager/core/vitest/vite/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/core/vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-core/@oxc-project/runtime": ["@oxc-project/runtime@0.129.0", "", {}, "sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-test/vite": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.48.0", "", { "os": "android", "cpu": "arm" }, "sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.48.0", "", { "os": "android", "cpu": "arm64" }, "sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.48.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.48.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.48.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.48.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.48.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.48.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.48.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.48.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.48.0", "", { "os": "win32", "cpu": "x64" }, "sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.63.0", "", { "os": "android", "cpu": "arm" }, "sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.63.0", "", { "os": "android", "cpu": "arm64" }, "sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.63.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.63.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.63.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.63.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.63.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.63.0", "", { "os": "none", "cpu": "arm64" }, "sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.63.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.63.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.63.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.22.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.22.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.22.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.22.1", "", { "os": "linux", "cpu": "x64" }, "sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.22.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.22.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg=="],
+
+    "@solid-imager/ui/vitest/@voidzero-dev/vite-plus-core/@oxc-project/runtime": ["@oxc-project/runtime@0.129.0", "", {}, "sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ=="],
+
+    "@solid-imager/ui/vitest/@voidzero-dev/vite-plus-core/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/ui/vitest/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/ui/vitest/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.129.0", "", {}, "sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ=="],
+
+    "@solid-imager/ui/vitest/vite/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/ui/vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "@tanstack/cli/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -2296,6 +2584,14 @@
     "ultracite/vitest/vite/@oxc-project/types": ["@oxc-project/types@0.115.0", "", {}, "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="],
 
     "ultracite/vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-test/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.129.0", "", {}, "sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-test/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-test/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.129.0", "", {}, "sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-test/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }

--- a/packages/core/src/domain/sources/events.ts
+++ b/packages/core/src/domain/sources/events.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+const sourceScopedEventSchema = z.object({
+	mediaSourceId: z.string().uuid().optional(),
+	filePath: z.string(),
+	mediaId: z.string().uuid().optional(),
+	timestamp: z.string().optional(),
+});
+
+export const mediaAddedEventSchema = sourceScopedEventSchema;
+export type MediaAddedEvent = z.infer<typeof mediaAddedEventSchema>;
+
+export const mediaDeletedEventSchema = sourceScopedEventSchema;
+export type MediaDeletedEvent = z.infer<typeof mediaDeletedEventSchema>;
+
+export const mediaChangedEventSchema = sourceScopedEventSchema;
+export type MediaChangedEvent = z.infer<typeof mediaChangedEventSchema>;
+
+export const mediaCopiedEventSchema = z.object({
+	sourceId: z.string().uuid().optional(),
+	targetId: z.string().uuid().optional(),
+	sourceMediaId: z.string().uuid().optional(),
+	mediaId: z.string().uuid().optional(),
+	media: z.unknown().optional(),
+	timestamp: z.string().optional(),
+});
+export type MediaCopiedEvent = z.infer<typeof mediaCopiedEventSchema>;
+
+export const mediaMovedEventSchema = z.object({
+	type: z.enum(["source", "target"]),
+	sourceId: z.string().uuid().optional(),
+	targetId: z.string().uuid().optional(),
+	mediaId: z.string().uuid().optional(),
+	media: z.unknown().optional(),
+	timestamp: z.string().optional(),
+});
+export type MediaMovedEvent = z.infer<typeof mediaMovedEventSchema>;
+
+export const thumbnailGeneratedEventSchema = z.object({
+	mediaSourceId: z.string().uuid().optional(),
+	mediaId: z.string().uuid(),
+	filePath: z.string().optional(),
+	timestamp: z.string().optional(),
+});
+export type ThumbnailGeneratedEvent = z.infer<
+	typeof thumbnailGeneratedEventSchema
+>;
+
+export const allJobsCompletedEventSchema = z.object({
+	mediaSourceId: z.string().uuid().optional(),
+	processed: z.number(),
+});
+export type AllJobsCompletedEvent = z.infer<typeof allJobsCompletedEventSchema>;
+
+export const watcherErrorEventSchema = z.object({
+	mediaSourceId: z.string().uuid().optional(),
+	error: z.string().optional(),
+});
+export type WatcherErrorEvent = z.infer<typeof watcherErrorEventSchema>;
+
+export const jobProgressEventSchema = z.object({
+	jobId: z.string().optional(),
+	processed: z.number(),
+	total: z.number(),
+});
+export type JobProgressEvent = z.infer<typeof jobProgressEventSchema>;
+
+export const jobCompletedEventSchema = z.object({
+	jobId: z.string().optional(),
+	message: z.string().optional(),
+});
+export type JobCompletedEvent = z.infer<typeof jobCompletedEventSchema>;
+
+export const jobFailedEventSchema = z.object({
+	jobId: z.string().optional(),
+	error: z.string().optional(),
+});
+export type JobFailedEvent = z.infer<typeof jobFailedEventSchema>;

--- a/packages/core/src/utils/deep-equal.ts
+++ b/packages/core/src/utils/deep-equal.ts
@@ -16,6 +16,10 @@ export function deepEqual(a: unknown, b: unknown): boolean {
 		return false;
 	}
 
+	if (Array.isArray(a) !== Array.isArray(b)) {
+		return false;
+	}
+
 	const keysA = Object.keys(a as object);
 	const keysB = Object.keys(b as object);
 
@@ -24,7 +28,7 @@ export function deepEqual(a: unknown, b: unknown): boolean {
 	}
 
 	for (const key of keysA) {
-		if (!keysB.includes(key)) {
+		if (!Object.hasOwn(b, key)) {
 			return false;
 		}
 		if (

--- a/packages/core/src/utils/deep-equal.ts
+++ b/packages/core/src/utils/deep-equal.ts
@@ -1,0 +1,41 @@
+export function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) {
+		return true;
+	}
+
+	if (a instanceof Date && b instanceof Date) {
+		return a.getTime() === b.getTime();
+	}
+
+	if (
+		typeof a !== "object" ||
+		a === null ||
+		typeof b !== "object" ||
+		b === null
+	) {
+		return false;
+	}
+
+	const keysA = Object.keys(a as object);
+	const keysB = Object.keys(b as object);
+
+	if (keysA.length !== keysB.length) {
+		return false;
+	}
+
+	for (const key of keysA) {
+		if (!keysB.includes(key)) {
+			return false;
+		}
+		if (
+			!deepEqual(
+				(a as Record<string, unknown>)[key],
+				(b as Record<string, unknown>)[key],
+			)
+		) {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,37 +1,39 @@
 {
-  "name": "@solid-imager/ui",
-  "version": "0.0.0",
-  "type": "module",
-  "scripts": {
-    "lint": "biome lint ./src",
-    "format": "biome format --fix ./src",
-    "check": "biome check --fix --unsafe ./src",
-    "test": "vp test run",
-    "test:unit": "vp test run",
-    "typecheck": "sh -c 'tsc --noEmit'"
-  },
-  "exports": {
-    "./*": "./src/*"
-  },
-  "dependencies": {
-    "@kobalte/core": "^0.13.11",
-    "@solidjs/router": "^0.15.4",
-    "@tanstack/solid-virtual": "^3.13.16",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "cmdk-solid": "^1.1.2",
-    "lucide-solid": "*",
-    "solid-js": "^1.9.12",
-    "solid-sonner": "^0.3.1",
-    "tailwind-merge": "^3.4.0",
-    "tailwindcss-animate": "^1.0.7"
-  },
-  "devDependencies": {
-    "typescript": "^5.9.3",
-    "@biomejs/biome": "^2.2.4",
-    "@solid-imager/core": "workspace:*",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
-    "vite-plus": "latest",
-    "vite-tsconfig-paths": "^5.1.4"
-  }
+	"name": "@solid-imager/ui",
+	"version": "0.0.0",
+	"type": "module",
+	"exports": {
+		"./*": "./src/*"
+	},
+	"scripts": {
+		"lint": "biome lint ./src",
+		"format": "biome format --fix ./src",
+		"check": "biome check --fix --unsafe ./src",
+		"test": "vp test run",
+		"test:unit": "vp test run",
+		"typecheck": "sh -c 'tsc --noEmit'"
+	},
+	"dependencies": {
+		"@kobalte/core": "^0.13.11",
+		"@solid-imager/core": "workspace:*",
+		"@solidjs/router": "^0.15.4",
+		"@tanstack/solid-query": "^5.0.0",
+		"@tanstack/solid-virtual": "^3.13.16",
+		"class-variance-authority": "^0.7.1",
+		"clsx": "^2.1.1",
+		"cmdk-solid": "^1.1.2",
+		"lucide-solid": "*",
+		"solid-js": "^1.9.12",
+		"solid-sonner": "^0.3.1",
+		"tailwind-merge": "^3.4.0",
+		"tailwindcss-animate": "^1.0.7",
+		"zod": "^4.3.5"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.4",
+		"typescript": "^5.9.3",
+		"vite-plus": "latest",
+		"vite-tsconfig-paths": "^5.1.4",
+		"vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+	}
 }

--- a/packages/ui/src/ai-tagging-modal.tsx
+++ b/packages/ui/src/ai-tagging-modal.tsx
@@ -1,0 +1,162 @@
+import type { TaggingResponse } from "@solid-imager/core/domain/tagging/schemas";
+import { createEffect, createSignal, For, onCleanup, Show } from "solid-js";
+import { Badge } from "./badge";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "./dialog";
+
+export type AiTaggingModalProps = {
+	isOpen: boolean;
+	onClose: () => void;
+	fetchTags: () => Promise<TaggingResponse>;
+	description?: string;
+};
+
+const PERCENTAGE_MULTIPLIER = 100;
+const DEFAULT_DESCRIPTION =
+	"Tags extracted from the image using the AI service.";
+
+export function AiTaggingModal(props: AiTaggingModalProps) {
+	const [isLoading, setIsLoading] = createSignal(false);
+	const [result, setResult] = createSignal<TaggingResponse | null>(null);
+	const [error, setError] = createSignal<string | null>(null);
+
+	createEffect(() => {
+		if (props.isOpen) {
+			let isCancelled = false;
+
+			const fetchTags = async () => {
+				setIsLoading(true);
+				setResult(null);
+				setError(null);
+				try {
+					const data = await props.fetchTags();
+					if (!isCancelled) {
+						setResult(data);
+					}
+				} catch (err) {
+					if (!isCancelled) {
+						setError(
+							err instanceof Error ? err.message : "Unknown error occurred",
+						);
+					}
+				} finally {
+					if (!isCancelled) {
+						setIsLoading(false);
+					}
+				}
+			};
+
+			fetchTags();
+
+			onCleanup(() => {
+				isCancelled = true;
+			});
+		} else {
+			setResult(null);
+			setError(null);
+			setIsLoading(false);
+		}
+	});
+
+	return (
+		<Dialog
+			onOpenChange={(open: boolean) => !open && props.onClose()}
+			open={props.isOpen}
+		>
+			<DialogContent class="max-h-[80vh] overflow-y-auto sm:max-w-[600px]">
+				<DialogHeader>
+					<DialogTitle>AI Tagging Results</DialogTitle>
+					<DialogDescription>
+						{props.description ?? DEFAULT_DESCRIPTION}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div class="py-4">
+					<Show when={isLoading()}>
+						<div class="flex items-center justify-center py-8">
+							<div class="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
+							<span class="ml-2 text-gray-600">Analyzing image...</span>
+						</div>
+					</Show>
+
+					<Show when={error()}>
+						<div class="rounded-md bg-red-50 p-4 text-red-600">
+							Error: {error()}
+						</div>
+					</Show>
+
+					<Show when={result()}>
+						{(res) => (
+							<div class="space-y-6">
+								<div>
+									<h3 class="mb-2 font-semibold text-lg">Characters</h3>
+									<Show
+										fallback={
+											<p class="text-gray-500 text-sm">
+												No characters detected.
+											</p>
+										}
+										when={Object.keys(res().character).length > 0}
+									>
+										<div class="flex flex-wrap gap-2">
+											<For each={Object.entries(res().character)}>
+												{([name, score]) => (
+													<Badge class="flex gap-1" variant="outline">
+														<span>{name}</span>
+														<span class="text-xs opacity-70">
+															({(score * PERCENTAGE_MULTIPLIER).toFixed(1)}%)
+														</span>
+													</Badge>
+												)}
+											</For>
+										</div>
+									</Show>
+								</div>
+
+								<div>
+									<h3 class="mb-2 font-semibold text-lg">IPs (Series)</h3>
+									<Show
+										fallback={
+											<p class="text-gray-500 text-sm">No IPs detected.</p>
+										}
+										when={res().ips.length > 0}
+									>
+										<div class="flex flex-wrap gap-2">
+											<For each={res().ips}>
+												{(ip) => <Badge variant="secondary">{ip}</Badge>}
+											</For>
+										</div>
+									</Show>
+								</div>
+
+								<div>
+									<h3 class="mb-2 font-semibold text-lg">General Tags</h3>
+									<div class="flex flex-wrap gap-2">
+										<For each={Object.entries(res().general)}>
+											{([name, score]) => (
+												<Badge
+													class="flex gap-1 bg-gray-100 text-gray-800 hover:bg-gray-200"
+													variant="default"
+												>
+													<span>{name}</span>
+													<span class="text-xs opacity-70">
+														({(score * PERCENTAGE_MULTIPLIER).toFixed(1)}%)
+													</span>
+												</Badge>
+											)}
+										</For>
+									</div>
+								</div>
+							</div>
+						)}
+					</Show>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/ui/src/association-manager.tsx
+++ b/packages/ui/src/association-manager.tsx
@@ -44,7 +44,7 @@ export function AssociationManager(props: AssociationManagerProps) {
 			await props.onRemove(id);
 		} catch (error) {
 			toast.error(
-				`${props.title} の削除に失敗しました: ${(error as Error).message}`,
+				`Failed to remove ${props.title.toLowerCase()}: ${(error as Error).message}`,
 			);
 		} finally {
 			setIsMutating(false);
@@ -59,7 +59,7 @@ export function AssociationManager(props: AssociationManagerProps) {
 			setSearch("");
 		} catch (error) {
 			toast.error(
-				`${props.title} の追加に失敗しました: ${(error as Error).message}`,
+				`Failed to add ${props.title.toLowerCase()}: ${(error as Error).message}`,
 			);
 		} finally {
 			setIsMutating(false);
@@ -79,7 +79,7 @@ export function AssociationManager(props: AssociationManagerProps) {
 			setSearch("");
 		} catch (error) {
 			toast.error(
-				`${props.title} の作成に失敗しました: ${(error as Error).message}`,
+				`Failed to create ${props.title.toLowerCase()}: ${(error as Error).message}`,
 			);
 		} finally {
 			setIsMutating(false);

--- a/packages/ui/src/association-manager.tsx
+++ b/packages/ui/src/association-manager.tsx
@@ -1,0 +1,200 @@
+import { createMemo, createSignal, For, Show } from "solid-js";
+import { Badge } from "./badge";
+import { Button } from "./button";
+import {
+	CommandDialog,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "./command";
+import { toast } from "./toast";
+
+type Item = {
+	id: string;
+	name: string;
+	description?: string | null;
+};
+
+type AssociationManagerProps = {
+	title: string;
+	items: Item[];
+	availableItems: Item[];
+	onAdd: (id: string) => void | Promise<void>;
+	onRemove: (id: string) => void | Promise<void>;
+	onCreate?: (name: string) => void | Promise<void>;
+	isLoading?: boolean;
+};
+
+export function AssociationManager(props: AssociationManagerProps) {
+	const [open, setOpen] = createSignal(false);
+	const [search, setSearch] = createSignal("");
+	const [isMutating, setIsMutating] = createSignal(false);
+	const selectableItems = createMemo(() =>
+		props.availableItems.filter(
+			(item) => !props.items.some((candidate) => candidate.id === item.id),
+		),
+	);
+	const isBusy = () => Boolean(props.isLoading) || isMutating();
+
+	const handleRemove = async (id: string) => {
+		setIsMutating(true);
+		try {
+			await props.onRemove(id);
+		} catch (error) {
+			toast.error(
+				`${props.title} の削除に失敗しました: ${(error as Error).message}`,
+			);
+		} finally {
+			setIsMutating(false);
+		}
+	};
+
+	const handleAdd = async (id: string) => {
+		setIsMutating(true);
+		try {
+			await props.onAdd(id);
+			setOpen(false);
+			setSearch("");
+		} catch (error) {
+			toast.error(
+				`${props.title} の追加に失敗しました: ${(error as Error).message}`,
+			);
+		} finally {
+			setIsMutating(false);
+		}
+	};
+
+	const handleCreate = async () => {
+		const name = search().trim();
+		if (!props.onCreate || name.length === 0) {
+			return;
+		}
+
+		setIsMutating(true);
+		try {
+			await props.onCreate(name);
+			setOpen(false);
+			setSearch("");
+		} catch (error) {
+			toast.error(
+				`${props.title} の作成に失敗しました: ${(error as Error).message}`,
+			);
+		} finally {
+			setIsMutating(false);
+		}
+	};
+
+	return (
+		<div class="space-y-2">
+			<div class="flex items-center justify-between">
+				<h2 class="font-semibold text-lg">{props.title}</h2>
+				<Button
+					disabled={isMutating()}
+					onClick={() => setOpen(true)}
+					size="sm"
+					variant="outline"
+				>
+					Add
+				</Button>
+			</div>
+			<div class="flex flex-wrap gap-2">
+				<For each={props.items}>
+					{(item) => (
+						<Badge class="gap-1 pr-1" variant="secondary">
+							{item.name}
+							<button
+								class="ml-1 rounded-full p-0.5 hover:bg-secondary-foreground/20"
+								disabled={isBusy()}
+								onClick={() => {
+									void handleRemove(item.id);
+								}}
+								type="button"
+							>
+								<svg
+									class="size-3"
+									fill="none"
+									stroke="currentColor"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									viewBox="0 0 24 24"
+									xmlns="http://www.w3.org/2000/svg"
+								>
+									<title>Remove</title>
+									<path d="M18 6 6 18" />
+									<path d="m6 6 12 12" />
+								</svg>
+								<span class="sr-only">Remove</span>
+							</button>
+						</Badge>
+					)}
+				</For>
+				<Show when={props.items.length === 0}>
+					<span class="text-muted-foreground text-sm italic">
+						No {props.title.toLowerCase()} associated
+					</span>
+				</Show>
+			</div>
+
+			<CommandDialog onOpenChange={setOpen} open={open()}>
+				<CommandInput
+					disabled={isBusy()}
+					onValueChange={setSearch}
+					placeholder={`Search ${props.title.toLowerCase()}...`}
+					value={search()}
+				/>
+				<CommandList>
+					<Show when={props.isLoading}>
+						<div class="px-2 py-6 text-center text-muted-foreground text-sm">
+							Loading {props.title.toLowerCase()}...
+						</div>
+					</Show>
+					<CommandEmpty>
+						<Show when={props.onCreate && search().length > 0}>
+							<div class="p-2">
+								<p class="mb-2 text-muted-foreground text-sm">
+									No {props.title.toLowerCase()} found.
+								</p>
+								<Button
+									class="w-full justify-start"
+									disabled={isBusy()}
+									onClick={() => {
+										void handleCreate();
+									}}
+									variant="outline"
+								>
+									Create "{search()}"
+								</Button>
+							</div>
+						</Show>
+						<Show when={!props.onCreate || search().length === 0}>
+							No {props.title.toLowerCase()} found.
+						</Show>
+					</CommandEmpty>
+					<CommandGroup heading="Available">
+						<For each={selectableItems()}>
+							{(item) => (
+								<CommandItem
+									onSelect={() => {
+										void handleAdd(item.id);
+									}}
+								>
+									<div class="flex flex-col">
+										<span>{item.name}</span>
+										<Show when={item.description}>
+											<span class="text-muted-foreground text-xs">
+												{item.description}
+											</span>
+										</Show>
+									</div>
+								</CommandItem>
+							)}
+						</For>
+					</CommandGroup>
+				</CommandList>
+			</CommandDialog>
+		</div>
+	);
+}

--- a/packages/ui/src/hooks/use-current-search-persistence.ts
+++ b/packages/ui/src/hooks/use-current-search-persistence.ts
@@ -27,6 +27,7 @@ export function useCurrentSearchPersistence(
 	presetClient: PresetClientLike,
 ) {
 	const [isInitialLoad, setIsInitialLoad] = createSignal(true);
+	const [cachedPresetId, setCachedPresetId] = createSignal<number | null>(null);
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 	const getCurrentPresetName = () => {
@@ -56,6 +57,7 @@ export function useCurrentSearchPersistence(
 			try {
 				const current = await presetClient.getByName(presetName);
 				if (current) {
+					setCachedPresetId(current.id);
 					const allPresets = await presetClient.list();
 
 					const matchingPreset = allPresets.find(
@@ -144,14 +146,20 @@ export function useCurrentSearchPersistence(
 		};
 
 		try {
-			const current = await presetClient.getByName(presetName);
-			if (current) {
-				await presetClient.update(current.id, presetData);
+			const presetId = cachedPresetId();
+			if (presetId !== null) {
+				await presetClient.update(presetId, presetData);
 			} else {
-				await presetClient.create({
-					name: presetName,
-					...presetData,
-				});
+				const current = await presetClient.getByName(presetName);
+				if (current) {
+					setCachedPresetId(current.id);
+					await presetClient.update(current.id, presetData);
+				} else {
+					await presetClient.create({
+						name: presetName,
+						...presetData,
+					});
+				}
 			}
 		} catch {
 			// silent — persistence errors should not disrupt the UI

--- a/packages/ui/src/hooks/use-current-search-persistence.ts
+++ b/packages/ui/src/hooks/use-current-search-persistence.ts
@@ -1,0 +1,160 @@
+import type {
+	CreatePresetRequest,
+	Preset,
+	UpdatePresetRequest,
+} from "@solid-imager/core/domain/media/schemas";
+import { deepEqual } from "@solid-imager/core/utils/deep-equal";
+import { type Accessor, createEffect, createSignal, onCleanup } from "solid-js";
+import {
+	getSearchCondition,
+	loadPreset,
+	resetSearchState,
+	searchState,
+	setSearchState,
+} from "../stores/search-store";
+
+export interface PresetClientLike {
+	list(): Promise<Preset[]>;
+	getByName(name: string): Promise<Preset | null | undefined>;
+	create(data: CreatePresetRequest): Promise<unknown>;
+	update(id: number, data: UpdatePresetRequest): Promise<unknown>;
+}
+
+const DEBOUNCE_MS = 1000;
+
+export function useCurrentSearchPersistence(
+	sourceId: string | Accessor<string | null | undefined> = "current",
+	presetClient: PresetClientLike,
+) {
+	const [isInitialLoad, setIsInitialLoad] = createSignal(true);
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const getCurrentPresetName = () => {
+		const id = typeof sourceId === "function" ? sourceId() : sourceId;
+		if (id === "current") {
+			return "current";
+		}
+		if (id === "current-all" || id === "all") {
+			return "current-all";
+		}
+		return id ? `current-${id}` : null;
+	};
+
+	createEffect(() => {
+		const presetName = getCurrentPresetName();
+		if (!presetName) {
+			return;
+		}
+
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+		}
+
+		const init = async () => {
+			setIsInitialLoad(true);
+
+			try {
+				const current = await presetClient.getByName(presetName);
+				if (current) {
+					const allPresets = await presetClient.list();
+
+					const matchingPreset = allPresets.find(
+						(p) => p.name !== presetName && deepEqual(p.value, current.value),
+					);
+
+					if (matchingPreset) {
+						loadPreset({
+							...matchingPreset,
+							mode: current.mode,
+							sort: current.sort,
+							order: current.order,
+						});
+					} else {
+						loadPreset(current);
+						setSearchState("activePresetId", null);
+					}
+				} else {
+					resetSearchState();
+					await presetClient.create({
+						name: presetName,
+						value: { type: "group", operator: "and", children: [] },
+						mode: "simple",
+					});
+				}
+			} catch {
+				// silent — persistence errors should not disrupt the UI
+			} finally {
+				setIsInitialLoad(false);
+			}
+		};
+		init();
+	});
+
+	createEffect(() => {
+		const _track = [
+			searchState.mode,
+			searchState.selectedSource,
+			searchState.searchQuery,
+			searchState.selectedTags,
+			searchState.excludeTags,
+			searchState.tagMode,
+			searchState.selectedProjects,
+			searchState.selectedIps,
+			searchState.selectedCharacters,
+			searchState.selectedAuthors,
+			searchState.advancedCondition,
+			searchState.sortBy,
+			searchState.sortOrder,
+		];
+		void _track;
+
+		if (isInitialLoad() || !getCurrentPresetName()) {
+			return;
+		}
+
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+		}
+		debounceTimer = setTimeout(saveCurrentState, DEBOUNCE_MS);
+	});
+
+	onCleanup(() => {
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+		}
+	});
+
+	const saveCurrentState = async () => {
+		const presetName = getCurrentPresetName();
+		if (!presetName) {
+			return;
+		}
+
+		const condition = getSearchCondition() || {
+			type: "group" as const,
+			operator: "and" as const,
+			children: [],
+		};
+
+		const presetData = {
+			value: condition,
+			sort: searchState.sortBy,
+			order: searchState.sortOrder,
+			mode: searchState.mode,
+		};
+
+		try {
+			const current = await presetClient.getByName(presetName);
+			if (current) {
+				await presetClient.update(current.id, presetData);
+			} else {
+				await presetClient.create({
+					name: presetName,
+					...presetData,
+				});
+			}
+		} catch {
+			// silent — persistence errors should not disrupt the UI
+		}
+	};
+}

--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -1,0 +1,483 @@
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import type {
+	JobCompletedEvent,
+	JobFailedEvent,
+	JobProgressEvent,
+} from "@solid-imager/core/domain/sources/events";
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import { createQuery, type QueryClient } from "@tanstack/solid-query";
+import {
+	type Accessor,
+	createEffect,
+	createSignal,
+	type Setter,
+} from "solid-js";
+import type { buildCharactersQueryOptions } from "../query-options/characters-query";
+import type { buildIpsQueryOptions } from "../query-options/ips-query";
+import type { buildProjectsQueryOptions } from "../query-options/projects-query";
+import type { buildSourcesQueryOptions } from "../query-options/sources-query";
+import { toast } from "../toast";
+
+export type ManagerEntityType = "projects" | "ips" | "characters" | "tagging";
+export type ManagerEntity = Project | Ip | Character;
+
+export type ManagerFormData = {
+	name: string;
+	description: string;
+	ipIds?: string[];
+};
+
+export type StartBatchTaggingResult = {
+	success: boolean;
+	jobId?: string;
+	message: string;
+};
+
+export type ManagerPageQueries = {
+	projects: Accessor<Project[] | undefined>;
+	ips: Accessor<Ip[] | undefined>;
+	characters: Accessor<Character[] | undefined>;
+	sources: Accessor<SafeMediaSource[] | undefined>;
+};
+
+export type ManagerPageActions = {
+	createProject: (data: ManagerFormData) => Promise<unknown>;
+	updateProject: (
+		id: string,
+		data: Partial<ManagerFormData>,
+	) => Promise<unknown>;
+	deleteProject: (id: string) => Promise<unknown>;
+	createIp: (data: ManagerFormData) => Promise<unknown>;
+	updateIp: (id: string, data: Partial<ManagerFormData>) => Promise<unknown>;
+	deleteIp: (id: string) => Promise<unknown>;
+	createCharacter: (data: ManagerFormData) => Promise<unknown>;
+	updateCharacter: (
+		id: string,
+		data: Partial<ManagerFormData>,
+	) => Promise<unknown>;
+	deleteCharacter: (id: string) => Promise<unknown>;
+	scanBatchTaggingTargets: (input: {
+		force: boolean;
+		mediaSourceId?: string;
+	}) => Promise<Media[]>;
+	startBatchTaggingWithIds: (input: {
+		force: boolean;
+		mediaSourceId?: string;
+		mediaIds: string[];
+	}) => Promise<StartBatchTaggingResult>;
+	invalidate: (entityType: Exclude<ManagerEntityType, "tagging">) => void;
+};
+
+export type ManagerPageMutationActions = Omit<ManagerPageActions, "invalidate">;
+
+export type ManagerPageQueryOptions = {
+	projects: () => ReturnType<typeof buildProjectsQueryOptions>;
+	ips: () => ReturnType<typeof buildIpsQueryOptions>;
+	characters: () => ReturnType<typeof buildCharactersQueryOptions>;
+	sources: () => ReturnType<typeof buildSourcesQueryOptions>;
+};
+
+export type UseManagerPageOptions = {
+	queryClient: QueryClient;
+	queryOptions: ManagerPageQueryOptions;
+	actions: ManagerPageMutationActions;
+	useBatchJobEvents?: (
+		activeJobId: Accessor<string | null>,
+		handlers: ManagerJobHandlers,
+	) => void;
+	onBatchTaggingStart?: (result: StartBatchTaggingResult) => void;
+	itemsPerPage?: number;
+};
+
+export async function prefetchManagerPageQueries(
+	queryClient: QueryClient,
+	queryOptions: ManagerPageQueryOptions,
+) {
+	await Promise.all([
+		queryClient.ensureQueryData(queryOptions.projects()),
+		queryClient.ensureQueryData(queryOptions.ips()),
+		queryClient.ensureQueryData(queryOptions.characters()),
+		queryClient.ensureQueryData(queryOptions.sources()),
+	]);
+}
+
+export type ManagerJobHandlers = {
+	handleJobProgress: (event: JobProgressEvent) => void;
+	handleJobCompleted: (event: JobCompletedEvent) => void;
+	handleJobFailed: (event: JobFailedEvent) => void;
+};
+
+export type UseManagerPageResult = {
+	activeTab: Accessor<ManagerEntityType>;
+	setActiveTab: Setter<ManagerEntityType>;
+	isDialogOpen: Accessor<boolean>;
+	setIsDialogOpen: Setter<boolean>;
+	isDeleteDialogOpen: Accessor<boolean>;
+	setIsDeleteDialogOpen: Setter<boolean>;
+	editingItem: Accessor<ManagerEntity | null>;
+	itemToDelete: Accessor<ManagerEntity | null>;
+	setItemToDelete: Setter<ManagerEntity | null>;
+	formData: Accessor<ManagerFormData>;
+	setFormData: Setter<ManagerFormData>;
+	selectedSourceId: Accessor<string | undefined>;
+	setSelectedSourceId: Setter<string | undefined>;
+	forceRetag: Accessor<boolean>;
+	setForceRetag: Setter<boolean>;
+	taggingStatus: Accessor<string | null>;
+	scannedMedia: Accessor<Media[]>;
+	selectedMedia: Accessor<Set<string>>;
+	jobProgress: Accessor<JobProgressEvent | null>;
+	activeJobId: Accessor<string | null>;
+	currentPage: Accessor<number>;
+	setCurrentPage: Setter<number>;
+	itemsPerPage: number;
+	totalPages: Accessor<number>;
+	paginatedMedia: Accessor<Media[]>;
+	sources: Accessor<SafeMediaSource[]>;
+	ips: Accessor<Ip[]>;
+	getActiveItems: Accessor<ManagerEntity[]>;
+	openCreateDialog: () => void;
+	openEditDialog: (item: ManagerEntity) => void;
+	handleSave: () => Promise<void>;
+	handleConfirmDelete: () => Promise<void>;
+	handleScan: () => Promise<void>;
+	handleStartBatchTagging: () => Promise<void>;
+	toggleMediaSelection: (mediaId: string) => void;
+	toggleSelectAll: () => void;
+	jobHandlers: ManagerJobHandlers;
+};
+
+function isCharacter(item: ManagerEntity): item is Character {
+	return "ips" in item;
+}
+
+function resetForm(setFormData: Setter<ManagerFormData>) {
+	setFormData({
+		name: "",
+		description: "",
+		ipIds: [],
+	});
+}
+
+function activeCrudTab(
+	activeTab: ManagerEntityType,
+): Exclude<ManagerEntityType, "tagging"> | null {
+	return activeTab === "tagging" ? null : activeTab;
+}
+
+export function useManagerPage(
+	options: UseManagerPageOptions,
+): UseManagerPageResult {
+	const {
+		actions,
+		queryClient,
+		queryOptions,
+		useBatchJobEvents,
+		onBatchTaggingStart,
+		itemsPerPage = 50,
+	} = options;
+	const projects = createQuery(() => queryOptions.projects());
+	const ipsQuery = createQuery(() => queryOptions.ips());
+	const characters = createQuery(() => queryOptions.characters());
+	const sourcesQuery = createQuery(() => queryOptions.sources());
+
+	const queries: ManagerPageQueries = {
+		projects: () => projects.data,
+		ips: () => ipsQuery.data,
+		characters: () => characters.data,
+		sources: () => sourcesQuery.data,
+	};
+
+	const [activeTab, setActiveTab] = createSignal<ManagerEntityType>("projects");
+	const [isDialogOpen, setIsDialogOpen] = createSignal(false);
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = createSignal(false);
+	const [editingItem, setEditingItem] = createSignal<ManagerEntity | null>(
+		null,
+	);
+	const [itemToDelete, setItemToDelete] = createSignal<ManagerEntity | null>(
+		null,
+	);
+	const [formData, setFormData] = createSignal<ManagerFormData>({
+		name: "",
+		description: "",
+		ipIds: [],
+	});
+
+	const [selectedSourceId, setSelectedSourceId] = createSignal<
+		string | undefined
+	>(undefined);
+	const [forceRetag, setForceRetag] = createSignal(false);
+	const [taggingStatus, setTaggingStatus] = createSignal<string | null>(null);
+	const [scannedMedia, setScannedMedia] = createSignal<Media[]>([]);
+	const [selectedMedia, setSelectedMedia] = createSignal<Set<string>>(
+		new Set(),
+	);
+	const [jobProgress, setJobProgress] = createSignal<JobProgressEvent | null>(
+		null,
+	);
+	const [activeJobId, setActiveJobId] = createSignal<string | null>(null);
+	const [currentPage, setCurrentPage] = createSignal(1);
+
+	const sources = () => queries.sources() || [];
+	const ips = () => queries.ips() || [];
+
+	const getActiveItems = () => {
+		switch (activeTab()) {
+			case "projects":
+				return queries.projects() || [];
+			case "ips":
+				return queries.ips() || [];
+			case "characters":
+				return queries.characters() || [];
+			default:
+				return [];
+		}
+	};
+
+	const totalPages = () => Math.ceil(scannedMedia().length / itemsPerPage);
+
+	const paginatedMedia = () => {
+		const start = (currentPage() - 1) * itemsPerPage;
+		return scannedMedia().slice(start, start + itemsPerPage);
+	};
+
+	createEffect(() => {
+		if (scannedMedia().length > 0) {
+			setCurrentPage(1);
+		}
+	});
+
+	const invalidateActive = () => {
+		const tab = activeCrudTab(activeTab());
+		if (tab) {
+			const option = queryOptions[tab]();
+			void queryClient.invalidateQueries({ queryKey: option.queryKey });
+		}
+	};
+
+	const openCreateDialog = () => {
+		setEditingItem(null);
+		resetForm(setFormData);
+		setIsDialogOpen(true);
+	};
+
+	const openEditDialog = (item: ManagerEntity) => {
+		setEditingItem(item);
+		setFormData({
+			name: item.name,
+			description: item.description || "",
+			ipIds: isCharacter(item) ? item.ips.map((ip) => ip.id) : [],
+		});
+		setIsDialogOpen(true);
+	};
+
+	const handleCreate = async () => {
+		const data = formData();
+		try {
+			if (activeTab() === "projects") {
+				await actions.createProject(data);
+			} else if (activeTab() === "ips") {
+				await actions.createIp(data);
+			} else if (activeTab() === "characters") {
+				await actions.createCharacter(data);
+			}
+
+			invalidateActive();
+			toast.success("Created successfully");
+			setIsDialogOpen(false);
+			setEditingItem(null);
+			resetForm(setFormData);
+		} catch (error) {
+			toast.error(`Failed to save: ${(error as Error).message}`);
+		}
+	};
+
+	const handleUpdate = async () => {
+		const data = formData();
+		const current = editingItem();
+		if (!current) {
+			return;
+		}
+
+		try {
+			if (activeTab() === "projects") {
+				await actions.updateProject(current.id, data);
+			} else if (activeTab() === "ips") {
+				await actions.updateIp(current.id, data);
+			} else if (activeTab() === "characters") {
+				await actions.updateCharacter(current.id, data);
+			}
+
+			invalidateActive();
+			toast.success("Updated successfully");
+			setIsDialogOpen(false);
+			setEditingItem(null);
+			resetForm(setFormData);
+		} catch (error) {
+			toast.error(`Failed to save: ${(error as Error).message}`);
+		}
+	};
+
+	const handleConfirmDelete = async () => {
+		const item = itemToDelete();
+		if (!item) {
+			return;
+		}
+
+		try {
+			if (activeTab() === "projects") {
+				await actions.deleteProject(item.id);
+			} else if (activeTab() === "ips") {
+				await actions.deleteIp(item.id);
+			} else if (activeTab() === "characters") {
+				await actions.deleteCharacter(item.id);
+			}
+			invalidateActive();
+			toast.success("Deleted successfully");
+		} catch (error) {
+			toast.error(`Failed to delete: ${(error as Error).message}`);
+		} finally {
+			setIsDeleteDialogOpen(false);
+			setItemToDelete(null);
+		}
+	};
+
+	const handleScan = async () => {
+		try {
+			setTaggingStatus("Scanning...");
+			setScannedMedia([]);
+			const result = await actions.scanBatchTaggingTargets({
+				force: forceRetag(),
+				mediaSourceId: selectedSourceId(),
+			});
+			setScannedMedia(result);
+			setSelectedMedia(new Set(result.map((item) => item.id)));
+			setTaggingStatus(`${result.length} items found.`);
+		} catch (error) {
+			toast.error(`Error: ${(error as Error).message}`);
+			setTaggingStatus(`Error during scan: ${(error as Error).message}`);
+		}
+	};
+
+	const handleStartBatchTagging = async () => {
+		if (selectedMedia().size === 0) {
+			toast.error("No media selected");
+			return;
+		}
+
+		try {
+			setTaggingStatus("Starting...");
+			setJobProgress(null);
+			const result = await actions.startBatchTaggingWithIds({
+				force: forceRetag(),
+				mediaSourceId: selectedSourceId(),
+				mediaIds: Array.from(selectedMedia()),
+			});
+			if (result.success && result.jobId) {
+				onBatchTaggingStart?.(result);
+				toast.success(result.message);
+				setTaggingStatus("Batch tagging in progress...");
+				setActiveJobId(result.jobId);
+				setScannedMedia([]);
+				setSelectedMedia(new Set<string>());
+			} else {
+				toast.error("Failed to start batch tagging.");
+				setTaggingStatus("Failed to start batch tagging.");
+			}
+		} catch (error) {
+			toast.error(`Error: ${(error as Error).message}`);
+			setTaggingStatus(`Error: ${(error as Error).message}`);
+		}
+	};
+
+	const toggleMediaSelection = (mediaId: string) => {
+		setSelectedMedia((previous) => {
+			const next = new Set(previous);
+			if (next.has(mediaId)) {
+				next.delete(mediaId);
+			} else {
+				next.add(mediaId);
+			}
+			return next;
+		});
+	};
+
+	const toggleSelectAll = () => {
+		if (selectedMedia().size === scannedMedia().length) {
+			setSelectedMedia(new Set<string>());
+		} else {
+			setSelectedMedia(new Set(scannedMedia().map((item) => item.id)));
+		}
+	};
+
+	const handleJobProgress = (event: JobProgressEvent) => {
+		setJobProgress(event);
+		setTaggingStatus(`Processing: ${event.processed} / ${event.total} tagged.`);
+	};
+
+	const handleJobCompleted = (event: JobCompletedEvent) => {
+		toast.success(event.message || "Batch tagging completed!");
+		setTaggingStatus("Batch tagging completed successfully.");
+		setActiveJobId(null);
+		setJobProgress(null);
+	};
+
+	const handleJobFailed = (event: JobFailedEvent) => {
+		const message = event.error || "unknown error";
+		toast.error(`Job failed: ${message}`);
+		setTaggingStatus(`Job failed: ${message}`);
+		setActiveJobId(null);
+		setJobProgress(null);
+	};
+
+	const jobHandlers: ManagerJobHandlers = {
+		handleJobProgress,
+		handleJobCompleted,
+		handleJobFailed,
+	};
+
+	useBatchJobEvents?.(activeJobId, jobHandlers);
+
+	return {
+		activeTab,
+		setActiveTab,
+		isDialogOpen,
+		setIsDialogOpen,
+		isDeleteDialogOpen,
+		setIsDeleteDialogOpen,
+		editingItem,
+		itemToDelete,
+		setItemToDelete,
+		formData,
+		setFormData,
+		selectedSourceId,
+		setSelectedSourceId,
+		forceRetag,
+		setForceRetag,
+		taggingStatus,
+		scannedMedia,
+		selectedMedia,
+		jobProgress,
+		activeJobId,
+		currentPage,
+		setCurrentPage,
+		itemsPerPage,
+		totalPages,
+		paginatedMedia,
+		sources,
+		ips,
+		getActiveItems,
+		openCreateDialog,
+		openEditDialog,
+		handleSave: () => (editingItem() ? handleUpdate() : handleCreate()),
+		handleConfirmDelete,
+		handleScan,
+		handleStartBatchTagging,
+		toggleMediaSelection,
+		toggleSelectAll,
+		jobHandlers,
+	};
+}

--- a/packages/ui/src/hooks/use-media-source-events.ts
+++ b/packages/ui/src/hooks/use-media-source-events.ts
@@ -1,0 +1,200 @@
+import {
+	type AllJobsCompletedEvent,
+	allJobsCompletedEventSchema,
+	type JobProgressEvent,
+	jobProgressEventSchema,
+	type MediaAddedEvent,
+	type MediaChangedEvent,
+	type MediaCopiedEvent,
+	type MediaDeletedEvent,
+	type MediaMovedEvent,
+	mediaAddedEventSchema,
+	mediaChangedEventSchema,
+	mediaCopiedEventSchema,
+	mediaDeletedEventSchema,
+	mediaMovedEventSchema,
+	type ThumbnailGeneratedEvent,
+	thumbnailGeneratedEventSchema,
+	type WatcherErrorEvent,
+	watcherErrorEventSchema,
+} from "@solid-imager/core/domain/sources/events";
+import { type Accessor, createEffect, onCleanup } from "solid-js";
+import { isServer } from "solid-js/web";
+
+export type {
+	AllJobsCompletedEvent,
+	JobProgressEvent,
+	MediaAddedEvent,
+	MediaChangedEvent,
+	MediaCopiedEvent,
+	MediaDeletedEvent,
+	MediaMovedEvent,
+	ThumbnailGeneratedEvent,
+	WatcherErrorEvent,
+};
+
+/**
+ * Transport adapter interface. Implementations bridge the shared hook to a
+ * concrete event source (oRPC SSE for server, Tauri event bus for desktop).
+ *
+ * `listen` must call `handler` with the event name and raw payload for every
+ * incoming event and return a cleanup function that cancels the subscription.
+ */
+export type MediaSourceEventTransport = {
+	listen(handler: (event: string, data: unknown) => void): () => void;
+};
+
+export type UseMediaSourceEventsOptions = {
+	transport: MediaSourceEventTransport;
+	enabled?: boolean | Accessor<boolean>;
+	onMediaAdded?: (data: MediaAddedEvent) => void;
+	onMediaDeleted?: (data: MediaDeletedEvent) => void;
+	onMediaChanged?: (data: MediaChangedEvent) => void;
+	onMediaCopied?: (data: MediaCopiedEvent) => void;
+	onMediaMoved?: (data: MediaMovedEvent) => void;
+	onThumbnailGenerated?: (data: ThumbnailGeneratedEvent) => void;
+	onAllJobsCompleted?: (data: AllJobsCompletedEvent) => void;
+	onWatcherError?: (data: WatcherErrorEvent) => void;
+	/** Tauri-only in practice, but included in the shared interface. */
+	onJobProgress?: (data: JobProgressEvent) => void;
+};
+
+type SafeParseSchema<T> = {
+	safeParse: (
+		input: unknown,
+	) => { success: true; data: T } | { success: false; error: unknown };
+};
+
+function validateAndDispatch<T>(
+	schema: SafeParseSchema<T>,
+	rawData: unknown,
+	callback: ((data: T) => void) | undefined,
+	eventName: string,
+): void {
+	if (!callback) {
+		return;
+	}
+	const result = schema.safeParse(rawData);
+	if (result.success) {
+		callback(result.data);
+	} else {
+		console.warn(
+			`[useMediaSourceEvents] Received invalid data for event "${eventName}":`,
+			result.error,
+		);
+	}
+}
+
+/**
+ * Shared hook that dispatches media-source events to caller-provided callbacks.
+ *
+ * Event delivery is decoupled from the transport via `MediaSourceEventTransport`,
+ * allowing the same hook to work with oRPC SSE (server) and the Tauri event bus
+ * (desktop) without any conditional logic inside the hook itself.
+ */
+export function useMediaSourceEvents(
+	options: UseMediaSourceEventsOptions,
+): void {
+	createEffect(() => {
+		if (isServer) {
+			return;
+		}
+
+		const isEnabled =
+			typeof options.enabled === "function"
+				? options.enabled()
+				: (options.enabled ?? true);
+
+		if (!isEnabled) {
+			return;
+		}
+
+		const cleanup = options.transport.listen((event, data) => {
+			switch (event) {
+				case "media-added":
+					validateAndDispatch(
+						mediaAddedEventSchema,
+						data,
+						options.onMediaAdded,
+						event,
+					);
+					break;
+				case "media-deleted":
+					validateAndDispatch(
+						mediaDeletedEventSchema,
+						data,
+						options.onMediaDeleted,
+						event,
+					);
+					break;
+				case "media-changed":
+					validateAndDispatch(
+						mediaChangedEventSchema,
+						data,
+						options.onMediaChanged,
+						event,
+					);
+					break;
+				case "media-copied":
+					validateAndDispatch(
+						mediaCopiedEventSchema,
+						data,
+						options.onMediaCopied,
+						event,
+					);
+					break;
+				case "media-moved":
+					validateAndDispatch(
+						mediaMovedEventSchema,
+						data,
+						options.onMediaMoved,
+						event,
+					);
+					break;
+				case "thumbnail-generated":
+					validateAndDispatch(
+						thumbnailGeneratedEventSchema,
+						data,
+						options.onThumbnailGenerated,
+						event,
+					);
+					break;
+				case "all-jobs-completed":
+					validateAndDispatch(
+						allJobsCompletedEventSchema,
+						data,
+						options.onAllJobsCompleted,
+						event,
+					);
+					break;
+				case "watcher-error":
+					validateAndDispatch(
+						watcherErrorEventSchema,
+						data,
+						options.onWatcherError,
+						event,
+					);
+					break;
+				case "job-progress":
+					validateAndDispatch(
+						jobProgressEventSchema,
+						data,
+						options.onJobProgress,
+						event,
+					);
+					break;
+				case "connected":
+					// Connection established — no action needed.
+					break;
+				default:
+					console.debug(
+						`[useMediaSourceEvents] Unknown event received: "${event}"`,
+						data,
+					);
+					break;
+			}
+		});
+
+		onCleanup(cleanup);
+	});
+}

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -1,0 +1,287 @@
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type {
+	Author,
+	MediaSearchRequest,
+	MediaSearchResponse,
+} from "@solid-imager/core/domain/media/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import type { QueryClient } from "@tanstack/solid-query";
+import {
+	createInfiniteQuery,
+	createQuery,
+	keepPreviousData,
+} from "@tanstack/solid-query";
+import { createEffect, createMemo, createSignal, onCleanup } from "solid-js";
+import { isServer } from "solid-js/web";
+import type { buildAuthorsQueryOptions } from "../query-options/authors-query";
+import type { buildCharactersQueryOptions } from "../query-options/characters-query";
+import type { buildIpsQueryOptions } from "../query-options/ips-query";
+import type { buildProjectsQueryOptions } from "../query-options/projects-query";
+import type { buildSourcesQueryOptions } from "../query-options/sources-query";
+import type { buildTagsQueryOptions } from "../query-options/tags-query";
+
+const DEFAULT_GC_TIME = 1000 * 60 * 5;
+const DEFAULT_REFRESH_DEBOUNCE_MS = 0;
+
+export type SearchPageFilterData = {
+	tags: TagResponse[] | undefined;
+	projects: Project[] | undefined;
+	ips: Ip[] | undefined;
+	characters: Character[] | undefined;
+	authors: Author[] | undefined;
+};
+
+export type SearchPageQueryOptions = {
+	tags: () => ReturnType<typeof buildTagsQueryOptions>;
+	sources: () => ReturnType<typeof buildSourcesQueryOptions>;
+	projects: () => ReturnType<typeof buildProjectsQueryOptions>;
+	ips: () => ReturnType<typeof buildIpsQueryOptions>;
+	characters: () => ReturnType<typeof buildCharactersQueryOptions>;
+	authors: () => ReturnType<typeof buildAuthorsQueryOptions>;
+};
+
+export interface UseSearchPageOptions {
+	searchMedia: (
+		sourceId: string | undefined,
+		params: MediaSearchRequest,
+	) => Promise<MediaSearchResponse>;
+	queryClient: QueryClient;
+	queries: SearchPageQueryOptions;
+	selectedSource: () => string | null | undefined;
+	getSearchCondition: () => MediaSearchRequest["condition"];
+	sortBy: () => MediaSearchRequest["sort"];
+	sortOrder: () => "asc" | "desc";
+	limit: () => number;
+	scrollY: () => number;
+	setScrollY: (y: number) => void;
+	setOffset: (o: number) => void;
+	gcTime?: number;
+	refreshDebounceMs?: number;
+}
+
+export interface UseSearchPageResult {
+	searchResultQuery: ReturnType<
+		typeof createInfiniteQuery<MediaSearchResponse>
+	>;
+	searchResults: () => MediaSearchResponse["media"];
+	filterData: SearchPageFilterData;
+	sources: () => SafeMediaSource[] | undefined;
+	getSourceRootPath: (mediaSourceId: string) => string | undefined;
+	isRestored: () => boolean;
+	handleSearch: () => void;
+	refreshSearchResults: () => void;
+	loadMoreRef: () => HTMLDivElement | undefined;
+	setLoadMoreRef: (el: HTMLDivElement | undefined) => void;
+	conditionKey: () => string;
+}
+
+export function useSearchPage(
+	options: UseSearchPageOptions,
+): UseSearchPageResult {
+	const {
+		searchMedia,
+		queryClient,
+		queries,
+		selectedSource,
+		getSearchCondition,
+		sortBy,
+		sortOrder,
+		limit,
+		scrollY,
+		setScrollY,
+		setOffset,
+		gcTime = DEFAULT_GC_TIME,
+		refreshDebounceMs = DEFAULT_REFRESH_DEBOUNCE_MS,
+	} = options;
+
+	const tags = createQuery(() => queries.tags());
+	const sources = createQuery(() => queries.sources());
+	const allProjects = createQuery(() => queries.projects());
+	const allIps = createQuery(() => queries.ips());
+	const allCharacters = createQuery(() => queries.characters());
+	const allAuthors = createQuery(() => queries.authors());
+
+	const conditionKey = createMemo(() =>
+		JSON.stringify(getSearchCondition() ?? null),
+	);
+
+	const buildSearchParams = (): Pick<
+		MediaSearchRequest,
+		"condition" | "sort" | "order" | "limit"
+	> => {
+		const condition = getSearchCondition();
+		return {
+			condition: condition || undefined,
+			sort: sortBy(),
+			order: sortOrder(),
+			limit: limit(),
+		};
+	};
+
+	const searchResultQuery = createInfiniteQuery<MediaSearchResponse>(() => {
+		const params = buildSearchParams();
+		const source = selectedSource() || undefined;
+		return {
+			queryKey: [
+				"searchResults",
+				source,
+				conditionKey(),
+				sortBy(),
+				sortOrder(),
+				limit(),
+			],
+			queryFn: async ({ pageParam }) =>
+				await searchMedia(source, {
+					...params,
+					offset: pageParam as number,
+				}),
+			initialPageParam: 0,
+			getNextPageParam: (lastPage, allPages) => {
+				const loadedCount = allPages.reduce(
+					(sum, page) => sum + page.media.length,
+					0,
+				);
+				if (loadedCount < lastPage.total) {
+					return loadedCount;
+				}
+			},
+			placeholderData: keepPreviousData,
+			gcTime,
+		};
+	});
+
+	const searchResults = createMemo(() => {
+		const seen = new Set<string>();
+		return (searchResultQuery.data?.pages.flatMap((p) => p.media) || []).filter(
+			(m) => {
+				if (seen.has(m.id)) {
+					return false;
+				}
+				seen.add(m.id);
+				return true;
+			},
+		);
+	});
+
+	const getSourceRootPath = (mediaSourceId: string) => {
+		const source = sources.data?.find((item) => item.id === mediaSourceId);
+		if (source?.type !== "local") {
+			return undefined;
+		}
+		const connectionInfo = source.connectionInfo as { path?: string };
+		return connectionInfo.path;
+	};
+
+	const [refreshTimer, setRefreshTimer] = createSignal<ReturnType<
+		typeof setTimeout
+	> | null>(null);
+
+	const refreshSearchResults = () => {
+		const timer = refreshTimer();
+		if (timer) {
+			clearTimeout(timer);
+		}
+		if (refreshDebounceMs <= 0) {
+			void queryClient.invalidateQueries({ queryKey: ["searchResults"] });
+			setRefreshTimer(null);
+			return;
+		}
+		setRefreshTimer(
+			setTimeout(() => {
+				void queryClient.invalidateQueries({ queryKey: ["searchResults"] });
+				setRefreshTimer(null);
+			}, refreshDebounceMs),
+		);
+	};
+
+	const [isRestored, setIsRestored] = createSignal(false);
+
+	createEffect(() => {
+		if (
+			!(searchResultQuery.isLoading || isRestored()) &&
+			searchResultQuery.data &&
+			searchResultQuery.data.pages.length > 0
+		) {
+			if (scrollY() > 0) {
+				requestAnimationFrame(() => {
+					window.scrollTo(0, scrollY());
+				});
+			}
+			setIsRestored(true);
+		}
+	});
+
+	onCleanup(() => {
+		if (!isServer) {
+			setScrollY(window.scrollY);
+		}
+		const timer = refreshTimer();
+		if (timer) {
+			clearTimeout(timer);
+		}
+	});
+
+	const handleSearch = () => {
+		setOffset(0);
+		setScrollY(0);
+		window.scrollTo(0, 0);
+	};
+
+	const [loadMoreRef, setLoadMoreRef] = createSignal<
+		HTMLDivElement | undefined
+	>(undefined);
+
+	createEffect(() => {
+		const el = loadMoreRef();
+		if (!el) {
+			return;
+		}
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (
+					entries[0].isIntersecting &&
+					searchResultQuery.hasNextPage &&
+					!searchResultQuery.isFetchingNextPage
+				) {
+					searchResultQuery.fetchNextPage();
+				}
+			},
+			{ threshold: 0.5, rootMargin: "1000px" },
+		);
+		observer.observe(el);
+		onCleanup(() => observer.disconnect());
+	});
+
+	return {
+		searchResultQuery,
+		searchResults,
+		filterData: {
+			get tags() {
+				return tags.data;
+			},
+			get projects() {
+				return allProjects.data;
+			},
+			get ips() {
+				return allIps.data;
+			},
+			get characters() {
+				return allCharacters.data;
+			},
+			get authors() {
+				return allAuthors.data;
+			},
+		},
+		sources: () => sources.data,
+		getSourceRootPath,
+		isRestored,
+		handleSearch,
+		refreshSearchResults,
+		loadMoreRef,
+		setLoadMoreRef,
+		conditionKey,
+	};
+}

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -104,9 +104,13 @@ export function useSearchPage(
 	const allCharacters = createQuery(() => queries.characters());
 	const allAuthors = createQuery(() => queries.authors());
 
-	const conditionKey = createMemo(() =>
-		JSON.stringify(getSearchCondition() ?? null),
-	);
+	const conditionKey = createMemo(() => {
+		const val = getSearchCondition() ?? null;
+		if (val === null || typeof val !== "object") {
+			return JSON.stringify(val);
+		}
+		return JSON.stringify(val, Object.keys(val).sort());
+	});
 
 	const buildSearchParams = (): Pick<
 		MediaSearchRequest,

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -224,6 +224,7 @@ export function useSourceMediaPage(
 				offset: pageParam as number,
 			});
 		},
+		enabled: !!id(),
 		initialPageParam: 0,
 		getNextPageParam: (lastPage, allPages) => {
 			const loadedCount = allPages.reduce(

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -1,0 +1,914 @@
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type {
+	Author,
+	DownloadItem,
+	MediaSearchRequest,
+	MediaSearchResponse,
+} from "@solid-imager/core/domain/media/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import type { JobProgressEvent } from "@solid-imager/core/domain/sources/events";
+import {
+	getScrollPosition,
+	setScrollPosition,
+} from "@solid-imager/core/domain/sources/store";
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import type { QueryClient } from "@tanstack/solid-query";
+import { createInfiniteQuery, keepPreviousData } from "@tanstack/solid-query";
+import type { Accessor, Setter } from "solid-js";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	onCleanup,
+	onMount,
+} from "solid-js";
+import { isServer } from "solid-js/web";
+import { z } from "zod";
+import type { PresetManagerClient } from "../search-control-panel";
+import { toast } from "../toast";
+import type { PresetClientLike } from "./use-current-search-persistence";
+import type { MediaSourceEventTransport } from "./use-media-source-events";
+import { useMediaSourceEvents } from "./use-media-source-events";
+
+const MEDIA_ITEMS_PER_PAGE = 200;
+const SCROLL_RESTORE_DELAY = 100;
+const DEBOUNCE_DELAY_MS = 1000;
+const MEDIA_REFRESH_DEBOUNCE_MS = 300;
+
+export type UploadOptions = {
+	file: File;
+	filename: string;
+	description: string;
+	sourceUrl?: string;
+	overwrite: boolean;
+	autoIncrement: boolean;
+};
+
+export type SourceMediaPageFilterData = {
+	tags: TagResponse[] | undefined;
+	projects: Project[] | undefined;
+	ips: Ip[] | undefined;
+	characters: Character[] | undefined;
+	authors: Author[] | undefined;
+};
+
+export type SourceMediaPageQueries = {
+	tags: Accessor<TagResponse[] | undefined>;
+	projects: Accessor<Project[] | undefined>;
+	ips: Accessor<Ip[] | undefined>;
+	characters: Accessor<Character[] | undefined>;
+	authors: Accessor<Author[] | undefined>;
+};
+
+export type SourceMediaPageActions = {
+	searchMedia: (
+		sourceId: string,
+		params: MediaSearchRequest,
+	) => Promise<MediaSearchResponse>;
+	uploadMedia: (
+		sourceId: string,
+		file: File,
+		opts: Omit<UploadOptions, "file">,
+	) => Promise<unknown>;
+	deleteMedia: (sourceId: string, mediaId: string) => Promise<unknown>;
+	copyMedia: (
+		sourceId: string,
+		mediaId: string,
+		targetId: string,
+	) => Promise<unknown>;
+	moveMedia: (
+		sourceId: string,
+		mediaId: string,
+		targetId: string,
+	) => Promise<unknown>;
+	syncMediaItems: (sourceId: string, ids: string[]) => Promise<unknown>;
+	startDownloadJobs: (
+		sourceId: string,
+		items: DownloadItem[],
+	) => Promise<unknown>;
+	fetchSourceDump: (sourceId: string, mode: "json" | "zip") => Promise<Blob>;
+	restoreSource: (
+		sourceId: string,
+		data: unknown,
+		opts?: {
+			signal?: AbortSignal;
+			onProgress?: (done: number, total: number) => void;
+		},
+	) => Promise<{
+		processed: number;
+		skipped: number;
+		errors: string[];
+		cancelled?: boolean;
+	}>;
+	importSourceZip: (
+		sourceId: string,
+		file: File,
+	) => Promise<{
+		success: boolean;
+		importedCount: number;
+		skippedCount: number;
+		errors: string[];
+		message: string;
+	}>;
+	parseRestoreFile?: (file: File) => Promise<unknown>;
+};
+
+export type SourceMediaPagePresetClient = PresetManagerClient &
+	PresetClientLike;
+
+export type UseSourceMediaPageOptions = {
+	mediaSourceId: () => string | undefined;
+	queries: SourceMediaPageQueries;
+	actions: SourceMediaPageActions;
+	queryClient: QueryClient;
+	presetClient: SourceMediaPagePresetClient;
+	transport: MediaSourceEventTransport;
+	getSearchCondition: () => MediaSearchRequest["condition"];
+	sortBy: () => MediaSearchRequest["sort"];
+	sortOrder: () => "asc" | "desc";
+	itemsPerPage?: number;
+	onThumbnailReady?: (mediaId: string) => void;
+};
+
+export type UseSourceMediaPageResult = {
+	mediaSourceId: () => string | undefined;
+	mediaQuery: ReturnType<typeof createInfiniteQuery<MediaSearchResponse>>;
+	mediaResults: () => MediaSearchResponse["media"];
+	filterData: () => SourceMediaPageFilterData;
+	handleSearch: () => void;
+	loadMoreRef: HTMLDivElement | undefined;
+	setLoadMoreRef: (el: HTMLDivElement) => void;
+	showUploadModal: () => boolean;
+	setShowUploadModal: Setter<boolean>;
+	fileToUpload: () => File | null;
+	setFileToUpload: Setter<File | null>;
+	pastedUrl: () => string | null;
+	setPastedUrl: Setter<string | null>;
+	deleteDialogOpen: () => boolean;
+	setDeleteDialogOpen: Setter<boolean>;
+	moveCopyDialogOpen: () => boolean;
+	setMoveCopyDialogOpen: Setter<boolean>;
+	moveCopyMode: () => "copy" | "move";
+	contextMenuMediaId: () => string | null;
+	setContextMenuMediaId: (
+		value: string | null | ((prev: string | null) => string | null),
+	) => void;
+	isSyncingMedia: () => boolean;
+	jobProgress: () => JobProgressEvent | null;
+	presetClient: SourceMediaPagePresetClient;
+	handleUpload: (options: UploadOptions) => Promise<void>;
+	handleFileSelect: (e: Event) => Promise<void>;
+	handleDumpDownload: (mode?: "json" | "zip") => Promise<void>;
+	handleRestoreSelect: (e: Event) => Promise<void>;
+	handleAddButtonClick: () => void;
+	handleDrop: (e: DragEvent) => void;
+	handleDragOver: (e: DragEvent) => void;
+	handleDelete: (mediaId: string) => void;
+	confirmDelete: () => Promise<void>;
+	handleCopyMove: (mediaId: string, mode: "copy" | "move") => void;
+	handleConfirmCopyMove: (targetSourceId: string) => Promise<void>;
+	handleSyncLoadedMedia: () => Promise<void>;
+	handleSyncSingleMedia: (mediaId: string) => Promise<void>;
+	fileInputRef: HTMLInputElement | undefined;
+	setFileInputRef: (el: HTMLInputElement) => void;
+	restoreInputRef: HTMLInputElement | undefined;
+	setRestoreInputRef: (el: HTMLInputElement) => void;
+};
+
+export function useSourceMediaPage(
+	options: UseSourceMediaPageOptions,
+): UseSourceMediaPageResult {
+	const {
+		mediaSourceId,
+		queries,
+		actions,
+		queryClient,
+		presetClient,
+		transport,
+		getSearchCondition,
+		sortBy,
+		sortOrder,
+		itemsPerPage = MEDIA_ITEMS_PER_PAGE,
+		onThumbnailReady,
+	} = options;
+
+	const id = mediaSourceId;
+
+	// --- Filter data queries ---
+	const filterData = (): SourceMediaPageFilterData => ({
+		tags: queries.tags(),
+		projects: queries.projects(),
+		ips: queries.ips(),
+		characters: queries.characters(),
+		authors: queries.authors(),
+	});
+
+	// --- Infinite query ---
+	const searchConditionKey = createMemo(() =>
+		JSON.stringify(getSearchCondition() ?? null),
+	);
+
+	const mediaQuery = createInfiniteQuery<MediaSearchResponse>(() => ({
+		queryKey: ["media", id(), searchConditionKey(), sortBy(), sortOrder()],
+		queryFn: ({ pageParam }) => {
+			const sourceId = id();
+			if (!sourceId) {
+				throw new Error("Media source ID is required");
+			}
+			return actions.searchMedia(sourceId, {
+				condition: getSearchCondition() || undefined,
+				sort: sortBy(),
+				order: sortOrder(),
+				limit: itemsPerPage,
+				offset: pageParam as number,
+			});
+		},
+		initialPageParam: 0,
+		getNextPageParam: (lastPage, allPages) => {
+			const loadedCount = allPages.reduce(
+				(sum, page) => sum + page.media.length,
+				0,
+			);
+			if (loadedCount < lastPage.total) {
+				return loadedCount;
+			}
+			return;
+		},
+		placeholderData: keepPreviousData,
+	}));
+
+	// --- Deduplicated results ---
+	const mediaResults = createMemo(() => {
+		const seen = new Set<string>();
+		return (mediaQuery.data?.pages.flatMap((page) => page.media) || []).filter(
+			(media) => {
+				if (seen.has(media.id)) {
+					return false;
+				}
+				seen.add(media.id);
+				return true;
+			},
+		);
+	});
+
+	// --- Search handler ---
+	const handleSearch = () => {
+		window.scrollTo(0, 0);
+	};
+
+	// --- Scroll restoration ---
+	const [isScrollRestored, setIsScrollRestored] = createSignal(false);
+
+	onMount(() => {
+		if (isServer) {
+			return;
+		}
+		if ("scrollRestoration" in history) {
+			history.scrollRestoration = "manual";
+		}
+	});
+
+	createEffect(() => {
+		if (isServer) {
+			return;
+		}
+		if (isScrollRestored()) {
+			return;
+		}
+
+		const sourceId = id();
+		if (!sourceId) {
+			return;
+		}
+
+		if (mediaQuery.data && !mediaQuery.isLoading) {
+			const targetScrollY = getScrollPosition(sourceId);
+			if (targetScrollY > 0) {
+				setTimeout(() => {
+					requestAnimationFrame(() => {
+						window.scrollTo(0, targetScrollY);
+						setIsScrollRestored(true);
+					});
+				}, SCROLL_RESTORE_DELAY);
+			} else {
+				setIsScrollRestored(true);
+			}
+		}
+	});
+
+	onCleanup(() => {
+		if (isServer) {
+			return;
+		}
+		const sourceId = id();
+		if (sourceId) {
+			setScrollPosition(sourceId, window.scrollY);
+		}
+	});
+
+	// --- Infinite scroll ---
+	let loadMoreRef: HTMLDivElement | undefined;
+	const setLoadMoreRef = (el: HTMLDivElement) => {
+		loadMoreRef = el;
+	};
+
+	onMount(() => {
+		if (isServer) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0].isIntersecting && mediaQuery.hasNextPage) {
+					mediaQuery.fetchNextPage();
+				}
+			},
+			{ threshold: 0.5, rootMargin: "1000px" },
+		);
+
+		if (loadMoreRef) {
+			observer.observe(loadMoreRef);
+		}
+
+		onCleanup(() => observer.disconnect());
+	});
+
+	// --- UI state ---
+	const [showUploadModal, setShowUploadModal] = createSignal(false);
+	const [fileToUpload, setFileToUpload] = createSignal<File | null>(null);
+	const [pastedUrl, setPastedUrl] = createSignal<string | null>(null);
+	const [deleteDialogOpen, setDeleteDialogOpen] = createSignal(false);
+	const [mediaIdToDelete, setMediaIdToDelete] = createSignal<string | null>(
+		null,
+	);
+	const [moveCopyDialogOpen, setMoveCopyDialogOpen] = createSignal(false);
+	const [moveCopyMode, setMoveCopyMode] = createSignal<"copy" | "move">("copy");
+	const [mediaIdToMoveCopy, setMediaIdToMoveCopy] = createSignal<string | null>(
+		null,
+	);
+	const [contextMenuMediaId, setContextMenuMediaId] = createSignal<
+		string | null
+	>(null);
+	const [isSyncingMedia, setIsSyncingMedia] = createSignal(false);
+	const [jobProgress, setJobProgress] = createSignal<JobProgressEvent | null>(
+		null,
+	);
+
+	let fileInputRef: HTMLInputElement | undefined;
+	const setFileInputRef = (el: HTMLInputElement) => {
+		fileInputRef = el;
+	};
+	let restoreInputRef: HTMLInputElement | undefined;
+	const setRestoreInputRef = (el: HTMLInputElement) => {
+		restoreInputRef = el;
+	};
+
+	// --- Refresh helpers ---
+	const refreshMediaQuery = () => {
+		void mediaQuery.refetch();
+		void queryClient.invalidateQueries({
+			queryKey: ["media", id()],
+		});
+	};
+
+	const [mediaRefreshTimer, setMediaRefreshTimer] = createSignal<ReturnType<
+		typeof setTimeout
+	> | null>(null);
+
+	const scheduleMediaRefresh = () => {
+		const timer = mediaRefreshTimer();
+		if (timer) {
+			clearTimeout(timer);
+		}
+		setMediaRefreshTimer(
+			setTimeout(() => {
+				refreshMediaQuery();
+				setMediaRefreshTimer(null);
+			}, MEDIA_REFRESH_DEBOUNCE_MS),
+		);
+	};
+
+	// --- Debounce for media-added events ---
+	const [addedCount, setAddedCount] = createSignal(0);
+	const [debounceTimer, setDebounceTimer] = createSignal<ReturnType<
+		typeof setTimeout
+	> | null>(null);
+
+	onCleanup(() => {
+		const timer = debounceTimer();
+		if (timer) {
+			clearTimeout(timer);
+		}
+		const refreshTimer = mediaRefreshTimer();
+		if (refreshTimer) {
+			clearTimeout(refreshTimer);
+		}
+	});
+
+	onCleanup(() => {
+		if (restoreAbortController) {
+			restoreAbortController.abort();
+			restoreAbortController = null;
+		}
+	});
+
+	// --- Media source events ---
+	useMediaSourceEvents({
+		transport,
+		enabled: () => !isServer,
+		onMediaAdded: () => {
+			setAddedCount((prev) => prev + 1);
+
+			const timer = debounceTimer();
+			if (timer) {
+				clearTimeout(timer);
+			}
+
+			setDebounceTimer(
+				setTimeout(() => {
+					const count = addedCount();
+					if (count > 0) {
+						toast.success(`${count} new media detected. Refreshing list...`);
+						setAddedCount(0);
+					}
+					refreshMediaQuery();
+				}, DEBOUNCE_DELAY_MS),
+			);
+		},
+		onMediaDeleted: () => {
+			scheduleMediaRefresh();
+		},
+		onMediaChanged: () => {
+			scheduleMediaRefresh();
+		},
+		onMediaCopied: () => {
+			scheduleMediaRefresh();
+		},
+		onMediaMoved: () => {
+			scheduleMediaRefresh();
+		},
+		onThumbnailGenerated: (data) => {
+			if (onThumbnailReady) {
+				onThumbnailReady(data.mediaId);
+			}
+			queryClient.invalidateQueries({
+				queryKey: ["media", id()],
+			});
+		},
+		onJobProgress: (data) => {
+			setJobProgress(data);
+		},
+		onAllJobsCompleted: (data) => {
+			setJobProgress(null);
+			toast.success(
+				`All jobs completed! Processed: ${data.processed ?? "N/A"}`,
+			);
+			refreshMediaQuery();
+		},
+		onWatcherError: (data) => {
+			toast.error(`Watcher Error: ${data.error || "Unknown error"}`);
+		},
+	});
+
+	// --- Handlers ---
+	const handleUpload = async (options: UploadOptions) => {
+		await actions.uploadMedia(id() || "", options.file, {
+			filename: options.filename,
+			description: options.description,
+			sourceUrl: options.sourceUrl,
+			overwrite: options.overwrite,
+			autoIncrement: options.autoIncrement,
+		});
+		toast.success("Media uploaded successfully");
+		refreshMediaQuery();
+	};
+
+	const handleJsonFileUpload = async (file: File) => {
+		try {
+			const text = await file.text();
+			const jsonContent = JSON.parse(text);
+			let items: DownloadItem[] = [];
+
+			if (Array.isArray(jsonContent)) {
+				items = jsonContent;
+			} else if (jsonContent.items && Array.isArray(jsonContent.items)) {
+				items = jsonContent.items;
+			} else if (jsonContent.images && Array.isArray(jsonContent.images)) {
+				items = jsonContent.images.flatMap((image: Record<string, unknown>) => {
+					const imageUrl =
+						(typeof image.originalUrl === "string" && image.originalUrl) ||
+						(typeof image.displayUrl === "string" && image.displayUrl);
+					if (!imageUrl) {
+						return [];
+					}
+
+					const metadata =
+						typeof image.metadata === "object" && image.metadata
+							? (image.metadata as Record<string, unknown>)
+							: undefined;
+					const postId =
+						metadata && typeof metadata.postId === "string"
+							? metadata.postId
+							: undefined;
+					const tweetUrl =
+						image.source === "twitter" && postId
+							? `https://twitter.com/i/web/status/${postId}`
+							: undefined;
+					const author =
+						metadata && typeof metadata.author === "string"
+							? metadata.author
+							: undefined;
+					const timestamp =
+						metadata && typeof metadata.timestamp === "string"
+							? metadata.timestamp
+							: typeof image.date === "string"
+								? image.date
+								: undefined;
+
+					return [
+						{
+							targetUrl: imageUrl,
+							description:
+								(metadata && typeof metadata.title === "string"
+									? metadata.title
+									: typeof image.title === "string"
+										? image.title
+										: undefined) ?? undefined,
+							sourceUrls: tweetUrl ? [tweetUrl] : undefined,
+							authors: author ? [{ name: author }] : undefined,
+							createdAt: timestamp,
+						},
+					];
+				});
+			} else {
+				throw new Error(
+					"JSONファイルはアイテムの配列であるか、'items'または'images'キーを含むオブジェクトである必要があります。",
+				);
+			}
+
+			if (items.length === 0) {
+				throw new Error(
+					"JSONファイルにはダウンロードするアイテムが含まれていません。",
+				);
+			}
+
+			await actions.startDownloadJobs(id() || "", items);
+			toast.success("Bulk download started");
+		} catch (error) {
+			toast.error(`Failed to start download: ${(error as Error).message}`);
+		}
+	};
+
+	const handleFileSelect = async (e: Event) => {
+		const target = e.target as HTMLInputElement;
+		if (target.files && target.files.length > 0) {
+			const file = target.files[0];
+
+			if (file.type === "application/json" || file.name.endsWith(".json")) {
+				await handleJsonFileUpload(file);
+			} else {
+				setFileToUpload(file);
+				setShowUploadModal(true);
+			}
+
+			target.value = "";
+		}
+	};
+
+	const handleDumpDownload = async (mode: "json" | "zip" = "json") => {
+		const sourceId = id();
+		if (!sourceId) {
+			return;
+		}
+
+		try {
+			const blob = await actions.fetchSourceDump(sourceId, mode);
+			const url = window.URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `source-${sourceId}-dump.${mode}`;
+			document.body.appendChild(a);
+			a.click();
+			window.URL.revokeObjectURL(url);
+			document.body.removeChild(a);
+			toast.success(`Dump (${mode.toUpperCase()}) downloaded successfully`);
+		} catch (_error) {
+			toast.error("Failed to download dump");
+		}
+	};
+
+	let restoreAbortController: AbortController | null = null;
+
+	const handleRestoreSelect = async (e: Event) => {
+		const target = e.target as HTMLInputElement;
+		if (!target.files || target.files.length === 0) {
+			return;
+		}
+
+		const file = target.files[0];
+		const sourceId = id();
+		if (!sourceId) {
+			return;
+		}
+
+		restoreAbortController = new AbortController();
+
+		try {
+			if (
+				file.name.endsWith(".zip") ||
+				file.type === "application/zip" ||
+				file.type === "application/x-zip-compressed"
+			) {
+				toast.loading("Importing ZIP dump...", { id: "restore-toast" });
+				const result = await actions.importSourceZip(sourceId, file);
+				toast.success(
+					`Import complete: ${result.importedCount} items imported.`,
+					{
+						id: "restore-toast",
+					},
+				);
+				refreshMediaQuery();
+				return;
+			}
+
+			const data = actions.parseRestoreFile
+				? await actions.parseRestoreFile(file)
+				: JSON.parse(await file.text());
+
+			const showCancel = typeof actions.parseRestoreFile === "function";
+			const cancelAction = showCancel
+				? {
+						label: "Cancel",
+						onClick: () => restoreAbortController?.abort(),
+					}
+				: undefined;
+
+			toast.loading("Restoring metadata...", {
+				id: "restore-toast",
+				cancel: cancelAction,
+			});
+
+			const total = Array.isArray(data)
+				? data.length
+				: ((data as { media?: unknown[] })?.media?.length ?? 0);
+
+			const result = await actions.restoreSource(sourceId, data, {
+				signal: restoreAbortController.signal,
+				onProgress: (done) => {
+					toast.loading(`Restoring metadata... ${done}/${total} items`, {
+						id: "restore-toast",
+						cancel: cancelAction,
+					});
+				},
+			});
+
+			if (result.cancelled) {
+				toast.info(`Restore cancelled: ${result.processed} items restored.`, {
+					id: "restore-toast",
+				});
+			} else {
+				toast.success(
+					`Restore complete: ${result.processed} processed, ${result.skipped} skipped`,
+					{
+						id: "restore-toast",
+					},
+				);
+			}
+			refreshMediaQuery();
+		} catch (error) {
+			toast.error(`Restore failed: ${(error as Error).message}`, {
+				id: "restore-toast",
+			});
+		} finally {
+			restoreAbortController = null;
+			target.value = "";
+		}
+	};
+
+	const handleAddButtonClick = () => {
+		fileInputRef?.click();
+	};
+
+	const handleDrop = (e: DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
+			const file = e.dataTransfer.files[0];
+			setFileToUpload(file);
+			setShowUploadModal(true);
+		}
+	};
+
+	const handleDragOver = (e: DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+	};
+
+	const handleImagePasteItem = (
+		item: DataTransferItem,
+		e: ClipboardEvent,
+	): boolean => {
+		if (item.type.indexOf("image") !== -1) {
+			const blob = item.getAsFile();
+			if (blob) {
+				const file = new File([blob], `pasted-image-${Date.now()}.png`, {
+					type: blob.type,
+				});
+				setFileToUpload(file);
+				setShowUploadModal(true);
+				e.preventDefault();
+				return true;
+			}
+		}
+		return false;
+	};
+
+	const handleUrlPasteItem = async (
+		item: DataTransferItem,
+		e: ClipboardEvent,
+	): Promise<boolean> => {
+		if (item.type === "text/plain") {
+			const text = await new Promise<string | null>((resolve) => {
+				item.getAsString((str) => resolve(str));
+			});
+
+			if (text && z.string().url().safeParse(text).success) {
+				setPastedUrl(text);
+				setShowUploadModal(true);
+				e.preventDefault();
+				return true;
+			}
+		}
+		return false;
+	};
+
+	const processClipboardItems = async (
+		items: DataTransferItemList,
+		e: ClipboardEvent,
+	): Promise<boolean> => {
+		for (const item of items) {
+			if (handleImagePasteItem(item, e)) {
+				return true;
+			}
+		}
+
+		for (const item of items) {
+			if (await handleUrlPasteItem(item, e)) {
+				return true;
+			}
+		}
+
+		return false;
+	};
+
+	const handlePaste = async (e: ClipboardEvent) => {
+		if (!e.clipboardData?.items) {
+			return;
+		}
+		await processClipboardItems(e.clipboardData.items, e);
+	};
+
+	onMount(() => {
+		if (!isServer) {
+			document.addEventListener("paste", handlePaste);
+			onCleanup(() => {
+				document.removeEventListener("paste", handlePaste);
+			});
+		}
+	});
+
+	const handleDelete = (mediaId: string) => {
+		setMediaIdToDelete(mediaId);
+		setDeleteDialogOpen(true);
+	};
+
+	const confirmDelete = async () => {
+		const mediaId = mediaIdToDelete();
+		if (!mediaId) {
+			return;
+		}
+
+		try {
+			await actions.deleteMedia(id() || "", mediaId);
+			toast.success("Media deleted successfully");
+			refreshMediaQuery();
+		} catch (_e) {
+			toast.error("Failed to delete media");
+		} finally {
+			setDeleteDialogOpen(false);
+			setMediaIdToDelete(null);
+		}
+	};
+
+	const handleCopyMove = (mediaId: string, mode: "copy" | "move") => {
+		setMediaIdToMoveCopy(mediaId);
+		setMoveCopyMode(mode);
+		setMoveCopyDialogOpen(true);
+	};
+
+	const handleConfirmCopyMove = async (targetSourceId: string) => {
+		const mediaId = mediaIdToMoveCopy();
+		const sourceId = id();
+		if (!(mediaId && sourceId)) {
+			return;
+		}
+
+		const mode = moveCopyMode();
+		const action = mode === "copy" ? actions.copyMedia : actions.moveMedia;
+		const actionName = mode === "copy" ? "copied" : "moved";
+
+		try {
+			await action(sourceId, mediaId, targetSourceId);
+			toast.success(`Media ${actionName} successfully`);
+			refreshMediaQuery();
+			if (sourceId !== targetSourceId) {
+				await queryClient.invalidateQueries({
+					queryKey: ["media", targetSourceId],
+				});
+			}
+		} catch (e) {
+			toast.error(`Failed to ${mode} media: ${(e as Error).message}`);
+		} finally {
+			setMediaIdToMoveCopy(null);
+		}
+	};
+
+	const handleSyncLoadedMedia = async () => {
+		const allPages = mediaQuery.data?.pages;
+		if (!allPages || isSyncingMedia()) {
+			return;
+		}
+		const mediaIds = allPages.flatMap((page) => page.media).map((m) => m.id);
+
+		if (mediaIds.length === 0) {
+			return;
+		}
+
+		setIsSyncingMedia(true);
+		toast.info("Starting batch sync for loaded media...");
+		try {
+			await actions.syncMediaItems(id() || "", mediaIds);
+			toast.success(`Batch sync completed for ${mediaIds.length} items`);
+			refreshMediaQuery();
+		} catch (error) {
+			toast.error(`Failed to batch sync: ${(error as Error).message}`);
+		} finally {
+			setIsSyncingMedia(false);
+		}
+	};
+
+	const handleSyncSingleMedia = async (mediaId: string) => {
+		toast.info("Starting metadata sync...");
+		try {
+			await actions.syncMediaItems(id() || "", [mediaId]);
+			toast.success("Metadata synced successfully");
+			refreshMediaQuery();
+		} catch (e) {
+			toast.error(`Failed to sync metadata: ${(e as Error).message}`);
+		}
+	};
+
+	return {
+		mediaSourceId: id,
+		mediaQuery,
+		mediaResults,
+		filterData,
+		handleSearch,
+		loadMoreRef,
+		setLoadMoreRef,
+		showUploadModal,
+		setShowUploadModal,
+		fileToUpload,
+		setFileToUpload,
+		pastedUrl,
+		setPastedUrl,
+		deleteDialogOpen,
+		setDeleteDialogOpen,
+		moveCopyDialogOpen,
+		setMoveCopyDialogOpen,
+		moveCopyMode,
+		contextMenuMediaId,
+		setContextMenuMediaId,
+		isSyncingMedia,
+		jobProgress,
+		presetClient,
+		handleUpload,
+		handleFileSelect,
+		handleDumpDownload,
+		handleRestoreSelect,
+		handleAddButtonClick,
+		handleDrop,
+		handleDragOver,
+		handleDelete,
+		confirmDelete,
+		handleCopyMove,
+		handleConfirmCopyMove,
+		handleSyncLoadedMedia,
+		handleSyncSingleMedia,
+		fileInputRef,
+		setFileInputRef,
+		restoreInputRef,
+		setRestoreInputRef,
+	};
+}

--- a/packages/ui/src/hooks/use-sources-events.ts
+++ b/packages/ui/src/hooks/use-sources-events.ts
@@ -1,0 +1,84 @@
+import {
+	allJobsCompletedEventSchema,
+	watcherErrorEventSchema,
+} from "@solid-imager/core/domain/sources/events";
+import type { QueryClient, QueryKey } from "@tanstack/solid-query";
+import { type Accessor, createEffect, onCleanup } from "solid-js";
+import { isServer } from "solid-js/web";
+import { toast } from "../toast";
+
+export type RawEventHandler = (eventName: string, payload: unknown) => void;
+
+/**
+ * Platform-specific event transport registration.
+ * Implementations must subscribe to the relevant events and call `handler`
+ * with the raw event name and payload for every incoming event.
+ * The returned cleanup function must cancel all subscriptions.
+ */
+export type RegisterEvents = (handler: RawEventHandler) => () => void;
+
+export type UseSourcesEventsOptions = {
+	registerEvents: RegisterEvents;
+	sourceIds: Accessor<string[]>;
+	queryClient: QueryClient;
+	queryKey: QueryKey;
+};
+
+export function useSourcesEvents(options: UseSourcesEventsOptions): void {
+	createEffect(() => {
+		if (isServer) {
+			return;
+		}
+
+		const cleanup = options.registerEvents((eventName, payload) => {
+			const activeSourceIds = new Set(options.sourceIds());
+
+			switch (eventName) {
+				case "all-jobs-completed": {
+					const result = allJobsCompletedEventSchema.safeParse(payload);
+					if (!result.success) {
+						console.warn(
+							"[useSourcesEvents] Invalid all-jobs-completed payload:",
+							result.error,
+						);
+						return;
+					}
+					if (
+						result.data.mediaSourceId &&
+						!activeSourceIds.has(result.data.mediaSourceId)
+					) {
+						return;
+					}
+					void options.queryClient.invalidateQueries({
+						queryKey: options.queryKey,
+					});
+					break;
+				}
+				case "watcher-error": {
+					const result = watcherErrorEventSchema.safeParse(payload);
+					if (!result.success) {
+						console.warn(
+							"[useSourcesEvents] Invalid watcher-error payload:",
+							result.error,
+						);
+						return;
+					}
+					if (
+						result.data.mediaSourceId &&
+						!activeSourceIds.has(result.data.mediaSourceId)
+					) {
+						return;
+					}
+					toast.error(
+						`Watcher Error for ${result.data.mediaSourceId?.slice(0, 4) ?? "unknown"}...: ${result.data.error || "Unknown error"}`,
+					);
+					break;
+				}
+				default:
+					break;
+			}
+		});
+
+		onCleanup(cleanup);
+	});
+}

--- a/packages/ui/src/hooks/use-sources-page.ts
+++ b/packages/ui/src/hooks/use-sources-page.ts
@@ -1,0 +1,179 @@
+import type {
+	MediaSourceInfo,
+	SafeMediaSource,
+} from "@solid-imager/core/domain/sources/schemas";
+import type { QueryClient, QueryKey } from "@tanstack/solid-query";
+import { type Accessor, createSignal } from "solid-js";
+import { toast } from "../toast";
+import { type RegisterEvents, useSourcesEvents } from "./use-sources-events";
+
+export type SourcesPageActions = {
+	createMediaSource: (data: unknown) => Promise<unknown>;
+	updateMediaSource: (id: string, data: unknown) => Promise<unknown>;
+	deleteMediaSource: (id: string) => Promise<unknown>;
+	syncMediaSources: (ids: string[]) => Promise<unknown>;
+};
+
+export type UseSourcesPageOptions = {
+	actions: SourcesPageActions;
+	queryClient: QueryClient;
+	invalidateQueryKey: QueryKey;
+	registerEvents?: RegisterEvents;
+	getSourceIds?: Accessor<string[]>;
+};
+
+export type UseSourcesPageResult = {
+	showFormModal: () => boolean;
+	setShowFormModal: (v: boolean) => void;
+	showDeleteModal: () => boolean;
+	setShowDeleteModal: (v: boolean) => void;
+	editingSource: () => SafeMediaSource | MediaSourceInfo | null;
+	deletingSource: () => SafeMediaSource | MediaSourceInfo | null;
+	isSyncing: () => boolean;
+	handleAddSource: () => void;
+	handleEditSource: (source: SafeMediaSource | MediaSourceInfo) => void;
+	handleFormSubmit: (sourceData: unknown) => Promise<void>;
+	handleDeleteSource: (source: SafeMediaSource | MediaSourceInfo) => void;
+	handleDeleteConfirm: (mediaSourceId: string) => Promise<void>;
+	handleSyncSource: (
+		source: SafeMediaSource | MediaSourceInfo,
+	) => Promise<void>;
+	handleSyncAll: (sources: SafeMediaSource[] | undefined) => Promise<void>;
+};
+
+export function useSourcesPage(
+	options: UseSourcesPageOptions,
+): UseSourcesPageResult {
+	const {
+		actions,
+		queryClient,
+		invalidateQueryKey,
+		registerEvents,
+		getSourceIds,
+	} = options;
+
+	const [showFormModal, setShowFormModal] = createSignal(false);
+	const [showDeleteModal, setShowDeleteModal] = createSignal(false);
+	const [editingSource, setEditingSource] = createSignal<
+		SafeMediaSource | MediaSourceInfo | null
+	>(null);
+	const [deletingSource, setDeletingSource] = createSignal<
+		SafeMediaSource | MediaSourceInfo | null
+	>(null);
+	const [isSyncing, setIsSyncing] = createSignal(false);
+
+	const invalidate = () => {
+		void queryClient.invalidateQueries({ queryKey: invalidateQueryKey });
+	};
+
+	if (registerEvents && getSourceIds) {
+		useSourcesEvents({
+			registerEvents,
+			sourceIds: getSourceIds,
+			queryClient,
+			queryKey: invalidateQueryKey,
+		});
+	}
+
+	const handleAddSource = () => {
+		setEditingSource(null);
+		setShowFormModal(true);
+	};
+
+	const handleEditSource = (source: SafeMediaSource | MediaSourceInfo) => {
+		setEditingSource(source);
+		setShowFormModal(true);
+	};
+
+	const handleFormSubmit = async (sourceData: unknown) => {
+		const editing = editingSource();
+		try {
+			if (editing?.id) {
+				await actions.updateMediaSource(editing.id, sourceData);
+			} else {
+				await actions.createMediaSource(sourceData);
+			}
+			invalidate();
+			setShowFormModal(false);
+		} catch (error) {
+			toast.error(
+				`Failed to save source: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	};
+
+	const handleDeleteSource = (source: SafeMediaSource | MediaSourceInfo) => {
+		setDeletingSource(source);
+		setShowDeleteModal(true);
+	};
+
+	const handleDeleteConfirm = async (mediaSourceId: string) => {
+		try {
+			await actions.deleteMediaSource(mediaSourceId);
+			invalidate();
+			setShowDeleteModal(false);
+			setDeletingSource(null);
+		} catch (error) {
+			toast.error(
+				`Failed to delete source: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	};
+
+	const handleSyncSource = async (
+		source: SafeMediaSource | MediaSourceInfo,
+	) => {
+		if (!source.id || isSyncing()) {
+			return;
+		}
+		setIsSyncing(true);
+		toast.info(`Starting sync for ${source.name}...`);
+		try {
+			await actions.syncMediaSources([source.id]);
+			toast.success(`Sync finished for ${source.name}`);
+		} catch (error) {
+			toast.error(
+				`Failed to sync ${source.name}: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		} finally {
+			setIsSyncing(false);
+		}
+	};
+
+	const handleSyncAll = async (sources: SafeMediaSource[] | undefined) => {
+		if (!sources || sources.length === 0 || isSyncing()) {
+			return;
+		}
+
+		setIsSyncing(true);
+		toast.info("Starting sync for all sources...");
+		try {
+			const ids = sources.map((s) => s.id).filter(Boolean) as string[];
+			await actions.syncMediaSources(ids);
+			toast.success("Sync finished for all sources");
+		} catch (error) {
+			toast.error(
+				`Failed to sync all sources: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		} finally {
+			setIsSyncing(false);
+		}
+	};
+
+	return {
+		showFormModal,
+		setShowFormModal,
+		showDeleteModal,
+		setShowDeleteModal,
+		editingSource,
+		deletingSource,
+		isSyncing,
+		handleAddSource,
+		handleEditSource,
+		handleFormSubmit,
+		handleDeleteSource,
+		handleDeleteConfirm,
+		handleSyncSource,
+		handleSyncAll,
+	};
+}

--- a/packages/ui/src/import-inbox-helpers.ts
+++ b/packages/ui/src/import-inbox-helpers.ts
@@ -1,0 +1,22 @@
+import type { DownloadItem } from "@solid-imager/core/domain/media/schemas";
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+
+export function getPreferredImportSourceId(sources: SafeMediaSource[]): string {
+	return (
+		sources.find((source) => source.name.toLowerCase() === "default")?.id ??
+		sources[0]?.id ??
+		""
+	);
+}
+
+export function getPendingImportPrimaryAuthor(item: DownloadItem): string {
+	return item.authors?.[0]?.name || "?";
+}
+
+export function isImportInboxEvent(event: string): boolean {
+	return (
+		event === "import-request:created" ||
+		event === "import-request:processed" ||
+		event === "import-request:deleted"
+	);
+}

--- a/packages/ui/src/import-inbox.test.ts
+++ b/packages/ui/src/import-inbox.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+	getPendingImportPrimaryAuthor,
+	getPreferredImportSourceId,
+	isImportInboxEvent,
+} from "./import-inbox-helpers";
+
+describe("import inbox helpers", () => {
+	it("prefers the source named default", () => {
+		expect(
+			getPreferredImportSourceId([
+				{
+					id: "source-1",
+					name: "Archive",
+					description: null,
+					type: "local",
+					connectionInfo: { path: "/archive" },
+				},
+				{
+					id: "source-2",
+					name: "Default",
+					description: null,
+					type: "local",
+					connectionInfo: { path: "/default" },
+				},
+			]),
+		).toBe("source-2");
+	});
+
+	it("returns the primary author label", () => {
+		expect(
+			getPendingImportPrimaryAuthor({
+				targetUrl: "https://example.com/image.png",
+				authors: [{ name: "author-1" }],
+			}),
+		).toBe("author-1");
+		expect(
+			getPendingImportPrimaryAuthor({
+				targetUrl: "https://example.com/image.png",
+			}),
+		).toBe("?");
+	});
+
+	it("matches supported inbox events", () => {
+		expect(isImportInboxEvent("import-request:created")).toBe(true);
+		expect(isImportInboxEvent("import-request:processed")).toBe(true);
+		expect(isImportInboxEvent("import-request:deleted")).toBe(true);
+		expect(isImportInboxEvent("connected")).toBe(false);
+	});
+});

--- a/packages/ui/src/import-review-modal.tsx
+++ b/packages/ui/src/import-review-modal.tsx
@@ -1,0 +1,294 @@
+import type { DownloadItem } from "@solid-imager/core/domain/media/schemas";
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import {
+	createEffect,
+	createResource,
+	createSignal,
+	For,
+	Show,
+} from "solid-js";
+import { Portal } from "solid-js/web";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "./alert-dialog";
+import {
+	getPendingImportPrimaryAuthor,
+	getPreferredImportSourceId,
+} from "./import-inbox-helpers";
+import { toast } from "./toast";
+
+export type PendingImportJob = {
+	id: string;
+	item: DownloadItem;
+	createdAt: Date | string;
+	targetSourceId?: string;
+};
+
+export type ImportReviewModalProps = {
+	isOpen: boolean;
+	onClose: () => void;
+	onImportCompleted: () => void;
+	listPending: () => Promise<PendingImportJob[]>;
+	listSources: () => Promise<SafeMediaSource[]>;
+	processPending: (
+		jobIds: string[],
+		targetSourceId: string,
+	) => Promise<{ success: boolean; processedCount: number }>;
+	cancelPending: (jobIds: string[]) => Promise<{ success: boolean }>;
+};
+
+function getPreviewUrl(url?: string): string {
+	if (!url) {
+		return "";
+	}
+
+	try {
+		const urlObject = new URL(url);
+		if (
+			urlObject.hostname === "pbs.twimg.com" &&
+			urlObject.searchParams.get("name") === "orig"
+		) {
+			urlObject.searchParams.set("name", "small");
+			return urlObject.toString();
+		}
+	} catch {
+		// Ignore invalid URLs and use the original string.
+	}
+
+	return url;
+}
+
+export function ImportReviewModal(props: ImportReviewModalProps) {
+	const createEmptySelection = () => new Set<string>();
+	const [selectedJobIds, setSelectedJobIds] = createSignal(
+		createEmptySelection(),
+	);
+	const [selectedSourceId, setSelectedSourceId] = createSignal("");
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = createSignal(false);
+
+	const [pendingJobs, { refetch: refetchJobs }] = createResource(
+		props.listPending,
+	);
+	const [sources] = createResource(props.listSources);
+
+	createEffect(() => {
+		if (props.isOpen) {
+			void refetchJobs();
+		}
+	});
+
+	createEffect(() => {
+		const jobs = pendingJobs();
+		if (jobs?.length) {
+			setSelectedJobIds(new Set(jobs.map((job) => job.id)));
+			return;
+		}
+		setSelectedJobIds(createEmptySelection());
+	});
+
+	createEffect(() => {
+		const sourceList = sources();
+		if (!sourceList?.length) {
+			setSelectedSourceId("");
+			return;
+		}
+
+		if (!selectedSourceId()) {
+			setSelectedSourceId(getPreferredImportSourceId(sourceList));
+		}
+	});
+
+	const toggleSelection = (id: string) => {
+		const current = new Set(selectedJobIds());
+		if (current.has(id)) {
+			current.delete(id);
+		} else {
+			current.add(id);
+		}
+		setSelectedJobIds(current);
+	};
+
+	const handleProcess = async () => {
+		const jobIds = Array.from(selectedJobIds());
+		const sourceId = selectedSourceId();
+		if (!jobIds.length || !sourceId) {
+			return;
+		}
+
+		try {
+			await props.processPending(jobIds, sourceId);
+			props.onImportCompleted();
+			props.onClose();
+		} catch (error) {
+			toast.error(`Failed to process imports: ${(error as Error).message}`);
+		}
+	};
+
+	const confirmDelete = async () => {
+		try {
+			await props.cancelPending(Array.from(selectedJobIds()));
+			await refetchJobs();
+			setSelectedJobIds(createEmptySelection());
+			toast.success("Requests deleted");
+		} catch (error) {
+			toast.error(`Failed to cancel imports: ${(error as Error).message}`);
+		} finally {
+			setIsDeleteDialogOpen(false);
+		}
+	};
+
+	return (
+		<Show when={props.isOpen}>
+			<Portal>
+				<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+					<div class="flex max-h-[85vh] w-full max-w-4xl flex-col rounded-lg bg-gray-900 shadow-xl">
+						<div class="flex items-center justify-between border-gray-700 border-b p-4">
+							<h2 class="font-bold text-white text-xl">
+								Review Pending Imports
+							</h2>
+							<button
+								class="text-gray-400 hover:text-white"
+								onClick={props.onClose}
+								type="button"
+							>
+								✕
+							</button>
+						</div>
+						<div class="flex-1 overflow-y-auto p-4">
+							<div class="mb-4 flex items-center justify-between">
+								<div class="flex gap-2">
+									<span class="text-gray-300">Target Source:</span>
+									<select
+										class="rounded border border-gray-600 bg-gray-800 p-1 text-white"
+										onChange={(event) =>
+											setSelectedSourceId(event.currentTarget.value)
+										}
+										value={selectedSourceId()}
+									>
+										<For each={sources()}>
+											{(source) => (
+												<option value={source.id}>
+													{source.name} ({source.type})
+												</option>
+											)}
+										</For>
+									</select>
+								</div>
+								<div class="text-gray-400 text-sm">
+									Selected: {selectedJobIds().size} /{" "}
+									{pendingJobs()?.length || 0}
+								</div>
+							</div>
+							<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+								<For each={pendingJobs()}>
+									{(job) => (
+										<button
+											class={`relative flex cursor-pointer flex-col rounded border p-2 text-left ${
+												selectedJobIds().has(job.id)
+													? "border-sky-500 bg-sky-900/20"
+													: "border-gray-700 bg-gray-800"
+											}`}
+											onClick={() => toggleSelection(job.id)}
+											type="button"
+										>
+											<div class="absolute top-1 right-1">
+												<input
+													checked={selectedJobIds().has(job.id)}
+													class="h-4 w-4"
+													type="checkbox"
+												/>
+											</div>
+											<div class="aspect-square w-full overflow-hidden rounded bg-black">
+												<Show
+													fallback={
+														<div class="flex h-full items-center justify-center text-gray-500">
+															No Preview
+														</div>
+													}
+													when={job.item.targetUrl}
+												>
+													<img
+														alt="Preview"
+														class="h-full w-full object-cover"
+														onError={(event) => {
+															event.currentTarget.style.display = "none";
+														}}
+														src={getPreviewUrl(job.item.targetUrl)}
+													/>
+												</Show>
+											</div>
+											<div class="mt-2 truncate text-gray-400 text-xs">
+												{job.item.description ||
+													job.item.targetUrl ||
+													"No description"}
+											</div>
+											<div class="text-[10px] text-gray-500">
+												AUTH: {getPendingImportPrimaryAuthor(job.item)}
+											</div>
+										</button>
+									)}
+								</For>
+							</div>
+						</div>
+						<div class="flex justify-end gap-2 border-gray-700 border-t p-4">
+							<button
+								class="rounded px-4 py-2 text-red-400 hover:bg-red-900/20 disabled:opacity-50"
+								disabled={selectedJobIds().size === 0}
+								onClick={() => setIsDeleteDialogOpen(true)}
+								type="button"
+							>
+								Delete Selected
+							</button>
+							<div class="flex-1" />
+							<button
+								class="rounded border border-gray-600 px-4 py-2 text-gray-300 hover:bg-gray-800"
+								onClick={props.onClose}
+								type="button"
+							>
+								Cancel
+							</button>
+							<button
+								class="rounded bg-sky-600 px-6 py-2 font-bold text-white hover:bg-sky-500 disabled:opacity-50"
+								disabled={selectedJobIds().size === 0 || !selectedSourceId()}
+								onClick={() => void handleProcess()}
+								type="button"
+							>
+								Import{" "}
+								{selectedJobIds().size ? `(${selectedJobIds().size})` : ""}
+							</button>
+						</div>
+					</div>
+				</div>
+			</Portal>
+			<AlertDialog
+				onOpenChange={setIsDeleteDialogOpen}
+				open={isDeleteDialogOpen()}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Are you sure?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This will remove {selectedJobIds().size} import requests.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+							onClick={() => void confirmDelete()}
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</Show>
+	);
+}

--- a/packages/ui/src/media-card-item.tsx
+++ b/packages/ui/src/media-card-item.tsx
@@ -1,0 +1,151 @@
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import type { JSX } from "solid-js";
+import { Show } from "solid-js";
+import { Card } from "./card";
+import { Checkbox, CheckboxControl, CheckboxLabel } from "./checkbox";
+import { cn } from "./utils/cn";
+
+export type MediaCardThumbnailProps = {
+	alt: string;
+	class: string;
+	height?: number | null;
+	loading: "eager" | "lazy";
+	media: Media;
+	sourceRootPath?: string;
+	width?: number | null;
+};
+
+export type MediaCardLinkProps = {
+	children: JSX.Element;
+	class: string;
+	href: string;
+	onClick: (event: MouseEvent) => void;
+};
+
+type MediaCardItemProps = {
+	media: Media;
+	selectable?: boolean;
+	isSelected?: boolean;
+	onSelect?: (id: string) => void;
+	priority?: boolean;
+	sourceRootPath?: string;
+	canRenderThumbnail?: (media: Media) => boolean;
+	linkComponent?: (props: MediaCardLinkProps) => JSX.Element;
+	renderThumbnail: (props: MediaCardThumbnailProps) => JSX.Element;
+	class?: string;
+	thumbnailContainerClass?: string;
+	thumbnailClass?: string;
+	checkboxContainerClass?: string;
+	dimensionSeparator?: string;
+};
+
+function formatFileSize(bytes: number | null | undefined) {
+	if (!bytes) {
+		return "N/A";
+	}
+	return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+function formatDimensions(media: Media, separator: string) {
+	return media.width && media.height
+		? `${media.width}${separator}${media.height}`
+		: "N/A";
+}
+
+export function MediaCardItem(props: MediaCardItemProps) {
+	const canRenderThumbnail = () =>
+		props.canRenderThumbnail?.(props.media) ??
+		props.media.mediaType !== "audio";
+	const selected = () => props.isSelected ?? false;
+	const href = () => `/sources/${props.media.mediaSourceId}/${props.media.id}`;
+
+	const handleSelect = () => {
+		if (props.selectable) {
+			props.onSelect?.(props.media.id);
+		}
+	};
+
+	return (
+		<Card
+			class={cn(
+				"overflow-hidden transition-shadow hover:shadow-lg",
+				selected() && "ring-2 ring-primary",
+				props.class,
+			)}
+			onClick={handleSelect}
+		>
+			<div class="group relative">
+				<div
+					class={cn(
+						"flex aspect-video w-full items-center justify-center overflow-hidden bg-gray-100 text-gray-400 text-sm",
+						props.thumbnailContainerClass,
+					)}
+				>
+					<Show
+						fallback={<div>{props.media.mediaType}</div>}
+						when={canRenderThumbnail()}
+					>
+						{props.renderThumbnail({
+							alt: props.media.fileName,
+							class: cn(
+								"h-full w-full object-cover transition-transform duration-300 group-hover:scale-105",
+								props.thumbnailClass,
+							),
+							height: props.media.height,
+							loading: props.priority ? "eager" : "lazy",
+							media: props.media,
+							sourceRootPath: props.sourceRootPath,
+							width: props.media.width,
+						})}
+					</Show>
+				</div>
+
+				<Show when={props.selectable}>
+					<div
+						class={cn(
+							"absolute top-2 right-2 z-10",
+							props.checkboxContainerClass,
+						)}
+					>
+						<Checkbox
+							checked={selected()}
+							onClick={(event) => event.stopPropagation()}
+							onChange={() => props.onSelect?.(props.media.id)}
+						>
+							<CheckboxControl class="h-5 w-5 rounded border-gray-300 bg-white text-primary shadow-sm focus:ring-primary" />
+							<CheckboxLabel class="sr-only">Select media</CheckboxLabel>
+						</Checkbox>
+					</div>
+				</Show>
+			</div>
+
+			<div class="space-y-1 p-3">
+				<h3 class="truncate font-semibold text-sm" title={props.media.fileName}>
+					{props.media.fileName}
+				</h3>
+				<p
+					class="truncate text-muted-foreground text-xs"
+					title={props.media.filePath}
+				>
+					{props.media.filePath}
+				</p>
+				<div class="flex justify-between pt-1 text-muted-foreground text-xs">
+					<span>
+						{formatDimensions(props.media, props.dimensionSeparator ?? "x")}
+					</span>
+					<span>{formatFileSize(props.media.fileSize)}</span>
+				</div>
+
+				<Show when={!props.selectable && props.linkComponent}>
+					{props.linkComponent?.({
+						children: "Check Details",
+						class:
+							"mt-2 block text-center text-primary text-sm hover:underline",
+						href: href(),
+						onClick: (event) => event.stopPropagation(),
+					})}
+				</Show>
+			</div>
+		</Card>
+	);
+}

--- a/packages/ui/src/media-grid-item.tsx
+++ b/packages/ui/src/media-grid-item.tsx
@@ -1,0 +1,95 @@
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import type { JSX } from "solid-js";
+import { Show } from "solid-js";
+import { cn } from "./utils/cn";
+
+export type MediaGridThumbnailProps = {
+	alt: string;
+	class: string;
+	height?: number | null;
+	loading: "eager" | "lazy";
+	media: Media;
+	sourceRootPath?: string;
+	width?: number | null;
+};
+
+export type MediaGridLinkProps = {
+	children: JSX.Element;
+	class: string;
+	"data-media-id": string;
+	href: string;
+	onContextMenu: (event: MouseEvent) => void;
+};
+
+type MediaGridItemProps = {
+	media: Media;
+	linkPrefix?: string;
+	priority?: boolean;
+	sourceRootPath?: string;
+	onContextMenu?: (event: MouseEvent) => void;
+	canRenderThumbnail?: (media: Media) => boolean;
+	linkComponent: (props: MediaGridLinkProps) => JSX.Element;
+	renderThumbnail: (props: MediaGridThumbnailProps) => JSX.Element;
+	class?: string;
+	thumbnailClass?: string;
+	overlayClass?: string;
+};
+
+export function MediaGridItem(props: MediaGridItemProps) {
+	const href = () =>
+		props.linkPrefix
+			? `${props.linkPrefix}/${props.media.id}`
+			: `/sources/${props.media.mediaSourceId}/${props.media.id}`;
+	const canRenderThumbnail = () =>
+		props.canRenderThumbnail?.(props.media) ??
+		props.media.mediaType !== "audio";
+
+	return props.linkComponent({
+		class: cn(
+			"group relative block aspect-[3/4] overflow-hidden rounded-lg bg-gray-100 transition-all hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2",
+			props.class,
+		),
+		"data-media-id": props.media.id,
+		href: href(),
+		onContextMenu: (event) => props.onContextMenu?.(event),
+		children: (
+			<>
+				<Show
+					fallback={
+						<div class="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400">
+							{props.media.mediaType}
+						</div>
+					}
+					when={canRenderThumbnail()}
+				>
+					{props.renderThumbnail({
+						alt: props.media.fileName,
+						class: cn(
+							"h-full w-full object-cover transition-transform duration-300 group-hover:scale-105",
+							props.thumbnailClass,
+						),
+						height: props.media.height,
+						loading: props.priority ? "eager" : "lazy",
+						media: props.media,
+						sourceRootPath: props.sourceRootPath,
+						width: props.media.width,
+					})}
+				</Show>
+
+				<div
+					class={cn(
+						"absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/60 to-transparent p-2 opacity-0 transition-opacity group-hover:opacity-100",
+						props.overlayClass,
+					)}
+				>
+					<p
+						class="truncate font-medium text-white text-xs"
+						title={props.media.fileName}
+					>
+						{props.media.fileName}
+					</p>
+				</div>
+			</>
+		),
+	});
+}

--- a/packages/ui/src/media-list-actions.tsx
+++ b/packages/ui/src/media-list-actions.tsx
@@ -1,0 +1,147 @@
+import type { ComponentProps } from "solid-js";
+import { Show } from "solid-js";
+import { isServer, Portal } from "solid-js/web";
+import { Button } from "./button";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "./dialog";
+import {
+	SearchControlPanel,
+	type SearchControlPanelProps,
+} from "./search-control-panel";
+
+type FilterData = ComponentProps<typeof SearchControlPanel>["filterData"];
+
+export type MediaListActionsProps = {
+	filterData: FilterData;
+	onDumpDownload: (mode: "json" | "zip") => void;
+	onSearch: () => void;
+	presetClient: SearchControlPanelProps["presetClient"];
+};
+
+export function MediaListActions(props: MediaListActionsProps) {
+	return (
+		<Show when={!isServer && document.getElementById("nav-actions")}>
+			<Portal mount={document.getElementById("nav-actions") as HTMLElement}>
+				<Button
+					class="mr-2 border-white text-white hover:bg-sky-700"
+					onClick={() => props.onDumpDownload("json")}
+					size="icon"
+					title="Download Backup JSON"
+					variant="outline"
+				>
+					<svg
+						class="lucide lucide-file-json"
+						fill="none"
+						height="20"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						viewBox="0 0 24 24"
+						width="20"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<title>Download JSON</title>
+						<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+						<path d="M14 2v4a2 2 0 0 0 2 2h4" />
+						<path d="M10 12a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1" />
+						<path d="M10 18a1 1 0 0 0-1-1v-1a1 1 0 0 0 1-1" />
+					</svg>
+				</Button>
+				<Button
+					class="mr-2 border-white text-white hover:bg-sky-700"
+					onClick={() => props.onDumpDownload("zip")}
+					size="icon"
+					title="Download Backup ZIP (with Images)"
+					variant="outline"
+				>
+					<svg
+						class="lucide lucide-archive"
+						fill="none"
+						height="20"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						viewBox="0 0 24 24"
+						width="20"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<title>Download ZIP</title>
+						<rect height="5" rx="1" width="20" x="2" y="3" />
+						<path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
+						<path d="M10 12h4" />
+					</svg>
+				</Button>
+				<Button
+					class="mr-2 border-white text-white hover:bg-sky-700"
+					onClick={() => document.getElementById("restore-input")?.click()}
+					size="icon"
+					title="Restore Metadata from Dump"
+					variant="outline"
+				>
+					<svg
+						class="lucide lucide-upload-cloud"
+						fill="none"
+						height="20"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						viewBox="0 0 24 24"
+						width="20"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<title>Restore from cloud</title>
+						<path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" />
+						<path d="M12 12v9" />
+						<path d="m16 16-4-4-4 4" />
+					</svg>
+				</Button>
+				<Dialog>
+					<DialogTrigger
+						as={Button}
+						class="border-white text-white hover:bg-sky-700 md:hidden"
+						size="icon"
+						variant="outline"
+					>
+						<svg
+							class="lucide lucide-filter"
+							fill="none"
+							height="24"
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							viewBox="0 0 24 24"
+							width="24"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<title>Filter results</title>
+							<polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+						</svg>
+					</DialogTrigger>
+					<DialogContent class="max-h-[80vh] overflow-y-auto">
+						<DialogHeader>
+							<DialogTitle>検索フィルター</DialogTitle>
+						</DialogHeader>
+						<div class="space-y-4">
+							<SearchControlPanel
+								class="w-full"
+								context="source"
+								filterData={props.filterData}
+								onSearch={props.onSearch}
+								presetClient={props.presetClient}
+							/>
+						</div>
+					</DialogContent>
+				</Dialog>
+			</Portal>
+		</Show>
+	);
+}

--- a/packages/ui/src/media-sidebar-content.tsx
+++ b/packages/ui/src/media-sidebar-content.tsx
@@ -1,0 +1,172 @@
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import type { JSX } from "solid-js";
+import { MediaSidebar } from "./media-sidebar";
+import { projectsQueryKeys } from "./query-options";
+
+export type MediaSidebarContentProps = {
+	media: MediaDetails;
+	isUpdating?: boolean;
+	onUpdate?: () => void;
+	aiTaggingModal: (props: {
+		isOpen: boolean;
+		onClose: () => void;
+	}) => JSX.Element;
+	projectsForMediaQueryOptions: (
+		mediaSourceId: string,
+		mediaId: string,
+	) => unknown;
+	allProjectsQueryOptions: () => unknown;
+	allIpsQueryOptions: () => unknown;
+	allCharactersQueryOptions: () => unknown;
+	addProjectToMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		projectId: string,
+	) => Promise<unknown>;
+	removeProjectFromMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		projectId: string,
+	) => Promise<unknown>;
+	createProject: (data: { name: string }) => Promise<{ id: string }>;
+	addIpToMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		ipId: string,
+	) => Promise<unknown>;
+	removeIpFromMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		ipId: string,
+	) => Promise<unknown>;
+	createIp: (data: { name: string }) => Promise<{ id: string }>;
+	addCharacterToMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		characterId: string,
+	) => Promise<unknown>;
+	removeCharacterFromMedia: (
+		mediaSourceId: string,
+		mediaId: string,
+		characterId: string,
+	) => Promise<unknown>;
+	createCharacter: (data: { name: string }) => Promise<{ id: string }>;
+	updateMediaDescription: (
+		mediaSourceId: string,
+		mediaId: string,
+		description: string,
+	) => Promise<unknown>;
+};
+
+export function MediaSidebarContent(props: MediaSidebarContentProps) {
+	const queryClient = useQueryClient();
+
+	const projects = createQuery<Project[]>(
+		() =>
+			props.projectsForMediaQueryOptions(
+				props.media.mediaSourceId,
+				props.media.id,
+			) as any,
+	);
+	const allProjects = createQuery<Project[]>(
+		() => props.allProjectsQueryOptions() as any,
+	);
+	const allIps = createQuery<Ip[]>(() => props.allIpsQueryOptions() as any);
+	const allCharacters = createQuery<Character[]>(
+		() => props.allCharactersQueryOptions() as any,
+	);
+
+	const invalidateProjectsForMedia = () =>
+		queryClient.invalidateQueries({
+			queryKey: projectsQueryKeys.forMedia(props.media.id),
+		});
+
+	return (
+		<MediaSidebar
+			aiTaggingModal={props.aiTaggingModal}
+			allCharacters={allCharacters.data || []}
+			allIps={allIps.data || []}
+			allProjects={allProjects.data || []}
+			isAllCharactersLoading={allCharacters.isLoading}
+			isAllIpsLoading={allIps.isLoading}
+			isProjectsLoading={projects.isLoading}
+			isUpdating={props.isUpdating}
+			media={props.media}
+			onCharacterAdd={async (characterId) => {
+				await props.addCharacterToMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					characterId,
+				);
+			}}
+			onCharacterCreate={async (name) => {
+				const character = await props.createCharacter({ name });
+				await queryClient.invalidateQueries({ queryKey: ["allCharacters"] });
+				return character;
+			}}
+			onCharacterRemove={async (characterId) => {
+				await props.removeCharacterFromMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					characterId,
+				);
+				props.onUpdate?.();
+			}}
+			onDescriptionUpdate={async (description) => {
+				await props.updateMediaDescription(
+					props.media.mediaSourceId,
+					props.media.id,
+					description,
+				);
+			}}
+			onIpAdd={async (ipId) => {
+				await props.addIpToMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					ipId,
+				);
+				props.onUpdate?.();
+			}}
+			onIpCreate={async (name) => {
+				const ip = await props.createIp({ name });
+				await queryClient.invalidateQueries({ queryKey: ["allIps"] });
+				return ip;
+			}}
+			onIpRemove={async (ipId) => {
+				await props.removeIpFromMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					ipId,
+				);
+				props.onUpdate?.();
+			}}
+			onProjectAdd={async (projectId) => {
+				await props.addProjectToMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					projectId,
+				);
+				await invalidateProjectsForMedia();
+			}}
+			onProjectCreate={async (name) => {
+				const project = await props.createProject({ name });
+				await queryClient.invalidateQueries({ queryKey: ["allProjects"] });
+				return project;
+			}}
+			onProjectRemove={async (projectId) => {
+				await props.removeProjectFromMedia(
+					props.media.mediaSourceId,
+					props.media.id,
+					projectId,
+				);
+				await invalidateProjectsForMedia();
+			}}
+			onUpdate={props.onUpdate}
+			projects={projects.data || []}
+		/>
+	);
+}

--- a/packages/ui/src/media-sidebar.tsx
+++ b/packages/ui/src/media-sidebar.tsx
@@ -1,0 +1,424 @@
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	For,
+	type JSX,
+	Show,
+} from "solid-js";
+import { AssociationManager } from "./association-manager";
+import { Badge } from "./badge";
+import { Button } from "./button";
+import { ClipboardCopy } from "./clipboard-copy";
+import { CollapsibleRoot as Collapsible } from "./collapsible";
+import { toast } from "./toast";
+
+type MediaSidebarProps = {
+	media: MediaDetails;
+	isUpdating?: boolean;
+	projects: Project[];
+	allProjects: Project[];
+	allIps: Ip[];
+	allCharacters: Character[];
+	isProjectsLoading?: boolean;
+	isAllIpsLoading?: boolean;
+	isAllCharactersLoading?: boolean;
+	aiTaggingModal?: (props: {
+		isOpen: boolean;
+		onClose: () => void;
+	}) => JSX.Element;
+	onUpdate?: () => void;
+	onDescriptionUpdate: (description: string) => void | Promise<void>;
+	onProjectAdd: (projectId: string) => void | Promise<void>;
+	onProjectRemove: (projectId: string) => void | Promise<void>;
+	onProjectCreate: (name: string) => Promise<{ id: string }>;
+	onIpAdd: (ipId: string) => void | Promise<void>;
+	onIpRemove: (ipId: string) => void | Promise<void>;
+	onIpCreate: (name: string) => Promise<{ id: string }>;
+	onCharacterAdd: (characterId: string) => void | Promise<void>;
+	onCharacterRemove: (characterId: string) => void | Promise<void>;
+	onCharacterCreate: (name: string) => Promise<{ id: string }>;
+};
+
+function formatBytes(bytes: number, decimals = 2) {
+	if (bytes === 0) {
+		return "0 Bytes";
+	}
+	const k = 1024;
+	const dm = decimals < 0 ? 0 : decimals;
+	const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
+	const i = Math.floor(Math.log(bytes) / Math.log(k));
+	return `${Number.parseFloat((bytes / k ** i).toFixed(dm))} ${sizes[i]}`;
+}
+
+export function MediaSidebar(props: MediaSidebarProps) {
+	const tags = createMemo(() => props.media.tags || []);
+	const [isAiTaggingModalOpen, setIsAiTaggingModalOpen] = createSignal(false);
+	const [isEditingDescription, setIsEditingDescription] = createSignal(false);
+	const [descriptionValue, setDescriptionValue] = createSignal(
+		props.media.description || "",
+	);
+
+	createEffect(() => {
+		if (!isEditingDescription()) {
+			setDescriptionValue(props.media.description || "");
+		}
+	});
+
+	const positiveTags = createMemo(() =>
+		tags().filter((tag) => tag.type === "positive"),
+	);
+
+	const negativeTags = createMemo(() =>
+		tags().filter((tag) => tag.type === "negative"),
+	);
+
+	const genInfo = createMemo(() => props.media.generationInfo);
+
+	const availableCharacters = createMemo(() => {
+		const currentIps = props.media.ips || [];
+		const allChars = props.allCharacters || [];
+
+		if (currentIps.length === 0) {
+			return allChars;
+		}
+
+		const ipIds = new Set(currentIps.map((ip) => ip.id));
+		return allChars.filter((char) => char.ips.some((ip) => ipIds.has(ip.id)));
+	});
+
+	const handleSaveDescription = async () => {
+		try {
+			await props.onDescriptionUpdate(descriptionValue());
+			setIsEditingDescription(false);
+			props.onUpdate?.();
+		} catch (error) {
+			toast.error(`Failed to update description: ${(error as Error).message}`);
+		}
+	};
+
+	const handleCancelEdit = () => {
+		setDescriptionValue(props.media.description || "");
+		setIsEditingDescription(false);
+	};
+
+	const handleCreateProject = async (name: string) => {
+		const newProject = await props.onProjectCreate(name);
+		await props.onProjectAdd(newProject.id);
+	};
+
+	const handleCreateIp = async (name: string) => {
+		const newIp = await props.onIpCreate(name);
+		await props.onIpAdd(newIp.id);
+	};
+
+	const handleAddCharacter = async (characterId: string) => {
+		await props.onCharacterAdd(characterId);
+		props.onUpdate?.();
+
+		const character = props.allCharacters.find((c) => c.id === characterId);
+		if (character?.ips && character.ips.length > 0) {
+			const currentIpIds = new Set((props.media.ips || []).map((ip) => ip.id));
+			const ipsToAdd = character.ips.filter(
+				(charIp) => !currentIpIds.has(charIp.id),
+			);
+			await Promise.all(ipsToAdd.map((charIp) => props.onIpAdd(charIp.id)));
+		}
+	};
+
+	const handleCreateCharacter = async (name: string) => {
+		const newCharacter = await props.onCharacterCreate(name);
+		await handleAddCharacter(newCharacter.id);
+	};
+
+	return (
+		<aside class="h-full space-y-4 overflow-y-auto rounded-lg border bg-gray-50 p-4">
+			<div>
+				<h1 class="font-bold text-xl">{props.media.fileName}</h1>
+				<p class="text-gray-500 text-sm">{props.media.filePath}</p>
+			</div>
+
+			<Show when={props.aiTaggingModal}>
+				<div class="flex gap-2">
+					<button
+						class="flex w-full items-center justify-center gap-2 rounded-md bg-purple-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-purple-700"
+						onClick={() => setIsAiTaggingModalOpen(true)}
+						type="button"
+					>
+						<span class="i-lucide-sparkles" />
+						Extract Tags (AI)
+					</button>
+				</div>
+			</Show>
+			{props.aiTaggingModal?.({
+				isOpen: isAiTaggingModalOpen(),
+				onClose: () => setIsAiTaggingModalOpen(false),
+			})}
+
+			<div class="space-y-2">
+				<h2 class="font-semibold text-lg">Details</h2>
+				<dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+					<dt class="font-medium text-gray-600">Resolution</dt>
+					<dd class="text-gray-800">
+						{props.media.width} x {props.media.height}
+					</dd>
+					<dt class="font-medium text-gray-600">File Size</dt>
+					<dd class="text-gray-800">
+						{props.media.fileSize ? formatBytes(props.media.fileSize) : "N/A"}
+					</dd>
+				</dl>
+			</div>
+
+			<div class="space-y-2">
+				<div class="flex items-center justify-between">
+					<h2 class="font-semibold text-lg">Description</h2>
+					<Show when={!isEditingDescription()}>
+						<button
+							class="text-blue-600 text-sm hover:underline"
+							onClick={() => setIsEditingDescription(true)}
+							type="button"
+						>
+							Edit
+						</button>
+					</Show>
+				</div>
+				<Show
+					fallback={
+						<div class="rounded-md bg-gray-100 p-3 text-gray-500 text-sm italic">
+							No description
+						</div>
+					}
+					when={isEditingDescription() || props.media.description}
+				>
+					<Show
+						fallback={
+							<div class="whitespace-pre-wrap rounded-md bg-gray-100 p-3 text-sm">
+								{props.media.description}
+							</div>
+						}
+						when={isEditingDescription()}
+					>
+						<textarea
+							class="w-full rounded-md border border-gray-300 p-2 text-sm"
+							onInput={(e) => setDescriptionValue(e.currentTarget.value)}
+							placeholder="Enter description..."
+							rows={6}
+							value={descriptionValue()}
+						/>
+						<div class="flex gap-2">
+							<Button
+								onClick={() => {
+									void handleSaveDescription();
+								}}
+								size="sm"
+							>
+								Save
+							</Button>
+							<Button onClick={handleCancelEdit} size="sm" variant="outline">
+								Cancel
+							</Button>
+						</div>
+					</Show>
+				</Show>
+			</div>
+
+			<Show when={props.media.urls?.length > 0}>
+				<div class="space-y-2">
+					<h2 class="font-semibold text-lg">Source URLs</h2>
+					<ul class="space-y-1">
+						<For each={props.media.urls}>
+							{(url) => (
+								<li>
+									<a
+										class="block break-all text-blue-600 text-sm hover:underline"
+										href={url.url}
+										rel="noopener noreferrer"
+										target="_blank"
+									>
+										{url.url}
+									</a>
+								</li>
+							)}
+						</For>
+					</ul>
+				</div>
+			</Show>
+
+			<Show when={props.media.authors?.length > 0}>
+				<div class="space-y-2">
+					<h2 class="font-semibold text-lg">Authors</h2>
+					<ul class="space-y-1">
+						<For each={props.media.authors}>
+							{(author) => (
+								<li>
+									<div class="flex items-center gap-2">
+										<span class="font-medium">{author.name}</span>
+										<Show when={author.accountId}>
+											<span class="text-gray-500 text-xs">
+												({author.accountId})
+											</span>
+										</Show>
+									</div>
+								</li>
+							)}
+						</For>
+					</ul>
+				</div>
+			</Show>
+
+			<div class="space-y-4">
+				<AssociationManager
+					availableItems={props.allProjects}
+					isLoading={props.isProjectsLoading || props.isUpdating}
+					items={props.projects}
+					onAdd={props.onProjectAdd}
+					onCreate={handleCreateProject}
+					onRemove={props.onProjectRemove}
+					title="Projects"
+				/>
+
+				<AssociationManager
+					availableItems={props.allIps}
+					isLoading={props.isAllIpsLoading || props.isUpdating}
+					items={props.media.ips || []}
+					onAdd={props.onIpAdd}
+					onCreate={handleCreateIp}
+					onRemove={props.onIpRemove}
+					title="IPs"
+				/>
+
+				<AssociationManager
+					availableItems={availableCharacters()}
+					isLoading={props.isAllCharactersLoading || props.isUpdating}
+					items={props.media.characters || []}
+					onAdd={handleAddCharacter}
+					onCreate={handleCreateCharacter}
+					onRemove={props.onCharacterRemove}
+					title="Characters"
+				/>
+			</div>
+
+			<Show when={positiveTags().length > 0}>
+				<div class="space-y-2">
+					<h2 class="font-semibold text-lg">Positive Tags</h2>
+					<div class="flex flex-wrap gap-2">
+						<For each={positiveTags()}>
+							{(tag) => {
+								let badgeClass = "";
+								if (tag.source === "AI") {
+									badgeClass =
+										"bg-blue-100 text-blue-800 hover:bg-blue-200 border-blue-200";
+								} else if (tag.source === "comfyui_workflow") {
+									badgeClass =
+										"bg-green-100 text-green-800 hover:bg-green-200 border-green-200";
+								}
+								return (
+									<Badge class={badgeClass} title={`Source: ${tag.source}`}>
+										{tag.name}
+										<ClipboardCopy
+											class="ml-1.5 p-0.5"
+											iconSize={12}
+											text={tag.name}
+										/>
+									</Badge>
+								);
+							}}
+						</For>
+					</div>
+				</div>
+			</Show>
+
+			<Show when={negativeTags().length > 0}>
+				<div class="space-y-2">
+					<h2 class="font-semibold text-lg">Negative Tags</h2>
+					<div class="flex flex-wrap gap-2">
+						<For each={negativeTags()}>
+							{(tag) => {
+								let badgeClass = "";
+								if (tag.source === "AI") {
+									badgeClass =
+										"bg-blue-50 text-blue-800 hover:bg-blue-100 border-blue-200 border";
+								} else if (tag.source === "comfyui_workflow") {
+									badgeClass =
+										"bg-green-50 text-green-800 hover:bg-green-100 border-green-200 border";
+								}
+								return (
+									<Badge
+										class={badgeClass}
+										title={`Source: ${tag.source}`}
+										variant="destructive"
+									>
+										{tag.name}
+										<ClipboardCopy
+											class="ml-1.5 p-0.5"
+											iconSize={12}
+											text={tag.name}
+										/>
+									</Badge>
+								);
+							}}
+						</For>
+					</div>
+				</div>
+			</Show>
+
+			<Show when={genInfo()}>
+				<div class="space-y-2">
+					<Collapsible.Root>
+						<Collapsible.Trigger class="flex w-full items-center justify-between font-semibold text-lg">
+							Generation Info
+							<span class="i-lucide-chevron-down ui-expanded:rotate-180 transition-transform" />
+						</Collapsible.Trigger>
+						<Collapsible.Content class="space-y-2 text-sm">
+							<Show when={genInfo()?.prompt}>
+								<div>
+									<div class="mb-1 flex items-center justify-between">
+										<span class="font-medium text-gray-600">Prompt:</span>
+										<ClipboardCopy text={genInfo()?.prompt ?? ""} />
+									</div>
+									<p class="max-h-32 overflow-y-auto whitespace-pre-wrap rounded bg-gray-100 p-2 text-xs">
+										{genInfo()?.prompt}
+									</p>
+								</div>
+							</Show>
+							<Show when={genInfo()?.negativePrompt}>
+								<div>
+									<div class="mb-1 flex items-center justify-between">
+										<span class="font-medium text-gray-600">
+											Negative Prompt:
+										</span>
+										<ClipboardCopy text={genInfo()?.negativePrompt ?? ""} />
+									</div>
+									<p class="max-h-32 overflow-y-auto whitespace-pre-wrap rounded bg-gray-100 p-2 text-xs">
+										{genInfo()?.negativePrompt}
+									</p>
+								</div>
+							</Show>
+							<Show when={genInfo()?.workflow}>
+								<div>
+									<div class="mb-1 flex items-center justify-between">
+										<span class="font-medium text-gray-600">Workflow:</span>
+										<ClipboardCopy
+											text={
+												genInfo()?.workflow
+													? JSON.stringify(genInfo()?.workflow)
+													: ""
+											}
+										/>
+									</div>
+									<pre class="max-h-32 overflow-y-auto whitespace-pre-wrap rounded bg-gray-100 p-2 text-xs">
+										{JSON.stringify(genInfo()?.workflow, null, 2)}
+									</pre>
+								</div>
+							</Show>
+						</Collapsible.Content>
+					</Collapsible.Root>
+				</div>
+			</Show>
+		</aside>
+	);
+}

--- a/packages/ui/src/media-viewer.tsx
+++ b/packages/ui/src/media-viewer.tsx
@@ -1,0 +1,121 @@
+import {
+	createEffect,
+	createSignal,
+	Match,
+	onCleanup,
+	Show,
+	Switch,
+} from "solid-js";
+
+export interface MediaSource {
+	type: "image" | "video" | "audio";
+	getUrl(): string | Promise<string>;
+	revokeUrl?(url: string): void;
+}
+
+export interface MediaViewerProps {
+	source: MediaSource;
+	fileName: string;
+	width?: number;
+	height?: number;
+}
+
+export function MediaViewer(props: MediaViewerProps) {
+	const [mediaUrl, setMediaUrl] = createSignal<string | null>(null);
+
+	createEffect(() => {
+		const source = props.source;
+		let currentUrl: string | null = null;
+		let disposed = false;
+
+		void (async () => {
+			try {
+				const url = await source.getUrl();
+				if (disposed) {
+					source.revokeUrl?.(url);
+					return;
+				}
+				currentUrl = url;
+				setMediaUrl(url);
+			} catch {
+				if (!disposed) {
+					setMediaUrl(null);
+				}
+			}
+		})();
+
+		onCleanup(() => {
+			disposed = true;
+			if (currentUrl && source.revokeUrl) {
+				source.revokeUrl(currentUrl);
+			}
+		});
+	});
+
+	return (
+		<div class="flex h-full w-full items-center justify-center bg-black/5">
+			<Switch>
+				<Match when={props.source.type === "video"}>
+					<Show
+						fallback={
+							<div class="flex h-full max-h-full w-full items-center justify-center rounded-lg bg-slate-900 text-white">
+								Video preview unavailable
+							</div>
+						}
+						when={mediaUrl()}
+					>
+						{(url) => (
+							<video class="max-h-full max-w-full" controls src={url()}>
+								<track kind="captions" />
+							</video>
+						)}
+					</Show>
+				</Match>
+				<Match when={props.source.type === "audio"}>
+					<Show
+						fallback={
+							<div class="rounded-lg bg-slate-900 px-8 py-6 text-white">
+								Audio preview unavailable
+							</div>
+						}
+						when={mediaUrl()}
+					>
+						{(url) => (
+							<audio controls src={url()}>
+								<track kind="captions" />
+							</audio>
+						)}
+					</Show>
+				</Match>
+				<Match when={true}>
+					<Show
+						fallback={
+							<div
+								class="flex h-full w-full items-center justify-center rounded-lg border text-white"
+								style={{
+									background:
+										"linear-gradient(135deg, rgba(15,23,42,0.18), rgba(15,23,42,0.02)), linear-gradient(135deg, #0f766e, #60a5fa)",
+								}}
+							>
+								<div class="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-sm uppercase tracking-[0.35em]">
+									{props.fileName}
+								</div>
+							</div>
+						}
+						when={mediaUrl()}
+					>
+						{(url) => (
+							<img
+								alt={props.fileName}
+								class="max-h-full max-w-full object-contain"
+								height={props.height}
+								src={url()}
+								width={props.width}
+							/>
+						)}
+					</Show>
+				</Match>
+			</Switch>
+		</div>
+	);
+}

--- a/packages/ui/src/move-copy-media-dialog.tsx
+++ b/packages/ui/src/move-copy-media-dialog.tsx
@@ -1,0 +1,111 @@
+import { createEffect, createMemo, createSignal, Show } from "solid-js";
+import { Button } from "./button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "./dialog";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "./select";
+
+export type MoveCopyMediaDialogProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	mode: "copy" | "move";
+	currentSourceId: string;
+	sources: { id: string; name: string }[];
+	isLoading?: boolean;
+	error?: string | null;
+	onConfirm: (targetSourceId: string) => void;
+};
+
+export function MoveCopyMediaDialog(props: MoveCopyMediaDialogProps) {
+	const [targetSourceId, setTargetSourceId] = createSignal<string | null>(null);
+
+	createEffect(() => {
+		if (!props.open) setTargetSourceId(null);
+	});
+
+	const handleConfirm = () => {
+		const target = targetSourceId();
+		if (target) {
+			props.onConfirm(target);
+			props.onOpenChange(false);
+			setTargetSourceId(null);
+		}
+	};
+
+	const options = createMemo(() =>
+		props.sources.flatMap((s) =>
+			s.id !== props.currentSourceId ? [{ value: s.id, label: s.name }] : [],
+		),
+	);
+
+	return (
+		<Dialog onOpenChange={props.onOpenChange} open={props.open}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>
+						{props.mode === "copy" ? "Copy Media" : "Move Media"}
+					</DialogTitle>
+					<DialogDescription>
+						Select the destination source for this media item.
+						{props.mode === "move" &&
+							" The original item will be deleted after a successful copy."}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div class="py-4">
+					<Show when={props.isLoading}>
+						<p class="text-muted-foreground text-sm">Loading sources...</p>
+					</Show>
+					<Show when={props.error}>
+						<p class="text-red-500 text-sm">{props.error}</p>
+					</Show>
+					<Show when={!(props.isLoading || props.error)}>
+						<Select
+							itemComponent={(itemProps) => (
+								<SelectItem item={itemProps.item}>
+									{(itemProps.item.rawValue as { label: string }).label}
+								</SelectItem>
+							)}
+							onChange={(val) => setTargetSourceId(val?.value ?? null)}
+							options={options()}
+							optionTextValue="label"
+							optionValue="value"
+							value={
+								options().find((o) => o.value === targetSourceId()) ?? null
+							}
+						>
+							<SelectTrigger>
+								<SelectValue<{ label: string; value: string }>>
+									{(state) =>
+										state.selectedOption()?.label ?? "Select a source"
+									}
+								</SelectValue>
+							</SelectTrigger>
+							<SelectContent />
+						</Select>
+					</Show>
+				</div>
+
+				<DialogFooter>
+					<Button onClick={() => props.onOpenChange(false)} variant="outline">
+						Cancel
+					</Button>
+					<Button disabled={!targetSourceId()} onClick={handleConfirm}>
+						{props.mode === "copy" ? "Copy" : "Move"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/ui/src/pending-downloads-indicator.tsx
+++ b/packages/ui/src/pending-downloads-indicator.tsx
@@ -1,0 +1,116 @@
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import {
+	createResource,
+	createSignal,
+	onCleanup,
+	onMount,
+	Show,
+} from "solid-js";
+import { isServer } from "solid-js/web";
+import { isImportInboxEvent } from "./import-inbox-helpers";
+import {
+	ImportReviewModal,
+	type PendingImportJob,
+} from "./import-review-modal";
+import { toast } from "./toast";
+
+export type ImportEventHandler = (
+	event: string,
+	payload: unknown,
+) => void | Promise<void>;
+
+export type PendingDownloadsIndicatorProps = {
+	listPending: () => Promise<PendingImportJob[]>;
+	listSources: () => Promise<SafeMediaSource[]>;
+	processPending: (
+		jobIds: string[],
+		targetSourceId: string,
+	) => Promise<{ success: boolean; processedCount: number }>;
+	cancelPending: (jobIds: string[]) => Promise<{ success: boolean }>;
+	subscribeImportEvents: (
+		handler: ImportEventHandler,
+	) => Promise<(() => void) | undefined> | (() => void) | undefined;
+};
+
+export function PendingDownloadsIndicator(
+	props: PendingDownloadsIndicatorProps,
+) {
+	const [isModalOpen, setIsModalOpen] = createSignal(false);
+	const [pendingCount, { refetch }] = createResource(async () => {
+		try {
+			return (await props.listPending()).length;
+		} catch (error) {
+			if (!isServer) {
+				toast.error(`Failed to check inbox: ${(error as Error).message}`);
+			}
+			return 0;
+		}
+	});
+
+	onMount(() => {
+		if (isServer) {
+			return;
+		}
+
+		let disposed = false;
+		let cleanup: (() => void) | undefined;
+
+		void Promise.resolve(
+			props.subscribeImportEvents((event) => {
+				if (isImportInboxEvent(event)) {
+					void refetch();
+				}
+			}),
+		)
+			.then((unsub) => {
+				if (disposed) {
+					unsub?.();
+					return;
+				}
+				cleanup = unsub;
+			})
+			.catch(() => {
+				if (!disposed) {
+					toast.error("Connection to inbox lost");
+				}
+			});
+
+		onCleanup(() => {
+			disposed = true;
+			cleanup?.();
+		});
+	});
+
+	return (
+		<>
+			<button
+				class={`flex items-center gap-1 rounded px-3 py-1.5 font-bold text-xs transition-colors ${
+					(pendingCount() ?? 0) > 0
+						? "bg-sky-600 text-white hover:bg-sky-500"
+						: "cursor-default bg-gray-700 text-gray-400"
+				}`}
+				disabled={(pendingCount() ?? 0) === 0}
+				onClick={() => setIsModalOpen(true)}
+				type="button"
+			>
+				<span>Inbox</span>
+				<Show when={(pendingCount() ?? 0) > 0}>
+					<span class="rounded bg-white px-1.5 py-0.5 text-sky-700">
+						{pendingCount()}
+					</span>
+				</Show>
+			</button>
+			<ImportReviewModal
+				cancelPending={props.cancelPending}
+				isOpen={isModalOpen()}
+				listPending={props.listPending}
+				listSources={props.listSources}
+				onClose={() => setIsModalOpen(false)}
+				onImportCompleted={() => {
+					void refetch();
+				}}
+				processPending={props.processPending}
+			/>
+		</>
+	);
+}

--- a/packages/ui/src/preset-client.ts
+++ b/packages/ui/src/preset-client.ts
@@ -1,0 +1,58 @@
+import type {
+	Preset,
+	SearchGroup,
+} from "@solid-imager/core/domain/media/schemas";
+
+export interface PresetOrpcLike {
+	presets: {
+		list(): Promise<Preset[]>;
+		get(input: { id: number }): Promise<Preset>;
+		getByName(input: { name: string }): Promise<Preset | null | undefined>;
+		create(data: {
+			name: string;
+			value: SearchGroup;
+			sort?: "name" | "date" | "rating" | "viewCount" | "size";
+			order?: "asc" | "desc";
+			mode?: "simple" | "pro";
+		}): Promise<Preset>;
+		update(input: {
+			id: number;
+			data: {
+				name?: string;
+				value?: SearchGroup;
+				sort?: "name" | "date" | "rating" | "viewCount" | "size";
+				order?: "asc" | "desc";
+				mode?: "simple" | "pro";
+			};
+		}): Promise<Preset>;
+		delete(input: { id: number }): Promise<unknown>;
+	};
+}
+
+export function createPresetClient(orpc: PresetOrpcLike) {
+	return {
+		list: async () => await orpc.presets.list(),
+		get: async (id: number) => await orpc.presets.get({ id }),
+		getByName: async (name: string) => await orpc.presets.getByName({ name }),
+		create: async (data: {
+			name: string;
+			value: SearchGroup;
+			sort?: "name" | "date" | "rating" | "viewCount" | "size";
+			order?: "asc" | "desc";
+			mode?: "simple" | "pro";
+		}) => await orpc.presets.create(data),
+		update: async (
+			id: number,
+			data: {
+				name?: string;
+				value?: SearchGroup;
+				sort?: "name" | "date" | "rating" | "viewCount" | "size";
+				order?: "asc" | "desc";
+				mode?: "simple" | "pro";
+			},
+		) => await orpc.presets.update({ id, data }),
+		delete: async (id: number) => await orpc.presets.delete({ id }),
+	};
+}
+
+export type PresetClientType = ReturnType<typeof createPresetClient>;

--- a/packages/ui/src/preset-manager.tsx
+++ b/packages/ui/src/preset-manager.tsx
@@ -1,0 +1,303 @@
+import type {
+	Preset,
+	SearchGroup,
+} from "@solid-imager/core/domain/media/schemas";
+import { createEffect, createResource, createSignal, Show } from "solid-js";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "./alert-dialog";
+import { Button } from "./button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "./dialog";
+import { Input } from "./input";
+import { Label } from "./label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "./select";
+import {
+	clearPresetFilters,
+	getSearchCondition,
+	loadPreset,
+	searchState,
+} from "./stores/search-store";
+import { toast } from "./toast";
+import { cn } from "./utils/cn";
+
+export interface PresetManagerClient {
+	list(): Promise<Preset[]>;
+	create(data: {
+		name: string;
+		value: SearchGroup;
+		sort?: "name" | "date" | "rating" | "viewCount" | "size";
+		order?: "asc" | "desc";
+		mode?: "simple" | "pro";
+	}): Promise<unknown>;
+	delete(id: number): Promise<unknown>;
+}
+
+export function PresetManager(props: {
+	presetClient: PresetManagerClient;
+	class?: string;
+	onAction?: () => void;
+}) {
+	const [data, { refetch }] = createResource(props.presetClient.list);
+
+	const presets = () => data()?.filter((p) => !p.name.startsWith("current"));
+
+	const [isSaveDialogOpen, setIsSaveDialogOpen] = createSignal(false);
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = createSignal(false);
+	const [presetToDelete, setPresetToDelete] = createSignal<number | null>(null);
+	const [newPresetName, setNewPresetName] = createSignal("");
+	const [selectedPresetId, setSelectedPresetId] = createSignal<string | null>(
+		null,
+	);
+
+	createEffect(() => {
+		const active = searchState.activePresetId;
+		if (active) {
+			setSelectedPresetId(String(active));
+		} else {
+			setSelectedPresetId(null);
+		}
+	});
+
+	const handleSave = async (event: Event) => {
+		event.preventDefault();
+		if (!newPresetName()) {
+			return;
+		}
+
+		const condition = getSearchCondition();
+		if (!condition) {
+			toast.error("検索条件がありません");
+			return;
+		}
+
+		try {
+			await props.presetClient.create({
+				name: newPresetName(),
+				value: condition,
+				sort: searchState.sortBy,
+				order: searchState.sortOrder,
+				mode: searchState.mode,
+			});
+			setIsSaveDialogOpen(false);
+			setNewPresetName("");
+			refetch();
+			toast.success("プリセットを保存しました");
+			props.onAction?.();
+		} catch {
+			toast.error("プリセットの保存に失敗しました");
+		}
+	};
+
+	const confirmDelete = (id: number) => {
+		setPresetToDelete(id);
+		setIsDeleteDialogOpen(true);
+	};
+
+	const executeDelete = async () => {
+		const id = presetToDelete();
+		if (!id) {
+			return;
+		}
+
+		try {
+			await props.presetClient.delete(id);
+			if (selectedPresetId() === String(id)) {
+				setSelectedPresetId(null);
+			}
+			refetch();
+		} catch {
+			toast.error("プリセットの削除に失敗しました");
+		} finally {
+			setIsDeleteDialogOpen(false);
+			setPresetToDelete(null);
+		}
+	};
+
+	const handleLoad = () => {
+		const id = selectedPresetId();
+		if (!id) {
+			return;
+		}
+		const preset = presets()?.find((p: Preset) => p.id === Number(id));
+		if (preset) {
+			loadPreset(preset);
+			props.onAction?.();
+		}
+	};
+
+	const handleClearSelection = () => {
+		setSelectedPresetId(null);
+		clearPresetFilters();
+		props.onAction?.();
+	};
+
+	return (
+		<div class={cn("flex w-full flex-col gap-2", props.class)}>
+			<AlertDialog
+				onOpenChange={setIsDeleteDialogOpen}
+				open={isDeleteDialogOpen()}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>プリセットの削除</AlertDialogTitle>
+						<AlertDialogDescription>
+							本当にこのプリセットを削除しますか？この操作は取り消せません。
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>キャンセル</AlertDialogCancel>
+						<AlertDialogAction
+							class="bg-red-500 hover:bg-red-600"
+							onClick={executeDelete}
+						>
+							削除する
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<div class="flex items-center gap-2">
+				<div class="min-w-0 flex-1">
+					<Select
+						itemComponent={(itemProps) => {
+							const preset = presets()?.find(
+								(p: Preset) =>
+									String(p.id) ===
+									(itemProps.item as { rawValue: string }).rawValue,
+							);
+							return (
+								<SelectItem
+									class="flex w-full justify-between gap-2"
+									item={itemProps.item}
+								>
+									<span>{preset?.name}</span>
+								</SelectItem>
+							);
+						}}
+						onChange={setSelectedPresetId}
+						options={presets()?.map((p: Preset) => String(p.id)) || []}
+						placeholder="プリセットを選択..."
+						value={selectedPresetId()}
+					>
+						<SelectTrigger class="w-full">
+							<SelectValue<string>>
+								{(state) => {
+									const preset = presets()?.find(
+										(p: Preset) =>
+											String(p.id) === (state.selectedOption() as string),
+									);
+									return (
+										<span class="truncate">
+											{preset ? preset.name : "プリセットを選択..."}
+										</span>
+									);
+								}}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent />
+					</Select>
+				</div>
+
+				<Show when={selectedPresetId()}>
+					<Button
+						class="h-10 w-10 shrink-0"
+						onClick={handleClearSelection}
+						size="icon"
+						title="選択解除"
+						variant="ghost"
+					>
+						<svg
+							class="lucide lucide-x"
+							fill="none"
+							height="16"
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							viewBox="0 0 24 24"
+							width="16"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<title>選択解除</title>
+							<path d="M18 6 6 18" />
+							<path d="m6 6 12 12" />
+						</svg>
+					</Button>
+				</Show>
+			</div>
+
+			<div class="flex w-full items-center gap-2">
+				<Button
+					class="flex-1"
+					disabled={!selectedPresetId()}
+					onClick={handleLoad}
+					variant="outline"
+				>
+					読込
+				</Button>
+
+				<Dialog onOpenChange={setIsSaveDialogOpen} open={isSaveDialogOpen()}>
+					<DialogTrigger as={Button} class="flex-1" variant="secondary">
+						保存
+					</DialogTrigger>
+					<DialogContent>
+						<DialogHeader>
+							<DialogTitle>現在の検索条件を保存</DialogTitle>
+							<DialogDescription>
+								現在の検索条件に名前を付けて保存します。
+							</DialogDescription>
+						</DialogHeader>
+						<div class="grid gap-4 py-4">
+							<div class="grid grid-cols-4 items-center gap-4">
+								<Label class="text-right">名前</Label>
+								<Input
+									class="col-span-3"
+									onInput={(event) =>
+										setNewPresetName(event.currentTarget.value)
+									}
+									value={newPresetName()}
+								/>
+							</div>
+						</div>
+						<DialogFooter>
+							<Button onClick={handleSave}>保存する</Button>
+						</DialogFooter>
+					</DialogContent>
+				</Dialog>
+
+				<Show when={selectedPresetId()}>
+					<Button
+						class="hover:border-red-200 hover:bg-red-50"
+						onClick={() => confirmDelete(Number(selectedPresetId()))}
+						size="icon"
+						title="プリセット削除"
+						variant="outline"
+					>
+						<span class="i-lucide-trash-2 h-4 w-4 text-red-500" />
+					</Button>
+				</Show>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/src/pro-search-builder.tsx
+++ b/packages/ui/src/pro-search-builder.tsx
@@ -1,0 +1,537 @@
+import type { Author } from "@solid-imager/core/domain/authors/schemas";
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type {
+	SearchCriterion,
+	SearchGroup,
+} from "@solid-imager/core/domain/media/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import { createMemo, Index, Match, Show, Switch } from "solid-js";
+import { Button } from "./button";
+import { Card, CardContent } from "./card";
+import {
+	Combobox,
+	ComboboxContent,
+	ComboboxControl,
+	ComboboxInput,
+	ComboboxItem,
+	ComboboxItemLabel,
+} from "./combobox";
+import { Input } from "./input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "./select";
+import { cn } from "./utils/cn";
+
+const TARGET_LABELS: Record<string, string> = {
+	fileName: "ファイル名",
+	filePath: "ファイルパス",
+	description: "説明",
+	keyword: "キーワード",
+	tag: "タグ",
+	author: "作者",
+	project: "プロジェクト",
+	ip: "IP",
+	character: "キャラクター",
+	folder: "フォルダ",
+	rating: "評価",
+	viewCount: "閲覧数",
+	fileSize: "ファイルサイズ",
+	createdAt: "作成日",
+	aiGenerated: "AI生成",
+};
+
+const OPERATOR_LABELS: Record<string, string> = {
+	equals: "と一致する",
+	contains: "を含む",
+	startsWith: "で始まる",
+	endsWith: "で終わる",
+	gt: "より大きい (>)",
+	gte: "以上 (>=)",
+	lt: "より小さい (<)",
+	lte: "以下 (<=)",
+	in: "のいずれか",
+	notIn: "のいずれでもない",
+	isEmpty: "が空",
+	isNotEmpty: "が空でない",
+};
+
+const STRING_OPERATORS = [
+	"equals",
+	"contains",
+	"startsWith",
+	"endsWith",
+	"isEmpty",
+	"isNotEmpty",
+];
+const NUMERIC_OPERATORS = ["equals", "gt", "gte", "lt", "lte"];
+const RELATIONAL_OPERATORS = ["equals", "contains", "in", "notIn"];
+const BOOLEAN_OPERATORS = ["equals"];
+
+type Props = {
+	value: SearchGroup | null;
+	onChange: (value: SearchGroup | null) => void;
+	tags?: TagResponse[];
+	projects?: Project[];
+	ips?: Ip[];
+	characters?: Character[];
+	authors?: Author[];
+	className?: string;
+};
+
+type RelationOption = TagResponse | Project | Ip | Character | Author;
+
+export function ProSearchBuilder(props: Props) {
+	const rootGroup = createMemo<SearchGroup>(
+		() =>
+			props.value || {
+				type: "group",
+				operator: "and",
+				children: [],
+			},
+	);
+
+	return (
+		<div class={cn("space-y-4", props.className)}>
+			<GroupBuilder
+				authors={props.authors}
+				characters={props.characters}
+				depth={0}
+				group={rootGroup()}
+				ips={props.ips}
+				isRoot
+				onChange={props.onChange}
+				onRemove={() => props.onChange(null)}
+				projects={props.projects}
+				tags={props.tags}
+			/>
+		</div>
+	);
+}
+
+function getValidOperators(target: string) {
+	if (
+		["fileName", "filePath", "description", "keyword", "folder"].includes(
+			target,
+		)
+	) {
+		return STRING_OPERATORS;
+	}
+	if (["tag", "project", "ip", "character", "author"].includes(target)) {
+		return RELATIONAL_OPERATORS;
+	}
+	if (
+		[
+			"rating",
+			"viewCount",
+			"fileSize",
+			"createdAt",
+			"width",
+			"height",
+		].includes(target)
+	) {
+		return NUMERIC_OPERATORS;
+	}
+	if (["aiGenerated", "favorite", "isArchived"].includes(target)) {
+		return BOOLEAN_OPERATORS;
+	}
+	return Object.keys(OPERATOR_LABELS);
+}
+
+function GroupBuilder(props: {
+	group: SearchGroup;
+	onChange: (value: SearchGroup) => void;
+	onRemove: () => void;
+	depth: number;
+	isRoot?: boolean;
+	tags?: TagResponse[];
+	projects?: Project[];
+	ips?: Ip[];
+	characters?: Character[];
+	authors?: Author[];
+}) {
+	const addChild = (type: "criterion" | "group") => {
+		const nextChildren = [...props.group.children];
+		if (type === "group") {
+			nextChildren.push({
+				type: "group",
+				operator: "and",
+				children: [],
+			});
+		} else {
+			nextChildren.push({
+				type: "criterion",
+				target: "fileName",
+				operator: "contains",
+				value: "",
+			});
+		}
+		props.onChange({ ...props.group, children: nextChildren });
+	};
+
+	const updateChild = (index: number, child: SearchCriterion | SearchGroup) => {
+		const nextChildren = [...props.group.children];
+		nextChildren.splice(index, 1, child);
+		props.onChange({ ...props.group, children: nextChildren });
+	};
+
+	const removeChild = (index: number) => {
+		const nextChildren = [...props.group.children];
+		nextChildren.splice(index, 1);
+		props.onChange({ ...props.group, children: nextChildren });
+	};
+
+	return (
+		<Card
+			class={cn(
+				"border-l-2",
+				props.depth % 2 === 0 ? "border-l-blue-500" : "border-l-green-500",
+			)}
+		>
+			<CardContent class="space-y-4 p-2 sm:p-4">
+				<div class="flex flex-col gap-2">
+					<div class="flex flex-wrap items-center gap-2">
+						<Select
+							itemComponent={(itemProps) => (
+								<SelectItem item={itemProps.item}>
+									{itemProps.item.rawValue.toUpperCase()}
+								</SelectItem>
+							)}
+							onChange={(value) => {
+								if (value) {
+									props.onChange({
+										...props.group,
+										operator: value as SearchGroup["operator"],
+									});
+								}
+							}}
+							options={["and", "or"]}
+							value={props.group.operator}
+						>
+							<SelectTrigger class="w-20 sm:w-24">
+								<SelectValue<string>>
+									{(state) => state.selectedOption().toUpperCase()}
+								</SelectValue>
+							</SelectTrigger>
+							<SelectContent />
+						</Select>
+						<span class="text-muted-foreground text-sm">条件グループ</span>
+					</div>
+
+					<div class="flex w-full flex-col gap-2">
+						<div class="flex flex-wrap gap-2">
+							<Button
+								class="flex-1 whitespace-nowrap"
+								onClick={() => addChild("criterion")}
+								size="sm"
+								variant="outline"
+							>
+								+ 条件
+							</Button>
+							<Button
+								class="flex-1 whitespace-nowrap"
+								onClick={() => addChild("group")}
+								size="sm"
+								variant="outline"
+							>
+								+ グループ
+							</Button>
+						</div>
+						<Show when={!props.isRoot}>
+							<Button
+								class="w-full text-red-500"
+								onClick={props.onRemove}
+								size="sm"
+								variant="ghost"
+							>
+								削除
+							</Button>
+						</Show>
+					</div>
+				</div>
+
+				<div class="space-y-2 border-border border-l pl-2 sm:pl-4">
+					<Index each={props.group.children}>
+						{(child, index) => (
+							<Show
+								fallback={
+									<CriterionBuilder
+										authors={props.authors}
+										characters={props.characters}
+										criterion={child() as SearchCriterion}
+										ips={props.ips}
+										onChange={(value) => updateChild(index, value)}
+										onRemove={() => removeChild(index)}
+										projects={props.projects}
+										tags={props.tags}
+									/>
+								}
+								when={child().type === "group"}
+							>
+								<GroupBuilder
+									authors={props.authors}
+									characters={props.characters}
+									depth={props.depth + 1}
+									group={child() as SearchGroup}
+									ips={props.ips}
+									onChange={(value) => updateChild(index, value)}
+									onRemove={() => removeChild(index)}
+									projects={props.projects}
+									tags={props.tags}
+								/>
+							</Show>
+						)}
+					</Index>
+					<Show when={props.group.children.length === 0}>
+						<div class="p-2 text-muted-foreground text-sm italic">
+							条件がありません。「+ 条件」ボタンで追加してください。
+						</div>
+					</Show>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+function CriterionBuilder(props: {
+	criterion: SearchCriterion;
+	onChange: (value: SearchCriterion) => void;
+	onRemove: () => void;
+	tags?: TagResponse[];
+	projects?: Project[];
+	ips?: Ip[];
+	characters?: Character[];
+	authors?: Author[];
+}) {
+	const getAuthorLabel = (author: Author) =>
+		author.accountId
+			? `${author.name}：(twitter)${author.accountId}`
+			: author.name;
+
+	const autocompleteItems = createMemo<RelationOption[] | undefined>(() => {
+		switch (props.criterion.target) {
+			case "tag":
+				return props.tags;
+			case "project":
+				return props.projects;
+			case "ip":
+				return props.ips;
+			case "character":
+				return props.characters;
+			case "author":
+				return props.authors;
+			default:
+				return undefined;
+		}
+	});
+
+	const isNumericTarget = createMemo(() =>
+		[
+			"rating",
+			"viewCount",
+			"fileSize",
+			"createdAt",
+			"width",
+			"height",
+		].includes(props.criterion.target),
+	);
+	const isBooleanTarget = createMemo(() =>
+		["aiGenerated", "favorite", "isArchived"].includes(props.criterion.target),
+	);
+
+	return (
+		<div class="flex flex-col gap-2 rounded-md bg-muted/20 p-2">
+			<Select
+				itemComponent={(itemProps) => (
+					<SelectItem item={itemProps.item}>
+						{TARGET_LABELS[itemProps.item.rawValue]}
+					</SelectItem>
+				)}
+				onChange={(value) => {
+					if (!value || value === props.criterion.target) {
+						return;
+					}
+					const operators = getValidOperators(value);
+					props.onChange({
+						...props.criterion,
+						target: value as SearchCriterion["target"],
+						operator: (operators[0] || "equals") as SearchCriterion["operator"],
+						value: ["aiGenerated", "favorite", "isArchived"].includes(value)
+							? true
+							: "",
+					});
+				}}
+				options={Object.keys(TARGET_LABELS)}
+				value={props.criterion.target}
+			>
+				<SelectTrigger class="w-full">
+					<SelectValue<string>>
+						{(state) => TARGET_LABELS[state.selectedOption()]}
+					</SelectValue>
+				</SelectTrigger>
+				<SelectContent />
+			</Select>
+
+			<Select
+				itemComponent={(itemProps) => (
+					<SelectItem item={itemProps.item}>
+						{OPERATOR_LABELS[itemProps.item.rawValue]}
+					</SelectItem>
+				)}
+				onChange={(value) => {
+					if (value) {
+						props.onChange({
+							...props.criterion,
+							operator: value as SearchCriterion["operator"],
+						});
+					}
+				}}
+				options={getValidOperators(props.criterion.target)}
+				value={props.criterion.operator}
+			>
+				<SelectTrigger class="w-full">
+					<SelectValue<string>>
+						{(state) => OPERATOR_LABELS[state.selectedOption()]}
+					</SelectValue>
+				</SelectTrigger>
+				<SelectContent />
+			</Select>
+
+			<Switch>
+				<Match
+					when={
+						props.criterion.operator === "equals" &&
+						autocompleteItems() &&
+						(autocompleteItems()?.length ?? 0) > 0
+					}
+				>
+					<Combobox<RelationOption>
+						itemComponent={(itemProps) => (
+							<ComboboxItem item={itemProps.item}>
+								<ComboboxItemLabel>
+									{itemProps.item.textValue}
+								</ComboboxItemLabel>
+							</ComboboxItem>
+						)}
+						onChange={(value) => {
+							if (value) {
+								props.onChange({ ...props.criterion, value: value.name });
+							}
+						}}
+						optionLabel={(item) =>
+							"accountId" in item ? getAuthorLabel(item as Author) : item.name
+						}
+						options={autocompleteItems() || []}
+						optionTextValue={(item) =>
+							"accountId" in item ? getAuthorLabel(item as Author) : item.name
+						}
+						optionValue={(item) => item.name}
+						placeholder="検索..."
+						triggerMode="focus"
+						value={(autocompleteItems() || []).find(
+							(item) => item.name === props.criterion.value,
+						)}
+					>
+						<ComboboxControl>
+							<ComboboxInput />
+						</ComboboxControl>
+						<ComboboxContent class="max-h-[300px]" />
+					</Combobox>
+				</Match>
+
+				<Match when={isBooleanTarget()}>
+					<Select
+						itemComponent={(itemProps) => (
+							<SelectItem item={itemProps.item}>
+								{itemProps.item.rawValue === "true" ? "true" : "false"}
+							</SelectItem>
+						)}
+						onChange={(value) =>
+							props.onChange({
+								...props.criterion,
+								value: value === "true",
+							})
+						}
+						options={["true", "false"]}
+						value={String(Boolean(props.criterion.value))}
+					>
+						<SelectTrigger class="w-full">
+							<SelectValue<string>>
+								{(state) => state.selectedOption()}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent />
+					</Select>
+				</Match>
+
+				<Match when={["in", "notIn"].includes(props.criterion.operator)}>
+					<div class="space-y-1">
+						<Input
+							class="w-full"
+							onInput={(event) =>
+								props.onChange({
+									...props.criterion,
+									value: event.currentTarget.value
+										.split(",")
+										.map((value) => value.trim())
+										.filter((value) => value.length > 0),
+								})
+							}
+							placeholder="値をカンマ区切りで入力"
+							value={
+								Array.isArray(props.criterion.value)
+									? props.criterion.value.join(", ")
+									: ""
+							}
+						/>
+						<p class="text-muted-foreground text-xs">
+							カンマ区切りで複数の値を指定できます
+						</p>
+					</div>
+				</Match>
+
+				<Match
+					when={["isEmpty", "isNotEmpty"].includes(props.criterion.operator)}
+				>
+					<div class="rounded-md border border-dashed p-2 text-center text-muted-foreground text-xs italic">
+						この条件に値は不要です
+					</div>
+				</Match>
+
+				<Match when={true}>
+					<Input
+						class="w-full"
+						onInput={(event) =>
+							props.onChange({
+								...props.criterion,
+								value: isNumericTarget()
+									? Number(event.currentTarget.value)
+									: event.currentTarget.value,
+							})
+						}
+						placeholder="値..."
+						type={isNumericTarget() ? "number" : "text"}
+						value={
+							Array.isArray(props.criterion.value)
+								? props.criterion.value.join(", ")
+								: String(props.criterion.value ?? "")
+						}
+					/>
+				</Match>
+			</Switch>
+
+			<Button
+				class="w-full text-red-500"
+				onClick={props.onRemove}
+				variant="ghost"
+			>
+				削除
+			</Button>
+		</div>
+	);
+}

--- a/packages/ui/src/pro-search-dialog.tsx
+++ b/packages/ui/src/pro-search-dialog.tsx
@@ -1,0 +1,66 @@
+import type { Author } from "@solid-imager/core/domain/authors/schemas";
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type { SearchGroup } from "@solid-imager/core/domain/media/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import { createSignal } from "solid-js";
+import { Button } from "./button";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "./dialog";
+import { ProSearchBuilder } from "./pro-search-builder";
+
+type Props = {
+	tags?: TagResponse[];
+	projects?: Project[];
+	ips?: Ip[];
+	characters?: Character[];
+	authors?: Author[];
+	value: SearchGroup | null;
+	onChange: (value: SearchGroup | null) => void;
+	onSearch: () => void;
+};
+
+export function ProSearchDialog(props: Props) {
+	const [open, setOpen] = createSignal(false);
+
+	return (
+		<Dialog onOpenChange={setOpen} open={open()}>
+			<DialogTrigger as={Button} class="w-full" variant="outline">
+				詳細条件を編集
+			</DialogTrigger>
+			<DialogContent class="flex max-h-[90vh] max-w-5xl flex-col">
+				<DialogHeader>
+					<DialogTitle>詳細検索条件の編集</DialogTitle>
+				</DialogHeader>
+				<div class="flex-1 overflow-y-auto p-1">
+					<ProSearchBuilder
+						authors={props.authors}
+						characters={props.characters}
+						ips={props.ips}
+						onChange={props.onChange}
+						projects={props.projects}
+						tags={props.tags}
+						value={props.value}
+					/>
+				</div>
+				<DialogFooter>
+					<Button
+						onClick={() => {
+							props.onSearch();
+							setOpen(false);
+						}}
+					>
+						検索
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/ui/src/query-options/authors-query.ts
+++ b/packages/ui/src/query-options/authors-query.ts
@@ -1,0 +1,18 @@
+import type { Author } from "@solid-imager/core/domain/authors/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const authorsQueryKeys = {
+	all: () => ["allAuthors"] as const,
+};
+
+export const defaultAuthorsQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildAuthorsQueryOptions(queryFn: () => Promise<Author[]>) {
+	return queryOptions({
+		queryKey: authorsQueryKeys.all(),
+		queryFn,
+		...defaultAuthorsQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/characters-query.ts
+++ b/packages/ui/src/query-options/characters-query.ts
@@ -1,0 +1,20 @@
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const charactersQueryKeys = {
+	all: () => ["allCharacters"] as const,
+};
+
+export const defaultCharactersQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildCharactersQueryOptions(
+	queryFn: () => Promise<Character[]>,
+) {
+	return queryOptions({
+		queryKey: charactersQueryKeys.all(),
+		queryFn,
+		...defaultCharactersQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/config-query.ts
+++ b/packages/ui/src/query-options/config-query.ts
@@ -1,0 +1,18 @@
+import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const configQueryKeys = {
+	all: () => ["config"] as const,
+};
+
+export const defaultConfigQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildConfigQueryOptions(queryFn: () => Promise<AppConfig>) {
+	return queryOptions({
+		queryKey: configQueryKeys.all(),
+		queryFn,
+		...defaultConfigQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/index.ts
+++ b/packages/ui/src/query-options/index.ts
@@ -1,0 +1,41 @@
+export {
+	authorsQueryKeys,
+	buildAuthorsQueryOptions,
+	defaultAuthorsQueryConfig,
+} from "./authors-query";
+export {
+	buildCharactersQueryOptions,
+	charactersQueryKeys,
+	defaultCharactersQueryConfig,
+} from "./characters-query";
+export {
+	buildConfigQueryOptions,
+	configQueryKeys,
+	defaultConfigQueryConfig,
+} from "./config-query";
+export {
+	buildIpsQueryOptions,
+	defaultIpsQueryConfig,
+	ipsQueryKeys,
+} from "./ips-query";
+export {
+	buildMediaDetailsQueryOptions,
+	defaultMediaDetailsQueryConfig,
+	mediaDetailsQueryKeys,
+} from "./media-query";
+export {
+	buildProjectsForMediaQueryOptions,
+	buildProjectsQueryOptions,
+	defaultProjectsQueryConfig,
+	projectsQueryKeys,
+} from "./projects-query";
+export {
+	buildSourcesQueryOptions,
+	defaultSourcesQueryConfig,
+	sourcesQueryKeys,
+} from "./sources-query";
+export {
+	buildTagsQueryOptions,
+	defaultTagsQueryConfig,
+	tagsQueryKeys,
+} from "./tags-query";

--- a/packages/ui/src/query-options/ips-query.ts
+++ b/packages/ui/src/query-options/ips-query.ts
@@ -1,0 +1,18 @@
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const ipsQueryKeys = {
+	all: () => ["allIps"] as const,
+};
+
+export const defaultIpsQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildIpsQueryOptions(queryFn: () => Promise<Ip[]>) {
+	return queryOptions({
+		queryKey: ipsQueryKeys.all(),
+		queryFn,
+		...defaultIpsQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/media-query.ts
+++ b/packages/ui/src/query-options/media-query.ts
@@ -1,0 +1,24 @@
+import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
+import type { UUID } from "@solid-imager/core/domain/shared/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const mediaDetailsQueryKeys = {
+	detail: (mediaSourceId: UUID, mediaId: UUID) =>
+		["mediaDetails", mediaSourceId, mediaId] as const,
+};
+
+export const defaultMediaDetailsQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildMediaDetailsQueryOptions(
+	mediaSourceId: UUID,
+	mediaId: UUID,
+	queryFn: (sourceId: UUID, id: UUID) => Promise<MediaDetails>,
+) {
+	return queryOptions({
+		queryKey: mediaDetailsQueryKeys.detail(mediaSourceId, mediaId),
+		queryFn: () => queryFn(mediaSourceId, mediaId),
+		...defaultMediaDetailsQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/projects-query.ts
+++ b/packages/ui/src/query-options/projects-query.ts
@@ -1,0 +1,31 @@
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const projectsQueryKeys = {
+	all: () => ["allProjects"] as const,
+	forMedia: (mediaId: string) => ["projectsForMedia", mediaId] as const,
+};
+
+export const defaultProjectsQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildProjectsQueryOptions(queryFn: () => Promise<Project[]>) {
+	return queryOptions({
+		queryKey: projectsQueryKeys.all(),
+		queryFn,
+		...defaultProjectsQueryConfig,
+	});
+}
+
+export function buildProjectsForMediaQueryOptions(
+	mediaSourceId: string,
+	mediaId: string,
+	queryFn: (mediaSourceId: string, mediaId: string) => Promise<Project[]>,
+) {
+	return queryOptions({
+		queryKey: projectsQueryKeys.forMedia(mediaId),
+		queryFn: () => queryFn(mediaSourceId, mediaId),
+		...defaultProjectsQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/sources-query.ts
+++ b/packages/ui/src/query-options/sources-query.ts
@@ -1,0 +1,20 @@
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const sourcesQueryKeys = {
+	all: () => ["mediaSources"] as const,
+};
+
+export const defaultSourcesQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildSourcesQueryOptions(
+	queryFn: () => Promise<SafeMediaSource[]>,
+) {
+	return queryOptions({
+		queryKey: sourcesQueryKeys.all(),
+		queryFn,
+		...defaultSourcesQueryConfig,
+	});
+}

--- a/packages/ui/src/query-options/tags-query.ts
+++ b/packages/ui/src/query-options/tags-query.ts
@@ -1,0 +1,18 @@
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const tagsQueryKeys = {
+	all: () => ["tags"] as const,
+};
+
+export const defaultTagsQueryConfig = {
+	staleTime: 1000 * 60 * 5,
+};
+
+export function buildTagsQueryOptions(queryFn: () => Promise<TagResponse[]>) {
+	return queryOptions({
+		queryKey: tagsQueryKeys.all(),
+		queryFn,
+		...defaultTagsQueryConfig,
+	});
+}

--- a/packages/ui/src/screens/config-screen.tsx
+++ b/packages/ui/src/screens/config-screen.tsx
@@ -1,0 +1,527 @@
+import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+import { AppConfigSchema } from "@solid-imager/core/domain/config/config-schema";
+import { createForm } from "@tanstack/solid-form";
+import { zodValidator } from "@tanstack/zod-form-adapter";
+import { Show } from "solid-js";
+import { Button } from "../button";
+import { Input } from "../input";
+import { Label } from "../label";
+import { Switch, SwitchControl, SwitchLabel, SwitchThumb } from "../switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../tabs";
+import { Textarea } from "../textarea";
+import { toast } from "../toast";
+
+export type ConfigScreenProps = {
+	data: AppConfig;
+	onSubmit: (value: Partial<AppConfig>) => Promise<void>;
+	onSubmitSuccess?: () => void;
+};
+
+export function ConfigScreen(props: ConfigScreenProps) {
+	const form = createForm(() => ({
+		defaultValues: props.data,
+		validatorAdapter: zodValidator(),
+		validators: {
+			onChange: AppConfigSchema as any,
+		},
+		onSubmit: async ({ value }) => {
+			try {
+				await props.onSubmit(value);
+				props.onSubmitSuccess?.();
+				toast.success("Configuration saved successfully");
+			} catch (_error) {
+				toast.error("Failed to save configuration");
+			}
+		},
+	}));
+
+	return (
+		<>
+			<div class="mb-6 flex items-center justify-between">
+				<h1 class="font-bold text-3xl">Settings</h1>
+				<Button
+					disabled={form.state.isSubmitting}
+					onClick={() => form.handleSubmit()}
+				>
+					{form.state.isSubmitting ? "Saving..." : "Save Changes"}
+				</Button>
+			</div>
+
+			<Tabs class="w-full" defaultValue="jobs">
+				<TabsList class="grid w-full grid-cols-6">
+					<TabsTrigger value="jobs">Jobs</TabsTrigger>
+					<TabsTrigger value="ai">AI</TabsTrigger>
+					<TabsTrigger value="downloads">Downloads</TabsTrigger>
+					<TabsTrigger value="storage">Storage</TabsTrigger>
+					<TabsTrigger value="media">Media</TabsTrigger>
+					<TabsTrigger value="logging">Logging</TabsTrigger>
+				</TabsList>
+
+				<div class="mt-6 space-y-6">
+					<TabsContent value="jobs">
+						<div class="space-y-4 rounded-md border p-4">
+							<h2 class="mb-4 font-semibold text-xl">Job Processing</h2>
+
+							<form.Field name="jobs.concurrency">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>Concurrency</Label>
+										<Input
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(e) => {
+												const val = e.target.value;
+												field().handleChange(
+													(val === ""
+														? undefined
+														: Number(val)) as unknown as number,
+												);
+											}}
+											type="number"
+											value={(field().state.value as number) ?? ""}
+										/>
+										<Show when={field().state.meta.errors.length}>
+											<div class="text-red-500 text-sm">
+												{field().state.meta.errors[0]}
+											</div>
+										</Show>
+										<div class="text-muted-foreground text-xs">
+											Number of concurrent downloads/processings.
+										</div>
+									</div>
+								)}
+							</form.Field>
+
+							<form.Field name="jobs.aiConcurrency">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>AI Concurrency</Label>
+										<Input
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(e) => {
+												const val = e.target.value;
+												field().handleChange(
+													(val === ""
+														? undefined
+														: Number(val)) as unknown as number,
+												);
+											}}
+											type="number"
+											value={(field().state.value as number) ?? ""}
+										/>
+										<Show when={field().state.meta.errors.length}>
+											<div class="text-red-500 text-sm">
+												{field().state.meta.errors[0]}
+											</div>
+										</Show>
+										<div class="text-muted-foreground text-xs">
+											Number of concurrent AI tagging jobs.
+										</div>
+									</div>
+								)}
+							</form.Field>
+
+							<form.Field name="jobs.pollIntervalMs">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>Poll Interval (ms)</Label>
+										<Input
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(e) => {
+												const val = e.target.value;
+												field().handleChange(
+													(val === ""
+														? undefined
+														: Number(val)) as unknown as number,
+												);
+											}}
+											type="number"
+											value={(field().state.value as number) ?? ""}
+										/>
+										<Show when={field().state.meta.errors.length}>
+											<div class="text-red-500 text-sm">
+												{field().state.meta.errors[0]}
+											</div>
+										</Show>
+									</div>
+								)}
+							</form.Field>
+
+							<form.Field name="jobs.enableAutoTagging">
+								{(field) => (
+									<div class="flex items-center space-x-2">
+										<Switch
+											checked={(field().state.value as boolean) ?? false}
+											onChange={field().handleChange}
+										>
+											<SwitchControl>
+												<SwitchThumb />
+											</SwitchControl>
+											<SwitchLabel>Enable Auto Tagging</SwitchLabel>
+										</Switch>
+									</div>
+								)}
+							</form.Field>
+						</div>
+					</TabsContent>
+
+					<TabsContent value="ai">
+						<div class="space-y-4 rounded-md border p-4">
+							<h2 class="mb-4 font-semibold text-xl">AI Service</h2>
+							<form.Field name="ai.baseUrl">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>Base URL</Label>
+										<Input
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(e) =>
+												field().handleChange(e.target.value as any)
+											}
+											value={(field().state.value as string) ?? ""}
+										/>
+									</div>
+								)}
+							</form.Field>
+							<form.Field name="ai.timeoutMs">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>Timeout (ms)</Label>
+										<Input
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(e) => {
+												const val = e.target.value;
+												field().handleChange(
+													(val === ""
+														? undefined
+														: Number(val)) as unknown as number,
+												);
+											}}
+											type="number"
+											value={(field().state.value as number) ?? ""}
+										/>
+									</div>
+								)}
+							</form.Field>
+						</div>
+					</TabsContent>
+
+					<TabsContent value="downloads">
+						<div class="space-y-4 rounded-md border p-4">
+							<h2 class="mb-4 font-semibold text-xl">Downloads</h2>
+
+							<form.Field name="downloads.rateLimitEnabled">
+								{(field) => (
+									<div class="flex items-center space-x-2">
+										<Switch
+											checked={(field().state.value as boolean) ?? false}
+											onChange={field().handleChange}
+										>
+											<SwitchControl>
+												<SwitchThumb />
+											</SwitchControl>
+											<SwitchLabel>レートリミット有効</SwitchLabel>
+										</Switch>
+									</div>
+								)}
+							</form.Field>
+
+							<form.Field name="downloads.requestIntervalMs">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>リクエスト間隔 (ms)</Label>
+										<Input
+											id={field().name}
+											max="60000"
+											min="0"
+											onBlur={field().handleBlur}
+											onInput={(e) => {
+												const val = e.target.value;
+												field().handleChange(
+													(val === ""
+														? undefined
+														: Number(val)) as unknown as number,
+												);
+											}}
+											type="number"
+											value={(field().state.value as number) ?? ""}
+										/>
+										<Show when={field().state.meta.errors.length}>
+											<div class="text-red-500 text-sm">
+												{field().state.meta.errors[0]}
+											</div>
+										</Show>
+									</div>
+								)}
+							</form.Field>
+						</div>
+					</TabsContent>
+
+					<TabsContent value="storage">
+						<div class="space-y-4 rounded-md border p-4">
+							<h2 class="mb-4 font-semibold text-xl">Storage</h2>
+							<form.Field name="storage.thumbnailDir">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>Thumbnail Directory</Label>
+										<Input
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(e) =>
+												field().handleChange(e.target.value as any)
+											}
+											value={(field().state.value as string) ?? ""}
+										/>
+									</div>
+								)}
+							</form.Field>
+
+							<div class="grid grid-cols-2 gap-4">
+								<form.Field name="storage.thumbnailSize">
+									{(field) => (
+										<div class="space-y-2">
+											<Label for={field().name}>Thumbnail Size (px)</Label>
+											<Input
+												id={field().name}
+												onBlur={field().handleBlur}
+												onInput={(e) => {
+													const val = e.target.value;
+													field().handleChange(
+														(val === ""
+															? undefined
+															: Number(val)) as unknown as number,
+													);
+												}}
+												type="number"
+												value={(field().state.value as number) ?? ""}
+											/>
+										</div>
+									)}
+								</form.Field>
+								<form.Field name="storage.thumbnailQuality">
+									{(field) => (
+										<div class="space-y-2">
+											<Label for={field().name}>
+												Thumbnail Quality (1-100)
+											</Label>
+											<Input
+												id={field().name}
+												onBlur={field().handleBlur}
+												onInput={(e) => {
+													const val = e.target.value;
+													field().handleChange(
+														(val === ""
+															? undefined
+															: Number(val)) as unknown as number,
+													);
+												}}
+												type="number"
+												value={(field().state.value as number) ?? ""}
+											/>
+										</div>
+									)}
+								</form.Field>
+							</div>
+						</div>
+					</TabsContent>
+
+					<TabsContent value="media">
+						<div class="space-y-4 rounded-md border p-4">
+							<h2 class="mb-4 font-semibold text-xl">Media Extensions</h2>
+
+							<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+								<form.Field name="media.supportedExtensions.image">
+									{(field) => (
+										<div class="space-y-2">
+											<Label for={field().name}>Image Extensions</Label>
+											<Textarea
+												id={field().name}
+												onBlur={field().handleBlur}
+												onInput={(e) => {
+													const val = e.target.value;
+													const list = val
+														.split(",")
+														.map((s) => s.trim())
+														.filter(Boolean);
+													field().handleChange(list);
+												}}
+												placeholder=".jpg, .png"
+												value={
+													(field().state.value as string[] | undefined)?.join(
+														", ",
+													) ?? ""
+												}
+											/>
+											<div class="text-muted-foreground text-xs">
+												Comma separated
+											</div>
+										</div>
+									)}
+								</form.Field>
+								<form.Field name="media.supportedExtensions.video">
+									{(field) => (
+										<div class="space-y-2">
+											<Label for={field().name}>Video Extensions</Label>
+											<Textarea
+												id={field().name}
+												onBlur={field().handleBlur}
+												onInput={(e) => {
+													const val = e.target.value;
+													const list = val
+														.split(",")
+														.map((s) => s.trim())
+														.filter(Boolean);
+													field().handleChange(list);
+												}}
+												placeholder=".mp4, .webm"
+												value={
+													(field().state.value as string[] | undefined)?.join(
+														", ",
+													) ?? ""
+												}
+											/>
+										</div>
+									)}
+								</form.Field>
+								<form.Field name="media.supportedExtensions.audio">
+									{(field) => (
+										<div class="space-y-2">
+											<Label for={field().name}>Audio Extensions</Label>
+											<Textarea
+												id={field().name}
+												onBlur={field().handleBlur}
+												onInput={(e) => {
+													const val = e.target.value;
+													const list = val
+														.split(",")
+														.map((s) => s.trim())
+														.filter(Boolean);
+													field().handleChange(list);
+												}}
+												placeholder=".mp3, .wav"
+												value={
+													(field().state.value as string[] | undefined)?.join(
+														", ",
+													) ?? ""
+												}
+											/>
+										</div>
+									)}
+								</form.Field>
+							</div>
+
+							<h3 class="mt-6 mb-2 font-semibold text-lg">
+								Tag Extraction (ComfyUI)
+							</h3>
+							<form.Field name="media.tagExtraction.comfyui.positiveNodeTypes">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>Positive Node Types</Label>
+										<Textarea
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(e) => {
+												const val = e.target.value;
+												const list = val
+													.split(",")
+													.map((s) => s.trim())
+													.filter(Boolean);
+												field().handleChange(list);
+											}}
+											value={
+												(field().state.value as string[] | undefined)?.join(
+													", ",
+												) ?? ""
+											}
+										/>
+									</div>
+								)}
+							</form.Field>
+
+							<form.Field name="media.tagExtraction.comfyui.negativeKeywords">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>Negative Keywords</Label>
+										<Textarea
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(e) => {
+												const val = e.target.value;
+												const list = val
+													.split(",")
+													.map((s) => s.trim())
+													.filter(Boolean);
+												field().handleChange(list);
+											}}
+											value={
+												(field().state.value as string[] | undefined)?.join(
+													", ",
+												) ?? ""
+											}
+										/>
+									</div>
+								)}
+							</form.Field>
+
+							<form.Field name="media.tagExtraction.comfyui.negativeTags">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>Negative Tags</Label>
+										<Textarea
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(e) => {
+												const val = e.target.value;
+												const list = val
+													.split(",")
+													.map((s) => s.trim())
+													.filter(Boolean);
+												field().handleChange(list);
+											}}
+											value={
+												(field().state.value as string[] | undefined)?.join(
+													", ",
+												) ?? ""
+											}
+										/>
+									</div>
+								)}
+							</form.Field>
+						</div>
+					</TabsContent>
+
+					<TabsContent value="logging">
+						<div class="space-y-4 rounded-md border p-4">
+							<h2 class="mb-4 font-semibold text-xl">Logging</h2>
+							<form.Field name="logging.level">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>Log Level</Label>
+										<select
+											class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:font-medium file:text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+											id={field().name}
+											onInput={(e) =>
+												field().handleChange(e.target.value as any)
+											}
+											value={(field().state.value as string) ?? ""}
+										>
+											<option value="trace">Trace</option>
+											<option value="debug">Debug</option>
+											<option value="info">Info</option>
+											<option value="warn">Warn</option>
+											<option value="error">Error</option>
+											<option value="fatal">Fatal</option>
+										</select>
+									</div>
+								)}
+							</form.Field>
+						</div>
+					</TabsContent>
+				</div>
+			</Tabs>
+		</>
+	);
+}

--- a/packages/ui/src/screens/manager-screen.tsx
+++ b/packages/ui/src/screens/manager-screen.tsx
@@ -1,0 +1,433 @@
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import type { JSX } from "solid-js";
+import { For, Show } from "solid-js";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "../alert-dialog";
+import { Button } from "../button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "../card";
+import { Checkbox, CheckboxControl, CheckboxLabel } from "../checkbox";
+import {
+	Combobox,
+	ComboboxContent,
+	ComboboxControl,
+	ComboboxInput,
+	ComboboxItem,
+	ComboboxItemIndicator,
+	ComboboxItemLabel,
+	ComboboxTrigger,
+} from "../combobox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "../dialog";
+import type {
+	ManagerEntity,
+	ManagerEntityType,
+	UseManagerPageResult,
+} from "../hooks/use-manager-page";
+import { Input } from "../input";
+import { Label } from "../label";
+import { PaginationControls } from "../pagination-controls";
+import { Progress } from "../progress";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../select";
+
+export type ManagerScreenProps = {
+	manager: UseManagerPageResult;
+	renderMediaCard: (
+		media: Media,
+		selected: boolean,
+		onToggle: (mediaId: string) => void,
+	) => JSX.Element;
+};
+
+const managerTabs: ManagerEntityType[] = [
+	"projects",
+	"ips",
+	"characters",
+	"tagging",
+];
+
+function tabLabel(tab: ManagerEntityType) {
+	if (tab === "tagging") {
+		return "Batch Tagging";
+	}
+	if (tab === "ips") {
+		return "IPs";
+	}
+	return tab.charAt(0).toUpperCase() + tab.slice(1);
+}
+
+function isCharacter(item: ManagerEntity) {
+	return "ips" in item;
+}
+
+export function ManagerScreen(props: ManagerScreenProps) {
+	const manager = () => props.manager;
+
+	return (
+		<div class="container mx-auto p-8">
+			<div class="mb-8 flex items-center justify-between">
+				<h1 class="font-bold text-3xl">Entity Manager</h1>
+				<Show when={manager().activeTab() !== "tagging"}>
+					<Button onClick={manager().openCreateDialog}>Create New</Button>
+				</Show>
+			</div>
+
+			<div class="mb-6 flex space-x-4 border-b">
+				<For each={managerTabs}>
+					{(tab) => (
+						<button
+							class={`border-b-2 px-4 py-2 font-medium transition-colors ${
+								manager().activeTab() === tab
+									? "border-primary text-primary"
+									: "border-transparent text-muted-foreground hover:text-foreground"
+							}`}
+							onClick={() => manager().setActiveTab(tab)}
+							type="button"
+						>
+							{tabLabel(tab)}
+						</button>
+					)}
+				</For>
+			</div>
+
+			<Show when={manager().activeTab() === "tagging"}>
+				<div class="space-y-6">
+					<Card>
+						<CardHeader>
+							<CardTitle>Batch AI Tagging</CardTitle>
+							<CardDescription>
+								Analyze and tag images across your media sources using AI.
+							</CardDescription>
+						</CardHeader>
+						<CardContent class="space-y-4">
+							<div class="grid gap-2">
+								<Label>Target Media Source (Optional)</Label>
+								<Select
+									itemComponent={(selectProps) => (
+										<SelectItem item={selectProps.item}>
+											{selectProps.item.rawValue.name}
+										</SelectItem>
+									)}
+									onChange={(value) => manager().setSelectedSourceId(value?.id)}
+									options={manager().sources()}
+									optionTextValue="name"
+									optionValue="id"
+									placeholder="All Sources"
+									value={
+										manager().selectedSourceId()
+											? manager()
+													.sources()
+													.find(
+														(source) =>
+															source.id === manager().selectedSourceId(),
+													)
+											: null
+									}
+								>
+									<SelectTrigger>
+										<SelectValue<unknown>>
+											{(state) => {
+												const option = state.selectedOption();
+												return option &&
+													typeof option === "object" &&
+													"name" in option
+													? (option as { name: string }).name
+													: "All Sources";
+											}}
+										</SelectValue>
+									</SelectTrigger>
+									<SelectContent />
+								</Select>
+								<p class="text-muted-foreground text-xs">
+									Leave empty to process all sources.
+								</p>
+							</div>
+
+							<div class="flex items-center space-x-2">
+								<Checkbox
+									checked={manager().forceRetag()}
+									class="flex items-center space-x-2"
+									id="force-retag"
+									onChange={manager().setForceRetag}
+								>
+									<CheckboxControl />
+									<CheckboxLabel>Force Re-tagging</CheckboxLabel>
+								</Checkbox>
+							</div>
+							<p class="text-muted-foreground text-xs">
+								If checked, existing AI tags will be ignored and images will be
+								re-analyzed.
+							</p>
+
+							<div class="flex items-center gap-x-2 pt-2">
+								<Button onClick={manager().handleScan}>Scan for Targets</Button>
+								<Button
+									disabled={manager().scannedMedia().length === 0}
+									onClick={manager().handleStartBatchTagging}
+								>
+									Start Batch Tagging ({manager().selectedMedia().size})
+								</Button>
+							</div>
+
+							<Show when={manager().taggingStatus()}>
+								<div class="mt-4 rounded bg-gray-100 p-2 text-sm">
+									{manager().taggingStatus()}
+								</div>
+							</Show>
+							<Show when={manager().jobProgress()}>
+								{(progress) => (
+									<div class="mt-4">
+										<Progress
+											value={(progress().processed / progress().total) * 100}
+										/>
+									</div>
+								)}
+							</Show>
+						</CardContent>
+					</Card>
+
+					<Show when={manager().scannedMedia().length > 0}>
+						<div class="mt-4">
+							<div class="mb-2 flex items-center justify-between">
+								<h3 class="font-bold text-lg">
+									Scanned Media ({manager().scannedMedia().length})
+								</h3>
+								<div class="flex items-center gap-2">
+									<PaginationControls
+										currentPage={manager().currentPage()}
+										onPageChange={manager().setCurrentPage}
+										totalPages={manager().totalPages()}
+									/>
+									<Button
+										onClick={manager().toggleSelectAll}
+										size="sm"
+										variant="outline"
+									>
+										{manager().selectedMedia().size ===
+										manager().scannedMedia().length
+											? "Deselect All"
+											: "Select All"}
+									</Button>
+								</div>
+							</div>
+
+							<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+								<For each={manager().paginatedMedia()}>
+									{(media) =>
+										props.renderMediaCard(
+											media,
+											manager().selectedMedia().has(media.id),
+											manager().toggleMediaSelection,
+										)
+									}
+								</For>
+							</div>
+
+							<div class="mt-4 flex justify-center">
+								<PaginationControls
+									currentPage={manager().currentPage()}
+									onPageChange={manager().setCurrentPage}
+									totalPages={manager().totalPages()}
+								/>
+							</div>
+						</div>
+					</Show>
+				</div>
+			</Show>
+
+			<Show when={manager().activeTab() !== "tagging"}>
+				<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+					<For each={manager().getActiveItems()}>
+						{(item) => (
+							<Card>
+								<CardHeader>
+									<CardTitle>{item.name}</CardTitle>
+									<Show when={item.description}>
+										<CardDescription>{item.description}</CardDescription>
+									</Show>
+									<Show
+										when={
+											manager().activeTab() === "characters" &&
+											isCharacter(item) &&
+											item.ips.length > 0
+										}
+									>
+										<CardDescription>
+											IPs:{" "}
+											{isCharacter(item)
+												? item.ips.map((ip) => ip.name).join(", ")
+												: ""}
+										</CardDescription>
+									</Show>
+								</CardHeader>
+								<CardContent>
+									<div class="flex justify-end space-x-2">
+										<Button
+											onClick={() => manager().openEditDialog(item)}
+											size="sm"
+											variant="outline"
+										>
+											Edit
+										</Button>
+										<Button
+											onClick={() => {
+												manager().setItemToDelete(item);
+												manager().setIsDeleteDialogOpen(true);
+											}}
+											size="sm"
+											variant="destructive"
+										>
+											Delete
+										</Button>
+									</div>
+								</CardContent>
+							</Card>
+						)}
+					</For>
+				</div>
+			</Show>
+
+			<Dialog
+				onOpenChange={manager().setIsDialogOpen}
+				open={manager().isDialogOpen()}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{manager().editingItem() ? "Edit" : "Create"}{" "}
+							{manager().activeTab() === "tagging"
+								? "TAGGING"
+								: manager().activeTab().slice(0, -1).toUpperCase()}
+						</DialogTitle>
+						<DialogDescription>
+							{manager().editingItem()
+								? "Update the details of the item."
+								: "Enter the details for the new item."}
+						</DialogDescription>
+					</DialogHeader>
+					<div class="grid gap-4 py-4">
+						<div class="grid grid-cols-4 items-center gap-4">
+							<Label class="text-right">Name</Label>
+							<Input
+								class="col-span-3"
+								onInput={(event) =>
+									manager().setFormData({
+										...manager().formData(),
+										name: event.currentTarget.value,
+									})
+								}
+								value={manager().formData().name}
+							/>
+						</div>
+						<div class="grid grid-cols-4 items-center gap-4">
+							<Label class="text-right">Description</Label>
+							<Input
+								class="col-span-3"
+								onInput={(event) =>
+									manager().setFormData({
+										...manager().formData(),
+										description: event.currentTarget.value,
+									})
+								}
+								value={manager().formData().description}
+							/>
+						</div>
+						<Show when={manager().activeTab() === "characters"}>
+							<div class="grid grid-cols-4 items-center gap-4">
+								<Label class="text-right">IPs</Label>
+								<div class="col-span-3">
+									<Combobox<Ip>
+										itemComponent={(comboboxProps) => (
+											<ComboboxItem item={comboboxProps.item}>
+												<ComboboxItemLabel>
+													{comboboxProps.item.rawValue.name}
+												</ComboboxItemLabel>
+												<ComboboxItemIndicator />
+											</ComboboxItem>
+										)}
+										multiple
+										onChange={(values) =>
+											manager().setFormData({
+												...manager().formData(),
+												ipIds: values.map((value) => value.id),
+											})
+										}
+										optionLabel="name"
+										options={manager().ips()}
+										optionTextValue="name"
+										optionValue="id"
+										value={manager()
+											.ips()
+											.filter((ip) =>
+												manager().formData().ipIds?.includes(ip.id),
+											)}
+									>
+										<ComboboxControl>
+											<ComboboxInput placeholder="Select IPs..." />
+											<ComboboxTrigger />
+										</ComboboxControl>
+										<ComboboxContent />
+									</Combobox>
+								</div>
+							</div>
+						</Show>
+					</div>
+					<DialogFooter>
+						<Button onClick={manager().handleSave}>Save</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<AlertDialog
+				onOpenChange={manager().setIsDeleteDialogOpen}
+				open={manager().isDeleteDialogOpen()}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Are you sure?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This action cannot be undone. This will permanently delete the{" "}
+							{manager().activeTab().slice(0, -1)} and remove it from our
+							servers.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+							onClick={manager().handleConfirmDelete}
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
+}

--- a/packages/ui/src/screens/media-detail-screen.tsx
+++ b/packages/ui/src/screens/media-detail-screen.tsx
@@ -1,0 +1,112 @@
+import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
+import type {
+	MediaChangedEvent,
+	MediaDeletedEvent,
+	ThumbnailGeneratedEvent,
+} from "@solid-imager/core/domain/sources/events";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import { type JSX, Match, Switch } from "solid-js";
+import {
+	type MediaSourceEventTransport,
+	useMediaSourceEvents,
+} from "../hooks/use-media-source-events";
+
+export type MediaDetailScreenProps = {
+	mediaSourceId: string;
+	mediaId: string;
+	mediaDetailsQueryOptions: (mediaSourceId: string, mediaId: string) => unknown;
+	sourceRootPath?: string;
+	onAdditionalInvalidate?: () => Promise<void>;
+	transport: MediaSourceEventTransport;
+	renderMediaViewer: (
+		media: MediaDetails,
+		sourceRootPath?: string,
+	) => JSX.Element;
+	renderMediaSidebar: (
+		media: MediaDetails,
+		isUpdating: boolean,
+		onUpdate: () => void,
+		sourceRootPath?: string,
+	) => JSX.Element;
+};
+
+export function MediaDetailScreen(props: MediaDetailScreenProps) {
+	const queryClient = useQueryClient();
+
+	const mediaDetails = createQuery<MediaDetails>(
+		() =>
+			props.mediaDetailsQueryOptions(props.mediaSourceId, props.mediaId) as any,
+	);
+
+	const handleUpdate = async () => {
+		await queryClient.invalidateQueries({
+			queryKey: ["mediaDetails", props.mediaSourceId, props.mediaId],
+		});
+		if (props.onAdditionalInvalidate) {
+			await props.onAdditionalInvalidate();
+		}
+	};
+
+	useMediaSourceEvents({
+		transport: props.transport,
+		onMediaAdded: () => {
+			void queryClient.invalidateQueries({
+				queryKey: ["media", props.mediaSourceId],
+			});
+		},
+		onMediaDeleted: (data: MediaDeletedEvent) => {
+			void queryClient.invalidateQueries({
+				queryKey: ["media", props.mediaSourceId],
+			});
+			if (
+				data.mediaId === props.mediaId ||
+				data.filePath === mediaDetails.data?.filePath
+			) {
+				void handleUpdate();
+			}
+		},
+		onMediaChanged: (data: MediaChangedEvent) => {
+			void queryClient.invalidateQueries({
+				queryKey: ["media", props.mediaSourceId],
+			});
+			if (
+				data.mediaId === props.mediaId ||
+				data.filePath === mediaDetails.data?.filePath
+			) {
+				void handleUpdate();
+			}
+		},
+		onThumbnailGenerated: (data: ThumbnailGeneratedEvent) => {
+			if (data.mediaId === props.mediaId) {
+				void handleUpdate();
+			}
+		},
+	});
+
+	return (
+		<div class="container mx-auto p-4">
+			<Switch>
+				<Match when={mediaDetails.isError}>
+					<div class="text-red-500">Error: {mediaDetails.error?.message}</div>
+				</Match>
+				<Match when={mediaDetails.data}>
+					{(details) => (
+						<div class="flex h-[calc(100vh-80px)] flex-col gap-4 lg:flex-row">
+							<div class="flex-grow">
+								{props.renderMediaViewer(details(), props.sourceRootPath)}
+							</div>
+							<div class="w-full shrink-0 lg:w-96">
+								{props.renderMediaSidebar(
+									details(),
+									mediaDetails.isRefetching,
+									handleUpdate,
+									props.sourceRootPath,
+								)}
+							</div>
+						</div>
+					)}
+				</Match>
+			</Switch>
+		</div>
+	);
+}

--- a/packages/ui/src/screens/search-screen.tsx
+++ b/packages/ui/src/screens/search-screen.tsx
@@ -1,0 +1,140 @@
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import type { JSX } from "solid-js";
+import { createSignal, For, onMount, Show } from "solid-js";
+import { isServer } from "solid-js/web";
+import { Card, CardContent, CardHeader, CardTitle } from "../card";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../dialog";
+import type {
+	SearchPageFilterData,
+	UseSearchPageResult,
+} from "../hooks/use-search-page";
+import type { SourceMediaPagePresetClient } from "../hooks/use-source-media-page";
+import { SearchControlPanel } from "../search-control-panel";
+
+export type SearchScreenNavActions = {
+	openMobileFilters: () => void;
+};
+
+export type SearchScreenProps = {
+	page: UseSearchPageResult;
+	filterData: SearchPageFilterData;
+	sources: SafeMediaSource[] | undefined;
+	selectedSource: string | null;
+	onSelectSource: (id: string) => void;
+	presetClient: SourceMediaPagePresetClient;
+	renderNavActions?: (actions: SearchScreenNavActions) => JSX.Element;
+	renderMediaItem: (media: Media) => JSX.Element;
+	ssrGuard?: boolean;
+};
+
+export function SearchScreen(props: SearchScreenProps) {
+	const [isMounted, setIsMounted] = createSignal(false);
+	const [isMobileFilterOpen, setIsMobileFilterOpen] = createSignal(false);
+
+	onMount(() => {
+		if (!isServer) {
+			setIsMounted(true);
+		}
+	});
+
+	const page = () => props.page;
+	const openMobileFilters = () => setIsMobileFilterOpen(true);
+
+	const panel = (
+		<SearchControlPanel
+			context="global"
+			filterData={props.filterData}
+			onSearch={page().handleSearch}
+			onSelectSource={props.onSelectSource}
+			presetClient={props.presetClient}
+			selectedSource={props.selectedSource ?? undefined}
+			sources={props.sources}
+			usePopover={false}
+		/>
+	);
+
+	const showResults = () => {
+		if (props.ssrGuard) {
+			return !page().searchResultQuery.isLoading && isMounted();
+		}
+		return !page().searchResultQuery.isLoading;
+	};
+
+	return (
+		<main class="container mx-auto p-4">
+			{props.renderNavActions?.({ openMobileFilters })}
+			<Show when={!isServer}>
+				<Dialog
+					open={isMobileFilterOpen()}
+					onOpenChange={setIsMobileFilterOpen}
+				>
+					<DialogContent class="max-h-[80vh] overflow-y-auto">
+						<DialogHeader>
+							<DialogTitle>検索フィルター</DialogTitle>
+						</DialogHeader>
+						<div class="space-y-4">{panel}</div>
+					</DialogContent>
+				</Dialog>
+			</Show>
+
+			<div class="mb-8 flex items-center justify-between">
+				<div>
+					<h1 class="mb-2 font-bold text-3xl">メディア検索</h1>
+					<p class="text-gray-600">タグやファイル名でメディアを検索できます</p>
+				</div>
+			</div>
+
+			<div class="grid gap-6 md:grid-cols-[300px_1fr]">
+				<Card class="sticky top-20 hidden h-fit max-h-[calc(100vh-6rem)] overflow-y-auto md:block">
+					<CardHeader>
+						<CardTitle>検索フィルター</CardTitle>
+					</CardHeader>
+					<CardContent class="space-y-4">{panel}</CardContent>
+				</Card>
+
+				<div class="space-y-4">
+					<Show
+						fallback={<div class="py-8 text-center">読み込み中...</div>}
+						when={showResults()}
+					>
+						<Show
+							fallback={<div class="py-12 text-center text-gray-500" />}
+							when={page().searchResultQuery.data}
+						>
+							<div class="mb-4 flex items-center justify-between">
+								<p class="text-gray-600 text-sm">
+									{page().searchResultQuery.data?.pages[0]?.total || 0} 件の結果
+								</p>
+							</div>
+
+							<div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5">
+								<For each={page().searchResults()}>
+									{(media) => props.renderMediaItem(media)}
+								</For>
+							</div>
+
+							<div class="h-10 w-full" ref={page().setLoadMoreRef}>
+								<Show when={page().searchResultQuery.isFetchingNextPage}>
+									<div class="py-4 text-center text-gray-500">
+										読み込み中...
+									</div>
+								</Show>
+							</div>
+
+							<Show
+								when={
+									(page().searchResultQuery.data?.pages[0]?.total || 0) === 0
+								}
+							>
+								<div class="py-12 text-center text-gray-500">
+									検索結果が見つかりませんでした
+								</div>
+							</Show>
+						</Show>
+					</Show>
+				</div>
+			</div>
+		</main>
+	);
+}

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -1,0 +1,211 @@
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import type { Component, JSX } from "solid-js";
+import { Show } from "solid-js";
+import { Button } from "../button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "../dialog";
+import { useCurrentSearchPersistence } from "../hooks/use-current-search-persistence";
+import type {
+	UploadOptions,
+	UseSourceMediaPageResult,
+} from "../hooks/use-source-media-page";
+import { SearchControlPanel } from "../search-control-panel";
+import { SourceMediaGrid } from "../source-media-grid";
+
+export type SourceMediaScreenProps = {
+	page: UseSourceMediaPageResult;
+	renderActions: (props: {
+		isSyncing: boolean;
+		isSyncDisabled: boolean;
+		onDumpDownload: (mode?: "json" | "zip") => void;
+		onSyncLoadedMedia: () => void;
+		onAddMedia: () => void;
+		onRestore: () => void;
+	}) => JSX.Element;
+	/** Render a single media grid item. */
+	renderItem: (
+		media: Media,
+		options: { onContextMenu: () => void },
+	) => JSX.Element;
+	renderJobProgress?: (props: {
+		jobProgress: () =>
+			| import("@solid-imager/core/domain/sources/events").JobProgressEvent
+			| null;
+	}) => JSX.Element;
+	uploadModalComponent: Component<{
+		isOpen: boolean;
+		onClose: () => void;
+		onUpload: (options: UploadOptions) => Promise<void>;
+		initialFile: File | null;
+		onUrlFetch: (file: File) => void;
+		pastedUrl: string | null;
+	}>;
+	moveCopyDialogComponent: Component<{
+		open: boolean;
+		onOpenChange: (open: boolean) => void;
+		mode: "copy" | "move";
+		onConfirm: (targetSourceId: string) => void;
+		currentSourceId: string;
+	}>;
+	/** Enable virtualization for large lists. Default: false. */
+	enableVirtualization?: boolean;
+	/** Show "Open in New Tab" context menu item. Default: false. */
+	showOpenInNewTab?: boolean;
+};
+
+export function SourceMediaScreen(props: SourceMediaScreenProps) {
+	const page = () => props.page;
+
+	// Enable auto-save/restore of search conditions
+	useCurrentSearchPersistence(page().mediaSourceId, page().presetClient);
+
+	return (
+		<section
+			aria-label="Media upload area"
+			class="container mx-auto min-h-[calc(100vh-2rem)] p-4"
+			onDragOver={page().handleDragOver}
+			onDrop={page().handleDrop}
+		>
+			{props.renderActions({
+				isSyncing: page().isSyncingMedia(),
+				isSyncDisabled:
+					page().isSyncingMedia() || !page().mediaQuery.data?.pages.length,
+				onDumpDownload: page().handleDumpDownload,
+				onSyncLoadedMedia: page().handleSyncLoadedMedia,
+				onAddMedia: page().handleAddButtonClick,
+				onRestore: () => page().restoreInputRef?.click(),
+			})}
+
+			<Show when={props.renderJobProgress && page().jobProgress()}>
+				{props.renderJobProgress?.({
+					jobProgress: page().jobProgress,
+				})}
+			</Show>
+
+			<div class="grid gap-6 md:grid-cols-[300px_1fr]">
+				<div class="sticky top-20 hidden h-fit max-h-[calc(100vh-6rem)] overflow-y-auto rounded-lg border bg-card p-4 md:block">
+					<h3 class="mb-4 font-semibold text-lg">検索フィルター</h3>
+					<div class="space-y-4">
+						<SearchControlPanel
+							class="w-full"
+							context="source"
+							filterData={page().filterData()}
+							onSearch={page().handleSearch}
+							presetClient={page().presetClient}
+							usePopover={false}
+						/>
+					</div>
+				</div>
+
+				<SourceMediaGrid
+					contextMenuMediaId={page().contextMenuMediaId}
+					enableVirtualization={props.enableVirtualization}
+					isError={page().mediaQuery.isError}
+					isFetchingNextPage={page().mediaQuery.isFetchingNextPage}
+					isPending={page().mediaQuery.isPending}
+					mediaResults={page().mediaResults}
+					mediaSourceId={page().mediaSourceId}
+					onCopyMove={page().handleCopyMove}
+					onDelete={page().handleDelete}
+					onSyncSingleMedia={page().handleSyncSingleMedia}
+					queryError={page().mediaQuery.error ?? null}
+					renderItem={props.renderItem}
+					setContextMenuMediaId={page().setContextMenuMediaId}
+					setLoadMoreRef={page().setLoadMoreRef}
+					showOpenInNewTab={props.showOpenInNewTab}
+					totalCount={page().mediaQuery.data?.pages[0]?.total}
+				/>
+			</div>
+
+			{/* Hidden file inputs */}
+			<input
+				accept=".json,.zip"
+				class="hidden"
+				id="restore-input"
+				onChange={page().handleRestoreSelect}
+				ref={page().setRestoreInputRef}
+				type="file"
+			/>
+			<input
+				accept="image/*,.json"
+				class="hidden"
+				onChange={page().handleFileSelect}
+				ref={page().setFileInputRef}
+				type="file"
+			/>
+
+			{/* Floating add button */}
+			<button
+				aria-label="Add media"
+				class="fixed right-8 bottom-8 flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg transition-all hover:bg-blue-700 hover:shadow-xl"
+				onClick={page().handleAddButtonClick}
+				type="button"
+			>
+				<span class="text-3xl leading-none">＋</span>
+			</button>
+
+			{(() => {
+				const UploadModal = props.uploadModalComponent;
+				return (
+					<UploadModal
+						initialFile={page().fileToUpload()}
+						isOpen={page().showUploadModal()}
+						onClose={() => {
+							page().setShowUploadModal(false);
+							page().setPastedUrl(null);
+							page().setFileToUpload(null);
+						}}
+						onUpload={page().handleUpload}
+						onUrlFetch={(file) => page().setFileToUpload(file)}
+						pastedUrl={page().pastedUrl()}
+					/>
+				);
+			})()}
+
+			<Dialog
+				onOpenChange={page().setDeleteDialogOpen}
+				open={page().deleteDialogOpen()}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Delete Media</DialogTitle>
+						<DialogDescription>
+							Are you sure you want to delete this media? This action cannot be
+							undone.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							onClick={() => page().setDeleteDialogOpen(false)}
+							variant="outline"
+						>
+							Cancel
+						</Button>
+						<Button onClick={page().confirmDelete} variant="destructive">
+							Delete
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{(() => {
+				const MoveCopyDialog = props.moveCopyDialogComponent;
+				return (
+					<MoveCopyDialog
+						currentSourceId={page().mediaSourceId() || ""}
+						mode={page().moveCopyMode()}
+						onConfirm={page().handleConfirmCopyMove}
+						onOpenChange={page().setMoveCopyDialogOpen}
+						open={page().moveCopyDialogOpen()}
+					/>
+				);
+			})()}
+		</section>
+	);
+}

--- a/packages/ui/src/screens/sources-screen.tsx
+++ b/packages/ui/src/screens/sources-screen.tsx
@@ -1,0 +1,91 @@
+import type {
+	MediaSourceInfo,
+	SafeMediaSource,
+} from "@solid-imager/core/domain/sources/schemas";
+import type { JSX } from "solid-js";
+import { For, Show } from "solid-js";
+import type { UseSourcesPageResult } from "../hooks/use-sources-page";
+
+export type SourcesScreenProps = {
+	page: UseSourcesPageResult;
+	mediaSources: () => (SafeMediaSource | MediaSourceInfo)[] | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	error: Error | null;
+	renderSourceCard: (source: SafeMediaSource | MediaSourceInfo) => JSX.Element;
+	renderFormModal: (props: {
+		editingSource: SafeMediaSource | MediaSourceInfo | null;
+		isOpen: boolean;
+		onClose: () => void;
+		onSubmit: (data: unknown) => Promise<void>;
+	}) => JSX.Element;
+	renderDeleteModal: (props: {
+		isOpen: boolean;
+		onClose: () => void;
+		onConfirm: (mediaSourceId: string) => Promise<void>;
+		sourceToDelete: SafeMediaSource | MediaSourceInfo | null;
+	}) => JSX.Element;
+};
+
+export function SourcesScreen(props: SourcesScreenProps) {
+	const page = () => props.page;
+
+	return (
+		<div class="container mx-auto p-6">
+			<div class="mb-6 flex items-center justify-between">
+				<h1 class="font-bold text-3xl">Media Sources</h1>
+				<div class="flex items-center gap-2">
+					<button
+						class="rounded bg-green-500 px-4 py-2 text-white shadow hover:bg-green-600 disabled:cursor-not-allowed disabled:opacity-50"
+						disabled={page().isSyncing() || !props.mediaSources()?.length}
+						onClick={() => page().handleSyncAll(props.mediaSources())}
+						type="button"
+					>
+						{page().isSyncing() ? "Syncing..." : "Sync All"}
+					</button>
+					<button
+						class="rounded bg-blue-500 px-4 py-2 text-white shadow hover:bg-blue-600"
+						onClick={() => page().handleAddSource()}
+						type="button"
+					>
+						Add Source
+					</button>
+				</div>
+			</div>
+
+			<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+				<For each={props.mediaSources()}>
+					{(source) => props.renderSourceCard(source)}
+				</For>
+			</div>
+
+			<Show when={props.isLoading}>
+				<div class="mt-8 text-center">
+					<p class="text-muted-foreground">Loading sources...</p>
+				</div>
+			</Show>
+
+			<Show when={props.isError}>
+				<div class="mt-8 text-center">
+					<p class="text-red-500">
+						Error loading sources: {props.error?.message}
+					</p>
+				</div>
+			</Show>
+
+			{props.renderFormModal({
+				editingSource: page().editingSource(),
+				isOpen: page().showFormModal(),
+				onClose: () => page().setShowFormModal(false),
+				onSubmit: page().handleFormSubmit,
+			})}
+
+			{props.renderDeleteModal({
+				isOpen: page().showDeleteModal(),
+				onClose: () => page().setShowDeleteModal(false),
+				onConfirm: page().handleDeleteConfirm,
+				sourceToDelete: page().deletingSource(),
+			})}
+		</div>
+	);
+}

--- a/packages/ui/src/search-control-panel.tsx
+++ b/packages/ui/src/search-control-panel.tsx
@@ -1,0 +1,148 @@
+import type { Author } from "@solid-imager/core/domain/authors/schemas";
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import { Show } from "solid-js";
+import { Button } from "./button";
+import { Label } from "./label";
+import { PresetManager, type PresetManagerClient } from "./preset-manager";
+import { ProSearchDialog } from "./pro-search-dialog";
+import { SearchFilters } from "./search-filters";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "./select";
+import { SortControls } from "./sort-controls";
+import {
+	searchState,
+	setSearchMode,
+	setSearchState,
+} from "./stores/search-store";
+
+export type { PresetManagerClient };
+
+export type SearchControlPanelProps = {
+	presetClient: PresetManagerClient;
+	context: "source" | "global";
+	onSearch: () => void;
+	filterData: {
+		tags: TagResponse[] | undefined;
+		projects: Project[] | undefined;
+		ips: Ip[] | undefined;
+		characters: Character[] | undefined;
+		authors: Author[] | undefined;
+	};
+	sources?: SafeMediaSource[];
+	selectedSource?: string;
+	onSelectSource?: (id: string) => void;
+	class?: string;
+	usePopover?: boolean;
+};
+
+export function SearchControlPanel(props: SearchControlPanelProps) {
+	return (
+		<div class={props.class}>
+			<Show when={props.context === "global" && props.sources}>
+				<div class="mb-4 space-y-2">
+					<Label>メディアソース</Label>
+					<Select
+						itemComponent={(itemProps) => (
+							<SelectItem item={itemProps.item}>
+								{itemProps.item.rawValue.name}
+							</SelectItem>
+						)}
+						onChange={(value) => {
+							const selected = value as { id: string } | undefined;
+							props.onSelectSource?.(selected?.id ?? "");
+						}}
+						options={[
+							{ id: "", name: "すべてのソース" },
+							...(props.sources || []),
+						]}
+						optionValue="id"
+						placeholder="ソースを選択"
+						value={[
+							{ id: "", name: "すべてのソース" },
+							...(props.sources || []),
+						].find((source) => source.id === props.selectedSource)}
+					>
+						<SelectTrigger>
+							<SelectValue<{ name: string }>>
+								{(state) => state.selectedOption()?.name || "ソースを選択"}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent />
+					</Select>
+				</div>
+			</Show>
+
+			<div class="mb-4 flex items-center justify-between">
+				<Label class="font-medium text-sm">検索モード</Label>
+				<div class="flex gap-2">
+					<Button
+						onClick={() => setSearchMode("simple")}
+						size="sm"
+						variant={searchState.mode === "simple" ? "default" : "outline"}
+					>
+						簡易
+					</Button>
+					<Button
+						onClick={() => setSearchMode("pro")}
+						size="sm"
+						variant={searchState.mode === "pro" ? "default" : "outline"}
+					>
+						詳細
+					</Button>
+				</div>
+			</div>
+
+			<SortControls
+				className="mb-4"
+				onSortByChange={(value) => setSearchState("sortBy", value)}
+				onSortOrderChange={(value) => setSearchState("sortOrder", value)}
+				sortBy={searchState.sortBy}
+				sortOrder={searchState.sortOrder}
+			/>
+
+			<div class="my-4 h-px bg-border" />
+
+			<div class={searchState.mode === "simple" ? "block" : "hidden"}>
+				<SearchFilters
+					authors={props.filterData.authors}
+					characters={props.filterData.characters}
+					ips={props.filterData.ips}
+					onSearch={props.onSearch}
+					projects={props.filterData.projects}
+					setState={setSearchState}
+					state={searchState}
+					tags={props.filterData.tags}
+					usePopover={props.usePopover}
+				/>
+			</div>
+
+			<div class={searchState.mode === "pro" ? "block" : "hidden"}>
+				<div class="space-y-4">
+					<PresetManager
+						class="w-full flex-col items-stretch"
+						presetClient={props.presetClient}
+					/>
+					<ProSearchDialog
+						authors={props.filterData.authors}
+						characters={props.filterData.characters}
+						ips={props.filterData.ips}
+						onChange={(value) => setSearchState("advancedCondition", value)}
+						onSearch={props.onSearch}
+						projects={props.filterData.projects}
+						tags={props.filterData.tags}
+						value={searchState.advancedCondition || null}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/src/search-filters.tsx
+++ b/packages/ui/src/search-filters.tsx
@@ -1,0 +1,279 @@
+import type { Author } from "@solid-imager/core/domain/authors/schemas";
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import type { SearchState } from "@solid-imager/core/domain/search/schema";
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import { createSignal, For } from "solid-js";
+import type { SetStoreFunction } from "solid-js/store";
+import { Badge } from "./badge";
+import { Button } from "./button";
+import {
+	Combobox,
+	ComboboxContent,
+	ComboboxControl,
+	ComboboxInput,
+	ComboboxItem,
+	ComboboxItemLabel,
+} from "./combobox";
+import { Input } from "./input";
+import { Label } from "./label";
+import { cn } from "./utils/cn";
+
+type SearchFiltersProps = {
+	state: SearchState;
+	setState: SetStoreFunction<SearchState>;
+	tags: TagResponse[] | undefined;
+	projects: Project[] | undefined;
+	ips: Ip[] | undefined;
+	characters: Character[] | undefined;
+	authors: Author[] | undefined;
+	onSearch?: () => void;
+	className?: string;
+	usePopover?: boolean;
+};
+
+function FilterSection<T>(props: {
+	label: string;
+	items: T[] | undefined;
+	selectedItems: string[];
+	onSelect: (item: T) => void;
+	onRemove: (id: string) => void;
+	getItemKey: (item: T) => string;
+	getItemLabel: (item: T) => string;
+	getItemDescription?: (item: T) => string | undefined | null;
+	placeholder?: string;
+	badgeVariant?: "default" | "destructive" | "secondary" | "outline";
+}) {
+	const [value, _setValue] = createSignal<T | null>(null);
+
+	return (
+		<div class="space-y-2">
+			<Label>{props.label}</Label>
+			<div class="mb-2 flex flex-wrap gap-2">
+				<For each={props.selectedItems}>
+					{(id) => {
+						const item = props.items?.find(
+							(i) => props.getItemKey(i) === id,
+						) as T;
+						return (
+							<Badge
+								class="cursor-pointer"
+								variant={props.badgeVariant || "default"}
+							>
+								{item ? props.getItemLabel(item) : id}
+								<button
+									class="ml-1 hover:text-red-500"
+									onClick={() => props.onRemove(id)}
+									type="button"
+								>
+									×
+								</button>
+							</Badge>
+						);
+					}}
+				</For>
+			</div>
+			<Combobox<T>
+				itemComponent={(itemProps) => (
+					<ComboboxItem item={itemProps.item}>
+						<ComboboxItemLabel>{itemProps.item.textValue}</ComboboxItemLabel>
+					</ComboboxItem>
+				)}
+				onChange={(val) => {
+					if (val) {
+						props.onSelect(val);
+					}
+				}}
+				optionLabel={props.getItemLabel}
+				options={props.items || []}
+				optionTextValue={props.getItemLabel}
+				optionValue={(item) => props.getItemKey(item)}
+				placeholder={props.placeholder}
+				triggerMode="focus"
+				value={value()}
+			>
+				<ComboboxControl>
+					<ComboboxInput />
+				</ComboboxControl>
+				<ComboboxContent class="max-h-[300px]" />
+			</Combobox>
+		</div>
+	);
+}
+
+const getAuthorLabel = (author: Author) =>
+	author.accountId
+		? `${author.name}：(twitter)${author.accountId}`
+		: author.name;
+
+export function SearchFilters(props: SearchFiltersProps) {
+	const addTag = (tagName: string) => {
+		if (!props.state.selectedTags.includes(tagName)) {
+			props.setState("selectedTags", [...props.state.selectedTags, tagName]);
+		}
+	};
+
+	const removeTag = (tagName: string) => {
+		props.setState(
+			"selectedTags",
+			props.state.selectedTags.filter((t) => t !== tagName),
+		);
+	};
+
+	const addExcludeTag = (tagName: string) => {
+		if (!props.state.excludeTags.includes(tagName)) {
+			props.setState("excludeTags", [...props.state.excludeTags, tagName]);
+		}
+	};
+
+	const removeExcludeTag = (tagName: string) => {
+		props.setState(
+			"excludeTags",
+			props.state.excludeTags.filter((t) => t !== tagName),
+		);
+	};
+
+	return (
+		<div class={cn("space-y-4", props.className)}>
+			<div class="space-y-2">
+				<Label>ファイル名検索</Label>
+				<Input
+					onInput={(e) => props.setState("searchQuery", e.currentTarget.value)}
+					placeholder="ファイル名を入力..."
+					type="text"
+					value={props.state.searchQuery}
+				/>
+			</div>
+
+			<FilterSection
+				badgeVariant="secondary"
+				getItemDescription={(ip) => ip.description}
+				getItemKey={(ip) => ip.name}
+				getItemLabel={(ip) => ip.name}
+				items={props.ips}
+				label="IP"
+				onRemove={(name) =>
+					props.setState(
+						"selectedIps",
+						props.state.selectedIps.filter((iName) => iName !== name),
+					)
+				}
+				onSelect={(ip) => {
+					if (!props.state.selectedIps.includes(ip.name)) {
+						props.setState("selectedIps", [
+							...props.state.selectedIps,
+							ip.name,
+						]);
+					}
+				}}
+				placeholder="IPを検索..."
+				selectedItems={props.state.selectedIps}
+			/>
+
+			<FilterSection
+				badgeVariant="secondary"
+				getItemDescription={(char) => char.description}
+				getItemKey={(char) => char.name}
+				getItemLabel={(char) => char.name}
+				items={props.characters}
+				label="キャラクター"
+				onRemove={(name) =>
+					props.setState(
+						"selectedCharacters",
+						props.state.selectedCharacters.filter((cName) => cName !== name),
+					)
+				}
+				onSelect={(char) => {
+					if (!props.state.selectedCharacters.includes(char.name)) {
+						props.setState("selectedCharacters", [
+							...props.state.selectedCharacters,
+							char.name,
+						]);
+					}
+				}}
+				placeholder="キャラクターを検索..."
+				selectedItems={props.state.selectedCharacters}
+			/>
+
+			<FilterSection
+				badgeVariant="default"
+				getItemKey={(tag) => tag.name}
+				getItemLabel={(tag) => tag.name}
+				items={props.tags}
+				label="タグ (すべて含む)"
+				onRemove={(id) => removeTag(id)}
+				onSelect={(tag) => addTag(tag.name)}
+				placeholder="タグを検索..."
+				selectedItems={props.state.selectedTags}
+			/>
+
+			<FilterSection
+				badgeVariant="destructive"
+				getItemKey={(tag) => tag.name}
+				getItemLabel={(tag) => tag.name}
+				items={props.tags}
+				label="除外タグ"
+				onRemove={(id) => removeExcludeTag(id)}
+				onSelect={(tag) => addExcludeTag(tag.name)}
+				placeholder="除外タグを検索..."
+				selectedItems={props.state.excludeTags}
+			/>
+
+			<FilterSection
+				badgeVariant="secondary"
+				getItemKey={(author) => author.name}
+				getItemLabel={getAuthorLabel}
+				items={props.authors}
+				label="作者"
+				onRemove={(name) =>
+					props.setState(
+						"selectedAuthors",
+						props.state.selectedAuthors.filter((aName) => aName !== name),
+					)
+				}
+				onSelect={(author) => {
+					if (!props.state.selectedAuthors.includes(author.name)) {
+						props.setState("selectedAuthors", [
+							...props.state.selectedAuthors,
+							author.name,
+						]);
+					}
+				}}
+				placeholder="作者・IDを検索..."
+				selectedItems={props.state.selectedAuthors}
+			/>
+
+			<FilterSection
+				badgeVariant="secondary"
+				getItemDescription={(project) => project.description}
+				getItemKey={(project) => project.id}
+				getItemLabel={(project) => project.name}
+				items={props.projects}
+				label="プロジェクト"
+				onRemove={(name) =>
+					props.setState(
+						"selectedProjects",
+						props.state.selectedProjects.filter((pName) => pName !== name),
+					)
+				}
+				onSelect={(project) => {
+					if (!props.state.selectedProjects.includes(project.name)) {
+						props.setState("selectedProjects", [
+							...props.state.selectedProjects,
+							project.name,
+						]);
+					}
+				}}
+				placeholder="プロジェクトを検索..."
+				selectedItems={props.state.selectedProjects}
+			/>
+
+			{props.onSearch && (
+				<Button class="w-full" onClick={props.onSearch}>
+					検索
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/packages/ui/src/select.tsx
+++ b/packages/ui/src/select.tsx
@@ -72,7 +72,9 @@ const SelectTrigger = <T extends ValidComponent = "button">(
 };
 
 type SelectContentProps<T extends ValidComponent = "div"> =
-	SelectPrimitiveContentProps<T> & { class?: string | undefined };
+	SelectPrimitiveContentProps<T> & {
+		class?: string | undefined;
+	};
 
 const SelectContent = <T extends ValidComponent = "div">(
 	props: PolymorphicProps<T, SelectContentProps<T>>,

--- a/packages/ui/src/sort-controls.tsx
+++ b/packages/ui/src/sort-controls.tsx
@@ -1,0 +1,88 @@
+import { Label } from "./label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "./select";
+
+export type SortOption = "date" | "name" | "size" | "rating" | "viewCount";
+
+type SortControlsProps = {
+	sortBy: SortOption;
+	sortOrder: "asc" | "desc";
+	onSortByChange: (value: SortOption) => void;
+	onSortOrderChange: (value: "asc" | "desc") => void;
+	className?: string;
+};
+
+function getSortLabel(value: SortOption) {
+	if (value === "date") {
+		return "作成日";
+	}
+	if (value === "name") {
+		return "ファイル名";
+	}
+	if (value === "size") {
+		return "サイズ";
+	}
+	if (value === "rating") {
+		return "評価";
+	}
+	return "閲覧数";
+}
+
+export function SortControls(props: SortControlsProps) {
+	return (
+		<div class={props.className}>
+			<div class="space-y-2">
+				<Label>ソート</Label>
+				<div class="grid grid-cols-2 gap-2">
+					<Select
+						itemComponent={(itemProps) => (
+							<SelectItem item={itemProps.item}>
+								{getSortLabel(itemProps.item.rawValue as SortOption)}
+							</SelectItem>
+						)}
+						onChange={(value) =>
+							props.onSortByChange((value as SortOption) || "date")
+						}
+						options={["date", "name", "size", "rating", "viewCount"]}
+						placeholder="項目"
+						value={props.sortBy}
+					>
+						<SelectTrigger>
+							<SelectValue<string>>
+								{(state) =>
+									getSortLabel((state.selectedOption() as SortOption) || "date")
+								}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent />
+					</Select>
+					<Select
+						itemComponent={(itemProps) => (
+							<SelectItem item={itemProps.item}>
+								{itemProps.item.rawValue === "asc" ? "昇順" : "降順"}
+							</SelectItem>
+						)}
+						onChange={(value) => props.onSortOrderChange(value || "desc")}
+						options={["asc", "desc"]}
+						placeholder="順序"
+						value={props.sortOrder}
+					>
+						<SelectTrigger>
+							<SelectValue<string>>
+								{(state) =>
+									state.selectedOption() === "asc" ? "昇順" : "降順"
+								}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent />
+					</Select>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/src/source-card.tsx
+++ b/packages/ui/src/source-card.tsx
@@ -1,0 +1,123 @@
+import type {
+	MediaSourceInfo,
+	SafeMediaSource,
+} from "@solid-imager/core/domain/sources/schemas";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "./card";
+
+type SourceCardProps = {
+	mediaSource: SafeMediaSource | MediaSourceInfo;
+	href?: string;
+	onEdit?: (source: SafeMediaSource | MediaSourceInfo) => void;
+	onDelete?: (source: SafeMediaSource | MediaSourceInfo) => void;
+	onSync?: (source: SafeMediaSource | MediaSourceInfo) => void;
+};
+
+const getTypeLabel = (type: string) => {
+	switch (type) {
+		case "local":
+			return "Local Filesystem";
+		case "sftp":
+			return "SFTP";
+		case "s3":
+			return "S3 Compatible Storage";
+		default:
+			return type;
+	}
+};
+
+const getConnectionDetails = (source: SafeMediaSource | MediaSourceInfo) => {
+	const info = source.connectionInfo as Record<string, string>;
+
+	if (source.type === "local") {
+		return `Path: ${info.path || "N/A"}`;
+	}
+	if (source.type === "sftp") {
+		return `SFTP: ${info.host || "?"}:${info.remotePath || "?"}`;
+	}
+	if (source.type === "s3") {
+		return `S3: ${info.bucket || "?"} (${info.region || "?"})`;
+	}
+	return "Unknown Connection";
+};
+
+export function SourceCard(props: SourceCardProps) {
+	const handleEditClick = (event: MouseEvent) => {
+		event.stopPropagation();
+		event.preventDefault();
+		props.onEdit?.(props.mediaSource);
+	};
+
+	const handleSyncClick = (event: MouseEvent) => {
+		event.stopPropagation();
+		event.preventDefault();
+		props.onSync?.(props.mediaSource);
+	};
+
+	const handleDeleteClick = (event: MouseEvent) => {
+		event.stopPropagation();
+		event.preventDefault();
+		props.onDelete?.(props.mediaSource);
+	};
+
+	return (
+		<a
+			class="block text-current no-underline"
+			href={props.href ?? `/sources/${props.mediaSource.id}`}
+		>
+			<Card class="relative h-full hover:bg-gray-50" data-testid="source-card">
+				<CardHeader>
+					<CardTitle data-testid="source-name">
+						{props.mediaSource.name}
+					</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<CardDescription>{props.mediaSource.description}</CardDescription>
+					<div class="mt-4 space-y-2 text-sm">
+						<p>
+							<span class="font-semibold">Type:</span>{" "}
+							{getTypeLabel(props.mediaSource.type)}
+						</p>
+						<p class="truncate" title={getConnectionDetails(props.mediaSource)}>
+							{getConnectionDetails(props.mediaSource)}
+						</p>
+					</div>
+				</CardContent>
+				<div class="absolute top-2 right-2 z-10 flex gap-1">
+					{props.onSync && (
+						<button
+							class="rounded border bg-white px-2 py-1 text-xs shadow hover:bg-gray-50"
+							onClick={handleSyncClick}
+							type="button"
+						>
+							Sync
+						</button>
+					)}
+					{props.onEdit && (
+						<button
+							class="rounded border bg-white px-2 py-1 text-xs shadow hover:bg-gray-50"
+							onClick={handleEditClick}
+							type="button"
+						>
+							Edit
+						</button>
+					)}
+					{props.onDelete && (
+						<button
+							class="rounded bg-red-500 px-2 py-1 text-white text-xs shadow hover:bg-red-600"
+							onClick={handleDeleteClick}
+							type="button"
+						>
+							Delete
+						</button>
+					)}
+				</div>
+			</Card>
+		</a>
+	);
+}

--- a/packages/ui/src/source-delete-modal.tsx
+++ b/packages/ui/src/source-delete-modal.tsx
@@ -1,0 +1,47 @@
+import { Button } from "./button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "./dialog";
+
+export type SourceDeleteModalProps = {
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: (id: string) => void;
+	sourceToDelete?: { id?: string | null; name?: string | null } | null;
+};
+
+export function SourceDeleteModal(props: SourceDeleteModalProps) {
+	return (
+		<Dialog onOpenChange={() => props.onClose()} open={props.isOpen}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Delete Media Source</DialogTitle>
+					<DialogDescription>
+						Are you sure you want to delete{" "}
+						<span class="font-bold">{props.sourceToDelete?.name}</span>? This
+						action cannot be undone. Files on disk will NOT be deleted.
+					</DialogDescription>
+				</DialogHeader>
+				<DialogFooter>
+					<Button onClick={() => props.onClose()} variant="outline">
+						Cancel
+					</Button>
+					<Button
+						onClick={() =>
+							props.sourceToDelete?.id &&
+							props.onConfirm(props.sourceToDelete.id)
+						}
+						variant="destructive"
+					>
+						Delete
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/ui/src/source-form-modal.tsx
+++ b/packages/ui/src/source-form-modal.tsx
@@ -1,0 +1,471 @@
+import type {
+	MediaSourceInfo,
+	SafeMediaSource,
+} from "@solid-imager/core/domain/sources/schemas";
+import { createEffect, createSignal, Show } from "solid-js";
+import { createStore } from "solid-js/store";
+import { Button } from "./button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "./dialog";
+import { Input } from "./input";
+import { Label } from "./label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "./select";
+
+const DEFAULT_SFTP_PORT = 22;
+
+export type SourceFormType = "local" | "sftp" | "s3";
+
+export type SourceFormData = {
+	name: string;
+	description: string;
+	type: SourceFormType;
+	connectionInfo: Record<string, string | number>;
+};
+
+export type SourceFormSubmitData = Omit<
+	SourceFormData,
+	"connectionInfo" | "description"
+> & {
+	description: string | null;
+	connectionInfo: Record<string, string | number | undefined>;
+};
+
+export type SourceFormModalProps = {
+	isOpen: boolean;
+	onClose: () => void;
+	onSubmit: (data: SourceFormSubmitData) => void;
+	editingSource?: MediaSourceInfo | SafeMediaSource | null;
+	initialValues?: SourceFormData;
+	validationRules?: (data: SourceFormData) => Record<string, string>;
+	sourceTypes?: SourceFormType[];
+	description?: string;
+	submitLabel?: string;
+};
+
+const SOURCE_TYPE_OPTIONS: { value: SourceFormType; label: string }[] = [
+	{ value: "local", label: "Local Filesystem" },
+	{ value: "sftp", label: "SFTP" },
+	{ value: "s3", label: "S3 Compatible Storage" },
+];
+
+const getTypeLabel = (type: SourceFormType) =>
+	SOURCE_TYPE_OPTIONS.find((option) => option.value === type)?.label ?? type;
+
+export function defaultSourceFormValidationRules(
+	data: SourceFormData,
+	editingSource?: MediaSourceInfo | SafeMediaSource | null,
+) {
+	const errors: Record<string, string> = {};
+	if (!data.name.trim()) {
+		errors.name = "Name is required";
+	}
+
+	if (data.type === "local") {
+		if (!data.connectionInfo.path) {
+			errors.path = "Path is required";
+		}
+	} else if (data.type === "sftp") {
+		if (!data.connectionInfo.host) {
+			errors.host = "Host is required";
+		}
+		if (!data.connectionInfo.username) {
+			errors.username = "Username is required";
+		}
+		if (!data.connectionInfo.remotePath) {
+			errors.remotePath = "Remote path is required";
+		}
+	} else if (data.type === "s3") {
+		if (!data.connectionInfo.bucket) {
+			errors.bucket = "Bucket is required";
+		}
+		if (!data.connectionInfo.region) {
+			errors.region = "Region is required";
+		}
+		if (!editingSource) {
+			if (!data.connectionInfo.accessKeyId) {
+				errors.accessKeyId = "Access Key ID is required";
+			}
+			if (!data.connectionInfo.secretAccessKey) {
+				errors.secretAccessKey = "Secret Access Key is required";
+			}
+		}
+	}
+
+	return errors;
+}
+
+export function SourceFormModal(props: SourceFormModalProps) {
+	const sourceTypes = () => props.sourceTypes ?? ["local", "sftp", "s3"];
+	const emptyValues = (): SourceFormData => ({
+		name: "",
+		description: "",
+		type: sourceTypes()[0] ?? "local",
+		connectionInfo: {},
+	});
+
+	const [formData, setFormData] = createStore<SourceFormData>(emptyValues());
+	const [errors, setErrors] = createSignal<Record<string, string>>({});
+
+	createEffect(() => {
+		if (props.initialValues) {
+			setFormData(props.initialValues);
+		} else if (props.editingSource) {
+			setFormData({
+				name: props.editingSource.name,
+				description: props.editingSource.description || "",
+				type: props.editingSource.type as SourceFormType,
+				connectionInfo:
+					(props.editingSource.connectionInfo as Record<
+						string,
+						string | number
+					>) || {},
+			});
+		} else {
+			setFormData(emptyValues());
+		}
+		setErrors({});
+	});
+
+	const validate = () => {
+		const nextErrors = props.validationRules
+			? props.validationRules(formData)
+			: defaultSourceFormValidationRules(formData, props.editingSource);
+
+		setErrors(nextErrors);
+		return Object.keys(nextErrors).length === 0;
+	};
+
+	const handleSubmit = (event: Event) => {
+		event.preventDefault();
+		if (!validate()) {
+			return;
+		}
+		const connectionInfo: Record<string, string | number | undefined> = {
+			...formData.connectionInfo,
+			port: formData.connectionInfo.port
+				? Number(formData.connectionInfo.port)
+				: undefined,
+		};
+
+		props.onSubmit({
+			...formData,
+			description: formData.description || null,
+			connectionInfo,
+		});
+	};
+
+	const selectOptions = () =>
+		SOURCE_TYPE_OPTIONS.filter((option) =>
+			sourceTypes().includes(option.value),
+		);
+
+	return (
+		<Dialog onOpenChange={() => props.onClose()} open={props.isOpen}>
+			<DialogContent class="max-h-[80vh] overflow-y-auto sm:max-w-[500px]">
+				<DialogHeader>
+					<DialogTitle>
+						{props.editingSource ? "Edit Source" : "Add New Source"}
+					</DialogTitle>
+					<DialogDescription>
+						{props.description ??
+							"Configure the connection details for your media source."}
+					</DialogDescription>
+				</DialogHeader>
+
+				<form class="space-y-4" onSubmit={handleSubmit}>
+					<div class="space-y-2">
+						<Label for="name">Name</Label>
+						<Input
+							id="name"
+							onInput={(event) =>
+								setFormData("name", event.currentTarget.value)
+							}
+							placeholder="My Media Source"
+							value={formData.name}
+						/>
+						<Show when={errors().name}>
+							<p class="text-red-500 text-sm">{errors().name}</p>
+						</Show>
+					</div>
+
+					<div class="space-y-2">
+						<Label for="description">Description (Optional)</Label>
+						<Input
+							id="description"
+							onInput={(event) =>
+								setFormData("description", event.currentTarget.value)
+							}
+							placeholder="Photos from my camera"
+							value={formData.description}
+						/>
+					</div>
+
+					<Show when={sourceTypes().length > 1}>
+						<div class="space-y-2">
+							<Label>Type</Label>
+							<Select
+								itemComponent={(itemProps) => (
+									<SelectItem item={itemProps.item}>
+										{itemProps.item.rawValue.label}
+									</SelectItem>
+								)}
+								onChange={(value) =>
+									setFormData("type", value?.value as SourceFormType)
+								}
+								options={selectOptions()}
+								value={{
+									value: formData.type,
+									label: getTypeLabel(formData.type),
+								}}
+							>
+								<SelectTrigger>
+									<SelectValue<{ value: string; label: string }>>
+										{(state) => state.selectedOption().label}
+									</SelectValue>
+								</SelectTrigger>
+								<SelectContent />
+							</Select>
+						</div>
+					</Show>
+
+					<div class="space-y-4 rounded-md border p-4">
+						<h4 class="font-medium text-sm">Connection Details</h4>
+
+						<Show when={formData.type === "local"}>
+							<div class="space-y-2">
+								<Label for="path">Directory Path</Label>
+								<Input
+									id="path"
+									onInput={(event) =>
+										setFormData(
+											"connectionInfo",
+											"path",
+											event.currentTarget.value,
+										)
+									}
+									placeholder="/mnt/data/photos"
+									value={(formData.connectionInfo.path as string) || ""}
+								/>
+								<Show when={errors().path}>
+									<p class="text-red-500 text-sm">{errors().path}</p>
+								</Show>
+							</div>
+						</Show>
+
+						<Show when={formData.type === "sftp"}>
+							<div class="grid grid-cols-2 gap-4">
+								<div class="space-y-2">
+									<Label for="host">Host</Label>
+									<Input
+										id="host"
+										onInput={(event) =>
+											setFormData(
+												"connectionInfo",
+												"host",
+												event.currentTarget.value,
+											)
+										}
+										placeholder="192.168.1.10"
+										value={(formData.connectionInfo.host as string) || ""}
+									/>
+									<Show when={errors().host}>
+										<p class="text-red-500 text-sm">{errors().host}</p>
+									</Show>
+								</div>
+								<div class="space-y-2">
+									<Label for="port">Port</Label>
+									<Input
+										id="port"
+										onInput={(event) =>
+											setFormData(
+												"connectionInfo",
+												"port",
+												event.currentTarget.value,
+											)
+										}
+										placeholder="22"
+										type="number"
+										value={formData.connectionInfo.port || DEFAULT_SFTP_PORT}
+									/>
+								</div>
+							</div>
+							<div class="space-y-2">
+								<Label for="username">Username</Label>
+								<Input
+									id="username"
+									onInput={(event) =>
+										setFormData(
+											"connectionInfo",
+											"username",
+											event.currentTarget.value,
+										)
+									}
+									placeholder="user"
+									value={(formData.connectionInfo.username as string) || ""}
+								/>
+								<Show when={errors().username}>
+									<p class="text-red-500 text-sm">{errors().username}</p>
+								</Show>
+							</div>
+							<div class="space-y-2">
+								<Label for="password">Password (Optional)</Label>
+								<Input
+									id="password"
+									onInput={(event) =>
+										setFormData(
+											"connectionInfo",
+											"password",
+											event.currentTarget.value,
+										)
+									}
+									placeholder="********"
+									type="password"
+									value={(formData.connectionInfo.password as string) || ""}
+								/>
+							</div>
+							<div class="space-y-2">
+								<Label for="remotePath">Remote Path</Label>
+								<Input
+									id="remotePath"
+									onInput={(event) =>
+										setFormData(
+											"connectionInfo",
+											"remotePath",
+											event.currentTarget.value,
+										)
+									}
+									placeholder="/home/user/photos"
+									value={(formData.connectionInfo.remotePath as string) || ""}
+								/>
+								<Show when={errors().remotePath}>
+									<p class="text-red-500 text-sm">{errors().remotePath}</p>
+								</Show>
+							</div>
+						</Show>
+
+						<Show when={formData.type === "s3"}>
+							<div class="grid grid-cols-2 gap-4">
+								<div class="space-y-2">
+									<Label for="bucket">Bucket</Label>
+									<Input
+										id="bucket"
+										onInput={(event) =>
+											setFormData(
+												"connectionInfo",
+												"bucket",
+												event.currentTarget.value,
+											)
+										}
+										placeholder="my-bucket"
+										value={(formData.connectionInfo.bucket as string) || ""}
+									/>
+									<Show when={errors().bucket}>
+										<p class="text-red-500 text-sm">{errors().bucket}</p>
+									</Show>
+								</div>
+								<div class="space-y-2">
+									<Label for="region">Region</Label>
+									<Input
+										id="region"
+										onInput={(event) =>
+											setFormData(
+												"connectionInfo",
+												"region",
+												event.currentTarget.value,
+											)
+										}
+										placeholder="us-east-1"
+										value={(formData.connectionInfo.region as string) || ""}
+									/>
+									<Show when={errors().region}>
+										<p class="text-red-500 text-sm">{errors().region}</p>
+									</Show>
+								</div>
+							</div>
+							<div class="space-y-2">
+								<Label for="accessKeyId">Access Key ID</Label>
+								<Input
+									id="accessKeyId"
+									onInput={(event) =>
+										setFormData(
+											"connectionInfo",
+											"accessKeyId",
+											event.currentTarget.value,
+										)
+									}
+									placeholder="AKIA..."
+									value={(formData.connectionInfo.accessKeyId as string) || ""}
+								/>
+								<Show when={errors().accessKeyId}>
+									<p class="text-red-500 text-sm">{errors().accessKeyId}</p>
+								</Show>
+							</div>
+							<div class="space-y-2">
+								<Label for="secretAccessKey">Secret Access Key</Label>
+								<Input
+									id="secretAccessKey"
+									onInput={(event) =>
+										setFormData(
+											"connectionInfo",
+											"secretAccessKey",
+											event.currentTarget.value,
+										)
+									}
+									placeholder="********"
+									type="password"
+									value={
+										(formData.connectionInfo.secretAccessKey as string) || ""
+									}
+								/>
+								<Show when={errors().secretAccessKey}>
+									<p class="text-red-500 text-sm">{errors().secretAccessKey}</p>
+								</Show>
+							</div>
+							<div class="space-y-2">
+								<Label for="prefix">Prefix (Optional)</Label>
+								<Input
+									id="prefix"
+									onInput={(event) =>
+										setFormData(
+											"connectionInfo",
+											"prefix",
+											event.currentTarget.value,
+										)
+									}
+									placeholder="photos/"
+									value={(formData.connectionInfo.prefix as string) || ""}
+								/>
+							</div>
+						</Show>
+					</div>
+
+					<DialogFooter>
+						<Button
+							onClick={() => props.onClose()}
+							type="button"
+							variant="outline"
+						>
+							Cancel
+						</Button>
+						<Button type="submit">
+							{props.submitLabel ??
+								(props.editingSource ? "Save Changes" : "Add Source")}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -1,0 +1,326 @@
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import { createWindowVirtualizer } from "@tanstack/solid-virtual";
+import type { Accessor, JSX, Setter } from "solid-js";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	For,
+	onCleanup,
+	onMount,
+	Show,
+} from "solid-js";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from "./context-menu";
+
+const VIRTUALIZATION_THRESHOLD = 100;
+const GRID_GAP_PX = 16;
+const GRID_ITEM_ASPECT_RATIO = 4 / 3;
+const VIRTUAL_ROWS_OVERSCAN = 4;
+
+type SourceMediaGridProps = {
+	mediaResults: Accessor<Media[]>;
+	mediaSourceId: Accessor<string | undefined>;
+	isPending: boolean;
+	isError: boolean;
+	isFetchingNextPage: boolean;
+	queryError: Error | null;
+	contextMenuMediaId: Accessor<string | null>;
+	setContextMenuMediaId: Setter<string | null>;
+	onDelete: (mediaId: string) => void;
+	onCopyMove: (mediaId: string, mode: "copy" | "move") => void;
+	onSyncSingleMedia: (mediaId: string) => void;
+	setLoadMoreRef: (el: HTMLDivElement) => void;
+	/** Render a single media grid item. */
+	renderItem: (
+		media: Media,
+		options: { onContextMenu: () => void },
+	) => JSX.Element;
+	/** Enable virtualization for large lists. Default: false. */
+	enableVirtualization?: boolean;
+	/** Show result count above grid. Default: true. */
+	showResultCount?: boolean;
+	/** Show empty state message. Default: true. */
+	showEmptyState?: boolean;
+	/** Show "Open in New Tab" context menu item. Default: false. */
+	showOpenInNewTab?: boolean;
+	/** Total result count. If omitted, uses mediaResults().length (may not reflect total). */
+	totalCount?: number;
+};
+
+export function SourceMediaGrid(props: SourceMediaGridProps) {
+	const showResultCount = () => props.showResultCount ?? true;
+	const showEmptyState = () => props.showEmptyState ?? true;
+	const showOpenInNewTab = () => props.showOpenInNewTab ?? false;
+	const enableVirtualization = () => props.enableVirtualization ?? false;
+	const totalCount = () => props.totalCount ?? props.mediaResults().length;
+
+	// --- Virtual grid setup ---
+	const [windowWidth, setWindowWidth] = createSignal(0);
+	const [mediaGridWidth, setMediaGridWidth] = createSignal(0);
+	let mediaGridRef: HTMLDivElement | undefined;
+
+	const columnCount = createMemo(() => {
+		const width = windowWidth();
+		if (width >= 1024) return 5;
+		if (width >= 768) return 3;
+		return 2;
+	});
+
+	const mediaItemWidth = createMemo(() => {
+		const width = mediaGridWidth();
+		const columns = columnCount();
+		if (!(width > 0 && columns > 0)) return 0;
+		return Math.max((width - GRID_GAP_PX * (columns - 1)) / columns, 0);
+	});
+
+	const mediaItemHeight = createMemo(() => {
+		const width = mediaItemWidth();
+		if (width <= 0) return 0;
+		return width * GRID_ITEM_ASPECT_RATIO;
+	});
+
+	const mediaRows = createMemo(() => {
+		const results = props.mediaResults();
+		const columns = columnCount();
+		const rows: Media[][] = [];
+		for (let index = 0; index < results.length; index += columns) {
+			rows.push(results.slice(index, index + columns));
+		}
+		return rows;
+	});
+
+	const rowCount = createMemo(() => mediaRows().length);
+
+	const mediaRowVirtualizer = createWindowVirtualizer<HTMLDivElement>({
+		get count() {
+			return rowCount();
+		},
+		estimateSize: () => mediaItemHeight() || 320,
+		gap: GRID_GAP_PX,
+		getItemKey: (index) => index,
+		overscan: VIRTUAL_ROWS_OVERSCAN,
+		scrollMargin: 0,
+	});
+
+	const shouldVirtualize = createMemo(
+		() =>
+			enableVirtualization() &&
+			props.mediaResults().length > VIRTUALIZATION_THRESHOLD &&
+			mediaItemWidth() > 0,
+	);
+
+	const updateMediaGridMetrics = () => {
+		if (!mediaGridRef) return;
+		setMediaGridWidth(mediaGridRef.getBoundingClientRect().width);
+	};
+
+	onMount(() => {
+		setWindowWidth(window.innerWidth);
+		updateMediaGridMetrics();
+
+		const handleResize = () => {
+			setWindowWidth(window.innerWidth);
+			updateMediaGridMetrics();
+		};
+		window.addEventListener("resize", handleResize);
+
+		const resizeObserver = new ResizeObserver(() => {
+			updateMediaGridMetrics();
+		});
+		if (mediaGridRef) {
+			resizeObserver.observe(mediaGridRef);
+		}
+
+		onCleanup(() => {
+			window.removeEventListener("resize", handleResize);
+			resizeObserver.disconnect();
+		});
+	});
+
+	createEffect(() => {
+		rowCount();
+		mediaItemHeight();
+		columnCount();
+		mediaRowVirtualizer.measure();
+	});
+
+	return (
+		<div class="min-h-0 space-y-4">
+			{/* Loading state */}
+			<Show when={props.isPending && props.mediaResults().length === 0}>
+				<div class="flex h-64 items-center justify-center">
+					<div class="animate-pulse text-lg text-muted-foreground">
+						Loading media...
+					</div>
+				</div>
+			</Show>
+
+			{/* Error state */}
+			<Show when={props.isError}>
+				<div class="text-red-500">Error: {props.queryError?.message}</div>
+			</Show>
+
+			{/* Result count */}
+			<Show when={showResultCount() && props.mediaResults().length > 0}>
+				<div class="mb-4 flex items-center justify-between">
+					<p class="text-gray-600 text-sm">{totalCount()} 件の結果</p>
+				</div>
+			</Show>
+
+			{/* Grid with context menu */}
+			<ContextMenu>
+				<ContextMenuTrigger class="block w-full">
+					<div
+						class="relative w-full"
+						ref={(element) => {
+							mediaGridRef = element;
+							requestAnimationFrame(() => {
+								updateMediaGridMetrics();
+							});
+						}}
+						style={{
+							height: shouldVirtualize()
+								? `${mediaRowVirtualizer.getTotalSize()}px`
+								: undefined,
+						}}
+					>
+						<Show
+							fallback={
+								<div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5">
+									<For each={props.mediaResults()}>
+										{(media) =>
+											props.renderItem(media, {
+												onContextMenu: () =>
+													props.setContextMenuMediaId(media.id),
+											})
+										}
+									</For>
+								</div>
+							}
+							when={shouldVirtualize()}
+						>
+							<For each={mediaRowVirtualizer.getVirtualItems()}>
+								{(virtualRow) => {
+									const rowMedia = () => mediaRows()[virtualRow.index] || [];
+									return (
+										<div
+											class="absolute left-0 top-0 grid gap-4"
+											style={{
+												"grid-template-columns": `repeat(${columnCount()}, minmax(0, 1fr))`,
+												height: `${virtualRow.size}px`,
+												transform: `translateY(${virtualRow.start}px)`,
+												width: "100%",
+											}}
+										>
+											<For each={rowMedia()}>
+												{(media) =>
+													props.renderItem(media, {
+														onContextMenu: () =>
+															props.setContextMenuMediaId(media.id),
+													})
+												}
+											</For>
+										</div>
+									);
+								}}
+							</For>
+						</Show>
+					</div>
+				</ContextMenuTrigger>
+
+				{/* Context menu content */}
+				<ContextMenuContent>
+					<Show
+						fallback={
+							<ContextMenuItem disabled>No media selected</ContextMenuItem>
+						}
+						when={props.contextMenuMediaId()}
+					>
+						<Show when={showOpenInNewTab()}>
+							<ContextMenuItem
+								onSelect={() => {
+									const id = props.contextMenuMediaId();
+									const sourceId = props.mediaSourceId();
+									if (id && sourceId) {
+										window.open(`/sources/${sourceId}/${id}`, "_blank");
+									}
+								}}
+							>
+								Open in New Tab
+							</ContextMenuItem>
+						</Show>
+
+						<ContextMenuItem
+							class="text-red-600 focus:text-red-600"
+							onSelect={() => {
+								const id = props.contextMenuMediaId();
+								if (id) props.onDelete(id);
+							}}
+						>
+							Delete
+						</ContextMenuItem>
+
+						<ContextMenuSeparator />
+
+						<ContextMenuItem
+							onSelect={() => {
+								const id = props.contextMenuMediaId();
+								if (id) props.onCopyMove(id, "copy");
+							}}
+						>
+							Copy to Source
+						</ContextMenuItem>
+						<ContextMenuItem
+							onSelect={() => {
+								const id = props.contextMenuMediaId();
+								if (id) props.onCopyMove(id, "move");
+							}}
+						>
+							Move to Source
+						</ContextMenuItem>
+
+						<ContextMenuSeparator />
+
+						<ContextMenuItem
+							onSelect={() => {
+								const id = props.contextMenuMediaId();
+								if (id) props.onSyncSingleMedia(id);
+							}}
+						>
+							Sync Metadata
+						</ContextMenuItem>
+					</Show>
+				</ContextMenuContent>
+			</ContextMenu>
+
+			{/* Empty state */}
+			<Show
+				when={
+					showEmptyState() &&
+					props.mediaResults().length === 0 &&
+					!props.isPending
+				}
+			>
+				<div class="py-12 text-center text-gray-500">
+					検索結果が見つかりませんでした
+				</div>
+			</Show>
+
+			{/* Load more sentinel */}
+			<div
+				class="flex h-10 w-full items-center justify-center text-gray-500"
+				ref={props.setLoadMoreRef}
+			>
+				<Show when={props.isFetchingNextPage}>
+					<div class="text-center text-gray-500">Loading more...</div>
+				</Show>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -1,0 +1,98 @@
+import type { Character } from "@solid-imager/core/domain/characters/schemas";
+import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type {
+	Author,
+	MediaSearchRequest,
+} from "@solid-imager/core/domain/media/schemas";
+import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import type { Accessor, JSX } from "solid-js";
+import type { MediaSourceEventTransport } from "./hooks/use-media-source-events";
+import {
+	type SourceMediaPageActions,
+	type SourceMediaPagePresetClient,
+	useSourceMediaPage,
+} from "./hooks/use-source-media-page";
+import { MediaListActions } from "./media-list-actions";
+import {
+	SourceMediaScreen,
+	type SourceMediaScreenProps,
+} from "./screens/source-media-screen";
+
+type QueryOptionFactory<_TData> = () => any;
+
+export type SourceMediaPageProps = {
+	mediaSourceId: Accessor<string>;
+	transport: MediaSourceEventTransport;
+	presetClient: SourceMediaPagePresetClient;
+	actions: SourceMediaPageActions;
+	getSearchCondition: () => MediaSearchRequest["condition"];
+	sortBy: () => MediaSearchRequest["sort"];
+	sortOrder: () => "asc" | "desc";
+	onThumbnailReady?: (mediaId: string) => void;
+	tagsQueryOptions: QueryOptionFactory<TagResponse[]>;
+	projectsQueryOptions: QueryOptionFactory<Project[]>;
+	ipsQueryOptions: QueryOptionFactory<Ip[]>;
+	charactersQueryOptions: QueryOptionFactory<Character[]>;
+	authorsQueryOptions: QueryOptionFactory<Author[]>;
+	enableVirtualization?: boolean;
+	moveCopyDialogComponent: SourceMediaScreenProps["moveCopyDialogComponent"];
+	uploadModalComponent: SourceMediaScreenProps["uploadModalComponent"];
+	renderItem: SourceMediaScreenProps["renderItem"];
+	showOpenInNewTab?: boolean;
+};
+
+export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
+	const queryClient = useQueryClient();
+
+	const tags = createQuery<TagResponse[]>(() => props.tagsQueryOptions());
+	const allProjects = createQuery<Project[]>(() =>
+		props.projectsQueryOptions(),
+	);
+	const allIps = createQuery<Ip[]>(() => props.ipsQueryOptions());
+	const allCharacters = createQuery<Character[]>(() =>
+		props.charactersQueryOptions(),
+	);
+	const allAuthors = createQuery<Author[]>(() => props.authorsQueryOptions());
+
+	const page = useSourceMediaPage({
+		mediaSourceId: props.mediaSourceId,
+		queries: {
+			tags: () => tags.data,
+			projects: () => allProjects.data,
+			ips: () => allIps.data,
+			characters: () => allCharacters.data,
+			authors: () => allAuthors.data,
+		},
+		actions: props.actions,
+		queryClient,
+		presetClient: props.presetClient,
+		transport: props.transport,
+		getSearchCondition: props.getSearchCondition,
+		sortBy: props.sortBy,
+		sortOrder: props.sortOrder,
+		onThumbnailReady: props.onThumbnailReady,
+	});
+
+	const renderActions: SourceMediaScreenProps["renderActions"] = () => (
+		<MediaListActions
+			filterData={page.filterData()}
+			onDumpDownload={page.handleDumpDownload}
+			onSearch={page.handleSearch}
+			presetClient={props.presetClient}
+		/>
+	);
+
+	return (
+		<SourceMediaScreen
+			enableVirtualization={props.enableVirtualization}
+			page={page}
+			renderActions={renderActions}
+			renderItem={props.renderItem}
+			moveCopyDialogComponent={props.moveCopyDialogComponent}
+			uploadModalComponent={props.uploadModalComponent}
+			showOpenInNewTab={props.showOpenInNewTab}
+		/>
+	);
+}

--- a/packages/ui/src/stores/search-store.ts
+++ b/packages/ui/src/stores/search-store.ts
@@ -1,0 +1,43 @@
+import type { Preset } from "@solid-imager/core/domain/media/schemas";
+import {
+	calculateNextModeState,
+	getSearchConditionFromState,
+	preparePresetState,
+} from "@solid-imager/core/domain/search/logic";
+import {
+	defaultState,
+	type SearchState,
+} from "@solid-imager/core/domain/search/schema";
+import { createStore } from "solid-js/store";
+
+export const [searchState, setSearchState] = createStore<SearchState>({
+	...defaultState,
+});
+
+export const resetSearchState = () => {
+	setSearchState({ ...defaultState });
+};
+
+export const clearPresetFilters = () => {
+	setSearchState((prev) => ({
+		...defaultState,
+		mode: prev.mode,
+		selectedSource: prev.selectedSource,
+		sortBy: prev.sortBy,
+		sortOrder: prev.sortOrder,
+		tagMode: prev.tagMode,
+	}));
+};
+
+export const loadPreset = (preset: Preset) => {
+	const nextState = preparePresetState(preset, searchState);
+	setSearchState(nextState);
+};
+
+export const setSearchMode = (mode: "simple" | "pro") => {
+	const nextState = calculateNextModeState(searchState, mode);
+	setSearchState(nextState);
+};
+
+export const getSearchCondition = () =>
+	getSearchConditionFromState(searchState);

--- a/packages/ui/src/thumbnail-image.tsx
+++ b/packages/ui/src/thumbnail-image.tsx
@@ -1,0 +1,98 @@
+import { createEffect, createSignal, onCleanup, Show } from "solid-js";
+
+export interface ThumbnailSource {
+	getUrl(): string | Promise<string>;
+	onError?(): void;
+	onLoad?(): void;
+	subscribe?(callback: () => void): () => void;
+}
+
+export interface ThumbnailImageProps {
+	alt: string;
+	class?: string;
+	fallback?: string;
+	height?: number | null;
+	loading?: "eager" | "lazy";
+	source: ThumbnailSource;
+	width?: number | null;
+}
+
+export function ThumbnailImage(props: ThumbnailImageProps) {
+	const [url, setUrl] = createSignal<string | null>(null);
+	const [error, setError] = createSignal(false);
+
+	createEffect(() => {
+		const source = props.source;
+		setError(false);
+		let cancelled = false;
+
+		const load = async () => {
+			try {
+				const resolved = await source.getUrl();
+				if (!cancelled) {
+					setUrl(resolved);
+				}
+			} catch {
+				if (!cancelled) {
+					setError(true);
+					source.onError?.();
+				}
+			}
+		};
+
+		void load();
+
+		const unsubscribe = source.subscribe?.(() => {
+			setError(false);
+			void load();
+		});
+
+		onCleanup(() => {
+			cancelled = true;
+			unsubscribe?.();
+		});
+	});
+
+	const handleLoad = () => {
+		props.source.onLoad?.();
+	};
+
+	const handleError = () => {
+		setError(true);
+		props.source.onError?.();
+		// Re-evaluate URL in case onError updated internal fallback state
+		void (async () => {
+			try {
+				const resolved = await props.source.getUrl();
+				setUrl(resolved);
+				setError(false);
+			} catch {
+				// keep error state
+			}
+		})();
+	};
+
+	return (
+		<Show
+			fallback={
+				<div class="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400">
+					{props.fallback ?? props.alt}
+				</div>
+			}
+			when={!error() ? url() : undefined}
+		>
+			{(resolvedUrl) => (
+				<img
+					alt={props.alt}
+					class={props.class}
+					height={props.height ?? undefined}
+					loading={props.loading}
+					onError={handleError}
+					onLoad={handleLoad}
+					src={resolvedUrl()}
+					width={props.width ?? undefined}
+				/>
+			)}
+		</Show>
+	);
+}

--- a/packages/ui/src/thumbnail-source.test.ts
+++ b/packages/ui/src/thumbnail-source.test.ts
@@ -1,0 +1,351 @@
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import { createRoot } from "solid-js";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vite-plus/test";
+import {
+	createHttpThumbnailSource,
+	createLocalThumbnailSource,
+	type ObjectUrlAdapter,
+} from "./thumbnail-source";
+
+const media: Media = {
+	createdAt: new Date("2026-01-01T00:00:00.000Z"),
+	description: null,
+	fileName: "image.png",
+	filePath: "nested/image.png",
+	fileSize: 1024,
+	height: 100,
+	id: "11111111-1111-4111-8111-111111111111",
+	indexedAt: new Date("2026-01-01T00:00:00.000Z"),
+	mediaSourceId: "22222222-2222-4222-8222-222222222222",
+	mediaType: "image",
+	modifiedAt: new Date("2026-02-03T04:05:06.000Z"),
+	status: "active",
+	width: 100,
+};
+
+const flushPromises = () =>
+	new Promise<void>((resolve) => queueMicrotask(resolve));
+
+function createObjectUrlAdapter(): ObjectUrlAdapter & {
+	readonly created: string[];
+	readonly revoked: string[];
+} {
+	const created: string[] = [];
+	const revoked: string[] = [];
+
+	return {
+		created,
+		create(_bytes, mimeType) {
+			const url = `blob:${mimeType}:${created.length + 1}`;
+			created.push(url);
+			return url;
+		},
+		revoke(url) {
+			revoked.push(url);
+		},
+		revoked,
+	};
+}
+
+describe("createHttpThumbnailSource", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-03-01T00:00:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("builds the URL with the modifiedAt cache key", () => {
+		let dispose = () => {};
+		const source = createRoot((rootDispose) => {
+			dispose = rootDispose;
+			return createHttpThumbnailSource({
+				buildUrl: ({ cacheKey, mediaId, mediaSourceId }) =>
+					`/api/sources/${mediaSourceId}/${mediaId}/thumbnail?t=${cacheKey}`,
+				mediaId: media.id,
+				mediaSourceId: media.mediaSourceId,
+				modifiedAt: media.modifiedAt,
+			});
+		});
+
+		expect(source.getUrl()).toBe(
+			`/api/sources/${media.mediaSourceId}/${media.id}/thumbnail?t=${media.modifiedAt.getTime()}`,
+		);
+
+		dispose();
+	});
+
+	it("updates the cache key after an error retry delay", () => {
+		let dispose = () => {};
+		const source = createRoot((rootDispose) => {
+			dispose = rootDispose;
+			return createHttpThumbnailSource({
+				buildUrl: ({ cacheKey }) => `/thumbnail?t=${cacheKey}`,
+				mediaId: media.id,
+				mediaSourceId: media.mediaSourceId,
+				modifiedAt: media.modifiedAt,
+				retryDelayMs: 100,
+			});
+		});
+
+		source.onError?.();
+		vi.setSystemTime(new Date("2026-03-01T00:00:01.000Z"));
+		vi.advanceTimersByTime(100);
+
+		expect(source.getUrl()).toBe("/thumbnail?t=1772323201100");
+
+		dispose();
+	});
+
+	it("stops scheduling retries after maxRetries is reached", () => {
+		let dispose = () => {};
+		const source = createRoot((rootDispose) => {
+			dispose = rootDispose;
+			return createHttpThumbnailSource({
+				buildUrl: ({ cacheKey }) => `/thumbnail?t=${cacheKey}`,
+				maxRetries: 1,
+				mediaId: media.id,
+				mediaSourceId: media.mediaSourceId,
+				modifiedAt: media.modifiedAt,
+				retryDelayMs: 100,
+			});
+		});
+
+		source.onError?.();
+		vi.setSystemTime(new Date("2026-03-01T00:00:01.000Z"));
+		vi.advanceTimersByTime(100);
+		expect(source.getUrl()).toBe("/thumbnail?t=1772323201100");
+
+		source.onError?.();
+		vi.setSystemTime(new Date("2026-03-01T00:00:02.000Z"));
+		vi.advanceTimersByTime(100);
+		expect(source.getUrl()).toBe("/thumbnail?t=1772323201100");
+
+		dispose();
+	});
+});
+
+describe("createLocalThumbnailSource", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("prefers the thumbnail resource URL", async () => {
+		let dispose = () => {};
+		const source = createRoot((rootDispose) => {
+			dispose = rootDispose;
+			return createLocalThumbnailSource({
+				getThumbnailResource: vi.fn().mockResolvedValue({
+					filePath: "/thumb/source/media.webp",
+					url: "asset://thumb.webp?t=1",
+				}),
+				joinPath: (rootPath, filePath) => `${rootPath}/${filePath}`,
+				media,
+				objectUrl: createObjectUrlAdapter(),
+				readFile: vi.fn(),
+				subscribeToThumbnailReady: () => () => {},
+			});
+		});
+
+		await flushPromises();
+
+		expect(await source.getUrl()).toBe("asset://thumb.webp?t=1");
+
+		dispose();
+	});
+
+	it("falls back to reading the thumbnail file when the resource URL fails", async () => {
+		let dispose = () => {};
+		const objectUrl = createObjectUrlAdapter();
+		const readFile = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+		const source = createRoot((rootDispose) => {
+			dispose = rootDispose;
+			return createLocalThumbnailSource({
+				getThumbnailResource: vi.fn().mockResolvedValue({
+					filePath: "/thumb/source/media.webp",
+					url: "asset://thumb.webp?t=1",
+				}),
+				joinPath: (rootPath, filePath) => `${rootPath}/${filePath}`,
+				media,
+				objectUrl,
+				readFile,
+				subscribeToThumbnailReady: () => () => {},
+			});
+		});
+
+		await flushPromises();
+		await Promise.resolve(source.onError?.());
+
+		expect(readFile).toHaveBeenCalledWith("/thumb/source/media.webp");
+		expect(await source.getUrl()).toBe("blob:image/webp:1");
+
+		source.onLoad?.();
+		expect(objectUrl.revoked).toEqual(["blob:image/webp:1"]);
+
+		dispose();
+	});
+
+	it("falls back to the original file and keeps retrying for a thumbnail", async () => {
+		let dispose = () => {};
+		const objectUrl = createObjectUrlAdapter();
+		const getThumbnailResource = vi
+			.fn()
+			.mockRejectedValue(new Error("not ready"));
+		const readFile = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+		const source = createRoot((rootDispose) => {
+			dispose = rootDispose;
+			return createLocalThumbnailSource({
+				getThumbnailResource,
+				joinPath: (rootPath, filePath) => `${rootPath}/${filePath}`,
+				media,
+				objectUrl,
+				readFile,
+				retryDelayMs: 100,
+				sourceRootPath: "/source-root",
+				subscribeToThumbnailReady: () => () => {},
+			});
+		});
+
+		await flushPromises();
+		await Promise.resolve(source.onError?.());
+
+		expect(readFile).toHaveBeenCalledWith("/source-root/nested/image.png");
+		expect(await source.getUrl()).toBe("blob:image/png:1");
+
+		vi.advanceTimersByTime(100);
+		await flushPromises();
+		expect(getThumbnailResource).toHaveBeenCalledTimes(2);
+
+		dispose();
+	});
+
+	it("re-fetches the thumbnail resource when thumbnail ready is published", async () => {
+		let dispose = () => {};
+		let listener: (() => void) | undefined;
+		const callback = vi.fn();
+		const getThumbnailResource = vi
+			.fn()
+			.mockResolvedValueOnce({
+				filePath: "/thumb/source/media.webp",
+				url: "asset://thumb.webp?t=1",
+			})
+			.mockResolvedValueOnce({
+				filePath: "/thumb/source/media.webp",
+				url: "asset://thumb.webp?t=2",
+			});
+		const source = createRoot((rootDispose) => {
+			dispose = rootDispose;
+			return createLocalThumbnailSource({
+				getThumbnailResource,
+				joinPath: (rootPath, filePath) => `${rootPath}/${filePath}`,
+				media,
+				objectUrl: createObjectUrlAdapter(),
+				readFile: vi.fn(),
+				subscribeToThumbnailReady: (_mediaId, readyCallback) => {
+					listener = readyCallback;
+					return () => {
+						listener = undefined;
+					};
+				},
+			});
+		});
+
+		await flushPromises();
+		const unsubscribe = source.subscribe?.(callback);
+		listener?.();
+		await flushPromises();
+
+		expect(callback).toHaveBeenCalledOnce();
+		expect(await source.getUrl()).toBe("asset://thumb.webp?t=2");
+
+		unsubscribe?.();
+		dispose();
+	});
+
+	it("ignores stale thumbnail resource responses", async () => {
+		let dispose = () => {};
+		let listener: (() => void) | undefined;
+		let resolveFirst:
+			| ((resource: { filePath: string; url: string }) => void)
+			| undefined;
+		const getThumbnailResource = vi
+			.fn()
+			.mockImplementationOnce(
+				() =>
+					new Promise<{ filePath: string; url: string }>((resolve) => {
+						resolveFirst = resolve;
+					}),
+			)
+			.mockResolvedValueOnce({
+				filePath: "/thumb/source/media-new.webp",
+				url: "asset://thumb-new.webp?t=2",
+			});
+		const source = createRoot((rootDispose) => {
+			dispose = rootDispose;
+			return createLocalThumbnailSource({
+				getThumbnailResource,
+				joinPath: (rootPath, filePath) => `${rootPath}/${filePath}`,
+				media,
+				objectUrl: createObjectUrlAdapter(),
+				readFile: vi.fn(),
+				subscribeToThumbnailReady: (_mediaId, readyCallback) => {
+					listener = readyCallback;
+					return () => {};
+				},
+			});
+		});
+
+		source.subscribe?.(vi.fn());
+		listener?.();
+		await flushPromises();
+		expect(await source.getUrl()).toBe("asset://thumb-new.webp?t=2");
+
+		resolveFirst?.({
+			filePath: "/thumb/source/media-old.webp",
+			url: "asset://thumb-old.webp?t=1",
+		});
+		await flushPromises();
+
+		expect(await source.getUrl()).toBe("asset://thumb-new.webp?t=2");
+
+		dispose();
+	});
+
+	it("does not revoke the same fallback object URL twice during cleanup", async () => {
+		let dispose = () => {};
+		const objectUrl = createObjectUrlAdapter();
+		const source = createRoot((rootDispose) => {
+			dispose = rootDispose;
+			return createLocalThumbnailSource({
+				getThumbnailResource: vi.fn().mockResolvedValue({
+					filePath: "/thumb/source/media.webp",
+					url: "asset://thumb.webp?t=1",
+				}),
+				joinPath: (rootPath, filePath) => `${rootPath}/${filePath}`,
+				media,
+				objectUrl,
+				readFile: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+				subscribeToThumbnailReady: () => () => {},
+			});
+		});
+
+		await flushPromises();
+		await Promise.resolve(source.onError?.());
+		dispose();
+
+		expect(objectUrl.revoked).toEqual(["blob:image/webp:1"]);
+	});
+});

--- a/packages/ui/src/thumbnail-source.ts
+++ b/packages/ui/src/thumbnail-source.ts
@@ -1,0 +1,275 @@
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import { createRenderEffect, createSignal, onCleanup } from "solid-js";
+import type { ThumbnailSource } from "./thumbnail-image";
+
+const DEFAULT_HTTP_MAX_RETRIES = 10;
+const DEFAULT_HTTP_RETRY_DELAY_MS = 1500;
+const DEFAULT_LOCAL_MAX_RETRIES = 40;
+const DEFAULT_LOCAL_RETRY_DELAY_MS = 1500;
+const THUMBNAIL_MIME_TYPE = "image/webp";
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+	jpg: "image/jpeg",
+	jpeg: "image/jpeg",
+	png: "image/png",
+	webp: "image/webp",
+	gif: "image/gif",
+	bmp: "image/bmp",
+	svg: "image/svg+xml",
+};
+
+export type BuildThumbnailUrlArgs = {
+	cacheKey: number;
+	mediaId: string;
+	mediaSourceId: string;
+};
+
+export type CreateHttpThumbnailSourceProps = {
+	buildUrl: (args: BuildThumbnailUrlArgs) => string;
+	maxRetries?: number;
+	mediaId: string;
+	mediaSourceId: string;
+	modifiedAt: Date | string;
+	retryDelayMs?: number;
+};
+
+export type ThumbnailResource = {
+	filePath: string;
+	url: string;
+};
+
+export type ObjectUrlAdapter = {
+	create(bytes: Uint8Array, mimeType: string): string;
+	revoke(url: string): void;
+};
+
+export type CreateLocalThumbnailSourceProps = {
+	getThumbnailResource: (
+		mediaSourceId: string,
+		mediaId: string,
+		cacheKey: number,
+	) => Promise<ThumbnailResource>;
+	joinPath: (rootPath: string, filePath: string) => string;
+	maxRetries?: number;
+	media: Media;
+	objectUrl: ObjectUrlAdapter;
+	readFile: (path: string) => Promise<Uint8Array>;
+	retryDelayMs?: number;
+	sourceRootPath?: string;
+	subscribeToThumbnailReady: (
+		mediaId: string,
+		callback: () => void,
+	) => () => void;
+};
+
+function revokeObjectUrl(adapter: ObjectUrlAdapter, url: string | null) {
+	if (url?.startsWith("blob:")) {
+		adapter.revoke(url);
+	}
+}
+
+function resolveMimeType(fileName: string) {
+	const extension = fileName.split(".").pop()?.toLowerCase();
+	return (
+		(extension && MIME_BY_EXTENSION[extension]) || "application/octet-stream"
+	);
+}
+
+export function createHttpThumbnailSource(
+	props: CreateHttpThumbnailSourceProps,
+): ThumbnailSource {
+	const [cacheKey, setCacheKey] = createSignal(0);
+	const [retryCount, setRetryCount] = createSignal(0);
+	let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+	const clearRetryTimer = () => {
+		if (retryTimer) {
+			clearTimeout(retryTimer);
+			retryTimer = undefined;
+		}
+	};
+
+	createRenderEffect(() => {
+		void props.mediaId;
+		void props.mediaSourceId;
+		void props.modifiedAt;
+		clearRetryTimer();
+		setRetryCount(0);
+		setCacheKey(new Date(props.modifiedAt).getTime());
+	});
+
+	onCleanup(() => {
+		clearRetryTimer();
+	});
+
+	return {
+		getUrl() {
+			return props.buildUrl({
+				cacheKey: cacheKey(),
+				mediaId: props.mediaId,
+				mediaSourceId: props.mediaSourceId,
+			});
+		},
+		onLoad() {
+			clearRetryTimer();
+		},
+		onError() {
+			if (retryCount() >= (props.maxRetries ?? DEFAULT_HTTP_MAX_RETRIES)) {
+				return;
+			}
+			clearRetryTimer();
+			retryTimer = setTimeout(() => {
+				setRetryCount((prev) => prev + 1);
+				setCacheKey(Date.now());
+			}, props.retryDelayMs ?? DEFAULT_HTTP_RETRY_DELAY_MS);
+		},
+	};
+}
+
+export function createLocalThumbnailSource(
+	props: CreateLocalThumbnailSourceProps,
+): ThumbnailSource {
+	const [url, setUrl] = createSignal<string | null>(null);
+	const [fallbackUrl, setFallbackUrl] = createSignal<string | null>(null);
+	const [thumbnailFilePath, setThumbnailFilePath] = createSignal<string | null>(
+		null,
+	);
+	const [retryCount, setRetryCount] = createSignal(0);
+	let retryTimer: ReturnType<typeof setTimeout> | undefined;
+	let revokeOnLoad: string | null = null;
+	let lastRequestId = 0;
+
+	const clearRetryTimer = () => {
+		if (retryTimer) {
+			clearTimeout(retryTimer);
+			retryTimer = undefined;
+		}
+	};
+
+	const scheduleRetry = () => {
+		if (retryCount() >= (props.maxRetries ?? DEFAULT_LOCAL_MAX_RETRIES)) {
+			return;
+		}
+		clearRetryTimer();
+		retryTimer = setTimeout(() => {
+			setRetryCount((count) => count + 1);
+			void loadThumbnail();
+		}, props.retryDelayMs ?? DEFAULT_LOCAL_RETRY_DELAY_MS);
+	};
+
+	const loadThumbnail = async () => {
+		lastRequestId += 1;
+		const requestId = lastRequestId;
+		try {
+			const resource = await props.getThumbnailResource(
+				props.media.mediaSourceId,
+				props.media.id,
+				new Date(props.media.modifiedAt).getTime(),
+			);
+			if (requestId !== lastRequestId) {
+				return;
+			}
+			setThumbnailFilePath(resource.filePath);
+			setUrl(resource.url);
+		} catch {
+			if (requestId !== lastRequestId) {
+				return;
+			}
+			setThumbnailFilePath(null);
+			setUrl(null);
+		}
+	};
+
+	const setBlobFallbackUrl = (blobUrl: string) => {
+		setFallbackUrl((current) => {
+			revokeObjectUrl(props.objectUrl, current);
+			return blobUrl;
+		});
+		revokeOnLoad = blobUrl;
+	};
+
+	const handleOriginalFallback = async (rootPath: string | undefined) => {
+		if (rootPath && !fallbackUrl()) {
+			try {
+				const bytes = await props.readFile(
+					props.joinPath(rootPath, props.media.filePath),
+				);
+				setBlobFallbackUrl(
+					props.objectUrl.create(bytes, resolveMimeType(props.media.fileName)),
+				);
+				scheduleRetry();
+			} catch {
+				scheduleRetry();
+			}
+			return;
+		}
+		scheduleRetry();
+	};
+
+	createRenderEffect(() => {
+		void props.media.id;
+		void props.media.mediaSourceId;
+		void props.media.modifiedAt;
+		clearRetryTimer();
+		setRetryCount(0);
+		setFallbackUrl((current) => {
+			revokeObjectUrl(props.objectUrl, current);
+			return null;
+		});
+		setThumbnailFilePath(null);
+		setUrl(null);
+		void loadThumbnail();
+	});
+
+	onCleanup(() => {
+		clearRetryTimer();
+		const current = fallbackUrl();
+		if (current) {
+			revokeObjectUrl(props.objectUrl, current);
+		}
+		if (revokeOnLoad && revokeOnLoad !== current) {
+			revokeObjectUrl(props.objectUrl, revokeOnLoad);
+		}
+	});
+
+	return {
+		async getUrl() {
+			return fallbackUrl() ?? url() ?? "";
+		},
+		subscribe(callback) {
+			return props.subscribeToThumbnailReady(props.media.id, () => {
+				clearRetryTimer();
+				setRetryCount(0);
+				void loadThumbnail().finally(callback);
+			});
+		},
+		onLoad() {
+			clearRetryTimer();
+			if (revokeOnLoad) {
+				revokeObjectUrl(props.objectUrl, revokeOnLoad);
+				revokeOnLoad = null;
+			}
+		},
+		async onError() {
+			setUrl(null);
+			const currentThumbnailFilePath = thumbnailFilePath();
+			const rootPath = props.sourceRootPath;
+
+			if (currentThumbnailFilePath) {
+				try {
+					const bytes = await props.readFile(currentThumbnailFilePath);
+					setBlobFallbackUrl(
+						props.objectUrl.create(bytes, THUMBNAIL_MIME_TYPE),
+					);
+					clearRetryTimer();
+				} catch {
+					setThumbnailFilePath(null);
+					await handleOriginalFallback(rootPath);
+				}
+				return;
+			}
+
+			await handleOriginalFallback(rootPath);
+		},
+	};
+}

--- a/packages/ui/src/upload-media-modal-content.tsx
+++ b/packages/ui/src/upload-media-modal-content.tsx
@@ -1,0 +1,57 @@
+import {
+	UploadMediaModalContent as SharedUploadMediaModalContent,
+	type UploadMediaModalSubmitOptions,
+} from "./upload-media-modal";
+
+type UploadMediaModalContentProps = {
+	isOpen: boolean;
+	onClose: () => void;
+	onUpload: (options: {
+		file: File;
+		filename: string;
+		description: string;
+		sourceUrl?: string;
+		overwrite: boolean;
+		autoIncrement: boolean;
+	}) => Promise<void>;
+	initialFile: File | null;
+	onUrlFetch: (file: File) => void;
+	pastedUrl: string | null;
+	onFetchUrl: (url: string) => Promise<File>;
+};
+
+export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
+	const handleUploadStart = async (options: UploadMediaModalSubmitOptions) => {
+		await Promise.all(
+			options.files.map((file, index) =>
+				props.onUpload({
+					file,
+					filename: index === 0 ? options.filename : file.name,
+					description: options.description,
+					sourceUrl: index === 0 ? options.sourceUrl : undefined,
+					overwrite: options.overwrite,
+					autoIncrement: options.autoIncrement,
+				}),
+			),
+		);
+	};
+
+	return (
+		<SharedUploadMediaModalContent
+			initialFile={props.initialFile}
+			isOpen={props.isOpen}
+			onClose={props.onClose}
+			onFetchUrl={props.onFetchUrl}
+			onFilesSelected={(files) => {
+				const firstFile = files[0];
+				if (firstFile) {
+					props.onUrlFetch(firstFile);
+				}
+			}}
+			onUploadStart={handleUploadStart}
+			pastedUrl={props.pastedUrl}
+		/>
+	);
+}
+
+export { UploadMediaModalContent as UploadMediaModal };

--- a/packages/ui/src/upload-media-modal.tsx
+++ b/packages/ui/src/upload-media-modal.tsx
@@ -1,0 +1,451 @@
+import { createEffect, createSignal, For, on, onCleanup, Show } from "solid-js";
+import { z } from "zod";
+import { Button } from "./button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "./dialog";
+import { Input } from "./input";
+import { Label } from "./label";
+
+export type UploadConflictResolution = "overwrite" | "skip" | "rename";
+
+export type UploadConflict = {
+	filename: string;
+	existingFile?: string;
+	suggestedName?: string;
+};
+
+export type UploadProgress = {
+	filename?: string;
+	status?: string;
+	current?: number;
+	total?: number;
+};
+
+export type UploadMediaModalSubmitOptions = {
+	files: File[];
+	filename: string;
+	description: string;
+	sourceUrl?: string;
+	conflictResolution: UploadConflictResolution;
+	overwrite: boolean;
+	autoIncrement: boolean;
+};
+
+export type UploadMediaModalContentProps = {
+	isOpen: boolean;
+	onClose: () => void;
+	initialFile: File | null;
+	pastedUrl: string | null;
+	onFilesSelected: (files: File[]) => void;
+	onUploadStart: (options: UploadMediaModalSubmitOptions) => Promise<void>;
+	onFetchUrl?: (url: string) => Promise<File>;
+	conflicts?: UploadConflict[];
+	uploadProgress?: UploadProgress | null;
+};
+
+const resolutionOptions: Array<{
+	value: UploadConflictResolution;
+	label: string;
+	description: string;
+}> = [
+	{
+		value: "overwrite",
+		label: "上書き",
+		description: "同名ファイルがある場合は既存ファイルを置き換えます。",
+	},
+	{
+		value: "skip",
+		label: "スキップ",
+		description: "同名ファイルがある場合はアップロードを実行しません。",
+	},
+	{
+		value: "rename",
+		label: "リネーム",
+		description: "同名ファイルがある場合は連番を付けて保存します。",
+	},
+];
+
+function fileSizeLabel(file: File) {
+	if (file.size < 1024) {
+		return `${file.size} B`;
+	}
+	if (file.size < 1024 * 1024) {
+		return `${(file.size / 1024).toFixed(1)} KB`;
+	}
+	return `${(file.size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
+	const [selectedFiles, setSelectedFiles] = createSignal<File[]>([]);
+	const [filename, setFilename] = createSignal("");
+	const [description, setDescription] = createSignal("");
+	const [sourceUrl, setSourceUrl] = createSignal("");
+	const [conflictResolution, setConflictResolution] =
+		createSignal<UploadConflictResolution>("skip");
+	const [isDragging, setIsDragging] = createSignal(false);
+	const [isFetchingUrl, setIsFetchingUrl] = createSignal(false);
+	const [lastFetchedUrl, setLastFetchedUrl] = createSignal<string | null>(null);
+	const [previewUrl, setPreviewUrl] = createSignal<string | null>(null);
+	const [error, setError] = createSignal<string | null>(null);
+	const [isSubmitting, setIsSubmitting] = createSignal(false);
+	let fileInputRef: HTMLInputElement | undefined;
+
+	const setFiles = (files: File[]) => {
+		setSelectedFiles(files);
+		props.onFilesSelected(files);
+		if (files[0] && !filename()) {
+			setFilename(files[0].name);
+		}
+	};
+
+	const updatePreview = (file: File | null) => {
+		const currentPreview = previewUrl();
+		if (currentPreview) {
+			URL.revokeObjectURL(currentPreview);
+			setPreviewUrl(null);
+		}
+		if (file) {
+			setPreviewUrl(URL.createObjectURL(file));
+		}
+	};
+
+	createEffect(
+		on(
+			() => props.initialFile,
+			(file) => {
+				if (file) {
+					setSelectedFiles([file]);
+					if (!filename()) {
+						setFilename(file.name);
+					}
+				} else {
+					setSelectedFiles([]);
+				}
+				updatePreview(file);
+			},
+		),
+	);
+
+	createEffect(
+		on(
+			() => props.pastedUrl,
+			(url) => {
+				setSourceUrl(url || "");
+			},
+		),
+	);
+
+	createEffect(() => {
+		const url = sourceUrl();
+		if (
+			!(url && props.onFetchUrl && z.string().url().safeParse(url).success) ||
+			url === lastFetchedUrl()
+		) {
+			return;
+		}
+		void handleUrlFetch(url);
+	});
+
+	const handleUrlFetch = async (url: string) => {
+		if (isFetchingUrl()) {
+			return;
+		}
+		setIsFetchingUrl(true);
+		setLastFetchedUrl(url);
+		setError(null);
+		try {
+			const file = await props.onFetchUrl?.(url);
+			if (!file) {
+				return;
+			}
+			setFilename(file.name);
+			setFiles([file]);
+			updatePreview(file);
+		} catch (fetchError) {
+			setError((fetchError as Error).message);
+		} finally {
+			setIsFetchingUrl(false);
+		}
+	};
+
+	const handleDroppedFiles = (files: FileList | null | undefined) => {
+		if (!(files && files.length > 0)) {
+			return;
+		}
+		setError(null);
+		const nextFiles = Array.from(files);
+		setFiles(nextFiles);
+		updatePreview(nextFiles[0] ?? null);
+	};
+
+	const handleSubmit = async () => {
+		const files = selectedFiles();
+		if (files.length === 0) {
+			setError("アップロードするファイルがありません。");
+			return;
+		}
+
+		const resolvedFilename = filename() || files[0]?.name || "";
+		if (!resolvedFilename) {
+			setError("ファイル名を入力してください。");
+			return;
+		}
+
+		const resolution = conflictResolution();
+		setIsSubmitting(true);
+		setError(null);
+		try {
+			await props.onUploadStart({
+				files,
+				filename: resolvedFilename,
+				description: description(),
+				sourceUrl: sourceUrl() || undefined,
+				conflictResolution: resolution,
+				overwrite: resolution === "overwrite",
+				autoIncrement: resolution === "rename",
+			});
+			props.onClose();
+		} catch (submitError) {
+			setError((submitError as Error).message);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	onCleanup(() => {
+		const currentPreview = previewUrl();
+		if (currentPreview) {
+			URL.revokeObjectURL(currentPreview);
+		}
+	});
+
+	return (
+		<Dialog onOpenChange={props.onClose} open={props.isOpen}>
+			<Show when={props.isOpen}>
+				<DialogContent class="sm:max-w-[560px]">
+					<DialogHeader>
+						<DialogTitle>メディアをアップロード</DialogTitle>
+						<DialogDescription>
+							アップロードするメディアの詳細を入力してください。
+						</DialogDescription>
+					</DialogHeader>
+
+					<div class="grid gap-4 py-4">
+						<button
+							class={`rounded-lg border-2 border-dashed p-6 text-center transition-colors ${
+								isDragging() ? "border-primary bg-primary/5" : "border-muted"
+							}`}
+							onClick={() => fileInputRef?.click()}
+							onKeyDown={(event) => {
+								if (event.key === "Enter" || event.key === " ") {
+									event.preventDefault();
+									fileInputRef?.click();
+								}
+							}}
+							onDragEnter={(event) => {
+								event.preventDefault();
+								setIsDragging(true);
+							}}
+							onDragLeave={(event) => {
+								event.preventDefault();
+								setIsDragging(false);
+							}}
+							onDragOver={(event) => event.preventDefault()}
+							onDrop={(event) => {
+								event.preventDefault();
+								setIsDragging(false);
+								handleDroppedFiles(event.dataTransfer?.files);
+							}}
+							type="button"
+						>
+							<p class="font-medium text-sm">ファイルをドラッグ&ドロップ</p>
+							<p class="mt-1 text-muted-foreground text-xs">
+								またはファイル選択ダイアログから追加します。
+							</p>
+							<span class="mt-3 inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 font-medium text-sm ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50">
+								ファイルを選択
+							</span>
+						</button>
+						<input
+							class="hidden"
+							multiple
+							onChange={(event) => {
+								handleDroppedFiles(event.currentTarget.files);
+								event.currentTarget.value = "";
+							}}
+							ref={(element) => {
+								fileInputRef = element;
+							}}
+							type="file"
+						/>
+
+						<Show when={selectedFiles().length > 0}>
+							<div class="rounded-md border p-3">
+								<p class="mb-2 font-medium text-sm">選択中のファイル</p>
+								<ul class="space-y-2">
+									<For each={selectedFiles()}>
+										{(file) => (
+											<li class="flex items-center justify-between gap-3 text-sm">
+												<span class="truncate">{file.name}</span>
+												<span class="shrink-0 text-muted-foreground text-xs">
+													{fileSizeLabel(file)}
+												</span>
+											</li>
+										)}
+									</For>
+								</ul>
+							</div>
+						</Show>
+
+						<div class="grid grid-cols-4 items-center gap-4">
+							<Label class="text-right" for="filename">
+								ファイル名
+							</Label>
+							<Input
+								class="col-span-3"
+								id="filename"
+								onInput={(event) => setFilename(event.currentTarget.value)}
+								value={filename()}
+							/>
+						</div>
+
+						<div class="grid grid-cols-4 items-center gap-4">
+							<Label class="text-right" for="description">
+								説明
+							</Label>
+							<Input
+								class="col-span-3"
+								id="description"
+								onInput={(event) => setDescription(event.currentTarget.value)}
+								value={description()}
+							/>
+						</div>
+
+						<div class="grid grid-cols-4 items-center gap-4">
+							<Label class="text-right" for="sourceUrl">
+								ソースURL
+							</Label>
+							<div class="relative col-span-3">
+								<Input
+									disabled={isFetchingUrl()}
+									id="sourceUrl"
+									onInput={(event) => setSourceUrl(event.currentTarget.value)}
+									value={sourceUrl()}
+								/>
+								<Show when={isFetchingUrl()}>
+									<div class="-translate-y-1/2 absolute top-1/2 right-2 text-muted-foreground text-xs">
+										Loading...
+									</div>
+								</Show>
+							</div>
+							<Show when={previewUrl()}>
+								<div class="col-span-4 mt-2 flex justify-center">
+									<img
+										alt="Fetched preview"
+										class="max-h-48 rounded-md object-contain"
+										src={previewUrl() || undefined}
+									/>
+								</div>
+							</Show>
+						</div>
+
+						<div class="space-y-2">
+							<Label>競合時の処理</Label>
+							<div class="grid gap-2 sm:grid-cols-3">
+								<For each={resolutionOptions}>
+									{(option) => (
+										<label class="rounded-md border p-3 text-sm has-[:checked]:border-primary has-[:checked]:bg-primary/5">
+											<div class="flex items-center gap-2">
+												<input
+													checked={conflictResolution() === option.value}
+													onChange={() => setConflictResolution(option.value)}
+													type="radio"
+												/>
+												<span class="font-medium">{option.label}</span>
+											</div>
+											<p class="mt-1 text-muted-foreground text-xs">
+												{option.description}
+											</p>
+										</label>
+									)}
+								</For>
+							</div>
+						</div>
+
+						<Show when={(props.conflicts?.length ?? 0) > 0}>
+							<div class="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-950 text-sm">
+								<p class="font-medium">同名ファイルがあります</p>
+								<ul class="mt-2 list-disc space-y-1 pl-5">
+									<For each={props.conflicts}>
+										{(conflict) => (
+											<li>
+												{conflict.filename}
+												<Show when={conflict.suggestedName}>
+													<span> → {conflict.suggestedName}</span>
+												</Show>
+											</li>
+										)}
+									</For>
+								</ul>
+							</div>
+						</Show>
+
+						<Show when={props.uploadProgress}>
+							{(progress) => (
+								<div class="rounded-md border p-3 text-sm">
+									<div class="flex justify-between gap-3">
+										<span>{progress().filename || "アップロード中"}</span>
+										<span class="text-muted-foreground">
+											{progress().status ||
+												(progress().total
+													? `${progress().current ?? 0}/${progress().total}`
+													: "処理中")}
+										</span>
+									</div>
+									<div class="mt-2 h-2 overflow-hidden rounded bg-muted">
+										<div
+											class="h-full bg-primary transition-all"
+											style={{
+												width: (() => {
+													const total = progress().total;
+													return total
+														? `${Math.min(100, ((progress().current ?? 0) / total) * 100)}%`
+														: "35%";
+												})(),
+											}}
+										/>
+									</div>
+								</div>
+							)}
+						</Show>
+
+						<Show when={error()}>
+							<p class="text-center text-red-500 text-sm">{error()}</p>
+						</Show>
+					</div>
+
+					<DialogFooter>
+						<Button onClick={props.onClose} type="button" variant="outline">
+							キャンセル
+						</Button>
+						<Button
+							disabled={isSubmitting() || isFetchingUrl()}
+							onClick={() => void handleSubmit()}
+							type="button"
+						>
+							{isSubmitting() ? "アップロード中..." : "アップロード"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Show>
+		</Dialog>
+	);
+}
+
+export { UploadMediaModalContent as UploadMediaModal };

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,17 +1,19 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "preserve",
-    "jsxImportSource": "solid-js",
-    "strict": true,
-    "skipLibCheck": true,
-    "baseUrl": ".",
-    "paths": {
-      "~/*": ["./src/*"],
-      "@/*": ["../core/src/*"]
-    }
-  },
-  "include": ["src/**/*"]
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"jsx": "preserve",
+		"jsxImportSource": "solid-js",
+		"strict": true,
+		"skipLibCheck": true,
+		"baseUrl": ".",
+		"paths": {
+			"~/*": ["./src/*"],
+			"@/*": ["../core/src/*"],
+			"@solid-imager/core": ["../core/src/index.ts"],
+			"@solid-imager/core/*": ["../core/src/*"]
+		}
+	},
+	"include": ["src/**/*"]
 }

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,11 +1,11 @@
-import path from "node:path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
-  test: {
-    environment: "node",
-    globals: true,
-  },
+	plugins: [tsconfigPaths()],
+	test: {
+		environment: "node",
+		globals: true,
+		passWithNoTests: true,
+	},
 });


### PR DESCRIPTION
## Summary
- Cherry-picks shared screens, hooks, and business components from `fix/issue-165-tauri` into `packages/ui/`
- Adds 2 new core utility files needed by UI: `deep-equal.ts` and `domain/sources/events.ts`
- Preserves all existing shadcn UI components (button, dialog, badge, etc.)

## Changes
- **packages/ui/src/**: 57 new files including screens (config, manager, media-detail, search, source-media, sources), hooks (use-current-search-persistence, use-manager-page, use-media-source-events, use-search-page, use-source-media-page, use-sources-events, use-sources-page), query-options, stores, and shared business components
- **packages/ui/package.json**: Added `@solid-imager/core` (moved from devDeps), `@tanstack/solid-query`, and `zod` dependencies
- **packages/ui/tsconfig.json**: Added path aliases for `@solid-imager/core` sub-path resolution
- **packages/core/src/**: Added `utils/deep-equal.ts` and `domain/sources/events.ts` required by new UI files

## Verification
- `packages/ui`: typecheck pass, lint pass, test 13/13 pass
- `packages/core`: typecheck pass, lint pass, test 12/12 pass

fixes #353