### PR TITLE
feat: extract packages/db schema and query foundation (#351)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -36,6 +36,7 @@
     "@orpc/tanstack-query": "^1.13.13",
     "@orpc/zod": "^1.13.13",
     "@solid-imager/core": "workspace:*",
+    "@solid-imager/db": "workspace:*",
     "@solid-imager/ui": "workspace:*",
     "@tanstack/router-plugin": "latest",
     "@tanstack/solid-form": "latest",

--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -4,9 +4,6 @@ import {
 	type MediaDumpItem,
 	mediaDumpItemSchema,
 } from "@solid-imager/core/domain/media/schemas";
-import { and, eq, inArray, sql } from "drizzle-orm";
-import yauzl from "yauzl";
-import { db } from "~/infrastructure/db";
 import {
 	authors,
 	characterIps,
@@ -23,7 +20,10 @@ import {
 	mediaUrls,
 	projects,
 	tags,
-} from "~/infrastructure/db/schema";
+} from "@solid-imager/db/schema";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import yauzl from "yauzl";
+import { db } from "~/infrastructure/db";
 import { logger } from "~/infrastructure/logger";
 import { getDriver } from "~/infrastructure/storage/factory";
 

--- a/apps/server/src/application/services/job-dispatch-service.ts
+++ b/apps/server/src/application/services/job-dispatch-service.ts
@@ -1,5 +1,5 @@
+import type { Job as DbJob } from "@solid-imager/db/schema";
 import { services } from "~/application/registry";
-import type { Job as DbJob } from "~/infrastructure/db/schema";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
 import {
 	processAutoTaggingJob,

--- a/apps/server/src/application/services/media-processing-service.ts
+++ b/apps/server/src/application/services/media-processing-service.ts
@@ -19,10 +19,10 @@ import type { IMediaRepository } from "@solid-imager/core/domain/repositories/me
 import type { IProjectRepository } from "@solid-imager/core/domain/repositories/project-repository";
 import type { SourceRepository } from "@solid-imager/core/domain/repositories/source-repository";
 import type { TagRepository } from "@solid-imager/core/domain/repositories/tag-repository";
+import type { Job } from "@solid-imager/db/schema";
 import type { CharacterServiceImpl } from "~/application/services/character-service";
 import type { ServerConfigService } from "~/application/services/server-config-service";
 import type { IJobRepository } from "~/domain/repositories/job-repository";
-import type { Job } from "~/infrastructure/db/schema";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
 import { generateThumbnail } from "~/infrastructure/jobs/thumbnails";
 import { logger } from "~/infrastructure/logger";

--- a/apps/server/src/application/services/media-source-service.ts
+++ b/apps/server/src/application/services/media-source-service.ts
@@ -2,7 +2,7 @@ import type {
 	MediaSource,
 	NewMediaSource,
 } from "@solid-imager/core/domain/repositories/source-repository";
-import type { MediaSource as DbMediaSource } from "~/infrastructure/db/schema";
+import type { MediaSource as DbMediaSource } from "@solid-imager/db/schema";
 import { DrizzleSourceRepository } from "~/infrastructure/repositories/source-repository";
 
 /**

--- a/apps/server/src/domain/repositories/job-repository.ts
+++ b/apps/server/src/domain/repositories/job-repository.ts
@@ -1,4 +1,4 @@
-import type { Job, NewJob } from "~/infrastructure/db/schema";
+import type { Job, NewJob } from "@solid-imager/db/schema";
 
 export type IJobRepository = {
 	/**

--- a/apps/server/src/infrastructure/api/routers/ai-router.ts
+++ b/apps/server/src/infrastructure/api/routers/ai-router.ts
@@ -5,17 +5,17 @@ import {
 	ccipFeatureRequestSchema,
 	tagImageRequestSchema,
 } from "@solid-imager/core/domain/tagging/schemas";
-import { and, asc, eq, getTableColumns, inArray, isNull } from "drizzle-orm";
-import { z } from "zod";
-import { services } from "~/application/registry";
-import { taggingService } from "~/application/services/tagging-service";
-import { db } from "~/infrastructure/db";
 import {
 	mediaCharacters,
 	mediaIps,
 	medias,
 	mediaTags,
-} from "~/infrastructure/db/schema";
+} from "@solid-imager/db/schema";
+import { and, asc, eq, getTableColumns, inArray, isNull } from "drizzle-orm";
+import { z } from "zod";
+import { services } from "~/application/registry";
+import { taggingService } from "~/application/services/tagging-service";
+import { db } from "~/infrastructure/db";
 import { logger } from "~/infrastructure/logger";
 
 export const aiRouter = {

--- a/apps/server/src/infrastructure/api/routers/imports-router.ts
+++ b/apps/server/src/infrastructure/api/routers/imports-router.ts
@@ -1,9 +1,9 @@
 import { os } from "@orpc/server";
 import { downloadItemSchema } from "@solid-imager/core/domain/media/schemas";
+import { jobs } from "@solid-imager/db/schema";
 import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "~/infrastructure/db";
-import { jobs } from "~/infrastructure/db/schema";
 import { queueDownloadJobs } from "~/infrastructure/jobs/download-jobs";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
 

--- a/apps/server/src/infrastructure/db/__mocks__/index.ts
+++ b/apps/server/src/infrastructure/db/__mocks__/index.ts
@@ -1,6 +1,6 @@
+import type { Media, MediaSource, NewMedia } from "@solid-imager/db/schema";
 import { v4 as uuidv4 } from "uuid";
 import { vi } from "vite-plus/test";
-import type { Media, MediaSource, NewMedia } from "~/infrastructure/db/schema";
 
 let mockDbState: { mediaSources: MediaSource[]; medias: Media[] };
 

--- a/apps/server/src/infrastructure/db/data-migration.ts
+++ b/apps/server/src/infrastructure/db/data-migration.ts
@@ -1,11 +1,11 @@
-import { and, eq, inArray } from "drizzle-orm";
-import { db } from "~/infrastructure/db/index";
 import {
 	type MediaSource,
 	mediaSources,
 	medias,
 	type NewMedia,
-} from "~/infrastructure/db/schema";
+} from "@solid-imager/db/schema";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "~/infrastructure/db/index";
 import { NotFoundError, UnknownDbError } from "./errors";
 
 /**

--- a/apps/server/src/infrastructure/db/index.ts
+++ b/apps/server/src/infrastructure/db/index.ts
@@ -1,85 +1,50 @@
 import path from "node:path";
-import { PGlite } from "@electric-sql/pglite";
-import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
-import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
-import { Pool } from "pg";
-import * as schema from "./schema";
+import { createDbClient } from "@solid-imager/db/client";
+import { createTransactionManager } from "@solid-imager/db/transaction-manager";
+import type {
+	DbConfig,
+	DbInstance,
+	TransactionClient,
+} from "@solid-imager/db/types";
+import type { DatabaseConfig } from "~/config/database";
 
-export type NodePostgresDb = ReturnType<
-	typeof drizzleNodePostgres<typeof schema>
->;
-export type PgLiteDb = ReturnType<typeof drizzlePglite<typeof schema>>;
-export type DbInstance = NodePostgresDb | PgLiteDb;
+export type { TransactionClient };
 
-/**
- * Type representing either a database instance or a transaction client.
- * In Drizzle, both share the same common interface for queries.
- */
-export type TransactionClient = NodePostgresDb | PgLiteDb;
+function _convertConfig(config: DatabaseConfig): DbConfig {
+	return config as DbConfig;
+}
 
 let _db: DbInstance | null = null;
-let _queryClient: Pool | PGlite | null = null;
 
-/**
- * Initializes and returns the Drizzle ORM database instance.
- * This function ensures that the database connection is established only once.
- * It reads database connection details from environment variables.
- * @returns {NodePostgresDb | PgLiteDb} The initialized Drizzle ORM database instance.
- * @throws {Error} If required database environment variables are not set.
- */
-function initializeDb() {
+function initializeDb(config?: DatabaseConfig): DbInstance {
 	if (_db) {
 		return _db;
 	}
 
-	const dbHost = process.env.DB_HOST;
-	const isTestEnv =
-		process.env.NODE_ENV === "test" || process.env.VITEST === "true";
+	const dbConfig = config ?? {
+		databaseType: "pglite" as const,
+		pglite: {
+			path:
+				process.env.PGLITE_DATA_DIR ||
+				path.join(process.cwd(), ".data", "pglite"),
+		},
+	};
 
-	console.log(
-		`[DB] Initializing. Host: ${dbHost}, Env: ${process.env.NODE_ENV}`,
-	);
-
-	// テスト環境では必ずPGliteを使用
-	if (isTestEnv || dbHost === "pglite") {
-		const pglitePath =
-			process.env.PGLITE_DATA_DIR ||
-			path.join(process.cwd(), ".data", "pglite");
-		console.log(
-			`[DB] Using persistent PGlite at path: ${pglitePath} (Absolute: ${path.resolve(
-				pglitePath,
-			)})`,
-		);
-		_queryClient = new PGlite(pglitePath);
-		_db = drizzlePglite(_queryClient, { schema });
-		return _db;
-	}
-
-	const dbPort = process.env.DB_PORT || "5432";
-	const dbName = process.env.DB_DATABASE || process.env.DB_NAME;
-	const dbUser = process.env.DB_USER;
-	const dbPassword = process.env.DB_PASSWORD;
-
-	if (!(dbHost && dbName && dbUser && dbPassword)) {
-		throw new Error(
-			"Database environment variables are not set (DB_HOST, DB_DATABASE/DB_NAME, DB_USER, DB_PASSWORD)",
-		);
-	}
-
-	const connectionString = `postgres://${dbUser}:${dbPassword}@${dbHost}:${dbPort}/${dbName}`;
-	_queryClient = new Pool({ connectionString });
-	_db = drizzleNodePostgres(_queryClient, { schema });
+	_db = createDbClient(dbConfig);
 	return _db;
 }
 
-/**
- * A proxy object for the Drizzle ORM database instance.
- * It ensures that the database is initialized lazily upon first access.
- */
-export const db = new Proxy({} as NodePostgresDb | PgLiteDb, {
+const dbProxy = new Proxy({} as DbInstance, {
 	get(_target, prop) {
 		const instance = initializeDb();
 		const value = instance[prop as keyof typeof instance];
 		return typeof value === "function" ? value.bind(instance) : value;
 	},
 });
+
+export const db = dbProxy;
+export const DrizzleTransactionManager = createTransactionManager(dbProxy);
+
+export function initializeDatabase(config: DatabaseConfig): DbInstance {
+	return initializeDb(config);
+}

--- a/apps/server/src/infrastructure/db/transaction-manager.ts
+++ b/apps/server/src/infrastructure/db/transaction-manager.ts
@@ -1,14 +1,4 @@
-import type {
-	Transaction,
-	TransactionManager,
-} from "@solid-imager/core/domain/interfaces/transaction-manager";
+import { createTransactionManager } from "@solid-imager/db/transaction-manager";
 import { db } from "~/infrastructure/db/index";
 
-export const DrizzleTransactionManager: TransactionManager = {
-	async transaction<T>(callback: (tx: Transaction) => Promise<T>): Promise<T> {
-		return await db.transaction(async (tx) => {
-			// Pass the Drizzle transaction object as the opaque Transaction type
-			return await callback(tx);
-		});
-	},
-};
+export const DrizzleTransactionManager = createTransactionManager(db);

--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -11,10 +11,10 @@ import type {
 } from "@solid-imager/core/domain/media/schemas";
 import { generateMediaFilename } from "@solid-imager/core/domain/media/utils/filename-utils";
 import { getMediaTypeFromExtension } from "@solid-imager/core/domain/media/utils/media-type-utils";
+import type { Job } from "@solid-imager/db/schema";
 import ffmpegPath from "ffmpeg-static";
 import youtubedl from "youtube-dl-exec";
 import { services } from "~/application/registry";
-import type { Job } from "~/infrastructure/db/schema";
 import { waitForDownloadRateLimit } from "~/infrastructure/jobs/download-rate-limiter";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
 import { logger } from "~/infrastructure/logger";

--- a/apps/server/src/infrastructure/jobs/job-worker.ts
+++ b/apps/server/src/infrastructure/jobs/job-worker.ts
@@ -1,6 +1,6 @@
 import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+import type { Job } from "@solid-imager/db/schema";
 import type { IJobRepository } from "~/domain/repositories/job-repository";
-import type { Job } from "~/infrastructure/db/schema";
 import { logger } from "~/infrastructure/logger";
 
 export class JobWorker {

--- a/apps/server/src/infrastructure/jobs/tagging-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/tagging-jobs.ts
@@ -1,15 +1,15 @@
-import { and, asc, eq, notExists } from "drizzle-orm";
-import { z } from "zod";
-import { services } from "~/application/registry";
-import { taggingService } from "~/application/services/tagging-service";
-import { db } from "~/infrastructure/db";
 import {
 	type Job,
 	mediaCharacters,
 	mediaIps,
 	medias,
 	mediaTags,
-} from "~/infrastructure/db/schema";
+} from "@solid-imager/db/schema";
+import { and, asc, eq, notExists } from "drizzle-orm";
+import { z } from "zod";
+import { services } from "~/application/registry";
+import { taggingService } from "~/application/services/tagging-service";
+import { db } from "~/infrastructure/db";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
 import { logger } from "~/infrastructure/logger";
 

--- a/apps/server/src/infrastructure/jobs/thumbnails.ts
+++ b/apps/server/src/infrastructure/jobs/thumbnails.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { services } from "~/application/registry";
 // import {
 //   selectMediaById,
 //   selectMediaBySourceId,
 // } from "~/infrastructure/db/queries/media"; // Removed
-import type { Media } from "~/infrastructure/db/schema";
+import type { Media } from "@solid-imager/db/schema";
+import { services } from "~/application/registry";
 import { ImageProcessor } from "~/infrastructure/processing/image-processor";
 import { MediaRepository } from "~/infrastructure/repositories/media-repository"; // Added
 import { DrizzleSourceRepository } from "~/infrastructure/repositories/source-repository";

--- a/apps/server/src/infrastructure/repositories/author-repository.ts
+++ b/apps/server/src/infrastructure/repositories/author-repository.ts
@@ -1,14 +1,15 @@
 import { ResourceNotFoundError } from "@solid-imager/core/domain/errors";
 import type { Transaction } from "@solid-imager/core/domain/interfaces/transaction-manager";
 import type { IAuthorRepository } from "@solid-imager/core/domain/repositories/author-repository";
-import { and, eq } from "drizzle-orm";
-import { db, type TransactionClient } from "~/infrastructure/db/index";
+import { getClient } from "@solid-imager/db";
 import {
 	type Author,
 	authors,
 	mediaAuthors,
 	type NewAuthor,
-} from "~/infrastructure/db/schema";
+} from "@solid-imager/db/schema";
+import { and, eq } from "drizzle-orm";
+import { db } from "~/infrastructure/db/index";
 
 export const AuthorRepository: IAuthorRepository = {
 	async findAll(): Promise<Author[]> {
@@ -25,7 +26,7 @@ export const AuthorRepository: IAuthorRepository = {
 	},
 
 	async findByName(name: string, tx?: Transaction): Promise<Author | null> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.select()
 			.from(authors)
@@ -35,7 +36,7 @@ export const AuthorRepository: IAuthorRepository = {
 	},
 
 	async create(author: NewAuthor, tx?: Transaction): Promise<Author> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		// Check duplication
 		// If accountId exists, check by accountId.
 		// If not, check by name (fallback for local files/legacy data)
@@ -62,7 +63,7 @@ export const AuthorRepository: IAuthorRepository = {
 		updates: Partial<Author>,
 		tx?: Transaction,
 	): Promise<Author> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.update(authors)
 			.set(updates)
@@ -76,12 +77,12 @@ export const AuthorRepository: IAuthorRepository = {
 	},
 
 	async delete(id: string, tx?: Transaction): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		await client.delete(authors).where(eq(authors.id, id));
 	},
 
 	async findByMediaId(mediaId: string, tx?: Transaction): Promise<Author[]> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.select({
 				id: authors.id,
@@ -101,7 +102,7 @@ export const AuthorRepository: IAuthorRepository = {
 		authorId: string,
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		await client
 			.insert(mediaAuthors)
 			.values({
@@ -116,7 +117,7 @@ export const AuthorRepository: IAuthorRepository = {
 		authorId: string,
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		await client
 			.delete(mediaAuthors)
 			.where(
@@ -131,7 +132,7 @@ export const AuthorRepository: IAuthorRepository = {
 		authorIds: string[],
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		if (authorIds.length === 0) {
 			return;
 		}

--- a/apps/server/src/infrastructure/repositories/authors-repository.ts
+++ b/apps/server/src/infrastructure/repositories/authors-repository.ts
@@ -1,7 +1,7 @@
 import { authorSchema } from "@solid-imager/core/domain/authors/schemas";
+import { authors } from "@solid-imager/db/schema";
 import { desc, like, or } from "drizzle-orm";
 import { db } from "~/infrastructure/db";
-import { authors } from "~/infrastructure/db/schema";
 
 export const AuthorsRepository = {
 	list: async () => {

--- a/apps/server/src/infrastructure/repositories/category-repository.ts
+++ b/apps/server/src/infrastructure/repositories/category-repository.ts
@@ -11,9 +11,10 @@ import type {
 	Category,
 	CategoryRepository,
 } from "@solid-imager/core/domain/repositories/category-repository";
+import { getClient } from "@solid-imager/db";
+import { categories } from "@solid-imager/db/schema";
 import { eq } from "drizzle-orm";
-import { db, type TransactionClient } from "~/infrastructure/db/index";
-import { categories } from "~/infrastructure/db/schema";
+import { db } from "~/infrastructure/db/index";
 
 export class DrizzleCategoryRepository implements CategoryRepository {
 	async findAll(): Promise<Category[]> {
@@ -27,7 +28,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
 
 	async findById(id: string, tx?: Transaction): Promise<Category | null> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.select()
 				.from(categories)
@@ -46,7 +47,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
 
 	async create(category: NewCategory, tx?: Transaction): Promise<Category> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.insert(categories)
 				.values({
@@ -67,7 +68,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
 		tx?: Transaction,
 	): Promise<Category> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.update(categories)
 				.set(category)
@@ -91,7 +92,7 @@ export class DrizzleCategoryRepository implements CategoryRepository {
 
 	async delete(id: string, tx?: Transaction): Promise<void> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.delete(categories)
 				.where(eq(categories.id, id))

--- a/apps/server/src/infrastructure/repositories/character-repository.ts
+++ b/apps/server/src/infrastructure/repositories/character-repository.ts
@@ -10,13 +10,14 @@ import {
 } from "@solid-imager/core/domain/errors";
 import type { Transaction } from "@solid-imager/core/domain/interfaces/transaction-manager";
 import type { CharacterRepository } from "@solid-imager/core/domain/repositories/character-repository";
-import { and, eq, sql } from "drizzle-orm";
-import { db, type TransactionClient } from "~/infrastructure/db/index";
+import { getClient, type TransactionClient } from "@solid-imager/db";
 import {
 	characterIps,
 	characters,
 	mediaCharacters,
-} from "~/infrastructure/db/schema";
+} from "@solid-imager/db/schema";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "~/infrastructure/db/index";
 
 export class DrizzleCharacterRepository implements CharacterRepository {
 	async findAll(): Promise<Character[]> {
@@ -41,7 +42,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 
 	async findById(id: string, tx?: Transaction): Promise<Character | null> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client.query.characters.findFirst({
 				where: eq(characters.id, id),
 				with: {
@@ -69,7 +70,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 
 	async findByName(name: string, tx?: Transaction): Promise<Character | null> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client.query.characters.findFirst({
 				where: eq(characters.name, name),
 				with: {
@@ -97,7 +98,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 
 	async create(character: NewCharacter, tx?: Transaction): Promise<Character> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const { ipIds, ...charData } = character;
 
 			const [insertedChar] = await client
@@ -160,10 +161,10 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 			};
 
 			if (tx) {
-				return await operation(tx as unknown as TransactionClient);
+				return await operation(getClient(db, tx));
 			}
 			return await db.transaction((innerTx) =>
-				operation(innerTx as unknown as TransactionClient),
+				operation(getClient(db, innerTx)),
 			);
 		} catch (error) {
 			if (error instanceof ResourceNotFoundError) {
@@ -242,7 +243,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 
 	async delete(id: string, tx?: Transaction): Promise<void> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.delete(characters)
 				.where(eq(characters.id, id))
@@ -264,7 +265,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 
 	async findByMediaId(mediaId: string, tx?: Transaction): Promise<Character[]> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			// Use query builder to get relations
 			const results = await client.query.mediaCharacters.findMany({
 				where: eq(mediaCharacters.mediaId, mediaId),
@@ -300,7 +301,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 		(Character & { confidence: number | null; associationSource: string })[]
 	> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const results = await client.query.mediaCharacters.findMany({
 				where: eq(mediaCharacters.mediaId, mediaId),
 				with: {
@@ -338,7 +339,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 		tx?: Transaction,
 	): Promise<void> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 
 			let sourceUpdateSql = sql`excluded.source`;
 			let confidenceUpdateSql = sql`excluded.confidence`;
@@ -382,7 +383,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 		tx?: Transaction,
 	): Promise<void> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			await client
 				.delete(mediaCharacters)
 				.where(
@@ -404,7 +405,7 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 		source = "manual",
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		if (charactersData.length === 0) {
 			return;
 		}

--- a/apps/server/src/infrastructure/repositories/collection-repository.ts
+++ b/apps/server/src/infrastructure/repositories/collection-repository.ts
@@ -11,9 +11,10 @@ import {
 } from "@solid-imager/core/domain/errors";
 import type { Transaction } from "@solid-imager/core/domain/interfaces/transaction-manager";
 import type { ICollectionRepository } from "@solid-imager/core/domain/repositories/collection-repository";
+import { getClient } from "@solid-imager/db";
+import { collections, mediaCollections } from "@solid-imager/db/schema";
 import { and, eq } from "drizzle-orm";
-import { db, type TransactionClient } from "~/infrastructure/db/index";
-import { collections, mediaCollections } from "~/infrastructure/db/schema";
+import { db } from "~/infrastructure/db/index";
 
 export const CollectionRepository: ICollectionRepository = {
 	async findAll(): Promise<Collection[]> {
@@ -21,7 +22,7 @@ export const CollectionRepository: ICollectionRepository = {
 	},
 
 	async findById(id: string, tx?: Transaction): Promise<Collection | null> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.select()
 			.from(collections)
@@ -35,7 +36,7 @@ export const CollectionRepository: ICollectionRepository = {
 		tx?: Transaction,
 	): Promise<Collection> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.insert(collections)
 				.values(collection)
@@ -57,7 +58,7 @@ export const CollectionRepository: ICollectionRepository = {
 		tx?: Transaction,
 	): Promise<Collection> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.update(collections)
 				.set(updates)
@@ -82,7 +83,7 @@ export const CollectionRepository: ICollectionRepository = {
 	},
 
 	async delete(id: string, tx?: Transaction): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.delete(collections)
 			.where(eq(collections.id, id))
@@ -99,7 +100,7 @@ export const CollectionRepository: ICollectionRepository = {
 		tx?: Transaction,
 	): Promise<void> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			await client.insert(mediaCollections).values({
 				collectionId,
 				mediaId: item.mediaId,
@@ -120,7 +121,7 @@ export const CollectionRepository: ICollectionRepository = {
 		mediaId: string,
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.delete(mediaCollections)
 			.where(

--- a/apps/server/src/infrastructure/repositories/ip-repository.ts
+++ b/apps/server/src/infrastructure/repositories/ip-repository.ts
@@ -10,9 +10,10 @@ import type {
 	UpdateIp,
 } from "@solid-imager/core/domain/ips/schemas";
 import type { IIpRepository } from "@solid-imager/core/domain/repositories/ip-repository";
+import { getClient } from "@solid-imager/db";
+import { ips, mediaIps } from "@solid-imager/db/schema";
 import { and, eq, sql } from "drizzle-orm";
-import { db, type TransactionClient } from "~/infrastructure/db";
-import { ips, mediaIps } from "~/infrastructure/db/schema";
+import { db } from "~/infrastructure/db/index";
 
 const mapToDomain = (dbIp: typeof ips.$inferSelect): Ip => ({
 	id: dbIp.id,
@@ -30,13 +31,13 @@ export const IpRepository: IIpRepository = {
 	},
 
 	async findById(id: string, tx?: Transaction): Promise<Ip | null> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client.select().from(ips).where(eq(ips.id, id));
 		return result[0] ? mapToDomain(result[0]) : null;
 	},
 
 	async findByName(name: string, tx?: Transaction): Promise<Ip | null> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client.select().from(ips).where(eq(ips.name, name));
 		return result[0] ? mapToDomain(result[0]) : null;
 	},
@@ -45,7 +46,7 @@ export const IpRepository: IIpRepository = {
 			return [];
 		}
 		const { inArray } = await import("drizzle-orm");
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.select()
 			.from(ips)
@@ -55,7 +56,7 @@ export const IpRepository: IIpRepository = {
 
 	async create(ip: NewIp, tx?: Transaction): Promise<Ip> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client.insert(ips).values(ip).returning();
 			return mapToDomain(result[0]);
 		} catch (error: unknown) {
@@ -68,7 +69,7 @@ export const IpRepository: IIpRepository = {
 
 	async update(id: string, ip: UpdateIp, tx?: Transaction): Promise<Ip> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.update(ips)
 				.set({ ...ip, updatedAt: new Date() })
@@ -91,7 +92,7 @@ export const IpRepository: IIpRepository = {
 	},
 
 	async delete(id: string, tx?: Transaction): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client.delete(ips).where(eq(ips.id, id)).returning();
 		if (result.length === 0) {
 			throw new ResourceNotFoundError("IP", id);
@@ -99,7 +100,7 @@ export const IpRepository: IIpRepository = {
 	},
 
 	async findByMediaId(mediaId: string, tx?: Transaction): Promise<Ip[]> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.select({
 				id: ips.id,
@@ -126,7 +127,7 @@ export const IpRepository: IIpRepository = {
 	): Promise<
 		(Ip & { confidence: number | null; associationSource: string })[]
 	> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.select({
 				id: ips.id,
@@ -156,7 +157,7 @@ export const IpRepository: IIpRepository = {
 		source = "manual",
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 
 		let sourceUpdateSql = sql`excluded.source`;
 		let confidenceUpdateSql = sql`excluded.confidence`;
@@ -191,7 +192,7 @@ export const IpRepository: IIpRepository = {
 		ipId: string,
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.delete(mediaIps)
 			.where(and(eq(mediaIps.mediaId, mediaId), eq(mediaIps.ipId, ipId)))
@@ -207,7 +208,7 @@ export const IpRepository: IIpRepository = {
 		source = "manual",
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		if (ipsData.length === 0) {
 			return;
 		}

--- a/apps/server/src/infrastructure/repositories/job-repository.ts
+++ b/apps/server/src/infrastructure/repositories/job-repository.ts
@@ -1,7 +1,7 @@
+import { type Job, jobs, type NewJob } from "@solid-imager/db/schema";
 import { and, asc, eq, inArray, ne, notInArray, sql } from "drizzle-orm";
 import type { IJobRepository } from "~/domain/repositories/job-repository";
 import { db } from "~/infrastructure/db";
-import { type Job, jobs, type NewJob } from "~/infrastructure/db/schema";
 
 export class JobRepository implements IJobRepository {
 	async create(job: NewJob): Promise<Job> {

--- a/apps/server/src/infrastructure/repositories/media-repository-utils.ts
+++ b/apps/server/src/infrastructure/repositories/media-repository-utils.ts
@@ -1,4 +1,13 @@
 import { UnexpectedError } from "@solid-imager/core/domain/errors";
+import type { TransactionClient } from "@solid-imager/db";
+import {
+	mediaCharacters,
+	mediaIps,
+	mediaProjects,
+	medias,
+	mediaTags,
+	tags,
+} from "@solid-imager/db/schema";
 import {
 	and,
 	asc,
@@ -14,15 +23,7 @@ import {
 	type SQL,
 	sql,
 } from "drizzle-orm";
-import { db, type TransactionClient } from "~/infrastructure/db/index";
-import {
-	mediaCharacters,
-	mediaIps,
-	mediaProjects,
-	medias,
-	mediaTags,
-	tags,
-} from "~/infrastructure/db/schema";
+import { db } from "~/infrastructure/db/index";
 
 /**
  * Escapes special characters ...

--- a/apps/server/src/infrastructure/repositories/media-repository.ts
+++ b/apps/server/src/infrastructure/repositories/media-repository.ts
@@ -17,6 +17,24 @@ import {
 	type UpdateMediaRequest,
 } from "@solid-imager/core/domain/media/schemas";
 import type { IMediaRepository } from "@solid-imager/core/domain/repositories/media-repository";
+import { getClient } from "@solid-imager/db";
+import {
+	authors,
+	characters,
+	ips,
+	mediaAuthors,
+	mediaCharacters,
+	mediaDetails,
+	mediaGenerationInfo,
+	mediaIps,
+	mediaProjects,
+	medias,
+	mediaTags,
+	mediaUrls,
+	type NewMedia,
+	projects,
+	tags,
+} from "@solid-imager/db/schema";
 import {
 	and,
 	asc,
@@ -39,24 +57,7 @@ import {
 	sql,
 } from "drizzle-orm";
 import type { z } from "zod";
-import { db, type TransactionClient } from "~/infrastructure/db/index";
-import {
-	authors,
-	characters,
-	ips,
-	mediaAuthors,
-	mediaCharacters,
-	mediaDetails,
-	mediaGenerationInfo,
-	mediaIps,
-	mediaProjects,
-	medias,
-	mediaTags,
-	mediaUrls,
-	type NewMedia,
-	projects,
-	tags,
-} from "~/infrastructure/db/schema";
+import { db } from "~/infrastructure/db/index";
 import { logger } from "~/infrastructure/logger";
 import { AuthorRepository } from "~/infrastructure/repositories/author-repository";
 
@@ -156,7 +157,7 @@ export const MediaRepository: IMediaRepository = {
 	 */
 	async findById(mediaId: string, tx?: Transaction): Promise<Media | null> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.select()
 				.from(medias)
@@ -182,7 +183,7 @@ export const MediaRepository: IMediaRepository = {
 		tx?: Transaction,
 	): Promise<Media | null> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.select()
 				.from(medias)
@@ -209,7 +210,7 @@ export const MediaRepository: IMediaRepository = {
 	 */
 	async create(media: AddMediaRequest, tx?: Transaction): Promise<Media> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const newMedia: NewMedia = {
 				...media,
 				status: "active",
@@ -227,7 +228,7 @@ export const MediaRepository: IMediaRepository = {
 	 */
 	async upsert(media: AddMediaRequest, tx?: Transaction): Promise<Media> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const newMedia: NewMedia = {
 				...media,
 				status: "active",
@@ -267,7 +268,7 @@ export const MediaRepository: IMediaRepository = {
 		tx?: Transaction,
 	): Promise<Media> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const dbUpdates: Partial<NewMedia> = {};
 
 			if (updates.filePath !== undefined) {
@@ -323,7 +324,7 @@ export const MediaRepository: IMediaRepository = {
 	 */
 	async delete(mediaId: string, tx?: Transaction): Promise<void> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.delete(medias)
 				.where(eq(medias.id, mediaId))
@@ -372,7 +373,7 @@ export const MediaRepository: IMediaRepository = {
 		tx?: Transaction,
 	): Promise<MediaDetails | null> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client.query.medias.findFirst({
 				where: eq(medias.id, mediaId),
 				with: {
@@ -423,7 +424,7 @@ export const MediaRepository: IMediaRepository = {
 		tx?: Transaction,
 	): Promise<MediaGenerationInfo | null> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.select()
 				.from(mediaGenerationInfo)
@@ -454,7 +455,7 @@ export const MediaRepository: IMediaRepository = {
 
 	async getUrls(mediaId: string, tx?: Transaction): Promise<MediaUrl[]> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const results = await client
 				.select()
 				.from(mediaUrls)
@@ -477,7 +478,7 @@ export const MediaRepository: IMediaRepository = {
 			return [];
 		}
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const values = urls.map((url) => ({
 				mediaId,
 				url,
@@ -502,7 +503,7 @@ export const MediaRepository: IMediaRepository = {
 		tx?: Transaction,
 	): Promise<MediaGenerationInfo> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const values = {
 				mediaId,
 				prompt,
@@ -543,7 +544,7 @@ export const MediaRepository: IMediaRepository = {
 		tx?: Transaction,
 	): Promise<Media[]> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const query = client
 				.select()
 				.from(medias)
@@ -566,7 +567,7 @@ export const MediaRepository: IMediaRepository = {
 		params: { query?: string; tags?: string[] },
 		tx?: Transaction,
 	): Promise<Media[]> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		// searchMediaInDirectory internally uses searchMediaQuery structure so it returns formatted results,
 		// hopefully compatible with Media. But let's check media-repository-utils.ts for that.
 		const results = await searchMediaInDirectory(
@@ -584,7 +585,7 @@ export const MediaRepository: IMediaRepository = {
 		if (urls.length === 0) {
 			return [];
 		}
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		try {
 			const results = await client
 				.select({ url: mediaUrls.url })
@@ -599,7 +600,7 @@ export const MediaRepository: IMediaRepository = {
 	async findIdsWithMissingGenerationInfo(
 		tx?: Transaction,
 	): Promise<{ id: string; mediaSourceId: string; filePath: string }[]> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		return await client
 			.select({
 				id: medias.id,
@@ -617,7 +618,7 @@ export const MediaRepository: IMediaRepository = {
 		tx?: Transaction,
 		options?: { limit: number; offset: number },
 	): Promise<{ id: string; mediaSourceId: string; filePath: string }[]> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		let query = client
 			.select({
 				id: medias.id,
@@ -640,7 +641,7 @@ export const MediaRepository: IMediaRepository = {
 		tx?: Transaction,
 	): Promise<{ id: string; filePath: string }[]> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			return await client
 				.select({
 					id: medias.id,
@@ -1076,7 +1077,7 @@ async function executeSearch(
 	mediaSourceId?: string,
 	tx?: Transaction,
 ): Promise<MediaSearchResponse> {
-	const client = (tx as unknown as TransactionClient) || db;
+	const client = getClient(db, tx);
 
 	const conditions: SQL[] = [];
 	if (mediaSourceId) {

--- a/apps/server/src/infrastructure/repositories/preset-repository.ts
+++ b/apps/server/src/infrastructure/repositories/preset-repository.ts
@@ -5,9 +5,9 @@ import type {
 	UpdatePresetRequest,
 } from "@solid-imager/core/domain/media/schemas";
 import type { PresetRepository } from "@solid-imager/core/domain/repositories/preset-repository";
+import { presets } from "@solid-imager/db/schema";
 import { eq, type InferSelectModel } from "drizzle-orm";
 import { db } from "~/infrastructure/db";
-import { presets } from "~/infrastructure/db/schema";
 
 export class DrizzlePresetRepository implements PresetRepository {
 	async list(): Promise<Preset[]> {

--- a/apps/server/src/infrastructure/repositories/project-repository.ts
+++ b/apps/server/src/infrastructure/repositories/project-repository.ts
@@ -6,9 +6,10 @@ import type {
 	UpdateProject,
 } from "@solid-imager/core/domain/projects/schemas";
 import type { IProjectRepository } from "@solid-imager/core/domain/repositories/project-repository";
+import { getClient } from "@solid-imager/db";
+import { mediaProjects, projects } from "@solid-imager/db/schema";
 import { and, eq } from "drizzle-orm";
-import { db, type TransactionClient } from "~/infrastructure/db";
-import { mediaProjects, projects } from "~/infrastructure/db/schema";
+import { db } from "~/infrastructure/db/index";
 
 const mapToDomain = (dbProject: typeof projects.$inferSelect): Project => ({
 	id: dbProject.id,
@@ -26,7 +27,7 @@ export const ProjectRepository: IProjectRepository = {
 	},
 
 	async findById(id: string, tx?: Transaction): Promise<Project | null> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.select()
 			.from(projects)
@@ -35,7 +36,7 @@ export const ProjectRepository: IProjectRepository = {
 	},
 
 	async findByName(name: string, tx?: Transaction): Promise<Project | null> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.select()
 			.from(projects)
@@ -44,7 +45,7 @@ export const ProjectRepository: IProjectRepository = {
 	},
 
 	async create(project: NewProject, tx?: Transaction): Promise<Project> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client.insert(projects).values(project).returning();
 		return mapToDomain(result[0]);
 	},
@@ -54,7 +55,7 @@ export const ProjectRepository: IProjectRepository = {
 		project: UpdateProject,
 		tx?: Transaction,
 	): Promise<Project> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const { archivedAt, ...rest } = project;
 		const updateData: Partial<typeof projects.$inferInsert> = {
 			...rest,
@@ -79,7 +80,7 @@ export const ProjectRepository: IProjectRepository = {
 	},
 
 	async delete(id: string, tx?: Transaction): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.delete(projects)
 			.where(eq(projects.id, id))
@@ -91,7 +92,7 @@ export const ProjectRepository: IProjectRepository = {
 	},
 
 	async findByMediaId(mediaId: string, tx?: Transaction): Promise<Project[]> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.select({
 				id: projects.id,
@@ -117,7 +118,7 @@ export const ProjectRepository: IProjectRepository = {
 		projectId: string,
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		await client
 			.insert(mediaProjects)
 			.values({ mediaId, projectId })
@@ -129,7 +130,7 @@ export const ProjectRepository: IProjectRepository = {
 		projectId: string,
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		const result = await client
 			.delete(mediaProjects)
 			.where(
@@ -149,7 +150,7 @@ export const ProjectRepository: IProjectRepository = {
 		projectIds: string[],
 		tx?: Transaction,
 	): Promise<void> {
-		const client = (tx as unknown as TransactionClient) || db;
+		const client = getClient(db, tx);
 		if (projectIds.length === 0) {
 			return;
 		}

--- a/apps/server/src/infrastructure/repositories/source-repository.ts
+++ b/apps/server/src/infrastructure/repositories/source-repository.ts
@@ -9,9 +9,10 @@ import type {
 	NewMediaSource,
 	SourceRepository,
 } from "@solid-imager/core/domain/repositories/source-repository";
+import { getClient } from "@solid-imager/db";
+import { mediaSources } from "@solid-imager/db/schema";
 import { eq, type InferSelectModel } from "drizzle-orm";
-import { db, type TransactionClient } from "~/infrastructure/db/index";
-import { mediaSources } from "~/infrastructure/db/schema";
+import { db } from "~/infrastructure/db/index";
 
 type DbMediaSource = InferSelectModel<typeof mediaSources>;
 
@@ -39,7 +40,7 @@ export class DrizzleSourceRepository implements SourceRepository {
 
 	async findById(id: string, tx?: Transaction): Promise<MediaSource | null> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.select()
 				.from(mediaSources)
@@ -59,7 +60,7 @@ export class DrizzleSourceRepository implements SourceRepository {
 
 	async create(source: NewMediaSource, tx?: Transaction): Promise<MediaSource> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			// Drizzle insert expects values matching the schema.
 			const result = await client
 				.insert(mediaSources)
@@ -87,7 +88,7 @@ export class DrizzleSourceRepository implements SourceRepository {
 		tx?: Transaction,
 	): Promise<MediaSource> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.update(mediaSources)
 				.set(source as typeof mediaSources.$inferInsert)
@@ -121,7 +122,7 @@ export class DrizzleSourceRepository implements SourceRepository {
 
 	async delete(id: string, tx?: Transaction): Promise<void> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.delete(mediaSources)
 				.where(eq(mediaSources.id, id))

--- a/apps/server/src/infrastructure/repositories/tag-repository.ts
+++ b/apps/server/src/infrastructure/repositories/tag-repository.ts
@@ -11,9 +11,10 @@ import type {
 	TagRepository as TagRepositoryDef,
 } from "@solid-imager/core/domain/repositories/tag-repository";
 import type { UpdateTag } from "@solid-imager/core/domain/tags/schemas";
+import { getClient, type TransactionClient } from "@solid-imager/db";
+import { mediaTags, tags } from "@solid-imager/db/schema";
 import { eq, type InferSelectModel, inArray, sql } from "drizzle-orm";
-import { db, type TransactionClient } from "~/infrastructure/db/index";
-import { mediaTags, tags } from "~/infrastructure/db/schema";
+import { db } from "~/infrastructure/db/index";
 
 type DbTag = InferSelectModel<typeof tags>;
 
@@ -98,7 +99,7 @@ export class DrizzleTagRepository implements TagRepositoryDef {
 
 	async create(tag: NewTag, tx?: Transaction): Promise<Tag> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client.insert(tags).values(tag).returning();
 			return mapToDomain(result[0]);
 		} catch (error: unknown) {
@@ -118,7 +119,7 @@ export class DrizzleTagRepository implements TagRepositoryDef {
 
 	async update(id: string, tag: UpdateTag, tx?: Transaction): Promise<Tag> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.update(tags)
 				.set(tag)
@@ -149,7 +150,7 @@ export class DrizzleTagRepository implements TagRepositoryDef {
 
 	async delete(id: string, tx?: Transaction): Promise<void> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.delete(tags)
 				.where(eq(tags.id, id))
@@ -168,7 +169,7 @@ export class DrizzleTagRepository implements TagRepositoryDef {
 
 	async findByMediaId(mediaId: string, tx?: Transaction): Promise<MediaTag[]> {
 		try {
-			const client = (tx as unknown as TransactionClient) || db;
+			const client = getClient(db, tx);
 			const result = await client
 				.select({
 					id: tags.id,
@@ -207,7 +208,7 @@ export class DrizzleTagRepository implements TagRepositoryDef {
 		tx?: Transaction,
 	): Promise<void> {
 		try {
-			// const _client = (tx as unknown as TransactionClient) || db;
+			// const _client = getClient(db, tx);
 			const execute = async (t: Transaction) => {
 				const uniqueTagNames = Array.from(
 					new Set(tagsToInsert.map((tag) => tag.name)),

--- a/apps/server/src/infrastructure/repositories/user-repository.ts
+++ b/apps/server/src/infrastructure/repositories/user-repository.ts
@@ -9,9 +9,9 @@ import type {
 	User,
 	UserRepository as UserRepositoryDef,
 } from "@solid-imager/core/domain/repositories/user-repository";
+import { users } from "@solid-imager/db/schema";
 import { eq } from "drizzle-orm";
 import { db } from "~/infrastructure/db/index";
-import { users } from "~/infrastructure/db/schema";
 
 export class DrizzleUserRepository implements UserRepositoryDef {
 	async findAll(): Promise<User[]> {

--- a/apps/server/src/infrastructure/storage/factory.ts
+++ b/apps/server/src/infrastructure/storage/factory.ts
@@ -4,7 +4,7 @@
  */
 
 import { localConnectionSchema } from "@solid-imager/core/domain/sources/schemas";
-import type { MediaSource } from "~/infrastructure/db/schema";
+import type { MediaSource } from "@solid-imager/db/schema";
 import { LocalDriver } from "./local";
 import type { MediaSourceDriver } from "./schema";
 

--- a/apps/server/src/tests/api/categories/category-id-test.ts
+++ b/apps/server/src/tests/api/categories/category-id-test.ts
@@ -1,5 +1,5 @@
+import type { Category } from "@solid-imager/db/schema";
 import { describe, expect, it } from "vite-plus/test";
-import type { Category } from "~/infrastructure/db/schema";
 
 describe("GET /api/categories/:id", () => {
 	it("should return category by id", () => {

--- a/apps/server/src/tests/api/categories/index.test.ts
+++ b/apps/server/src/tests/api/categories/index.test.ts
@@ -1,5 +1,5 @@
+import type { Category } from "@solid-imager/db/schema";
 import { describe, expect, it } from "vite-plus/test";
-import type { Category } from "~/infrastructure/db/schema";
 
 describe("GET /api/categories", () => {
 	it("should return an array of categories", () => {

--- a/apps/server/src/tests/api/characters/character-id-test.ts
+++ b/apps/server/src/tests/api/characters/character-id-test.ts
@@ -1,5 +1,5 @@
+import type { Character } from "@solid-imager/db/schema";
 import { describe, expect, it } from "vite-plus/test";
-import type { Character } from "~/infrastructure/db/schema";
 
 describe("GET /api/characters/:id", () => {
 	it("should return character by id", () => {

--- a/apps/server/src/tests/api/ips/ip-id-test.ts
+++ b/apps/server/src/tests/api/ips/ip-id-test.ts
@@ -1,5 +1,5 @@
+import type { Ip } from "@solid-imager/db/schema";
 import { describe, expect, it } from "vite-plus/test";
-import type { Ip } from "~/infrastructure/db/schema";
 
 describe("GET /api/ips/:id", () => {
 	it("should return IP by id", () => {

--- a/apps/server/src/tests/api/media/add-media.test.ts
+++ b/apps/server/src/tests/api/media/add-media.test.ts
@@ -1,7 +1,7 @@
 import { addMediaRequestSchema } from "@solid-imager/core/domain/media/schemas";
+import type { Media } from "@solid-imager/db/schema"; // Assuming Media type will be exported from schema
 import { describe, expect, it } from "vite-plus/test";
 import { ZodError } from "zod";
-import type { Media } from "~/infrastructure/db/schema"; // Assuming Media type will be exported from schema
 
 describe("addMedia Contract", () => {
 	it("should return a Media object on successful addition", () => {

--- a/apps/server/src/tests/api/media/get-media.test.ts
+++ b/apps/server/src/tests/api/media/get-media.test.ts
@@ -1,8 +1,8 @@
 import { mediaIdSchema } from "@solid-imager/core/domain/media/schemas";
 import { mediaSourceIdSchema } from "@solid-imager/core/domain/sources/schemas";
+import type { Media } from "@solid-imager/db/schema"; // Assuming Media type will be exported from schema
 import { describe, expect, it } from "vite-plus/test";
 import { ZodError } from "zod";
-import type { Media } from "~/infrastructure/db/schema"; // Assuming Media type will be exported from schema
 
 describe("getMedia Contract", () => {
 	it("should return a Media object for a valid mediaId", () => {

--- a/apps/server/src/tests/api/media/list-media.test.ts
+++ b/apps/server/src/tests/api/media/list-media.test.ts
@@ -1,8 +1,8 @@
 import { directoryPathSchema } from "@solid-imager/core/domain/media/schemas";
 import { mediaSourceIdSchema } from "@solid-imager/core/domain/sources/schemas";
+import type { Media } from "@solid-imager/db/schema"; // Assuming Media type will be exported from schema
 import { describe, expect, it } from "vite-plus/test";
 import { ZodError } from "zod";
-import type { Media } from "~/infrastructure/db/schema"; // Assuming Media type will be exported from schema
 
 describe("listMedia Contract", () => {
 	it("should return an array of Media objects for a valid directoryPath", () => {

--- a/apps/server/src/tests/api/media/update-media.test.ts
+++ b/apps/server/src/tests/api/media/update-media.test.ts
@@ -3,9 +3,9 @@ import {
 	mediaSourceIdSchema,
 	updateMediaRequestSchema,
 } from "@solid-imager/core/domain/media/schemas";
+import type { Media } from "@solid-imager/db/schema"; // Assuming Media type will be exported from schema
 import { describe, expect, it } from "vite-plus/test";
 import { ZodError } from "zod";
-import type { Media } from "~/infrastructure/db/schema"; // Assuming Media type will be exported from schema
 
 describe("updateMedia Contract", () => {
 	it("should return an updated Media object on successful update", () => {

--- a/apps/server/src/tests/api/tags/index.test.ts
+++ b/apps/server/src/tests/api/tags/index.test.ts
@@ -1,5 +1,5 @@
+import type { Tag } from "@solid-imager/db/schema";
 import { describe, expect, it } from "vite-plus/test";
-import type { Tag } from "~/infrastructure/db/schema";
 
 describe("GET /api/tags", () => {
 	it("should return an array of tags", () => {

--- a/apps/server/src/tests/api/tags/tag-id-test.ts
+++ b/apps/server/src/tests/api/tags/tag-id-test.ts
@@ -1,5 +1,5 @@
+import type { Tag } from "@solid-imager/db/schema";
 import { describe, expect, it } from "vite-plus/test";
-import type { Tag } from "~/infrastructure/db/schema";
 
 describe("GET /api/tags/:id", () => {
 	it("should return tag by id", () => {

--- a/apps/server/src/tests/integration/backup/backup-service.test.ts
+++ b/apps/server/src/tests/integration/backup/backup-service.test.ts
@@ -1,14 +1,3 @@
-import { eq } from "drizzle-orm";
-import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	vi,
-} from "vite-plus/test";
-import { BackupService } from "~/application/services/backup-service";
-import { db } from "~/infrastructure/db";
 import {
 	authors,
 	characterIps,
@@ -24,7 +13,18 @@ import {
 	mediaUrls,
 	projects,
 	tags,
-} from "~/infrastructure/db/schema";
+} from "@solid-imager/db/schema";
+import { eq } from "drizzle-orm";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vite-plus/test";
+import { BackupService } from "~/application/services/backup-service";
+import { db } from "~/infrastructure/db";
 
 // Mock external modules if necessary (e.g. storage driver, archiver)
 vi.mock("~/infrastructure/storage/factory", () => ({

--- a/apps/server/src/tests/integration/backup/performance.test.ts
+++ b/apps/server/src/tests/integration/backup/performance.test.ts
@@ -1,14 +1,3 @@
-import { eq } from "drizzle-orm";
-import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	vi,
-} from "vite-plus/test";
-import { BackupService } from "~/application/services/backup-service";
-import { db } from "~/infrastructure/db";
 import {
 	authors,
 	characters,
@@ -21,7 +10,18 @@ import {
 	medias,
 	projects,
 	tags,
-} from "~/infrastructure/db/schema";
+} from "@solid-imager/db/schema";
+import { eq } from "drizzle-orm";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vite-plus/test";
+import { BackupService } from "~/application/services/backup-service";
+import { db } from "~/infrastructure/db";
 
 describe("BackupService Performance", () => {
 	const testSourceId = "dce7b2a1-93ba-4c49-b1eb-f25dafb12949";

--- a/apps/server/src/tests/integration/backup/zip-backup.test.ts
+++ b/apps/server/src/tests/integration/backup/zip-backup.test.ts
@@ -3,17 +3,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
-import { eq } from "drizzle-orm";
-import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	vi,
-} from "vite-plus/test";
-import { BackupService } from "~/application/services/backup-service";
-import { db } from "~/infrastructure/db";
 import {
 	authors,
 	characters,
@@ -27,7 +16,18 @@ import {
 	mediaTags,
 	projects,
 	tags,
-} from "~/infrastructure/db/schema";
+} from "@solid-imager/db/schema";
+import { eq } from "drizzle-orm";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vite-plus/test";
+import { BackupService } from "~/application/services/backup-service";
+import { db } from "~/infrastructure/db";
 
 describe("BackupService ZIP Integration", () => {
 	const sourceId1 = "dce7b2a1-93ba-4c49-b1eb-f25dafb12949";

--- a/apps/server/src/tests/integration/media/add-media-integration.test.ts
+++ b/apps/server/src/tests/integration/media/add-media-integration.test.ts
@@ -1,8 +1,8 @@
+import type { NewMedia } from "@solid-imager/db/schema";
+import { mediaSources, medias } from "@solid-imager/db/schema";
 import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import { db } from "~/infrastructure/db/index";
-import type { NewMedia } from "~/infrastructure/db/schema";
-import { mediaSources, medias } from "~/infrastructure/db/schema";
 import { MediaRepository } from "~/infrastructure/repositories/media-repository";
 
 const TEST_FILE_SIZE = 1024 * 1024;

--- a/apps/server/src/tests/integration/media/copy-media-integration.test.ts
+++ b/apps/server/src/tests/integration/media/copy-media-integration.test.ts
@@ -1,3 +1,17 @@
+import {
+	authors,
+	characterIps,
+	characters,
+	ips,
+	jobs,
+	mediaAuthors,
+	mediaCharacters,
+	mediaIps,
+	mediaProjects,
+	mediaSources,
+	medias,
+	projects,
+} from "@solid-imager/db/schema";
 import { eq } from "drizzle-orm";
 import {
 	afterEach,
@@ -12,20 +26,6 @@ import { CharacterServiceImpl } from "~/application/services/character-service";
 import { MediaProcessingServiceImpl } from "~/application/services/media-processing-service";
 import { MediaService } from "~/application/services/media-service";
 import { db } from "~/infrastructure/db/index";
-import {
-	authors,
-	characterIps,
-	characters,
-	ips,
-	jobs,
-	mediaAuthors,
-	mediaCharacters,
-	mediaIps,
-	mediaProjects,
-	mediaSources,
-	medias,
-	projects,
-} from "~/infrastructure/db/schema";
 import { DrizzleTransactionManager } from "~/infrastructure/db/transaction-manager";
 import { AuthorRepository } from "~/infrastructure/repositories/author-repository";
 import { DrizzleCharacterRepository } from "~/infrastructure/repositories/character-repository";

--- a/apps/server/src/tests/integration/media/delete-media-integration.test.ts
+++ b/apps/server/src/tests/integration/media/delete-media-integration.test.ts
@@ -1,3 +1,5 @@
+import type { NewMedia } from "@solid-imager/db/schema";
+import { mediaSources, medias } from "@solid-imager/db/schema";
 import { eq } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import { ZodError } from "zod";
@@ -5,8 +7,6 @@ import { services } from "~/application/registry";
 import { MediaService } from "~/application/services/media-service";
 import { PythonClient } from "~/infrastructure/ai/python-client";
 import { db } from "~/infrastructure/db/index";
-import type { NewMedia } from "~/infrastructure/db/schema";
-import { mediaSources, medias } from "~/infrastructure/db/schema";
 import { ImageProcessor } from "~/infrastructure/processing/image-processor";
 import { AuthorRepository } from "~/infrastructure/repositories/author-repository";
 import { DrizzleCharacterRepository } from "~/infrastructure/repositories/character-repository";

--- a/apps/server/src/tests/integration/media/get-media-details-integration.test.ts
+++ b/apps/server/src/tests/integration/media/get-media-details-integration.test.ts
@@ -30,7 +30,7 @@ let testDb: any, db: any;
 vi.mock("~/infrastructure/db/index", async () => {
 	const { PGlite: PgLiteClass } = await import("@electric-sql/pglite");
 	const { drizzle: drizzleFunc } = await import("drizzle-orm/pglite");
-	const schemaModule = await import("~/infrastructure/db/schema");
+	const schemaModule = await import("@solid-imager/db/schema");
 
 	const pg = new PgLiteClass();
 	const dbInstance = drizzleFunc(pg, { schema: schemaModule });
@@ -68,7 +68,7 @@ describe("getMediaDetails", () => {
 		_eq = drizzleOrm.eq;
 		const migratorModule = await import("drizzle-orm/pglite/migrator");
 		migrate = migratorModule.migrate;
-		schema = await import("~/infrastructure/db/schema");
+		schema = await import("@solid-imager/db/schema");
 
 		testDb = (global as any).vitestTestDb;
 		db = drizzle(testDb, { schema });

--- a/apps/server/src/tests/integration/media/get-media-integration.test.ts
+++ b/apps/server/src/tests/integration/media/get-media-integration.test.ts
@@ -1,11 +1,11 @@
+import type { NewMedia } from "@solid-imager/db/schema";
+import { mediaSources, medias } from "@solid-imager/db/schema";
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import { ZodError } from "zod";
 import { services } from "~/application/registry";
 import { MediaService } from "~/application/services/media-service";
 import { PythonClient } from "~/infrastructure/ai/python-client";
 import { db } from "~/infrastructure/db/index";
-import type { NewMedia } from "~/infrastructure/db/schema";
-import { mediaSources, medias } from "~/infrastructure/db/schema";
 import { ImageProcessor } from "~/infrastructure/processing/image-processor";
 import { AuthorRepository } from "~/infrastructure/repositories/author-repository";
 import { DrizzleCharacterRepository } from "~/infrastructure/repositories/character-repository";

--- a/apps/server/src/tests/integration/media/list-media-integration.test.ts
+++ b/apps/server/src/tests/integration/media/list-media-integration.test.ts
@@ -1,11 +1,11 @@
+import type { NewMedia } from "@solid-imager/db/schema";
+import { mediaSources, medias } from "@solid-imager/db/schema";
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import { ZodError } from "zod";
 import { services } from "~/application/registry";
 import { MediaService } from "~/application/services/media-service";
 import { PythonClient } from "~/infrastructure/ai/python-client";
 import { db } from "~/infrastructure/db/index";
-import type { NewMedia } from "~/infrastructure/db/schema";
-import { mediaSources, medias } from "~/infrastructure/db/schema";
 import { ImageProcessor } from "~/infrastructure/processing/image-processor";
 import { AuthorRepository } from "~/infrastructure/repositories/author-repository";
 import { DrizzleCharacterRepository } from "~/infrastructure/repositories/character-repository";

--- a/apps/server/src/tests/integration/media/media-type-handling.test.ts
+++ b/apps/server/src/tests/integration/media/media-type-handling.test.ts
@@ -65,7 +65,7 @@ let migrate: any;
 let schema: any;
 let db: any;
 
-import type { MediaSource } from "~/infrastructure/db/schema";
+import type { MediaSource } from "@solid-imager/db/schema";
 
 describe("Media Type Handling Integration", () => {
 	let mediaSource: MediaSource;
@@ -88,7 +88,7 @@ describe("Media Type Handling Integration", () => {
 		try {
 			const migratorModule = await import("drizzle-orm/pglite/migrator");
 			migrate = migratorModule.migrate;
-			schema = await import("~/infrastructure/db/schema");
+			schema = await import("@solid-imager/db/schema");
 			const dbModule = await import("~/infrastructure/db/index");
 			db = dbModule.db;
 

--- a/apps/server/src/tests/integration/media/register-media-integration.test.ts
+++ b/apps/server/src/tests/integration/media/register-media-integration.test.ts
@@ -1,17 +1,16 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+	type MediaSource,
+	mediaSources,
+	medias,
+} from "@solid-imager/db/schema";
 import sharp from "sharp";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import { services } from "~/application/registry";
 import { MediaProcessingService } from "~/application/services/media-processing-service";
 import { MediaService } from "~/application/services/media-service";
-
 import { db } from "~/infrastructure/db/index";
-import {
-	type MediaSource,
-	mediaSources,
-	medias,
-} from "~/infrastructure/db/schema";
 
 const TEST_TIMEOUT = 15_000;
 

--- a/apps/server/src/tests/integration/media/update-media-integration.test.ts
+++ b/apps/server/src/tests/integration/media/update-media-integration.test.ts
@@ -1,3 +1,4 @@
+import { mediaSources, medias } from "@solid-imager/db/schema";
 import { eq } from "drizzle-orm";
 import {
 	afterEach,
@@ -12,7 +13,6 @@ import { services } from "~/application/registry";
 import { MediaService } from "~/application/services/media-service";
 import { PythonClient } from "~/infrastructure/ai/python-client";
 import { db } from "~/infrastructure/db/index";
-import { mediaSources, medias } from "~/infrastructure/db/schema";
 import { ImageProcessor } from "~/infrastructure/processing/image-processor";
 import { AuthorRepository } from "~/infrastructure/repositories/author-repository";
 import { DrizzleCharacterRepository } from "~/infrastructure/repositories/character-repository";

--- a/apps/server/src/tests/integration/queries/search.test.ts
+++ b/apps/server/src/tests/integration/queries/search.test.ts
@@ -1,5 +1,3 @@
-import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
-import { db } from "~/infrastructure/db";
 import {
 	mediaSources,
 	medias,
@@ -7,7 +5,9 @@ import {
 	type NewMedia,
 	type NewTag,
 	tags,
-} from "~/infrastructure/db/schema";
+} from "@solid-imager/db/schema";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import { db } from "~/infrastructure/db";
 import {
 	globalSearchMedia,
 	searchMedia,

--- a/apps/server/src/tests/integration/repository/author-dedupe.test.ts
+++ b/apps/server/src/tests/integration/repository/author-dedupe.test.ts
@@ -1,8 +1,8 @@
+import { authors } from "@solid-imager/db/schema";
 import { eq } from "drizzle-orm";
 import { migrate } from "drizzle-orm/pglite/migrator";
 import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
 import { db } from "~/infrastructure/db";
-import { authors } from "~/infrastructure/db/schema";
 import { AuthorRepository } from "~/infrastructure/repositories/author-repository";
 
 describe("AuthorRepository Deduplication", () => {

--- a/apps/server/src/tests/integration/repository/character-repository.test.ts
+++ b/apps/server/src/tests/integration/repository/character-repository.test.ts
@@ -1,8 +1,8 @@
+import { characterIps, characters, ips } from "@solid-imager/db/schema";
 import { eq } from "drizzle-orm";
 import { migrate } from "drizzle-orm/pglite/migrator";
 import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
 import { db } from "~/infrastructure/db";
-import { characterIps, characters, ips } from "~/infrastructure/db/schema";
 import { DrizzleCharacterRepository } from "~/infrastructure/repositories/character-repository";
 
 describe("CharacterRepository Multi-IP Support", () => {

--- a/apps/server/src/tests/setup-integration.ts
+++ b/apps/server/src/tests/setup-integration.ts
@@ -30,7 +30,7 @@ const { mockDbFactory } = vi.hoisted(() => {
 			const { PGlite } = await import("@electric-sql/pglite");
 			const { drizzle } = await import("drizzle-orm/pglite");
 			const { migrate } = await import("drizzle-orm/pglite/migrator");
-			const schema = await import("~/infrastructure/db/schema");
+			const schema = await import("@solid-imager/db/schema");
 			const nodePath = await import("node:path");
 
 			const client = new PGlite();

--- a/apps/server/src/tests/setup.ts
+++ b/apps/server/src/tests/setup.ts
@@ -150,7 +150,7 @@ const { mockDbInstance } = vi.hoisted(() => {
 				const { PGlite } = await import("@electric-sql/pglite");
 				const { drizzle } = await import("drizzle-orm/pglite");
 				const { migrate } = await import("drizzle-orm/pglite/migrator");
-				const schema = await import("~/infrastructure/db/schema");
+				const schema = await import("@solid-imager/db/schema");
 				const nodePath = await import("node:path");
 
 				const client = new PGlite();

--- a/apps/server/src/tests/unit/application/services/backup-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/backup-service.test.ts
@@ -1,12 +1,8 @@
 import type { MediaDumpItem } from "@solid-imager/core/domain/media/schemas";
+import { mediaCharacters, mediaIps, mediaTags } from "@solid-imager/db/schema";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { BackupService } from "~/application/services/backup-service";
 import { db } from "~/infrastructure/db";
-import {
-	mediaCharacters,
-	mediaIps,
-	mediaTags,
-} from "~/infrastructure/db/schema";
 
 const { mockValues, mockDelete, mockFindMany } = vi.hoisted(() => ({
 	mockValues: vi.fn(() => ({

--- a/apps/server/src/tests/unit/infrastructure/jobs/job-worker.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/job-worker.test.ts
@@ -1,4 +1,5 @@
 import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+import type { Job } from "@solid-imager/db/schema";
 import {
 	afterEach,
 	beforeEach,
@@ -8,7 +9,6 @@ import {
 	vi,
 } from "vite-plus/test";
 import type { IJobRepository } from "~/domain/repositories/job-repository";
-import type { Job } from "~/infrastructure/db/schema";
 import { JobWorker } from "~/infrastructure/jobs/job-worker";
 
 // Mock logger to avoid noise

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -12,6 +12,7 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["./src/*"],
+      "@solid-imager/db/*": ["../../packages/db/src/*"],
       "@solid-imager/ui/*": ["../../packages/ui/src/*"],
       "@/*": ["../../packages/core/src/*"]
     }

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "@orpc/tanstack-query": "^1.13.13",
         "@orpc/zod": "^1.13.13",
         "@solid-imager/core": "workspace:*",
+        "@solid-imager/db": "workspace:*",
         "@solid-imager/ui": "workspace:*",
         "@tanstack/router-plugin": "latest",
         "@tanstack/solid-form": "latest",
@@ -157,6 +158,22 @@
       "peerDependencies": {
         "solid-js": "^1.9.12",
         "zod": "^4.3.5",
+      },
+    },
+    "packages/db": {
+      "name": "@solid-imager/db",
+      "version": "0.0.0",
+      "dependencies": {
+        "@electric-sql/pglite": "^0.3.16",
+        "@solid-imager/core": "workspace:*",
+        "drizzle-orm": "^0.44.7",
+        "pg": "^8.20.0",
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vite-plus": "latest",
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
       },
     },
     "packages/ui": {
@@ -277,7 +294,7 @@
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.16", "", {}, "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA=="],
 
-    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw=="],
 
@@ -459,7 +476,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@nothing-but/utils": ["@nothing-but/utils@0.17.0", "", {}, "sha512-TuCHcHLOqDL0SnaAxACfuRHBNRgNJcNn9X0GiH5H3YSDBVquCr3qEIG3FOQAuMyZCbu9w8nk2CHhOsn7IvhIwQ=="],
 
@@ -507,7 +524,47 @@
 
     "@orpc/zod": ["@orpc/zod@1.13.13", "", { "dependencies": { "@orpc/json-schema": "1.13.13", "@orpc/openapi": "1.13.13", "@orpc/shared": "1.13.13", "escape-string-regexp": "^5.0.0", "wildcard-match": "^5.1.4" }, "peerDependencies": { "@orpc/contract": "1.13.13", "@orpc/server": "1.13.13", "zod": ">=3.25.0" } }, "sha512-K2iWGHopi3apExqNVb6EWJJqmq7cgytY3PjJyJ/Uy98UfJJ17Kwz7rAZKffNc7E967rNk9IH8MIcUcGkT7dmzQ=="],
 
-    "@oxc-project/runtime": ["@oxc-project/runtime@0.123.0", "", {}, "sha512-wRf0z8saz9tHLcK3YeTeBmwISrpy4bBimvKxUmryiIhbt+ZJb0nwwJNL3D8xpeWbNfZlGSlzRBZbfcbApIGZJw=="],
+    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.120.0", "", { "os": "android", "cpu": "arm" }, "sha512-WU3qtINx802wOl8RxAF1v0VvmC2O4D9M8Sv486nLeQ7iPHVmncYZrtBhB4SYyX+XZxj2PNnCcN+PW21jHgiOxg=="],
+
+    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.120.0", "", { "os": "android", "cpu": "arm64" }, "sha512-SEf80EHdhlbjZEgzeWm0ZA/br4GKMenDW3QB/gtyeTV1gStvvZeFi40ioHDZvds2m4Z9J1bUAUL8yn1/+A6iGg=="],
+
+    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.120.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xVrrbCai8R8CUIBu3CjryutQnEYhZqs1maIqDvtUCFZb8vY33H7uh9mHpL3a0JBIKoBUKjPH8+rzyAeXnS2d6A=="],
+
+    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.120.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-xyHBbnJ6mydnQUH7MAcafOkkrNzQC6T+LXgDH/3InEq2BWl/g424IMRiJVSpVqGjB+p2bd0h0WRR8iIwzjU7rw=="],
+
+    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.120.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMnVRllquXUYTeNfFKmxTTEdZ/ix1nLl0ducDzMSREoWYGVIHnOOxoKMWlCOvRr9Wk/HZqo2rh1jeumbPGPV9A=="],
+
+    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.120.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tkvn2CQ7QdcsMnpfiX3fd3wA3EFsWKYlcQzq9cFw/xc89Al7W6Y4O0FgLVkVQpo0Tnq/qtE1XfkJOnRRA9S/NA=="],
+
+    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.120.0", "", { "os": "linux", "cpu": "arm" }, "sha512-WN5y135Ic42gQDk9grbwY9++fDhqf8knN6fnP+0WALlAUh4odY/BDK1nfTJRSfpJD9P3r1BwU0m3pW2DU89whQ=="],
+
+    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.120.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-1GgQBCcXvFMw99EPdMy+4NZ3aYyXsxjf9kbUUg8HuAy3ZBXzOry5KfFEzT9nqmgZI1cuetvApkiJBZLAPo8uaw=="],
+
+    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.120.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-gmMQ70gsPdDBgpcErvJEoWNBr7bJooSLlvOBVBSGfOzlP5NvJ3bFvnUeZZ9d+dPrqSngtonf7nyzWUTUj/U+lw=="],
+
+    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.120.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-T/kZuU0ajop0xhzVMwH5r3srC9Nqup5HaIo+3uFjIN5uPxa0LvSxC1ZqP4aQGJVW5G0z8/nCkjIfSMS91P/wzw=="],
+
+    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.120.0", "", { "os": "linux", "cpu": "none" }, "sha512-vn21KXLAXzaI3N5CZWlBr1iWeXLl9QFIMor7S1hUjUGTeUuWCoE6JZB040/ZNDwf+JXPX8Ao9KbmJq9FMC2iGw=="],
+
+    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.120.0", "", { "os": "linux", "cpu": "none" }, "sha512-SUbUxlar007LTGmSLGIC5x/WJvwhdX+PwNzFJ9f/nOzZOrCFbOT4ikt7pJIRg1tXVsEfzk5mWpGO1NFiSs4PIw=="],
+
+    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.120.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hYiPJTxyfJY2+lMBFk3p2bo0R9GN+TtpPFlRqVchL1qvLG+pznstramHNvJlw9AjaoRUHwp9IKR7UZQnRPGjgQ=="],
+
+    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.120.0", "", { "os": "linux", "cpu": "x64" }, "sha512-q+5jSVZkprJCIy3dzJpApat0InJaoxQLsJuD6DkX8hrUS61z2lHQ1Fe9L2+TYbKHXCLWbL0zXe7ovkIdopBGMQ=="],
+
+    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.120.0", "", { "os": "linux", "cpu": "x64" }, "sha512-D9QDDZNnH24e7X4ftSa6ar/2hCavETfW3uk0zgcMIrZNy459O5deTbWrjGzZiVrSWigGtlQwzs2McBP0QsfV1w=="],
+
+    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.120.0", "", { "os": "none", "cpu": "arm64" }, "sha512-TBU8ZwOUWAOUWVfmI16CYWbvh4uQb9zHnGBHsw5Cp2JUVG044OIY1CSHODLifqzQIMTXvDvLzcL89GGdUIqNrA=="],
+
+    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.120.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-WG/FOZgDJCpJnuF3ToG/K28rcOmSY7FmFmfBKYb2fmLyhDzPpUldFGV7/Fz4ru0Iz/v4KPmf8xVgO8N3lO4KHA=="],
+
+    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.120.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1T0HKGcsz/BKo77t7+89L8Qvu4f9DoleKWHp3C5sJEcbCjDOLx3m9m722bWZTY+hANlUEs+yjlK+lBFsA+vrVQ=="],
+
+    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.120.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-L7vfLzbOXsjBXV0rv/6Y3Jd9BRjPeCivINZAqrSyAOZN3moCopDN+Psq9ZrGNZtJzP8946MtlRFZ0Als0wBCOw=="],
+
+    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.120.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ys+upfqNtSu58huAhJMBKl3XCkGzyVFBlMlGPzHeFKgpFF/OdgNs1MMf8oaJIbgMH8ZxgGF7qfue39eJohmKIg=="],
+
+    "@oxc-project/runtime": ["@oxc-project/runtime@0.129.0", "", {}, "sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.123.0", "", {}, "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew=="],
 
@@ -613,35 +670,35 @@
 
     "@readme/openapi-schemas": ["@readme/openapi-schemas@3.1.0", "", {}, "sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.14", "", { "os": "android", "cpu": "arm64" }, "sha512-rJgm6anlnBiT/lAhYXsBPaJhovM5JqRQ6k8UfDZdUXepaoxys8xcfNFp6bhJdbnTf2+I+YbLFJ5p1/VcI6wl2A=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-21+BaHtD0IF+cFaCJFMM5qMqtIDyT4dHcibIAEr7ZbtjG2MbXO5PjMqGN4rQkWAhrq638dcKWDZ5uUMUisJDHQ=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-5hvOzj4a70rybFDFdKc8EclxoEzY7DjB53Xolbq8Sbo3HaN4U7j7Z45aPQXzCKG2I7HvybzdM2xW/AL0Afmrfg=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.14", "", { "os": "freebsd", "cpu": "x64" }, "sha512-gVaINvIiN1YT7gjxs6d0//GDT2y2DTbKKIbLk5G5VOtCndHCTrbgceFlTgwq3h53k1OXTGd0gJtC5btDanjfbg=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.14", "", { "os": "linux", "cpu": "arm" }, "sha512-el0dPE3R7H4e3wmaFN+1/jJe4nbTCdkbNMtw9Myj5t38eZXtv+O46hngnwq2VjeZOjz4Rc/FQDI+oGtE9pbZqQ=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.1", "", { "os": "linux", "cpu": "arm" }, "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-+q7jyEYbYHVa+EhjmSh0LcJB46ve0SdGnqGaWfV+g4ud+wzUxIgv4MxZmqG7jNR4wLKX0+FHPn6RP6MDe6T5ZQ=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-MM5zJpuf1Hz6JZmkZDi0WuJBqxDneYoh7WE8Hwy3bj2ebBMpAntS0CWgL/423P/5s9CzE9lygolMMdSkrtmDVg=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.14", "", { "os": "linux", "cpu": "ppc64" }, "sha512-73h3xZDs0MSqJGjMyV4EjLXBIRs+YeIs0XN2/6DT5I0W5HyjTagH4QXa3CRHL77UAyS5xpr+RxKlJhkR5g05fA=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.14", "", { "os": "linux", "cpu": "s390x" }, "sha512-/Z9EkQlW8nnP1gmOjXIQRuGDadiRv/8gnYK0/dRv1nra4d2J2j70oqO4ltmpE0W24Ac7i1G0o/HIs9yXXj96mg=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.14", "", { "os": "linux", "cpu": "x64" }, "sha512-7V6pMjtRh0J7eIcLjs9EvcuSk5Vz4qDY+u8GojpPEQ8X4+6F8Qq1fOkeyTD6QQvZpiuWeWCvSNwjwfi86wIJ+w=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.14", "", { "os": "linux", "cpu": "x64" }, "sha512-Yxi4UdSPXJTtGjGEgObeWIWSOmVoXLXa8CmGCdb3GKmJS0kcmcklp1ClSC3VipQRxL0ALj9JuNUxfKUW6bIKjQ=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.14", "", { "os": "none", "cpu": "arm64" }, "sha512-YOC79AFS2WCHU6v47tNw/rsLXW/Lj/WDRf8IVDpqN3cZk8ucLFAPxGCeyrIuIE6mYlTQdgIvmj22c/NC9EHTvg=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.1", "", { "os": "none", "cpu": "arm64" }, "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.14", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-dXoc9dGlySSwrn5hj8gaHTpFhJhh+eEHEQyWdqc56X/BCYxD1tjOAm5mkMXyEvolne9y9KCQgL1A/xEd1J3RBw=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.1", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-G24v2feAC4rnKhlgzz0msbi4OCfvZHCS04Hayhy8Aj/kRLnUnN0JNMGJiNxsRLCmK2i9gBIR/X1geQysfr0h5g=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.14", "", { "os": "win32", "cpu": "x64" }, "sha512-yS/76wZ3HLwb20YbFHEiwoqz//0uFLyEye4IMmcyPFmxHMJnd7DgOcJCGjUG/7fswBkvGT2AJeT24UYOIBtBSw=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.40", "", {}, "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w=="],
 
@@ -670,6 +727,8 @@
     "@solid-imager/cli": ["@solid-imager/cli@workspace:apps/cli"],
 
     "@solid-imager/core": ["@solid-imager/core@workspace:packages/core"],
+
+    "@solid-imager/db": ["@solid-imager/db@workspace:packages/db"],
 
     "@solid-imager/server": ["@solid-imager/server@workspace:apps/server"],
 
@@ -761,9 +820,9 @@
 
     "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.3", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw=="],
 
-    "@tanstack/devtools-vite": ["@tanstack/devtools-vite@0.6.0", "", { "dependencies": { "@babel/core": "^7.28.4", "@babel/generator": "^7.28.3", "@babel/parser": "^7.28.4", "@babel/traverse": "^7.28.4", "@babel/types": "^7.28.4", "@tanstack/devtools-client": "0.0.6", "@tanstack/devtools-event-bus": "0.4.1", "chalk": "^5.6.2", "launch-editor": "^2.11.1", "picomatch": "^4.0.3" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-h0r0ct7zlrgjkhmn4QW6wRjgUXd4JMs+r7gtx+BXo9f5H9Y+jtUdtvC0rnZcPto6gw/9yMUq7yOmMK5qDWRExg=="],
+    "@tanstack/devtools-vite": ["@tanstack/devtools-vite@0.7.0", "", { "dependencies": { "@tanstack/devtools-client": "0.0.6", "@tanstack/devtools-event-bus": "0.4.1", "chalk": "^5.6.2", "launch-editor": "^2.11.1", "magic-string": "^0.30.0", "oxc-parser": "^0.120.0", "picomatch": "^4.0.3" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-VXki7K+Xwnpo3IKdNSWGe7YOvtZv33YlulGqaQ+YCpeQhYg8JFuxP50BXibDoRLj5EOX4r21Hs7COdxbRHXkTw=="],
 
-    "@tanstack/form-core": ["@tanstack/form-core@1.28.6", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1", "@tanstack/pacer-lite": "^0.1.1", "@tanstack/store": "^0.9.1" } }, "sha512-4zroxL6VDj5O+w7l3dYZnUeL/h30KtNSV7UWzKAL7cl+8clMFdISPDlDlluS37As7oqvPVKo8B83VlIBvgmRog=="],
+    "@tanstack/form-core": ["@tanstack/form-core@1.32.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1", "@tanstack/pacer-lite": "^0.1.1", "@tanstack/store": "^0.9.1" } }, "sha512-Tn5VRDSjyqjmaet2tJMuEWDRFyrCaon03vxXPlSSaiSs6C/N7lCIwGCXJbZXEUq1kTj8jYN9qyXHbsz4LQHcow=="],
 
     "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
@@ -771,47 +830,47 @@
 
     "@tanstack/query-core": ["@tanstack/query-core@5.95.2", "", {}, "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ=="],
 
-    "@tanstack/router-core": ["@tanstack/router-core@1.168.9", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g=="],
+    "@tanstack/router-core": ["@tanstack/router-core@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw=="],
 
-    "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.167.1", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.168.2", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-ECMM47J4KmifUvJguGituSiBpfN8SyCUEoxQks5RY09hpIBfR2eswCv2e6cJimjkKwBQXOVTPkTUk/yRvER+9w=="],
+    "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.167.3", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.168.11", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-fJ1VMhyQgnoashTrP763c2HRc9kofgF61L7Jb3F6eTHAmCKtGVx8BRtiFt37sr3U0P0jmaaiiSPGP6nT5JtVNg=="],
 
-    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.24", "", { "dependencies": { "@tanstack/router-core": "1.168.9", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "prettier": "^3.5.0", "recast": "^0.23.11", "source-map": "^0.7.4", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-vdaGKwuH+r+DPe6R1mjk+TDDmDH6NTG7QqwxHqGEvOH4aGf9sPjhmRKNJZqQr8cPIbfp6u5lXyZ1TeDcSNMVEA=="],
+    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.42", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.169.2", "@tanstack/router-utils": "1.161.8", "@tanstack/virtual-file-routes": "1.161.7", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^3.24.2" } }, "sha512-2qBWC0t78r6b3vI+AbnvCZcFAvbYBDlLuWZrTjQbcjUmwG3qyeQp983tJyDuj9wb5//adG1tgAGXZkJ3aDwdBg=="],
 
-    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.12", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.9", "@tanstack/router-generator": "1.166.24", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2", "@tanstack/react-router": "^1.168.10", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0", "vite-plugin-solid": "^2.11.10", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-StEHcctCuFI5taSjO+lhR/yQ+EK63BdyYa+ne6FoNQPB3MMrOUrz2ZVnbqILRLkh2b+p2EfBKt65sgAKdKygPQ=="],
+    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.35", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.169.2", "@tanstack/router-generator": "1.166.42", "@tanstack/router-utils": "1.161.8", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^3.0.0", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.169.2", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-UAScU5VAzLYVY4FML/Cbc5S5TucT4I8Ata05yozGOe4ZfepTKRffA5xWLtD2N+ov5svdv0KTX/kqlZnYPe28mA=="],
 
-    "@tanstack/router-ssr-query-core": ["@tanstack/router-ssr-query-core@1.167.0", "", { "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/router-core": ">=1.127.0" } }, "sha512-+fpK1U+NR8YzcUmXhEy2tdPfT/XxIn1AMd/ODkYGMExAAUWnV8Zptptf41djK5eBj6718P6YTfxLRkxtfUdnVA=="],
+    "@tanstack/router-ssr-query-core": ["@tanstack/router-ssr-query-core@1.168.0", "", { "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/router-core": ">=1.127.0" } }, "sha512-5yBUAF1d9z2kOFKoz1spvpvkMSTmRnRXEwi+bGKfrXYmt7CfHu3Pk8KUFMln67uQoKQ9VTkcd5tLkjJVrZ2/AQ=="],
 
-    "@tanstack/router-utils": ["@tanstack/router-utils@1.161.6", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw=="],
+    "@tanstack/router-utils": ["@tanstack/router-utils@1.161.8", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-xyiLWEKjfBAVhauDSSjXxyf7s8elU6SM+V050sbkofvGmIIvkwPFtDsX7Gvwh14kBd6iCwAT+RiPvXTxAptY0Q=="],
 
-    "@tanstack/solid-form": ["@tanstack/solid-form@1.28.6", "", { "dependencies": { "@tanstack/form-core": "1.28.6", "@tanstack/solid-store": "^0.9.1" }, "peerDependencies": { "solid-js": ">=1.9.9" } }, "sha512-XsSrlq7F/ySph+A2XyvW4WW92zHMw4CcEc/UeQBXMod1J5tCkZ/zPByLoKSmRNxSupU3o6T1trfs13gBjrfMKg=="],
+    "@tanstack/solid-form": ["@tanstack/solid-form@1.32.0", "", { "dependencies": { "@tanstack/form-core": "1.32.0", "@tanstack/solid-store": "^0.9.1" }, "peerDependencies": { "solid-js": ">=1.9.9" } }, "sha512-ItsbNHjCsti+idxQ+7x8grj4f8qSfR4PdSzTBgeUD8wy5X9Acz9q5liYSJ8WaU3om8b+kRyeBGswB0A+eI0ZdA=="],
 
-    "@tanstack/solid-query": ["@tanstack/solid-query@5.96.2", "", { "dependencies": { "@tanstack/query-core": "5.96.2" }, "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-gAJhm/aHtubM4gKrtBJy9lMIQggtG4pN3P47dIbYi7pESm8ud0EY/jWkj18TUIC65e1nbSOerKBtjRvzydz5+Q=="],
+    "@tanstack/solid-query": ["@tanstack/solid-query@5.100.10", "", { "dependencies": { "@tanstack/query-core": "5.100.10" }, "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-4uUqc+l9f7wNfL9/fxU9P+/RyA0wXh67jrl8EeNYsXHo5Xcy31uiSBq5wZ80NHBCbyw+eLtrkZZMW2ZXNe1ViQ=="],
 
-    "@tanstack/solid-router": ["@tanstack/solid-router@1.168.9", "", { "dependencies": { "@solid-devtools/logger": "^0.9.4", "@solid-primitives/refs": "^1.0.8", "@solidjs/meta": "^0.29.4", "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.168.9", "isbot": "^5.1.22" }, "peerDependencies": { "solid-js": "^1.9.10" }, "bin": { "intent": "bin/intent.js" } }, "sha512-ZgfcBS7lVhVlScxMhoh3U37K/LnNltMJV6Lor98ON3mKnE9XkOwZKvzkOVYj1JEi5HiQsYnC1lmZR5Ww0tc2og=="],
+    "@tanstack/solid-router": ["@tanstack/solid-router@1.169.2", "", { "dependencies": { "@solid-devtools/logger": "^0.9.4", "@solid-primitives/refs": "^1.0.8", "@solidjs/meta": "^0.29.4", "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.169.2", "isbot": "^5.1.22" }, "peerDependencies": { "solid-js": "^1.9.10" } }, "sha512-t4uthYxVqlhVu184QfrLXVpyrJyfl9Pr86y8V+LdKfR6ZEzW5xXDXPwB/VygqVPplCS6NIjory24KHci8RF8nA=="],
 
-    "@tanstack/solid-router-devtools": ["@tanstack/solid-router-devtools@1.166.11", "", { "dependencies": { "@tanstack/router-devtools-core": "1.167.1" }, "peerDependencies": { "@tanstack/router-core": "^1.168.2", "@tanstack/solid-router": "^1.168.2", "solid-js": "^1.9.10" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-cFHS/2nBTS/ds2wjIAYI/DkPWa6aS6a4OBPhQPdyxzRKKj21D8j3b17isNtlrg8AuGLuYv4eZdNZs6sKYTLE6g=="],
+    "@tanstack/solid-router-devtools": ["@tanstack/solid-router-devtools@1.166.13", "", { "dependencies": { "@tanstack/router-devtools-core": "1.167.3" }, "peerDependencies": { "@tanstack/router-core": "^1.168.11", "@tanstack/solid-router": "^1.168.14", "solid-js": "^1.9.10" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-0K/bhEWPuBjHjI9h9Ckc9iioHmHr/DW+rXbfETa6G+lNK9nArUgtvuVM58sITRaSmlpImm/OCMCuNkUhXrPP/w=="],
 
-    "@tanstack/solid-router-ssr-query": ["@tanstack/solid-router-ssr-query@1.166.10", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.167.0" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/solid-query": ">=5.90.0", "@tanstack/solid-router": ">=1.127.0", "solid-js": "^1.9.10" } }, "sha512-FPfjiXlhDCR5o+nkvR/rIRI6htEfNRTc38ROY4YQBS5OL4r6nitl23hCpt4JgiQ8t+jbsZsKe+qplw8Kk+JNmw=="],
+    "@tanstack/solid-router-ssr-query": ["@tanstack/solid-router-ssr-query@1.166.12", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.168.0" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/solid-query": ">=5.90.0", "@tanstack/solid-router": ">=1.127.0", "solid-js": "^1.9.10" } }, "sha512-B3N4JIW91nh/5epKkuWpDwxG2jMHpkh+Vh5fxnzebK7DzO97etd3TT2cRn/bebzk2xIfNjTmPh4uDgbamwy9TA=="],
 
-    "@tanstack/solid-start": ["@tanstack/solid-start@1.167.15", "", { "dependencies": { "@tanstack/solid-router": "1.168.9", "@tanstack/solid-start-client": "1.166.23", "@tanstack/solid-start-server": "1.166.23", "@tanstack/start-client-core": "1.167.9", "@tanstack/start-plugin-core": "1.167.17", "@tanstack/start-server-core": "1.167.9", "pathe": "^2.0.3" }, "peerDependencies": { "solid-js": ">=1.0.0", "vite": ">=7.0.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-+LqDiRmiBQfDE/qGT7u434QsHQxQPg3fpUc/4MfHklPzqMbZOXpOT3C11VNC2s8vD9zTZCDRAh8KXus09VPiMA=="],
+    "@tanstack/solid-start": ["@tanstack/solid-start@1.167.62", "", { "dependencies": { "@tanstack/solid-router": "1.169.2", "@tanstack/solid-start-client": "1.166.47", "@tanstack/solid-start-server": "1.166.51", "@tanstack/start-client-core": "1.168.2", "@tanstack/start-plugin-core": "1.169.20", "@tanstack/start-server-core": "1.167.30", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "solid-js": ">=1.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-4EdpZqRD7vet0eFjxJte3OIyEufA+uXIblZrZQ3U33LYsd93q9hGPl+f++8JQbb28Ep/Am/fbi8eKbVDaFGthw=="],
 
-    "@tanstack/solid-start-client": ["@tanstack/solid-start-client@1.166.23", "", { "dependencies": { "@tanstack/router-core": "1.168.9", "@tanstack/solid-router": "1.168.9", "@tanstack/start-client-core": "1.167.9" }, "peerDependencies": { "solid-js": ">=1.0.0" } }, "sha512-5JM/Lmibn0M4U9CgtiBfPQeJzp/vti5pN55ueARcUZoNcNGk/CoSOxlFhlOG7DbJ71qEHMIteRQpfb0b3HXPDA=="],
+    "@tanstack/solid-start-client": ["@tanstack/solid-start-client@1.166.47", "", { "dependencies": { "@tanstack/router-core": "1.169.2", "@tanstack/solid-router": "1.169.2", "@tanstack/start-client-core": "1.168.2" }, "peerDependencies": { "solid-js": ">=1.0.0" } }, "sha512-EV2MvNldD8lki0cXAsji0JKeBayN743GoEp3L1UGXGoUZnNrwwMiIxPlYd8KccCCC/uge+TGFVv2LsHNw6qX2w=="],
 
-    "@tanstack/solid-start-server": ["@tanstack/solid-start-server@1.166.23", "", { "dependencies": { "@solidjs/meta": "^0.29.4", "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.168.9", "@tanstack/solid-router": "1.168.9", "@tanstack/start-client-core": "1.167.9", "@tanstack/start-server-core": "1.167.9" }, "peerDependencies": { "solid-js": "^1.0.0" } }, "sha512-cXCmSPX3EjJnHuM9U9ijpG563fhuGdy0XrIqJVBhpmGgWetMGWvCRCrL1qxQXZTDIubuYzlbJtTWqCHA/b+tbA=="],
+    "@tanstack/solid-start-server": ["@tanstack/solid-start-server@1.166.51", "", { "dependencies": { "@solidjs/meta": "^0.29.4", "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.169.2", "@tanstack/solid-router": "1.169.2", "@tanstack/start-client-core": "1.168.2", "@tanstack/start-server-core": "1.167.30" }, "peerDependencies": { "solid-js": "^1.0.0" } }, "sha512-42+1Vip3zSXLusft8DaGjRjqvzg6BOmV3CQWKD/7aDIYHU4pOhebPVcZmz5CLXE0sCU0BSf0fdB9CKRMZYU4rg=="],
 
     "@tanstack/solid-store": ["@tanstack/solid-store@0.9.2", "", { "dependencies": { "@tanstack/store": "0.9.2" }, "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-W6D6WnIL0Fch2zcLd7qCFf3eLD6AqwZiPoQnoRFKhe8DFXdxM4GRvfLpsAIQQHsun97EcttbwbfVq14SZfT7jg=="],
 
     "@tanstack/solid-virtual": ["@tanstack/solid-virtual@3.13.23", "", { "dependencies": { "@tanstack/virtual-core": "3.13.23" }, "peerDependencies": { "solid-js": "^1.3.0" } }, "sha512-knSNOb1ev78yaf4CnhCY+JS2NZXzp6WO/8pzI/P9GitrG6QLgBzltOl3duN8+13QkVdSMxRrUKl8mioWNlTQxA=="],
 
-    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.167.9", "", { "dependencies": { "@tanstack/router-core": "1.168.9", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-storage-context": "1.166.23", "seroval": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-2ETQO/bxiZGsoTdPxZb7xR8YqCy5l4kv/QPkwIXuvx/A4BjufngXfgISjXUicXsFRIBZeiFnBzp9A38UMsS2iA=="],
+    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.168.2", "", { "dependencies": { "@tanstack/router-core": "1.169.2", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-storage-context": "1.166.35", "seroval": "^1.5.4" } }, "sha512-/bckv9k/yxY4VmSY2V2MeX7NBsS5uqGvdSPs5WIvW3Uv35DXPrdiumKXTNJeZRNRMtxrM+YfxQPjXLx3C7ykvg=="],
 
     "@tanstack/start-fn-stubs": ["@tanstack/start-fn-stubs@1.161.6", "", {}, "sha512-Y6QSlGiLga8cHfvxGGaonXIlt2bIUTVdH6AMjmpMp7+ANNCp+N96GQbjjhLye3JkaxDfP68x5iZA8NK4imgRig=="],
 
-    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.167.17", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.168.9", "@tanstack/router-generator": "1.166.24", "@tanstack/router-plugin": "1.167.12", "@tanstack/router-utils": "1.161.6", "@tanstack/start-client-core": "1.167.9", "@tanstack/start-server-core": "1.167.9", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "pathe": "^2.0.3", "picomatch": "^4.0.3", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "vite": ">=7.0.0" } }, "sha512-OkorpOobGOEDVr72QUmkzKjbawKC05CSz+1B3OObB/AxBIIw+lLLhTXbV45QkX2LZA7dcRvPJYZGOH1pkFqA1g=="],
+    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.169.20", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.169.2", "@tanstack/router-generator": "1.166.42", "@tanstack/router-plugin": "1.167.35", "@tanstack/router-utils": "1.161.8", "@tanstack/start-client-core": "1.168.2", "@tanstack/start-server-core": "1.167.30", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.4", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-MLSH5P3auFpnol1lMGQhUrpJH7+P5knzBXMnJjXG+nVOvmcYbY0JA+nQMl81kKiqfkEceAiaEdKhl8Zc5Ldolw=="],
 
-    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.167.9", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.168.9", "@tanstack/start-client-core": "1.167.9", "@tanstack/start-storage-context": "1.166.23", "h3-v2": "npm:h3@2.0.1-rc.16", "seroval": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-vKkslQIihoDDVumF73VXT7PVFmN7Nea0nKhZx7gMbc0m09yPQYYR1dn86/dz14k6/7cDkJ+qKXa09rlVlN/i9Q=="],
+    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.167.30", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.169.2", "@tanstack/start-client-core": "1.168.2", "@tanstack/start-storage-context": "1.166.35", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.4" } }, "sha512-GC0PXzYYSEwfAOC2NxGXFUyYvfbSjVoqnIrzJsyInKd8xQxGEQaVdrebbyx9TV5cj7A5e7EJcWAsf3G3wRDQBw=="],
 
-    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.23", "", { "dependencies": { "@tanstack/router-core": "1.168.9" } }, "sha512-3vEdiYRMx+r+Q7Xqxj3YmADPIpMm7fkKxDa8ITwodGXiw+SBJCGkpBXGUWjOXyXkIyqGHKM5UrReTcVUTkmaug=="],
+    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.35", "", { "dependencies": { "@tanstack/router-core": "1.169.2" } }, "sha512-ZKDkKiorJrKwfEHjatEwRHG7EP3raJPhh6CSl4CFmHW0naIvwaW5gQcxcT8IlHtoGDLYDAjBEcSr3MZyXgqmOA=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.2", "", {}, "sha512-K013lUJEFJK2ofFQ/hZKJUmCnpcV00ebLyOyFOWQvyQHUOZp/iYO84BM6aOGiV81JzwbX0APTVmW8YI7yiG5oA=="],
 
@@ -1059,7 +1118,7 @@
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
-    "cookie-es": ["cookie-es@2.0.0", "", {}, "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="],
+    "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -1195,6 +1254,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fetchdts": ["fetchdts@0.1.7", "", {}, "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA=="],
+
     "ffmpeg-static": ["ffmpeg-static@5.3.0", "", { "dependencies": { "@derhuerst/http-basic": "^8.2.0", "env-paths": "^2.2.0", "https-proxy-agent": "^5.0.0", "progress": "^2.0.3" } }, "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
@@ -1247,9 +1308,9 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "h3": ["h3@2.0.1-rc.20", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.13" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg=="],
+    "h3": ["h3@2.0.1-rc.22", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.15" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA=="],
 
-    "h3-v2": ["h3@2.0.1-rc.16", "", { "dependencies": { "rou3": "^0.8.0", "srvx": "^0.11.9" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-h+pjvyujdo9way8qj6FUbhaQcHlR8FEq65EhTX9ViT5pK8aLj68uFl4hBkF+hsTJAH+H1END2Yv6hTIsabGfag=="],
+    "h3-v2": ["h3@2.0.1-rc.20", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.13" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -1261,7 +1322,7 @@
 
     "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
 
-    "hookable": ["hookable@6.1.0", "", {}, "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw=="],
+    "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
     "html-entities": ["html-entities@2.3.3", "", {}, "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="],
 
@@ -1449,9 +1510,9 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "nf3": ["nf3@0.3.16", "", {}, "sha512-Gs0xRPpUm2nDkqbi40NJ9g7qDIcjcJzgExiydnq6LAyqhI2jfno8wG3NKTL+IiJsx799UHOb1CnSd4Wg4SG4Pw=="],
+    "nf3": ["nf3@0.3.17", "", {}, "sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ=="],
 
-    "nitro": ["nitro-nightly@3.0.1-20260402-182549-a5a3389c", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.4", "db0": "^0.3.4", "env-runner": "^0.1.7", "h3": "^2.0.1-rc.20", "hookable": "^6.1.0", "nf3": "^0.3.16", "ocache": "^0.1.4", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.0.0-rc.13", "srvx": "^0.11.14", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "dotenv": "*", "giget": "*", "jiti": "^2.6.1", "rollup": "^4.60.1", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.1.15" }, "optionalPeers": ["dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-FlUsSGgM0DMMl+N8pdWqpAllNguCgj983LUmWpio7HQsDv+mhX0JUc7WMwszBW+d1e+gb2pe6rjrMlJeFFiFUw=="],
+    "nitro": ["nitro-nightly@3.0.1-20260512-093145-0498ce70", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.5", "db0": "^0.3.4", "env-runner": "^0.1.7", "h3": "^2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.4", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.0.0", "srvx": "^0.11.15", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.1.6", "dotenv": "*", "giget": "*", "jiti": "^2.6.1", "rollup": "^4.60.3", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-5vIbEn1ORiNIymy9RtRx3AavX4CAQqWNnsh1vOLag/fzsEQRD2wLBhR+ZcMeVTUbQb0mo8fIbMH2NkSeiGu6fw=="],
 
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
@@ -1486,6 +1547,8 @@
     "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
+
+    "oxc-parser": ["oxc-parser@0.120.0", "", { "dependencies": { "@oxc-project/types": "^0.120.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.120.0", "@oxc-parser/binding-android-arm64": "0.120.0", "@oxc-parser/binding-darwin-arm64": "0.120.0", "@oxc-parser/binding-darwin-x64": "0.120.0", "@oxc-parser/binding-freebsd-x64": "0.120.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.120.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.120.0", "@oxc-parser/binding-linux-arm64-gnu": "0.120.0", "@oxc-parser/binding-linux-arm64-musl": "0.120.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.120.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.120.0", "@oxc-parser/binding-linux-riscv64-musl": "0.120.0", "@oxc-parser/binding-linux-s390x-gnu": "0.120.0", "@oxc-parser/binding-linux-x64-gnu": "0.120.0", "@oxc-parser/binding-linux-x64-musl": "0.120.0", "@oxc-parser/binding-openharmony-arm64": "0.120.0", "@oxc-parser/binding-wasm32-wasi": "0.120.0", "@oxc-parser/binding-win32-arm64-msvc": "0.120.0", "@oxc-parser/binding-win32-ia32-msvc": "0.120.0", "@oxc-parser/binding-win32-x64-msvc": "0.120.0" } }, "sha512-WyPWZlcIm+Fkte63FGfgFB8mAAk33aH9h5N9lphXVOHSXEBFFsmYdOBedVKly363aWABjZdaj/m9lBfEY4wt+w=="],
 
     "oxfmt": ["oxfmt@0.43.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.43.0", "@oxfmt/binding-android-arm64": "0.43.0", "@oxfmt/binding-darwin-arm64": "0.43.0", "@oxfmt/binding-darwin-x64": "0.43.0", "@oxfmt/binding-freebsd-x64": "0.43.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.43.0", "@oxfmt/binding-linux-arm-musleabihf": "0.43.0", "@oxfmt/binding-linux-arm64-gnu": "0.43.0", "@oxfmt/binding-linux-arm64-musl": "0.43.0", "@oxfmt/binding-linux-ppc64-gnu": "0.43.0", "@oxfmt/binding-linux-riscv64-gnu": "0.43.0", "@oxfmt/binding-linux-riscv64-musl": "0.43.0", "@oxfmt/binding-linux-s390x-gnu": "0.43.0", "@oxfmt/binding-linux-x64-gnu": "0.43.0", "@oxfmt/binding-linux-x64-musl": "0.43.0", "@oxfmt/binding-openharmony-arm64": "0.43.0", "@oxfmt/binding-win32-arm64-msvc": "0.43.0", "@oxfmt/binding-win32-ia32-msvc": "0.43.0", "@oxfmt/binding-win32-x64-msvc": "0.43.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-KTYNG5ISfHSdmeZ25Xzb3qgz9EmQvkaGAxgBY/p38+ZiAet3uZeu7FnMwcSQJg152Qwl0wnYAxDc+Z/H6cvrwA=="],
 
@@ -1617,7 +1680,7 @@
 
     "rimraf": ["rimraf@6.1.3", "", { "dependencies": { "glob": "^13.0.3", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA=="],
 
-    "rolldown": ["rolldown@1.0.0-rc.14", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.14" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.14", "@rolldown/binding-darwin-arm64": "1.0.0-rc.14", "@rolldown/binding-darwin-x64": "1.0.0-rc.14", "@rolldown/binding-freebsd-x64": "1.0.0-rc.14", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.14", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.14", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.14", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.14", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.14", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.14", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.14", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.14", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.14", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.14", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.14" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-bGQjaQyK9k7ovrbYNWNOHorqO0gYZpip+I3PTi4iDL1nDe1qkOOwYp2BHGnpCw4LVcTjM+rhJ0mvxX12lu3hiA=="],
+    "rolldown": ["rolldown@1.0.1", "", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
@@ -1811,7 +1874,7 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
-    "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
+    "unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
 
     "unstorage": ["unstorage@2.0.0-alpha.7", "", { "peerDependencies": { "@azure/app-configuration": "^1.11.0", "@azure/cosmos": "^4.9.1", "@azure/data-tables": "^13.3.2", "@azure/identity": "^4.13.0", "@azure/keyvault-secrets": "^4.10.0", "@azure/storage-blob": "^12.31.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.13.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.36.2", "@vercel/blob": ">=0.27.3", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1.0.1", "aws4fetch": "^1.0.20", "chokidar": "^4 || ^5", "db0": ">=0.3.4", "idb-keyval": "^6.2.2", "ioredis": "^5.9.3", "lru-cache": "^11.2.6", "mongodb": "^6 || ^7", "ofetch": "*", "uploadthing": "^7.7.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "chokidar", "db0", "idb-keyval", "ioredis", "lru-cache", "mongodb", "ofetch", "uploadthing"] }, "sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog=="],
 
@@ -1827,7 +1890,7 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
-    "vite": ["@voidzero-dev/vite-plus-core@0.1.16", "", { "dependencies": { "@oxc-project/runtime": "=0.123.0", "@oxc-project/types": "=0.123.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.7", "@tsdown/exe": "0.21.7", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-fOyf14CXjcXqANFs2fCXEX+0Tn9ZjmqfFV+qTnARwIF1Kzl8WquO4XtvlDgs/fTQ91H4AyoNUgkvWdKS+C4xYA=="],
+    "vite": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
 
     "vite-plugin-solid": ["vite-plugin-solid@2.11.11", "", { "dependencies": { "@babel/core": "^7.23.3", "@types/babel__core": "^7.20.4", "babel-preset-solid": "^1.8.4", "merge-anything": "^5.1.7", "solid-refresh": "^0.6.3", "vitefu": "^1.0.4" }, "peerDependencies": { "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*", "solid-js": "^1.7.2", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@testing-library/jest-dom"] }, "sha512-YMZCXsLw9kyuvQFEdwLP27fuTQJLmjNoHy90AOJnbRuJ6DwShUxKFo38gdFrWn9v11hnGicKCZEaeI/TFs6JKw=="],
 
@@ -1905,11 +1968,35 @@
 
     "@orpc/shared/type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
 
-    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@solid-imager/core/vite-plus": ["vite-plus@0.1.21", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@voidzero-dev/vite-plus-core": "0.1.21", "@voidzero-dev/vite-plus-test": "0.1.21", "oxfmt": "=0.48.0", "oxlint": "=1.63.0", "oxlint-tsgolint": "=0.22.1" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.21", "@voidzero-dev/vite-plus-darwin-x64": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.21", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.21", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.21" }, "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-7MLc9abMelE8g5/vj/xEY8joWT9PLnN/XjX3FhwOliB75WOX3YADcMEFrufmvnl+D4UhrMNZQa2k3A5CSuFJhw=="],
+
+    "@solid-imager/core/vitest": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
 
     "@solid-imager/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "@solid-imager/db/vite-plus": ["vite-plus@0.1.21", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@voidzero-dev/vite-plus-core": "0.1.21", "@voidzero-dev/vite-plus-test": "0.1.21", "oxfmt": "=0.48.0", "oxlint": "=1.63.0", "oxlint-tsgolint": "=0.22.1" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.21", "@voidzero-dev/vite-plus-darwin-x64": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.21", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.21", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.21" }, "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-7MLc9abMelE8g5/vj/xEY8joWT9PLnN/XjX3FhwOliB75WOX3YADcMEFrufmvnl+D4UhrMNZQa2k3A5CSuFJhw=="],
+
+    "@solid-imager/db/vitest": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
+
+    "@solid-imager/server/vite-plus": ["vite-plus@0.1.21", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@voidzero-dev/vite-plus-core": "0.1.21", "@voidzero-dev/vite-plus-test": "0.1.21", "oxfmt": "=0.48.0", "oxlint": "=1.63.0", "oxlint-tsgolint": "=0.22.1" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.21", "@voidzero-dev/vite-plus-darwin-x64": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.21", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.21", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.21" }, "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-7MLc9abMelE8g5/vj/xEY8joWT9PLnN/XjX3FhwOliB75WOX3YADcMEFrufmvnl+D4UhrMNZQa2k3A5CSuFJhw=="],
+
+    "@solid-imager/server/vitest": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
+
     "@solid-imager/server/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.12", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.9", "@tanstack/router-generator": "1.166.24", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2", "@tanstack/react-router": "^1.168.10", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0", "vite-plugin-solid": "^2.11.10", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-StEHcctCuFI5taSjO+lhR/yQ+EK63BdyYa+ne6FoNQPB3MMrOUrz2ZVnbqILRLkh2b+p2EfBKt65sgAKdKygPQ=="],
+
+    "@solid-imager/tauri/@tanstack/solid-query": ["@tanstack/solid-query@5.96.2", "", { "dependencies": { "@tanstack/query-core": "5.96.2" }, "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-gAJhm/aHtubM4gKrtBJy9lMIQggtG4pN3P47dIbYi7pESm8ud0EY/jWkj18TUIC65e1nbSOerKBtjRvzydz5+Q=="],
+
+    "@solid-imager/tauri/@tanstack/solid-router": ["@tanstack/solid-router@1.168.9", "", { "dependencies": { "@solid-devtools/logger": "^0.9.4", "@solid-primitives/refs": "^1.0.8", "@solidjs/meta": "^0.29.4", "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.168.9", "isbot": "^5.1.22" }, "peerDependencies": { "solid-js": "^1.9.10" }, "bin": { "intent": "bin/intent.js" } }, "sha512-ZgfcBS7lVhVlScxMhoh3U37K/LnNltMJV6Lor98ON3mKnE9XkOwZKvzkOVYj1JEi5HiQsYnC1lmZR5Ww0tc2og=="],
+
+    "@solid-imager/tauri/vite": ["@voidzero-dev/vite-plus-core@0.1.16", "", { "dependencies": { "@oxc-project/runtime": "=0.123.0", "@oxc-project/types": "=0.123.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.7", "@tsdown/exe": "0.21.7", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-fOyf14CXjcXqANFs2fCXEX+0Tn9ZjmqfFV+qTnARwIF1Kzl8WquO4XtvlDgs/fTQ91H4AyoNUgkvWdKS+C4xYA=="],
+
+    "@solid-imager/ui/vite-plus": ["vite-plus@0.1.21", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@voidzero-dev/vite-plus-core": "0.1.21", "@voidzero-dev/vite-plus-test": "0.1.21", "oxfmt": "=0.48.0", "oxlint": "=1.63.0", "oxlint-tsgolint": "=0.22.1" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.21", "@voidzero-dev/vite-plus-darwin-x64": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.21", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.21", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.21", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.21" }, "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-7MLc9abMelE8g5/vj/xEY8joWT9PLnN/XjX3FhwOliB75WOX3YADcMEFrufmvnl+D4UhrMNZQa2k3A5CSuFJhw=="],
+
+    "@solid-imager/ui/vitest": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
 
@@ -1927,15 +2014,25 @@
 
     "@tanstack/cli/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
-    "@tanstack/devtools-vite/vite": ["@voidzero-dev/vite-plus-core@0.1.14", "", { "dependencies": { "@oxc-project/runtime": "=0.121.0", "@oxc-project/types": "=0.122.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.4", "@tsdown/exe": "0.21.4", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-CCWzdkfW0fo0cQNlIsYp5fOuH2IwKuPZEb2UY2Z8gXcp5pG74A82H2Pthj0heAuvYTAnfT7kEC6zM+RbiBgQbg=="],
+    "@tanstack/router-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
+
+    "@tanstack/router-core/seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
+
+    "@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "@tanstack/router-utils/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
-    "@tanstack/solid-query/@tanstack/query-core": ["@tanstack/query-core@5.96.2", "", {}, "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA=="],
+    "@tanstack/solid-query/@tanstack/query-core": ["@tanstack/query-core@5.100.10", "", {}, "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w=="],
+
+    "@tanstack/start-client-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@tanstack/start-plugin-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
+
+    "@tanstack/start-server-core/seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
     "@tanstack/zod-form-adapter/@tanstack/form-core": ["@tanstack/form-core@0.42.1", "", { "dependencies": { "@tanstack/store": "^0.7.0" } }, "sha512-jTU0jyHqFceujdtPNv3jPVej1dTqBwa8TYdIyWB5BCwRVUBZEp1PiYEBkC9r92xu5fMpBiKc+JKud3eeVjuMiA=="],
 
@@ -1943,7 +2040,11 @@
 
     "@vitest/coverage-v8/vitest": ["@voidzero-dev/vite-plus-test@0.1.12", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.12", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/ui": "4.1.0", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-EE8Y2vQvqS4c/1qSa7qlhUY9koAG6wYev0NFAtDZsijQCHUqE7nYXGJYnyUInAE6GX4zlQDGg7tf2DAl+CISYw=="],
 
+    "@voidzero-dev/vite-plus-core/@oxc-project/runtime": ["@oxc-project/runtime@0.123.0", "", {}, "sha512-wRf0z8saz9tHLcK3YeTeBmwISrpy4bBimvKxUmryiIhbt+ZJb0nwwJNL3D8xpeWbNfZlGSlzRBZbfcbApIGZJw=="],
+
     "@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@voidzero-dev/vite-plus-test/vite": ["@voidzero-dev/vite-plus-core@0.1.16", "", { "dependencies": { "@oxc-project/runtime": "=0.123.0", "@oxc-project/types": "=0.123.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.7", "@tsdown/exe": "0.21.7", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-fOyf14CXjcXqANFs2fCXEX+0Tn9ZjmqfFV+qTnARwIF1Kzl8WquO4XtvlDgs/fTQ91H4AyoNUgkvWdKS+C4xYA=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1987,8 +2088,6 @@
 
     "h3/rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 
-    "h3/srvx": ["srvx@0.11.13", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-oknN6qduuMPafxKtHucUeG32Q963pjriA5g3/Bl05cwEsUe5VVbIU4qR9LrALHbipSCyBe+VmfDGGydqazDRkw=="],
-
     "h3-v2/rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 
     "h3-v2/srvx": ["srvx@0.11.13", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-oknN6qduuMPafxKtHucUeG32Q963pjriA5g3/Bl05cwEsUe5VVbIU4qR9LrALHbipSCyBe+VmfDGGydqazDRkw=="],
@@ -2003,7 +2102,11 @@
 
     "make-asynchronous/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
+    "nitro/crossws": ["crossws@0.4.5", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA=="],
+
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "oxc-parser/@oxc-project/types": ["@oxc-project/types@0.120.0", "", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -2015,9 +2118,9 @@
 
     "rimraf/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
-    "rolldown/@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+    "rolldown/@oxc-project/types": ["@oxc-project/types@0.130.0", "", {}, "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q=="],
 
-    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.14", "", {}, "sha512-ktoSqSpdex3xml4M3wV//KiF8MiQkMz8bz2e7SUJvCK9qyL/XjAnLLB+UO3+uE9RLxqUhuDzddc7Cf+EaZ169Q=="],
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -2047,11 +2150,15 @@
 
     "ultracite/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "vite/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vite-plugin-solid/vite": ["@voidzero-dev/vite-plus-core@0.1.12", "", { "dependencies": { "@oxc-project/runtime": "=0.115.0", "@oxc-project/types": "=0.115.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.3", "@tsdown/exe": "0.21.3", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-j8YNe7A+8JcSoddztf5whvom/yJ7OKUO3Y5a3UoLIUmOL8YEKVv5nPANrxJ7eaFfHJoMnBEwzBpq1YVZ+H3uPA=="],
 
     "vitefu/vite": ["@voidzero-dev/vite-plus-core@0.1.12", "", { "dependencies": { "@oxc-project/runtime": "=0.115.0", "@oxc-project/types": "=0.115.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.3", "@tsdown/exe": "0.21.3", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-j8YNe7A+8JcSoddztf5whvom/yJ7OKUO3Y5a3UoLIUmOL8YEKVv5nPANrxJ7eaFfHJoMnBEwzBpq1YVZ+H3uPA=="],
+
+    "vitest/vite": ["@voidzero-dev/vite-plus-core@0.1.16", "", { "dependencies": { "@oxc-project/runtime": "=0.123.0", "@oxc-project/types": "=0.123.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.7", "@tsdown/exe": "0.21.7", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-fOyf14CXjcXqANFs2fCXEX+0Tn9ZjmqfFV+qTnARwIF1Kzl8WquO4XtvlDgs/fTQ91H4AyoNUgkvWdKS+C4xYA=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -2121,6 +2228,144 @@
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util/@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="],
 
+    "@solid-imager/core/vite-plus/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-T7mPiDbE7VtjpegtJJ/e/uQOjOA/ufMo7npAaP9WVHxUEWLaR/OjVXXL9ALiW+CfKEQ0Qk/iWDB0mI6YMndzNQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-DqS0ZJ0sRtXu55loEIz/mkX99fl1HQ0b9UUj+Qm13NoMfh6JC8d0g6J+Dbu/EJy0TEU7QLjCXoALLQ7ZrsW34g=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-PoW375e3pSayRuN43agoe8LdItEa82bPhcaW7elPxoiO8puynB+4x5Xy5ozU5XgjEuCB3nYKE6R/b9peWsaFEQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5c6i1TyRuMELDcGozuI5Y0JhIZsSbAJ067Okty6XmoJ5tSmUnMzEO5HKRmgjfGryjJpn5dpUKXzj2eWsdx+6g=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-DquiIAvGIUIJBfqOnqAtBPoyhNIGLM1DzswzDPddO5kjg6NCE4hPbFr5ncjhSKqyp88Kd1YWYD93yg3FAdr/EA=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-/nVT+eFySYwf3uEv+n9FrdJ0bg3SbfqUkAnIxH7XMQ/hhmU4lAE2dH4SiUqk6h70gESaFHfJmhWtp5Qzt/W7Vw=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-KhEqfRKlfuuVJb2eY8ZCmmXcxUqy8/ZBZPWPipxcB1QDWIykyN5F4zbewLxXw18JL/Q0ISP0p7V8RIldAh4Gyw=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.21", "", { "os": "win32", "cpu": "x64" }, "sha512-lH8d2qElBfUUpejZhYvK3CrP6kHTz0z2jff/ZowlY6jkr1pQkYj3EVhRi5r81DXcbXZs9yAbXbBPw8mVZtG9FA=="],
+
+    "@solid-imager/core/vite-plus/oxfmt": ["oxfmt@0.48.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.48.0", "@oxfmt/binding-android-arm64": "0.48.0", "@oxfmt/binding-darwin-arm64": "0.48.0", "@oxfmt/binding-darwin-x64": "0.48.0", "@oxfmt/binding-freebsd-x64": "0.48.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.48.0", "@oxfmt/binding-linux-arm-musleabihf": "0.48.0", "@oxfmt/binding-linux-arm64-gnu": "0.48.0", "@oxfmt/binding-linux-arm64-musl": "0.48.0", "@oxfmt/binding-linux-ppc64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-musl": "0.48.0", "@oxfmt/binding-linux-s390x-gnu": "0.48.0", "@oxfmt/binding-linux-x64-gnu": "0.48.0", "@oxfmt/binding-linux-x64-musl": "0.48.0", "@oxfmt/binding-openharmony-arm64": "0.48.0", "@oxfmt/binding-win32-arm64-msvc": "0.48.0", "@oxfmt/binding-win32-ia32-msvc": "0.48.0", "@oxfmt/binding-win32-x64-msvc": "0.48.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g=="],
+
+    "@solid-imager/core/vite-plus/oxlint": ["oxlint@1.63.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.63.0", "@oxlint/binding-android-arm64": "1.63.0", "@oxlint/binding-darwin-arm64": "1.63.0", "@oxlint/binding-darwin-x64": "1.63.0", "@oxlint/binding-freebsd-x64": "1.63.0", "@oxlint/binding-linux-arm-gnueabihf": "1.63.0", "@oxlint/binding-linux-arm-musleabihf": "1.63.0", "@oxlint/binding-linux-arm64-gnu": "1.63.0", "@oxlint/binding-linux-arm64-musl": "1.63.0", "@oxlint/binding-linux-ppc64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-musl": "1.63.0", "@oxlint/binding-linux-s390x-gnu": "1.63.0", "@oxlint/binding-linux-x64-gnu": "1.63.0", "@oxlint/binding-linux-x64-musl": "1.63.0", "@oxlint/binding-openharmony-arm64": "1.63.0", "@oxlint/binding-win32-arm64-msvc": "1.63.0", "@oxlint/binding-win32-ia32-msvc": "1.63.0", "@oxlint/binding-win32-x64-msvc": "1.63.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint": ["oxlint-tsgolint@0.22.1", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.22.1", "@oxlint-tsgolint/darwin-x64": "0.22.1", "@oxlint-tsgolint/linux-arm64": "0.22.1", "@oxlint-tsgolint/linux-x64": "0.22.1", "@oxlint-tsgolint/win32-arm64": "0.22.1", "@oxlint-tsgolint/win32-x64": "0.22.1" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg=="],
+
+    "@solid-imager/core/vitest/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/db/vite-plus/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-T7mPiDbE7VtjpegtJJ/e/uQOjOA/ufMo7npAaP9WVHxUEWLaR/OjVXXL9ALiW+CfKEQ0Qk/iWDB0mI6YMndzNQ=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-DqS0ZJ0sRtXu55loEIz/mkX99fl1HQ0b9UUj+Qm13NoMfh6JC8d0g6J+Dbu/EJy0TEU7QLjCXoALLQ7ZrsW34g=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-PoW375e3pSayRuN43agoe8LdItEa82bPhcaW7elPxoiO8puynB+4x5Xy5ozU5XgjEuCB3nYKE6R/b9peWsaFEQ=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5c6i1TyRuMELDcGozuI5Y0JhIZsSbAJ067Okty6XmoJ5tSmUnMzEO5HKRmgjfGryjJpn5dpUKXzj2eWsdx+6g=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-DquiIAvGIUIJBfqOnqAtBPoyhNIGLM1DzswzDPddO5kjg6NCE4hPbFr5ncjhSKqyp88Kd1YWYD93yg3FAdr/EA=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-/nVT+eFySYwf3uEv+n9FrdJ0bg3SbfqUkAnIxH7XMQ/hhmU4lAE2dH4SiUqk6h70gESaFHfJmhWtp5Qzt/W7Vw=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-KhEqfRKlfuuVJb2eY8ZCmmXcxUqy8/ZBZPWPipxcB1QDWIykyN5F4zbewLxXw18JL/Q0ISP0p7V8RIldAh4Gyw=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.21", "", { "os": "win32", "cpu": "x64" }, "sha512-lH8d2qElBfUUpejZhYvK3CrP6kHTz0z2jff/ZowlY6jkr1pQkYj3EVhRi5r81DXcbXZs9yAbXbBPw8mVZtG9FA=="],
+
+    "@solid-imager/db/vite-plus/oxfmt": ["oxfmt@0.48.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.48.0", "@oxfmt/binding-android-arm64": "0.48.0", "@oxfmt/binding-darwin-arm64": "0.48.0", "@oxfmt/binding-darwin-x64": "0.48.0", "@oxfmt/binding-freebsd-x64": "0.48.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.48.0", "@oxfmt/binding-linux-arm-musleabihf": "0.48.0", "@oxfmt/binding-linux-arm64-gnu": "0.48.0", "@oxfmt/binding-linux-arm64-musl": "0.48.0", "@oxfmt/binding-linux-ppc64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-musl": "0.48.0", "@oxfmt/binding-linux-s390x-gnu": "0.48.0", "@oxfmt/binding-linux-x64-gnu": "0.48.0", "@oxfmt/binding-linux-x64-musl": "0.48.0", "@oxfmt/binding-openharmony-arm64": "0.48.0", "@oxfmt/binding-win32-arm64-msvc": "0.48.0", "@oxfmt/binding-win32-ia32-msvc": "0.48.0", "@oxfmt/binding-win32-x64-msvc": "0.48.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g=="],
+
+    "@solid-imager/db/vite-plus/oxlint": ["oxlint@1.63.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.63.0", "@oxlint/binding-android-arm64": "1.63.0", "@oxlint/binding-darwin-arm64": "1.63.0", "@oxlint/binding-darwin-x64": "1.63.0", "@oxlint/binding-freebsd-x64": "1.63.0", "@oxlint/binding-linux-arm-gnueabihf": "1.63.0", "@oxlint/binding-linux-arm-musleabihf": "1.63.0", "@oxlint/binding-linux-arm64-gnu": "1.63.0", "@oxlint/binding-linux-arm64-musl": "1.63.0", "@oxlint/binding-linux-ppc64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-musl": "1.63.0", "@oxlint/binding-linux-s390x-gnu": "1.63.0", "@oxlint/binding-linux-x64-gnu": "1.63.0", "@oxlint/binding-linux-x64-musl": "1.63.0", "@oxlint/binding-openharmony-arm64": "1.63.0", "@oxlint/binding-win32-arm64-msvc": "1.63.0", "@oxlint/binding-win32-ia32-msvc": "1.63.0", "@oxlint/binding-win32-x64-msvc": "1.63.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg=="],
+
+    "@solid-imager/db/vite-plus/oxlint-tsgolint": ["oxlint-tsgolint@0.22.1", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.22.1", "@oxlint-tsgolint/darwin-x64": "0.22.1", "@oxlint-tsgolint/linux-arm64": "0.22.1", "@oxlint-tsgolint/linux-x64": "0.22.1", "@oxlint-tsgolint/win32-arm64": "0.22.1", "@oxlint-tsgolint/win32-x64": "0.22.1" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg=="],
+
+    "@solid-imager/db/vitest/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/server/vite-plus/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-T7mPiDbE7VtjpegtJJ/e/uQOjOA/ufMo7npAaP9WVHxUEWLaR/OjVXXL9ALiW+CfKEQ0Qk/iWDB0mI6YMndzNQ=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-DqS0ZJ0sRtXu55loEIz/mkX99fl1HQ0b9UUj+Qm13NoMfh6JC8d0g6J+Dbu/EJy0TEU7QLjCXoALLQ7ZrsW34g=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-PoW375e3pSayRuN43agoe8LdItEa82bPhcaW7elPxoiO8puynB+4x5Xy5ozU5XgjEuCB3nYKE6R/b9peWsaFEQ=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5c6i1TyRuMELDcGozuI5Y0JhIZsSbAJ067Okty6XmoJ5tSmUnMzEO5HKRmgjfGryjJpn5dpUKXzj2eWsdx+6g=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-DquiIAvGIUIJBfqOnqAtBPoyhNIGLM1DzswzDPddO5kjg6NCE4hPbFr5ncjhSKqyp88Kd1YWYD93yg3FAdr/EA=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-/nVT+eFySYwf3uEv+n9FrdJ0bg3SbfqUkAnIxH7XMQ/hhmU4lAE2dH4SiUqk6h70gESaFHfJmhWtp5Qzt/W7Vw=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-KhEqfRKlfuuVJb2eY8ZCmmXcxUqy8/ZBZPWPipxcB1QDWIykyN5F4zbewLxXw18JL/Q0ISP0p7V8RIldAh4Gyw=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.21", "", { "os": "win32", "cpu": "x64" }, "sha512-lH8d2qElBfUUpejZhYvK3CrP6kHTz0z2jff/ZowlY6jkr1pQkYj3EVhRi5r81DXcbXZs9yAbXbBPw8mVZtG9FA=="],
+
+    "@solid-imager/server/vite-plus/oxfmt": ["oxfmt@0.48.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.48.0", "@oxfmt/binding-android-arm64": "0.48.0", "@oxfmt/binding-darwin-arm64": "0.48.0", "@oxfmt/binding-darwin-x64": "0.48.0", "@oxfmt/binding-freebsd-x64": "0.48.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.48.0", "@oxfmt/binding-linux-arm-musleabihf": "0.48.0", "@oxfmt/binding-linux-arm64-gnu": "0.48.0", "@oxfmt/binding-linux-arm64-musl": "0.48.0", "@oxfmt/binding-linux-ppc64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-musl": "0.48.0", "@oxfmt/binding-linux-s390x-gnu": "0.48.0", "@oxfmt/binding-linux-x64-gnu": "0.48.0", "@oxfmt/binding-linux-x64-musl": "0.48.0", "@oxfmt/binding-openharmony-arm64": "0.48.0", "@oxfmt/binding-win32-arm64-msvc": "0.48.0", "@oxfmt/binding-win32-ia32-msvc": "0.48.0", "@oxfmt/binding-win32-x64-msvc": "0.48.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g=="],
+
+    "@solid-imager/server/vite-plus/oxlint": ["oxlint@1.63.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.63.0", "@oxlint/binding-android-arm64": "1.63.0", "@oxlint/binding-darwin-arm64": "1.63.0", "@oxlint/binding-darwin-x64": "1.63.0", "@oxlint/binding-freebsd-x64": "1.63.0", "@oxlint/binding-linux-arm-gnueabihf": "1.63.0", "@oxlint/binding-linux-arm-musleabihf": "1.63.0", "@oxlint/binding-linux-arm64-gnu": "1.63.0", "@oxlint/binding-linux-arm64-musl": "1.63.0", "@oxlint/binding-linux-ppc64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-musl": "1.63.0", "@oxlint/binding-linux-s390x-gnu": "1.63.0", "@oxlint/binding-linux-x64-gnu": "1.63.0", "@oxlint/binding-linux-x64-musl": "1.63.0", "@oxlint/binding-openharmony-arm64": "1.63.0", "@oxlint/binding-win32-arm64-msvc": "1.63.0", "@oxlint/binding-win32-ia32-msvc": "1.63.0", "@oxlint/binding-win32-x64-msvc": "1.63.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg=="],
+
+    "@solid-imager/server/vite-plus/oxlint-tsgolint": ["oxlint-tsgolint@0.22.1", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.22.1", "@oxlint-tsgolint/darwin-x64": "0.22.1", "@oxlint-tsgolint/linux-arm64": "0.22.1", "@oxlint-tsgolint/linux-x64": "0.22.1", "@oxlint-tsgolint/win32-arm64": "0.22.1", "@oxlint-tsgolint/win32-x64": "0.22.1" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg=="],
+
+    "@solid-imager/server/vitest/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin/@tanstack/router-core": ["@tanstack/router-core@1.168.9", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin/@tanstack/router-generator": ["@tanstack/router-generator@1.166.24", "", { "dependencies": { "@tanstack/router-core": "1.168.9", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "prettier": "^3.5.0", "recast": "^0.23.11", "source-map": "^0.7.4", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-vdaGKwuH+r+DPe6R1mjk+TDDmDH6NTG7QqwxHqGEvOH4aGf9sPjhmRKNJZqQr8cPIbfp6u5lXyZ1TeDcSNMVEA=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin/@tanstack/router-utils": ["@tanstack/router-utils@1.161.6", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin/unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
+
+    "@solid-imager/tauri/@tanstack/solid-query/@tanstack/query-core": ["@tanstack/query-core@5.96.2", "", {}, "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA=="],
+
+    "@solid-imager/tauri/@tanstack/solid-router/@tanstack/router-core": ["@tanstack/router-core@1.168.9", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g=="],
+
+    "@solid-imager/tauri/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.123.0", "", {}, "sha512-wRf0z8saz9tHLcK3YeTeBmwISrpy4bBimvKxUmryiIhbt+ZJb0nwwJNL3D8xpeWbNfZlGSlzRBZbfcbApIGZJw=="],
+
+    "@solid-imager/tauri/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/ui/vite-plus/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-T7mPiDbE7VtjpegtJJ/e/uQOjOA/ufMo7npAaP9WVHxUEWLaR/OjVXXL9ALiW+CfKEQ0Qk/iWDB0mI6YMndzNQ=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-DqS0ZJ0sRtXu55loEIz/mkX99fl1HQ0b9UUj+Qm13NoMfh6JC8d0g6J+Dbu/EJy0TEU7QLjCXoALLQ7ZrsW34g=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-PoW375e3pSayRuN43agoe8LdItEa82bPhcaW7elPxoiO8puynB+4x5Xy5ozU5XgjEuCB3nYKE6R/b9peWsaFEQ=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5c6i1TyRuMELDcGozuI5Y0JhIZsSbAJ067Okty6XmoJ5tSmUnMzEO5HKRmgjfGryjJpn5dpUKXzj2eWsdx+6g=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-DquiIAvGIUIJBfqOnqAtBPoyhNIGLM1DzswzDPddO5kjg6NCE4hPbFr5ncjhSKqyp88Kd1YWYD93yg3FAdr/EA=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-/nVT+eFySYwf3uEv+n9FrdJ0bg3SbfqUkAnIxH7XMQ/hhmU4lAE2dH4SiUqk6h70gESaFHfJmhWtp5Qzt/W7Vw=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.21", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.21", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-KhEqfRKlfuuVJb2eY8ZCmmXcxUqy8/ZBZPWPipxcB1QDWIykyN5F4zbewLxXw18JL/Q0ISP0p7V8RIldAh4Gyw=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.21", "", { "os": "win32", "cpu": "x64" }, "sha512-lH8d2qElBfUUpejZhYvK3CrP6kHTz0z2jff/ZowlY6jkr1pQkYj3EVhRi5r81DXcbXZs9yAbXbBPw8mVZtG9FA=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt": ["oxfmt@0.48.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.48.0", "@oxfmt/binding-android-arm64": "0.48.0", "@oxfmt/binding-darwin-arm64": "0.48.0", "@oxfmt/binding-darwin-x64": "0.48.0", "@oxfmt/binding-freebsd-x64": "0.48.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.48.0", "@oxfmt/binding-linux-arm-musleabihf": "0.48.0", "@oxfmt/binding-linux-arm64-gnu": "0.48.0", "@oxfmt/binding-linux-arm64-musl": "0.48.0", "@oxfmt/binding-linux-ppc64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-gnu": "0.48.0", "@oxfmt/binding-linux-riscv64-musl": "0.48.0", "@oxfmt/binding-linux-s390x-gnu": "0.48.0", "@oxfmt/binding-linux-x64-gnu": "0.48.0", "@oxfmt/binding-linux-x64-musl": "0.48.0", "@oxfmt/binding-openharmony-arm64": "0.48.0", "@oxfmt/binding-win32-arm64-msvc": "0.48.0", "@oxfmt/binding-win32-ia32-msvc": "0.48.0", "@oxfmt/binding-win32-x64-msvc": "0.48.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g=="],
+
+    "@solid-imager/ui/vite-plus/oxlint": ["oxlint@1.63.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.63.0", "@oxlint/binding-android-arm64": "1.63.0", "@oxlint/binding-darwin-arm64": "1.63.0", "@oxlint/binding-darwin-x64": "1.63.0", "@oxlint/binding-freebsd-x64": "1.63.0", "@oxlint/binding-linux-arm-gnueabihf": "1.63.0", "@oxlint/binding-linux-arm-musleabihf": "1.63.0", "@oxlint/binding-linux-arm64-gnu": "1.63.0", "@oxlint/binding-linux-arm64-musl": "1.63.0", "@oxlint/binding-linux-ppc64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-gnu": "1.63.0", "@oxlint/binding-linux-riscv64-musl": "1.63.0", "@oxlint/binding-linux-s390x-gnu": "1.63.0", "@oxlint/binding-linux-x64-gnu": "1.63.0", "@oxlint/binding-linux-x64-musl": "1.63.0", "@oxlint/binding-openharmony-arm64": "1.63.0", "@oxlint/binding-win32-arm64-msvc": "1.63.0", "@oxlint/binding-win32-ia32-msvc": "1.63.0", "@oxlint/binding-win32-x64-msvc": "1.63.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint": ["oxlint-tsgolint@0.22.1", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.22.1", "@oxlint-tsgolint/darwin-x64": "0.22.1", "@oxlint-tsgolint/linux-arm64": "0.22.1", "@oxlint-tsgolint/linux-x64": "0.22.1", "@oxlint-tsgolint/win32-arm64": "0.22.1", "@oxlint-tsgolint/win32-x64": "0.22.1" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg=="],
+
+    "@solid-imager/ui/vitest/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.21", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA=="],
+
     "@tailwindcss/vite/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.121.0", "", {}, "sha512-p0bQukD8OEHxzY4T9OlANBbEFGnOnjo1CYi50HES7OD36UO2yPh6T+uOJKLtlg06eclxroipRCpQGMpeH8EJ/g=="],
 
     "@tailwindcss/vite/vite/@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
@@ -2130,12 +2375,6 @@
     "@tanstack/cli/chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@tanstack/cli/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
-
-    "@tanstack/devtools-vite/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.121.0", "", {}, "sha512-p0bQukD8OEHxzY4T9OlANBbEFGnOnjo1CYi50HES7OD36UO2yPh6T+uOJKLtlg06eclxroipRCpQGMpeH8EJ/g=="],
-
-    "@tanstack/devtools-vite/vite/@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
-
-    "@tanstack/devtools-vite/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@tanstack/router-plugin/chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -2150,6 +2389,10 @@
     "@vitest/coverage-v8/vitest/std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
     "@vitest/coverage-v8/vitest/vite": ["@voidzero-dev/vite-plus-core@0.1.12", "", { "dependencies": { "@oxc-project/runtime": "=0.115.0", "@oxc-project/types": "=0.115.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.3", "@tsdown/exe": "0.21.3", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-j8YNe7A+8JcSoddztf5whvom/yJ7OKUO3Y5a3UoLIUmOL8YEKVv5nPANrxJ7eaFfHJoMnBEwzBpq1YVZ+H3uPA=="],
+
+    "@voidzero-dev/vite-plus-test/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.123.0", "", {}, "sha512-wRf0z8saz9tHLcK3YeTeBmwISrpy4bBimvKxUmryiIhbt+ZJb0nwwJNL3D8xpeWbNfZlGSlzRBZbfcbApIGZJw=="],
+
+    "@voidzero-dev/vite-plus-test/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "archiver-utils/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
@@ -2249,11 +2492,401 @@
 
     "vitefu/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "vitest/vite/@oxc-project/runtime": ["@oxc-project/runtime@0.123.0", "", {}, "sha512-wRf0z8saz9tHLcK3YeTeBmwISrpy4bBimvKxUmryiIhbt+ZJb0nwwJNL3D8xpeWbNfZlGSlzRBZbfcbApIGZJw=="],
+
+    "vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "xtracter/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.48.0", "", { "os": "android", "cpu": "arm" }, "sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.48.0", "", { "os": "android", "cpu": "arm64" }, "sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.48.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.48.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.48.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.48.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.48.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.48.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.48.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.48.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg=="],
+
+    "@solid-imager/core/vite-plus/oxfmt/@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.48.0", "", { "os": "win32", "cpu": "x64" }, "sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.63.0", "", { "os": "android", "cpu": "arm" }, "sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.63.0", "", { "os": "android", "cpu": "arm64" }, "sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.63.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.63.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.63.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.63.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.63.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.63.0", "", { "os": "none", "cpu": "arm64" }, "sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.63.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.63.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w=="],
+
+    "@solid-imager/core/vite-plus/oxlint/@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.63.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.22.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.22.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.22.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.22.1", "", { "os": "linux", "cpu": "x64" }, "sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.22.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA=="],
+
+    "@solid-imager/core/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.22.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg=="],
+
+    "@solid-imager/core/vitest/@voidzero-dev/vite-plus-core/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/core/vitest/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.48.0", "", { "os": "android", "cpu": "arm" }, "sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.48.0", "", { "os": "android", "cpu": "arm64" }, "sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.48.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.48.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.48.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.48.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.48.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.48.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.48.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.48.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg=="],
+
+    "@solid-imager/db/vite-plus/oxfmt/@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.48.0", "", { "os": "win32", "cpu": "x64" }, "sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.63.0", "", { "os": "android", "cpu": "arm" }, "sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.63.0", "", { "os": "android", "cpu": "arm64" }, "sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.63.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.63.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.63.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.63.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.63.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.63.0", "", { "os": "none", "cpu": "arm64" }, "sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.63.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.63.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w=="],
+
+    "@solid-imager/db/vite-plus/oxlint/@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.63.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA=="],
+
+    "@solid-imager/db/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.22.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw=="],
+
+    "@solid-imager/db/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.22.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA=="],
+
+    "@solid-imager/db/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.22.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew=="],
+
+    "@solid-imager/db/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.22.1", "", { "os": "linux", "cpu": "x64" }, "sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA=="],
+
+    "@solid-imager/db/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.22.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA=="],
+
+    "@solid-imager/db/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.22.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg=="],
+
+    "@solid-imager/db/vitest/@voidzero-dev/vite-plus-core/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/db/vitest/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/server/vite-plus/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.48.0", "", { "os": "android", "cpu": "arm" }, "sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.48.0", "", { "os": "android", "cpu": "arm64" }, "sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.48.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.48.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.48.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.48.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.48.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.48.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.48.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.48.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg=="],
+
+    "@solid-imager/server/vite-plus/oxfmt/@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.48.0", "", { "os": "win32", "cpu": "x64" }, "sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.63.0", "", { "os": "android", "cpu": "arm" }, "sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.63.0", "", { "os": "android", "cpu": "arm64" }, "sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.63.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.63.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.63.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.63.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.63.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.63.0", "", { "os": "none", "cpu": "arm64" }, "sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.63.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.63.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w=="],
+
+    "@solid-imager/server/vite-plus/oxlint/@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.63.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA=="],
+
+    "@solid-imager/server/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.22.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw=="],
+
+    "@solid-imager/server/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.22.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA=="],
+
+    "@solid-imager/server/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.22.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew=="],
+
+    "@solid-imager/server/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.22.1", "", { "os": "linux", "cpu": "x64" }, "sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA=="],
+
+    "@solid-imager/server/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.22.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA=="],
+
+    "@solid-imager/server/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.22.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg=="],
+
+    "@solid-imager/server/vitest/@voidzero-dev/vite-plus-core/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/server/vitest/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin/@tanstack/router-core/cookie-es": ["cookie-es@2.0.0", "", {}, "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin/@tanstack/router-utils/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin/chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "@solid-imager/tauri/@tanstack/solid-router/@tanstack/router-core/cookie-es": ["cookie-es@2.0.0", "", {}, "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="],
+
+    "@solid-imager/ui/vite-plus/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.48.0", "", { "os": "android", "cpu": "arm" }, "sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.48.0", "", { "os": "android", "cpu": "arm64" }, "sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.48.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.48.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.48.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.48.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.48.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.48.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.48.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.48.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg=="],
+
+    "@solid-imager/ui/vite-plus/oxfmt/@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.48.0", "", { "os": "win32", "cpu": "x64" }, "sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.63.0", "", { "os": "android", "cpu": "arm" }, "sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.63.0", "", { "os": "android", "cpu": "arm64" }, "sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.63.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.63.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.63.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.63.0", "", { "os": "linux", "cpu": "arm" }, "sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.63.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.63.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.63.0", "", { "os": "linux", "cpu": "none" }, "sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.63.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.63.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.63.0", "", { "os": "none", "cpu": "arm64" }, "sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.63.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.63.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w=="],
+
+    "@solid-imager/ui/vite-plus/oxlint/@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.63.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.22.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.22.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.22.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.22.1", "", { "os": "linux", "cpu": "x64" }, "sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.22.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA=="],
+
+    "@solid-imager/ui/vite-plus/oxlint-tsgolint/@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.22.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg=="],
+
+    "@solid-imager/ui/vitest/@voidzero-dev/vite-plus-core/@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
+
+    "@solid-imager/ui/vitest/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@tanstack/cli/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -2296,6 +2929,8 @@
     "ultracite/vitest/vite/@oxc-project/types": ["@oxc-project/types@0.115.0", "", {}, "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="],
 
     "ultracite/vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/tauri/@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@solid-imager/db",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema": "./src/schema.ts",
+    "./client": "./src/client.ts",
+    "./transaction-manager": "./src/transaction-manager.ts",
+    "./types": "./src/types.ts",
+    "./utils": "./src/utils.ts",
+    "./migrations": "./src/migrations.ts"
+  },
+  "scripts": {
+    "check": "biome check --fix --unsafe ./src",
+    "typecheck": "sh -c 'tsc --noEmit'",
+    "lint": "biome lint ./src",
+    "test": "vp test run"
+  },
+  "dependencies": {
+    "@electric-sql/pglite": "^0.3.16",
+    "@solid-imager/core": "workspace:*",
+    "drizzle-orm": "^0.44.7",
+    "pg": "^8.20.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite-plus": "latest",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+  }
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
+import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import { Pool } from "pg";
+import * as schema from "./schema";
+import type { DbConfig, DbInstance } from "./types";
+
+export function createDbClient(config: DbConfig): DbInstance {
+	const isTestEnv =
+		typeof process !== "undefined" &&
+		(process.env.NODE_ENV === "test" || process.env.VITEST === "true");
+
+	if (isTestEnv) {
+		const pglitePath = path.join(process.cwd(), ".data", "pglite");
+		const pgliteClient = new PGlite(pglitePath);
+		return drizzlePglite(pgliteClient, { schema });
+	}
+
+	if (config.databaseType === "pglite") {
+		const pglitePath =
+			config.pglite.path ||
+			path.join(process.cwd(), ".data", "pglite");
+		const pgliteClient = new PGlite(pglitePath);
+		return drizzlePglite(pgliteClient, { schema });
+	}
+
+	const { host, port, user, password, database } =
+		config.dockerComposePostgres;
+	const connectionString = `postgres://${user}:${password}@${host}:${port}/${database}`;
+	const pool = new Pool({ connectionString });
+	return drizzleNodePostgres(pool, { schema });
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./schema";
+export { createDbClient } from "./client";
+export { createTransactionManager } from "./transaction-manager";
+export { getClient } from "./types";
+export type { DbConfig, DbInstance, TransactionClient } from "./types";
+export { escapeLikeString, paginatedQuery } from "./utils";
+export { createPgliteClient, runPgliteMigrations } from "./migrations";

--- a/packages/db/src/migrations.ts
+++ b/packages/db/src/migrations.ts
@@ -1,8 +1,9 @@
 import { PGlite } from "@electric-sql/pglite";
-import type { PgliteDatabase } from "drizzle-orm/pglite";
+import type { PgLiteDb } from "./types";
+import * as schema from "./schema";
 
 export async function runPgliteMigrations(
-	db: PgliteDatabase<Record<string, never>>,
+	db: PgLiteDb,
 	migrationsFolder: string,
 ): Promise<void> {
 	const { migrate } = await import("drizzle-orm/pglite/migrator");
@@ -11,9 +12,9 @@ export async function runPgliteMigrations(
 
 export async function createPgliteClient(
 	dataDir: string,
-): Promise<{ db: PgliteDatabase<Record<string, never>>; client: PGlite }> {
+): Promise<{ db: PgLiteDb; client: PGlite }> {
 	const { drizzle } = await import("drizzle-orm/pglite");
 	const client = new PGlite(dataDir);
-	const db = drizzle(client);
+	const db = drizzle(client, { schema });
 	return { db, client };
 }

--- a/packages/db/src/migrations.ts
+++ b/packages/db/src/migrations.ts
@@ -1,0 +1,19 @@
+import { PGlite } from "@electric-sql/pglite";
+import type { PgliteDatabase } from "drizzle-orm/pglite";
+
+export async function runPgliteMigrations(
+	db: PgliteDatabase<Record<string, never>>,
+	migrationsFolder: string,
+): Promise<void> {
+	const { migrate } = await import("drizzle-orm/pglite/migrator");
+	await migrate(db, { migrationsFolder });
+}
+
+export async function createPgliteClient(
+	dataDir: string,
+): Promise<{ db: PgliteDatabase<Record<string, never>>; client: PGlite }> {
+	const { drizzle } = await import("drizzle-orm/pglite");
+	const client = new PGlite(dataDir);
+	const db = drizzle(client);
+	return { db, client };
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,0 +1,1532 @@
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
+import {
+	type AnyPgColumn,
+	bigint,
+	boolean,
+	index,
+	integer,
+	jsonb,
+	pgEnum,
+	pgTable,
+	primaryKey,
+	real,
+	serial,
+	text,
+	timestamp,
+	unique,
+	uniqueIndex,
+	uuid,
+} from "drizzle-orm/pg-core";
+
+// 列挙型
+/**
+ * Enum for media source types.
+ * Defines where the media files are stored and how they are managed.
+ */
+export const mediaSourceTypeEnum = pgEnum("media_source_type", [
+	"local",
+	"sftp",
+	"s3",
+]);
+/**
+ * Enum for media organization status.
+ * Defines the lifecycle status of a media item within the system.
+ */
+export const mediaOrganizationStatusEnum = pgEnum("media_organization_status", [
+	"active",
+	"archived",
+	"deleted",
+]);
+/**
+ * Enum for media synchronization status.
+ * Defines the current state of a media item's synchronization with external backups or systems.
+ */
+export const mediaSyncStatusEnum = pgEnum("media_sync_status", [
+	"synced",
+	"pending",
+	"failed",
+]);
+/**
+ * Enum for media types.
+ * Defines the primary content type of a media file.
+ */
+export const mediaTypeEnum = pgEnum("media_type", ["image", "video", "audio"]);
+/**
+ * Enum for job status.
+ * Defines the current state of a background job.
+ */
+export const jobStatusEnum = pgEnum("job_status", [
+	"pending",
+	"in_progress",
+	"completed",
+	"failed",
+]);
+/**
+ * Enum for media relation types.
+ * Defines various ways media items can be related to each other.
+ */
+export const mediaRelationTypeEnum = pgEnum("media_relation_type", [
+	"variant", // 差分・バリエーション
+	"version", // 別バージョン
+	"page", // ページ（漫画等）
+	"derivative", // 派生作品
+	"edit", // 編集版
+	"source", // 元素材
+]);
+
+/**
+ * Enum for tag types.
+ * Defines whether a tag is positive (included) or negative (excluded).
+ */
+export const tagTypeEnum = pgEnum("tag_type", ["positive", "negative"]);
+
+// テーブル
+/**
+ * Schema for the media_sources table.
+ * Stores information about different media sources configured in the system.
+ */
+export const mediaSources = pgTable("media_sources", {
+	id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+	/** 表示されるメディアソースの名前 */
+	name: text("name").notNull(),
+	/** メディアソースの説明 */
+	description: text("description"),
+	/** メディアソースの種類 */
+	type: mediaSourceTypeEnum("type").notNull(),
+	/** 接続情報(JSON) */
+	connectionInfo: jsonb("connection_info").notNull(),
+	/** 作成日時 */
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+	/** 更新日時 */
+	updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+/**
+ * Schema for the media table.
+ * Stores core information about individual media files.
+ */
+export const medias = pgTable(
+	"media",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** どのメディアソースに属しているか */
+		mediaSourceId: uuid("source_id")
+			.notNull()
+			.references(() => mediaSources.id, { onDelete: "cascade" }),
+		/** ソース内の相対パス */
+		filePath: text("file_path").notNull(),
+		/** ファイル名 */
+		fileName: text("file_name").notNull(),
+		/** メディア種別 */
+		mediaType: mediaTypeEnum("media_type").notNull(),
+		/** メディアの幅 */
+		width: integer("width").notNull(),
+		/** メディアの高さ */
+		height: integer("height").notNull(),
+		/** ファイルサイズ(バイト) */
+		fileSize: bigint("file_size", { mode: "number" }),
+		/** メディアの説明(ユーザー入力) */
+		description: text("description"),
+		/** ファイル作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** ファイル更新日時 */
+		modifiedAt: timestamp("modified_at").notNull().defaultNow(),
+		/** DB登録日時 */
+		indexedAt: timestamp("indexed_at").notNull().defaultNow(),
+		/** メディアの状態 */
+		status: mediaOrganizationStatusEnum("status").notNull().default("active"),
+	},
+	(table) => ({
+		mediaSourceIdFilePathUnique: unique("source_id_file_path_unique").on(
+			table.mediaSourceId,
+			table.filePath,
+		),
+		mediaSourceIdIndex: index("idx_media_source_id").on(table.mediaSourceId),
+		fileSizeIndex: index("idx_media_file_size").on(table.fileSize),
+		fileNameIndex: index("idx_media_file_name").on(table.fileName),
+		createdAtIndex: index("idx_media_created_at").on(table.createdAt),
+		descriptionIndex: index("idx_media_description").on(table.description),
+	}),
+);
+
+/**
+ * Schema for the tags table.
+ * Stores information about tags used to categorize media.
+ */
+export const tags = pgTable(
+	"tags",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** タグの名前 (例: "blue eyes") */
+		name: text("name").notNull(),
+		/** タグの詳細な説明 */
+		description: text("description"),
+		/** タグの属性や分類 (例: "style", "clothing") */
+		attribute: text("attribute"),
+		/** UIで表示する際の色 (例: "#808080") */
+		color: text("color"),
+		/** タグの起源 (manual, comfyui_workflow, tagger_program_Aなど) */
+		source: text("source").notNull().default("manual"),
+		/** 関連するAuthor ID */
+		authorId: uuid("author_id").references(() => authors.id, {
+			onDelete: "set null",
+		}),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		nameUnique: unique("tags_name_unique").on(table.name),
+		authorIdIndex: index("idx_tags_author_id").on(table.authorId),
+	}),
+);
+
+/**
+ * Schema for the media_tags join table.
+ * Represents the many-to-many relationship between media items and tags.
+ */
+export const mediaTags = pgTable(
+	"media_tags",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** タグID */
+		tagId: uuid("tag_id")
+			.notNull()
+			.references(() => tags.id, { onDelete: "cascade" }),
+		/** タグのタイプ (positive/negative) */
+		tagType: tagTypeEnum("tag_type").notNull().default("positive"),
+		/** AIがタグを抽出した際の信頼度スコア (0.0-1.0)。手動の場合はNULL */
+		confidence: real("confidence"),
+		/** メディアへのタグ付与の起源 (manual, comfyui_workflow, tagger_program_Aなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.tagId, table.tagType] }),
+		tagIdTagTypeMediaIdIndex: index(
+			"idx_media_tags_tag_id_tag_type_media_id",
+		).on(table.tagId, table.tagType, table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the media_details table.
+ * Stores additional, often user-generated, details about media items.
+ */
+export const mediaDetails = pgTable(
+	"media_details",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.primaryKey()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 評価 (0-5) */
+		rating: integer("rating").default(0),
+		/** お気に入り */
+		favorite: boolean("favorite").default(false),
+		/** 閲覧回数 */
+		viewCount: integer("view_count").default(0),
+		/** 最終閲覧日時 */
+		lastViewedAt: timestamp("last_viewed_at").default(
+			sql`'1970-01-01 00:00:00'`,
+		),
+	},
+	(table) => ({
+		ratingIndex: index("idx_media_details_rating").on(table.rating),
+		favoriteIndex: index("idx_media_details_favorite").on(table.favorite),
+		viewCountIndex: index("idx_media_details_view_count").on(table.viewCount),
+	}),
+);
+
+/**
+ * Schema for the media_generation_info table.
+ * Stores information related to how a media item was generated, especially for AI-generated content.
+ */
+export const mediaGenerationInfo = pgTable(
+	"media_generation_info",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.primaryKey()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** prompt, workflowなどのメタデータ */
+		metadata: jsonb("metadata"),
+		/** プロンプト文字列 */
+		prompt: text("prompt"),
+		/** ネガティブプロンプト */
+		negativePrompt: text("negative_prompt"),
+		/** ComfyUIワークフロー全体 */
+		workflow: jsonb("workflow"),
+		/** LoRA情報 [{"name": "...", "weight": 0.8}] */
+		loras: jsonb("loras"),
+		/** VAE名 */
+		vae: text("vae"),
+		/** Hypernetwork情報 */
+		hypernetworks: jsonb("hypernetworks"),
+		/** Embedding/Textual Inversion情報 */
+		embeddings: jsonb("embeddings"),
+		/** AIによって生成されたかどうか */
+		aiGenerated: boolean("ai_generated").default(false),
+		/** 使用されたモデル名 */
+		modelName: text("model_name").default(""),
+		/** シード値 */
+		seed: bigint("seed", { mode: "number" }).default(-1),
+		/** CFGスケール */
+		cfgScale: real("cfg_scale").default(0),
+		/** ステップ数 */
+		steps: integer("steps").default(0),
+	},
+	(table) => ({
+		metadataIndex: index("idx_media_generation_info_metadata").on(
+			table.metadata,
+		),
+		aiGeneratedIndex: index("idx_media_generation_info_ai_generated").on(
+			table.aiGenerated,
+		),
+		modelNameIndex: index("idx_media_generation_info_model_name").on(
+			table.modelName,
+		),
+	}),
+);
+
+/**
+ * Schema for the categories table.
+ * Organizes media into user-defined categories.
+ */
+export const categories = pgTable(
+	"categories",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** カテゴリ名 */
+		name: text("name").notNull(),
+		/** カテゴリの説明 */
+		description: text("description").default(""),
+		/** UIで表示する際の色 */
+		color: text("color").default("#808080"),
+		/** 親カテゴリID */
+		parentId: uuid("parent_id").references((): AnyPgColumn => categories.id),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** カテゴリの起源 (manual) */
+		source: text("source").notNull().default("manual"),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		nameUnique: unique("categories_name_unique").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the projects table.
+ * Stores information about projects that media items can be associated with.
+ */
+export const projects = pgTable(
+	"projects",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** プロジェクト名 */
+		name: text("name").notNull(),
+		/** プロジェクトの説明 */
+		description: text("description").default(""),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").defaultNow(),
+		/** アーカイブ日時 */
+		archivedAt: timestamp("archived_at"),
+	},
+	(table) => ({
+		nameIndex: index("idx_projects_name").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the ips table.
+ * Stores information about Intellectual Properties (IPs) that media items or characters can be associated with.
+ */
+export const ips = pgTable(
+	"ips",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** IP(作品)名 */
+		name: text("name").notNull(),
+		/** IP(作品)の説明 */
+		description: text("description").default(""),
+		/** IPの起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		nameUnique: unique("ips_name_unique").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the characters table.
+ * Stores information about characters, potentially linked to IPs.
+ */
+export const characters = pgTable(
+	"characters",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** キャラクター名 */
+		name: text("name").notNull(),
+		/** キャラクターの説明 */
+		description: text("description").default(""),
+		/** キャラクターの起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+		/** キャラクターの別名（エイリアス）のリスト */
+		aliases: jsonb("aliases"),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		nameUnique: unique("characters_name_unique").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the character_ips join table.
+ * Represents the many-to-many relationship between characters and IPs.
+ */
+export const characterIps = pgTable(
+	"character_ips",
+	{
+		/** キャラクターID */
+		characterId: uuid("character_id")
+			.notNull()
+			.references(() => characters.id, { onDelete: "cascade" }),
+		/** IP(作品)ID */
+		ipId: uuid("ip_id")
+			.notNull()
+			.references(() => ips.id, { onDelete: "cascade" }),
+		/** 起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.characterId, table.ipId] }),
+		ipIdCharacterIdIndex: index("idx_character_ips_ip_id_character_id").on(
+			table.ipId,
+			table.characterId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_characters join table.
+ * Represents the many-to-many relationship between media items and characters.
+ */
+export const mediaCharacters = pgTable(
+	"media_characters",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** キャラクターID */
+		characterId: uuid("character_id")
+			.notNull()
+			.references(() => characters.id, { onDelete: "cascade" }),
+		/** AIがキャラクターを抽出した際の信頼度スコア (0.0-1.0)。手動の場合はNULL */
+		confidence: real("confidence"),
+		/** メディアへのキャラクター付与の起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.characterId] }),
+		characterIdMediaIdIndex: index(
+			"idx_media_characters_character_id_media_id",
+		).on(table.characterId, table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the media_categories join table.
+ * Represents the many-to-many relationship between media items and categories.
+ */
+export const mediaCategories = pgTable(
+	"media_categories",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** カテゴリID */
+		categoryId: uuid("category_id")
+			.notNull()
+			.references(() => categories.id, { onDelete: "cascade" }),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.categoryId] }),
+		categoryIdMediaIdIndex: index(
+			"idx_media_categories_category_id_media_id",
+		).on(table.categoryId, table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the media_projects join table.
+ * Represents the many-to-many relationship between media items and projects.
+ */
+export const mediaProjects = pgTable(
+	"media_projects",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** プロジェクトID */
+		projectId: uuid("project_id")
+			.notNull()
+			.references(() => projects.id, { onDelete: "cascade" }),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.projectId] }),
+		projectIdMediaIdIndex: index("idx_media_projects_project_id_media_id").on(
+			table.projectId,
+			table.mediaId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_ips join table.
+ * Represents the many-to-many relationship between media items and Intellectual Properties (IPs).
+ */
+export const mediaIps = pgTable(
+	"media_ips",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** IP(作品)ID */
+		ipId: uuid("ip_id")
+			.notNull()
+			.references(() => ips.id, { onDelete: "cascade" }),
+		/** AIがIPを抽出した際の信頼度スコア (0.0-1.0)。手動の場合はNULL */
+		confidence: real("confidence"),
+		/** メディアへのIP付与の起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.ipId] }),
+		ipIdMediaIdIndex: index("idx_media_ips_ip_id_media_id").on(
+			table.ipId,
+			table.mediaId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_technical_info table.
+ * Stores technical details about media files, such as color profiles, EXIF data, and video/audio codecs.
+ */
+export const mediaTechnicalInfo = pgTable(
+	"media_technical_info",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.primaryKey()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** カラープロファイル */
+		colorProfile: text("color_profile").default(""),
+		/** EXIFデータ */
+		exifData: jsonb("exif_data").default(sql`'{}'`),
+		/** MD5ハッシュ */
+		hashMd5: text("hash_md5").default(""),
+		/** 知覚ハッシュ */
+		hashPerceptual: text("hash_perceptual").default(""),
+
+		// 動画固有
+		/** 再生時間 (秒) */
+		durationSeconds: real("duration_seconds"),
+		/** フレームレート (fps) */
+		frameRate: real("frame_rate"),
+		/** ビットレート (kbps) */
+		bitrateKbps: integer("bitrate_kbps"),
+		/** 動画コーデック (例: H.264) */
+		videoCodec: text("video_codec"),
+		/** 音声コーデック (例: AAC) */
+		audioCodec: text("audio_codec"),
+	},
+	(table) => ({
+		hashMd5Index: index("idx_media_technical_info_hash_md5").on(table.hashMd5),
+	}),
+);
+
+/**
+ * Schema for the media_sync table.
+ * Manages synchronization and backup status for media items.
+ */
+export const mediaSync = pgTable("media_sync", {
+	/** メディアID */
+	mediaId: uuid("media_id")
+		.primaryKey()
+		.references(() => medias.id, { onDelete: "cascade" }),
+	/** 同期ステータス */
+	syncStatus: mediaSyncStatusEnum("sync_status").default("synced"),
+	/** バックアップURL */
+	backupUrls: text("backup_urls").array().default(sql`'{}'`),
+	/** 最後の同期日時 */
+	lastSyncedAt: timestamp("last_synced_at"),
+	/** 同期試行回数 */
+	syncAttempts: integer("sync_attempts").default(0),
+	/** 最後のエラーメッセージ */
+	lastError: text("last_error"),
+});
+
+/**
+ * Schema for the view_history table.
+ * Records user views of media items for analytics and personalized recommendations.
+ */
+export const viewHistory = pgTable("view_history", {
+	id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+	/** メディアID */
+	mediaId: uuid("media_id")
+		.notNull()
+		.references(() => medias.id, { onDelete: "cascade" }),
+	/** 閲覧日時 */
+	viewedAt: timestamp("viewed_at").defaultNow(),
+	/** IPアドレス */
+	ipAddress: text("ip_address"),
+	/** ユーザーエージェント */
+	userAgent: text("user_agent").default(""),
+});
+
+/**
+ * Schema for the similar_media table.
+ * Stores relationships between similar media items, often determined by perceptual hashing.
+ */
+export const similarMedia = pgTable(
+	"similar_media",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** メディア1のID */
+		media1Id: uuid("media1_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** メディア2のID */
+		media2Id: uuid("media2_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 類似度スコア */
+		similarityScore: real("similarity_score").default(0),
+		/** 類似度計算アルゴリズム */
+		algorithm: text("algorithm").default("perceptual"),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").defaultNow(),
+	},
+	(table) => ({
+		media1IdMedia2IdAlgorithmUnique: unique(
+			"media1Id_media2Id_algorithm_unique",
+		).on(table.media1Id, table.media2Id, table.algorithm),
+		similarityScoreIndex: index("idx_similar_media_score").on(
+			table.similarityScore,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_relations table.
+ * Manages relationships between media items, such as variants, versions, or pages in a series.
+ *
+ * @example Variant illustrations
+ * parent: "Character_Standing.png"
+ *   ├─ child (variant): "Character_Standing_Expression1.png"
+ *   ├─ child (variant): "Character_Standing_Expression2.png"
+ *   └─ child (variant): "Character_Standing_Outfit.png"
+ *
+ * @example Manga pages
+ * parent: "Manga_Chapter1"
+ *   ├─ child (page, order: 1): "page_001.png"
+ *   ├─ child (page, order: 2): "page_002.png"
+ *   └─ child (page, order: 3): "page_003.png"
+ */
+export const mediaRelationsTable = pgTable(
+	"media_relations",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** 親メディアID */
+		parentMediaId: uuid("parent_media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 子メディアID */
+		childMediaId: uuid("child_media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 関係の種類 */
+		relationType: mediaRelationTypeEnum("relation_type").notNull(),
+		/** ページ番号等の順序（オプショナル） */
+		orderIndex: integer("order_index"),
+		/** 追加情報（差分内容の説明等）をJSON形式で保存 */
+		metadata: jsonb("metadata"),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		parentChildTypeUnique: unique("parent_child_type_unique").on(
+			table.parentMediaId,
+			table.childMediaId,
+			table.relationType,
+		),
+		childMediaIdIndex: index("idx_media_relations_child").on(
+			table.childMediaId,
+		),
+		relationTypeIndex: index("idx_media_relations_type").on(table.relationType),
+	}),
+);
+
+/**
+ * Schema for the authors table.
+ * Stores information about authors/artists.
+ */
+export const authors = pgTable(
+	"authors",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** 表示名 */
+		name: text("name").notNull(),
+		/** 外部ID (例: Twitter ID, Pixiv ID) */
+		accountId: text("account_id"),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		accountIdIndex: index("idx_authors_account_id").on(table.accountId),
+		nameIndex: index("idx_authors_name").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the media_authors join table.
+ * Many-to-many relationship between media and authors.
+ */
+export const mediaAuthors = pgTable(
+	"media_authors",
+	{
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		authorId: uuid("author_id")
+			.notNull()
+			.references(() => authors.id, { onDelete: "cascade" }),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.authorId] }),
+		authorIdMediaIdIndex: index("idx_media_authors_author_id_media_id").on(
+			table.authorId,
+			table.mediaId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_urls table.
+ * Stores multiple source URLs for a media item.
+ */
+export const mediaUrls = pgTable(
+	"media_urls",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		url: text("url").notNull(),
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		mediaIdIndex: index("idx_media_urls_media_id").on(table.mediaId),
+		urlIndex: index("idx_media_urls_url").on(table.url),
+		mediaIdUrlUnique: uniqueIndex("idx_media_urls_media_id_url_unique").on(
+			table.mediaId,
+			table.url,
+		),
+	}),
+);
+
+/**
+ * Schema for the users table.
+ * Stores user account information.
+ */
+export const users = pgTable(
+	"users",
+	{
+		/** ユーザーID */
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** ユーザー名 */
+		name: text("name").notNull(),
+		/** メールアドレス */
+		email: text("email").notNull(),
+		/** パスワード */
+		password: text("password").notNull(),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		emailUnique: unique("users_email_unique").on(table.email),
+	}),
+);
+
+/**
+ * Schema for the collections table.
+ * Stores user-created collections of media items.
+ */
+export const collections = pgTable("collections", {
+	id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+	/** どのユーザーのコレクションか (ユーザー管理を導入する場合) */
+	userId: uuid("user_id")
+		.notNull()
+		.references(() => users.id, { onDelete: "cascade" }),
+	/** コレクション名 */
+	name: text("name").notNull(),
+	/** コレクションの説明 */
+	description: text("description").default(""),
+	/** 作成日時 */
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+	/** 更新日時 */
+	updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+/**
+ * Schema for the media_collections join table.
+ * Represents the many-to-many relationship between collections and media items.
+ */
+export const mediaCollections = pgTable(
+	"media_collections",
+	{
+		/** コレクションID */
+		collectionId: uuid("collection_id")
+			.notNull()
+			.references(() => collections.id, { onDelete: "cascade" }),
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** コレクション内での表示順序 */
+		displayOrder: integer("display_order"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.collectionId, table.mediaId] }),
+		mediaIdIndex: index("idx_media_collections_media_id").on(table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the jobs table.
+ * Manages background jobs such as thumbnail generation, metadata extraction, and bulk tagging.
+ * It tracks their progress and results.
+ */
+export const jobs = pgTable("jobs", {
+	id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+	/** ジョブの種類 (例: "thumbnail_generation", "metadata_extraction", "auto_tagging") */
+	type: text("type").notNull(),
+	/** 関連するメディアソースID (オプショナル) */
+	mediaSourceId: uuid("source_id").references(() => mediaSources.id, {
+		onDelete: "cascade",
+	}),
+	/** ジョブのステータス */
+	status: jobStatusEnum("status").notNull().default("pending"),
+	/** ジョブの入力パラメータ (JSON) */
+	payload: jsonb("payload"),
+	/** ジョブの実行結果 (JSON) */
+	result: jsonb("result"),
+	/** エラーメッセージ (失敗時) */
+	error: text("error"),
+	/** ジョブ作成日時 */
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+	/** 最終更新日時 */
+	updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	/** 親ジョブID (バッチ処理用) */
+	parentId: uuid("parent_id").references((): AnyPgColumn => jobs.id, {
+		onDelete: "cascade",
+	}),
+});
+
+/**
+ * Schema for the presets table.
+ * Stores user-defined filter presets for searching media.
+ * @example valueの保存例
+ * ```json
+ * {
+ *   "tags": [1, 5, 12],
+ *   "dateRange": { "from": "2024-01-01", "to": "2024-12-31" },
+ *   "rating": 5,
+ *   "favorite": true,
+ *   "mediaType": "image",
+ *   "characters": [3, 7],
+ *   "ips": [2]
+ * }
+ * ```
+ */
+export const presets = pgTable("presets", {
+	id: serial("id").primaryKey(),
+	/** プリセット名 (例: "お気に入りの高評価画像", "2024年の青い目キャラクター") */
+	name: text("name").notNull().unique(),
+	/** フィルター条件をJSON形式で保存 */
+	value: jsonb("value").notNull(),
+	/** ソート項目 */
+	sort: text("sort"),
+	/** ソート順 */
+	order: text("order"),
+	/** 検索モード ("simple" または "pro") */
+	mode: text("mode"),
+	/** 作成日時 */
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+});
+
+// リレーション
+/**
+ * Defines the relations for the media_sources table.
+ */
+export const mediaSourcesRelations = relations(mediaSources, ({ many }) => ({
+	/** メディアソースに属するメディア */
+	media: many(medias),
+}));
+
+/**
+ * Defines the relations for the medias table.
+ */
+export const mediaRelations = relations(medias, ({ one, many }) => ({
+	/** メディアが属するメディアソース */
+
+	source: one(mediaSources, {
+		fields: [medias.mediaSourceId],
+		references: [mediaSources.id],
+	}),
+	/** メディアに付けられたタグ */
+
+	tags: many(mediaTags),
+	/** メディアの詳細情報 */
+
+	details: one(mediaDetails, {
+		fields: [medias.id],
+		references: [mediaDetails.mediaId],
+	}),
+	/** メディアの生成情報 */
+
+	generationInfo: one(mediaGenerationInfo, {
+		fields: [medias.id],
+		references: [mediaGenerationInfo.mediaId],
+	}),
+	/** メディアが属するカテゴリ */
+
+	categories: many(mediaCategories),
+	/** メディアが属するプロジェクト */
+
+	projects: many(mediaProjects),
+	/** メディアが属するIP */
+
+	ips: many(mediaIps),
+	/** メディアの技術情報 */
+
+	technicalInfo: one(mediaTechnicalInfo, {
+		fields: [medias.id],
+		references: [mediaTechnicalInfo.mediaId],
+	}),
+	/** メディアの同期情報 */
+
+	sync: one(mediaSync, {
+		fields: [medias.id],
+		references: [mediaSync.mediaId],
+	}),
+	/** メディアの閲覧履歴 */
+
+	viewHistory: many(viewHistory),
+	/** 類似メディア (media1) */
+
+	similarMedia1: many(similarMedia, { relationName: "media1" }),
+	/** 類似メディア (media2) */
+
+	similarMedia2: many(similarMedia, { relationName: "media2" }),
+	/** メディアが属するコレクション */
+
+	collections: many(mediaCollections),
+	/** メディアに含まれるキャラクター */
+
+	characters: many(mediaCharacters),
+	/** このメディアを親とする関連メディア */
+
+	childRelations: many(mediaRelationsTable, { relationName: "parent" }),
+	/** このメディアを子とする関連メディア */
+
+	parentRelations: many(mediaRelationsTable, { relationName: "child" }),
+	/** メディアのSource URLリスト */
+
+	urls: many(mediaUrls),
+	/** メディアのAuthorリスト */
+
+	authors: many(mediaAuthors),
+}));
+
+/**
+ * Defines the relations for the tags table.
+ */
+export const tagsRelations = relations(tags, ({ one, many }) => ({
+	/** タグが付与されたメディア */
+	media: many(mediaTags),
+	/** タグに関連するAuthor */
+	author: one(authors, {
+		fields: [tags.authorId],
+		references: [authors.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_tags join table.
+ */
+export const mediaTagsRelations = relations(mediaTags, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+
+	media: one(medias, {
+		fields: [mediaTags.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するタグ */
+
+	tag: one(tags, {
+		fields: [mediaTags.tagId],
+		references: [tags.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the categories table.
+ */
+export const categoriesRelations = relations(categories, ({ one, many }) => ({
+	/** 親カテゴリ */
+
+	parent: one(categories, {
+		fields: [categories.parentId],
+		references: [categories.id],
+		relationName: "parent_category",
+	}),
+	/** 子カテゴリ */
+
+	children: many(categories, {
+		relationName: "parent_category",
+	}),
+	/** カテゴリに属するメディア */
+
+	media: many(mediaCategories),
+}));
+
+/**
+ * Defines the relations for the projects table.
+ */
+export const projectsRelations = relations(projects, ({ many }) => ({
+	/** プロジェクトに属するメディア */
+	media: many(mediaProjects),
+}));
+
+/**
+ * Defines the relations for the ips table.
+ */
+export const ipsRelations = relations(ips, ({ many }) => ({
+	/** IPに属するメディア */
+
+	media: many(mediaIps),
+	/** IPに属するキャラクター (中間テーブル経由) */
+
+	characters: many(characterIps),
+}));
+
+/**
+ * Defines the relations for the characters table.
+ */
+export const charactersRelations = relations(characters, ({ many }) => ({
+	/** キャラクターが属するIP (中間テーブル経由) */
+
+	ips: many(characterIps),
+	/** キャラクターが含まれるメディア */
+
+	media: many(mediaCharacters),
+}));
+
+/**
+ * Defines the relations for the character_ips join table.
+ */
+export const characterIpsRelations = relations(characterIps, ({ one }) => ({
+	/** 中間テーブルが参照するキャラクター */
+	character: one(characters, {
+		fields: [characterIps.characterId],
+		references: [characters.id],
+	}),
+	/** 中間テーブルが参照するIP */
+	ip: one(ips, {
+		fields: [characterIps.ipId],
+		references: [ips.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_characters join table.
+ */
+export const mediaCharactersRelations = relations(
+	mediaCharacters,
+	({ one }) => ({
+		/** 中間テーブルが参照するメディア */
+
+		media: one(medias, {
+			fields: [mediaCharacters.mediaId],
+			references: [medias.id],
+		}),
+		/** 中間テーブルが参照するキャラクター */
+
+		character: one(characters, {
+			fields: [mediaCharacters.characterId],
+			references: [characters.id],
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the media_categories join table.
+ */
+export const mediaCategoriesRelations = relations(
+	mediaCategories,
+	({ one }) => ({
+		/** 中間テーブルが参照するメディア */
+		media: one(medias, {
+			fields: [mediaCategories.mediaId],
+			references: [medias.id],
+		}),
+		/** 中間テーブルが参照するカテゴリ */
+		category: one(categories, {
+			fields: [mediaCategories.categoryId],
+			references: [categories.id],
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the media_projects join table.
+ */
+export const mediaProjectsRelations = relations(mediaProjects, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+	media: one(medias, {
+		fields: [mediaProjects.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するプロジェクト */
+	project: one(projects, {
+		fields: [mediaProjects.projectId],
+		references: [projects.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_ips join table.
+ */
+export const mediaIpsRelations = relations(mediaIps, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+	media: one(medias, {
+		fields: [mediaIps.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するIP */
+	ip: one(ips, {
+		fields: [mediaIps.ipId],
+		references: [ips.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the view_history table.
+ */
+export const viewHistoryRelations = relations(viewHistory, ({ one }) => ({
+	/** 閲覧履歴が参照するメディア */
+	media: one(medias, {
+		fields: [viewHistory.mediaId],
+		references: [medias.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the similar_media table.
+ */
+export const similarMediaRelations = relations(similarMedia, ({ one }) => ({
+	/** 類似メディア1 */
+
+	media1: one(medias, {
+		fields: [similarMedia.media1Id],
+		references: [medias.id],
+		relationName: "media1",
+	}),
+	/** 類似メディア2 */
+
+	media2: one(medias, {
+		fields: [similarMedia.media2Id],
+		references: [medias.id],
+		relationName: "media2",
+	}),
+}));
+
+/**
+ * Defines the relations for the mediaRelationsTable.
+ */
+export const mediaRelationsTableRelations = relations(
+	mediaRelationsTable,
+	({ one }) => ({
+		/** 親メディア */
+		parentMedia: one(medias, {
+			fields: [mediaRelationsTable.parentMediaId],
+			references: [medias.id],
+			relationName: "parent",
+		}),
+		/** 子メディア */
+		childMedia: one(medias, {
+			fields: [mediaRelationsTable.childMediaId],
+			references: [medias.id],
+			relationName: "child",
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the collections table.
+ */
+export const collectionsRelations = relations(collections, ({ one, many }) => ({
+	media: many(mediaCollections),
+	/** どのユーザーのコレクションか */
+	user: one(users, {
+		fields: [collections.userId],
+		references: [users.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_collections join table.
+ */
+export const mediaCollectionsRelations = relations(
+	mediaCollections,
+	({ one }) => ({
+		/** 中間テーブルが参照するコレクション */
+
+		collection: one(collections, {
+			fields: [mediaCollections.collectionId],
+			references: [collections.id],
+		}),
+		/** 中間テーブルが参照するメディア */
+
+		media: one(medias, {
+			fields: [mediaCollections.mediaId],
+			references: [medias.id],
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the authors table.
+ */
+export const authorsRelations = relations(authors, ({ many }) => ({
+	/** Authorに関連するメディア */
+	media: many(mediaAuthors),
+	/** Authorに関連するタグ */
+	tags: many(tags),
+}));
+
+/**
+ * Defines the relations for the media_authors join table.
+ */
+export const mediaAuthorsRelations = relations(mediaAuthors, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+	media: one(medias, {
+		fields: [mediaAuthors.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するAuthor */
+	author: one(authors, {
+		fields: [mediaAuthors.authorId],
+		references: [authors.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_urls table.
+ */
+export const mediaUrlsRelations = relations(mediaUrls, ({ one }) => ({
+	/** URLが属するメディア */
+	media: one(medias, {
+		fields: [mediaUrls.mediaId],
+		references: [medias.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the users table.
+ */
+export const usersRelations = relations(users, ({ many }) => ({
+	/** ユーザーが持つコレクション */
+	collections: many(collections),
+}));
+
+// 型
+/**
+ * Type definition for selecting a media source from the database.
+ */
+export type MediaSource = InferSelectModel<typeof mediaSources>;
+/**
+ * Type definition for inserting a new media source into the database.
+ */
+export type NewMediaSource = InferInsertModel<typeof mediaSources>;
+
+/**
+ * Type definition for selecting a media item from the database.
+ */
+export type Media = InferSelectModel<typeof medias>;
+/**
+ * Type definition for inserting a new media item into the database.
+ */
+export type NewMedia = InferInsertModel<typeof medias>;
+
+/**
+ * Type definition for selecting a tag from the database.
+ */
+export type Tag = InferSelectModel<typeof tags>;
+/**
+ * Type definition for inserting a new tag into the database.
+ */
+export type NewTag = InferInsertModel<typeof tags>;
+
+/**
+ * Type definition for selecting a media tag relationship from the database.
+ */
+export type MediaTag = InferSelectModel<typeof mediaTags>;
+/**
+ * Type definition for inserting a new media tag relationship into the database.
+ */
+export type NewMediaTag = InferInsertModel<typeof mediaTags>;
+
+/**
+ * Type definition for selecting media details from the database.
+ */
+export type MediaDetails = InferSelectModel<typeof mediaDetails>;
+/**
+ * Type definition for inserting new media details into the database.
+ */
+export type NewMediaDetails = InferInsertModel<typeof mediaDetails>;
+
+/**
+ * Type definition for selecting media generation information from the database.
+ */
+export type MediaGenerationInfo = InferSelectModel<typeof mediaGenerationInfo>;
+/**
+ * Type definition for inserting new media generation information into the database.
+ */
+export type NewMediaGenerationInfo = InferInsertModel<
+	typeof mediaGenerationInfo
+>;
+
+/**
+ * Type definition for selecting a category from the database.
+ */
+export type Category = InferSelectModel<typeof categories>;
+/**
+ * Type definition for inserting a new category into the database.
+ */
+export type NewCategory = InferInsertModel<typeof categories>;
+
+/**
+ * Type definition for selecting a project from the database.
+ */
+export type Project = InferSelectModel<typeof projects>;
+/**
+ * Type definition for inserting a new project into the database.
+ */
+export type NewProject = InferInsertModel<typeof projects>;
+
+/**
+ * Type definition for selecting an IP from the database.
+ */
+export type Ip = InferSelectModel<typeof ips>;
+/**
+ * Type definition for inserting a new IP into the database.
+ */
+export type NewIp = InferInsertModel<typeof ips>;
+
+/**
+ * Type definition for selecting a character from the database.
+ */
+export type Character = InferSelectModel<typeof characters>;
+/**
+ * Type definition for inserting a new character into the database.
+ */
+export type NewCharacter = InferInsertModel<typeof characters>;
+
+/**
+ * Type definition for selecting a character IP relationship from the database.
+ */
+export type CharacterIp = InferSelectModel<typeof characterIps>;
+/**
+ * Type definition for inserting a new character IP relationship into the database.
+ */
+export type NewCharacterIp = InferInsertModel<typeof characterIps>;
+
+/**
+ * Type definition for selecting a media character relationship from the database.
+ */
+export type MediaCharacter = InferSelectModel<typeof mediaCharacters>;
+/**
+ * Type definition for inserting a new media character relationship into the database.
+ */
+export type NewMediaCharacter = InferInsertModel<typeof mediaCharacters>;
+
+/**
+ * Type definition for selecting a media category relationship from the database.
+ */
+export type MediaCategory = InferSelectModel<typeof mediaCategories>;
+/**
+ * Type definition for inserting a new media category relationship into the database.
+ */
+export type NewMediaCategory = InferInsertModel<typeof mediaCategories>;
+
+/**
+ * Type definition for selecting a media project relationship from the database.
+ */
+export type MediaProject = InferSelectModel<typeof mediaProjects>;
+/**
+ * Type definition for inserting a new media project relationship into the database.
+ */
+export type NewMediaProject = InferInsertModel<typeof mediaProjects>;
+
+/**
+ * Type definition for selecting a media IP relationship from the database.
+ */
+export type MediaIp = InferSelectModel<typeof mediaIps>;
+/**
+ * Type definition for inserting a new media IP relationship into the database.
+ */
+export type NewMediaIp = InferInsertModel<typeof mediaIps>;
+
+/**
+ * Type definition for selecting media technical information from the database.
+ */
+export type MediaTechnicalInfo = InferSelectModel<typeof mediaTechnicalInfo>;
+/**
+ * Type definition for inserting new media technical information into the database.
+ */
+export type NewMediaTechnicalInfo = InferInsertModel<typeof mediaTechnicalInfo>;
+
+/**
+ * Type definition for selecting media sync information from the database.
+ */
+export type MediaSync = InferSelectModel<typeof mediaSync>;
+/**
+ * Type definition for inserting new media sync information into the database.
+ */
+export type NewMediaSync = InferInsertModel<typeof mediaSync>;
+
+/**
+ * Type definition for selecting a view history entry from the database.
+ */
+export type ViewHistory = InferSelectModel<typeof viewHistory>;
+/**
+ * Type definition for inserting a new view history entry into the database.
+ */
+export type NewViewHistory = InferInsertModel<typeof viewHistory>;
+
+/**
+ * Type definition for selecting similar media relationships from the database.
+ */
+export type SimilarMedia = InferSelectModel<typeof similarMedia>;
+/**
+ * Type definition for inserting new similar media relationships into the database.
+ */
+export type NewSimilarMedia = InferInsertModel<typeof similarMedia>;
+
+/**
+ * Type definition for selecting a collection from the database.
+ */
+export type Collection = InferSelectModel<typeof collections>;
+/**
+ * Type definition for inserting a new collection into the database.
+ */
+export type NewCollection = InferInsertModel<typeof collections>;
+
+/**
+ * Type definition for selecting a media collection relationship from the database.
+ */
+export type MediaCollection = InferSelectModel<typeof mediaCollections>;
+/**
+ * Type definition for inserting a new media collection relationship into the database.
+ */
+export type NewMediaCollection = InferInsertModel<typeof mediaCollections>;
+
+/**
+ * Type definition for selecting a user from the database.
+ */
+export type User = InferSelectModel<typeof users>;
+/**
+ * Type definition for inserting a new user into the database.
+ */
+export type NewUser = InferInsertModel<typeof users>;
+
+/**
+ * Type definition for selecting a job from the database.
+ */
+export type Job = InferSelectModel<typeof jobs>;
+/**
+ * Type definition for inserting a new job into the database.
+ */
+export type NewJob = InferInsertModel<typeof jobs>;
+
+/**
+ * Type definition for selecting a preset from the database.
+ */
+export type Preset = InferSelectModel<typeof presets>;
+/**
+ * Type definition for inserting a new preset into the database.
+ */
+export type NewPreset = InferInsertModel<typeof presets>;
+
+/**
+ * Type definition for selecting a media relation from the database.
+ */
+export type MediaRelation = InferSelectModel<typeof mediaRelationsTable>;
+/**
+ * Type definition for inserting a new media relation into the database.
+ */
+export type NewMediaRelation = InferInsertModel<typeof mediaRelationsTable>;
+
+/**
+ * Type definition for selecting an author from the database.
+ */
+export type Author = InferSelectModel<typeof authors>;
+/**
+ * Type definition for inserting a new author into the database.
+ */
+export type NewAuthor = InferInsertModel<typeof authors>;
+
+/**
+ * Type definition for selecting a media author relationship from the database.
+ */
+export type MediaAuthor = InferSelectModel<typeof mediaAuthors>;
+/**
+ * Type definition for inserting a new media author relationship into the database.
+ */
+export type NewMediaAuthor = InferInsertModel<typeof mediaAuthors>;
+
+/**
+ * Type definition for selecting a media url from the database.
+ */
+export type MediaUrl = InferSelectModel<typeof mediaUrls>;
+/**
+ * Type definition for inserting a new media url into the database.
+ */
+export type NewMediaUrl = InferInsertModel<typeof mediaUrls>;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -146,7 +146,6 @@ export const medias = pgTable(
 		fileSizeIndex: index("idx_media_file_size").on(table.fileSize),
 		fileNameIndex: index("idx_media_file_name").on(table.fileName),
 		createdAtIndex: index("idx_media_created_at").on(table.createdAt),
-		descriptionIndex: index("idx_media_description").on(table.description),
 	}),
 );
 
@@ -273,7 +272,7 @@ export const mediaGenerationInfo = pgTable(
 		aiGenerated: boolean("ai_generated").default(false),
 		/** 使用されたモデル名 */
 		modelName: text("model_name").default(""),
-		/** シード値 */
+		/** シード値 (AI seeds are well within JS safe integer range, so mode: "number" is acceptable) */
 		seed: bigint("seed", { mode: "number" }).default(-1),
 		/** CFGスケール */
 		cfgScale: real("cfg_scale").default(0),
@@ -281,7 +280,8 @@ export const mediaGenerationInfo = pgTable(
 		steps: integer("steps").default(0),
 	},
 	(table) => ({
-		metadataIndex: index("idx_media_generation_info_metadata").on(
+		metadataIndex: index("idx_media_generation_info_metadata").using(
+			"gin",
 			table.metadata,
 		),
 		aiGeneratedIndex: index("idx_media_generation_info_ai_generated").on(

--- a/packages/db/src/transaction-manager.ts
+++ b/packages/db/src/transaction-manager.ts
@@ -1,0 +1,19 @@
+import type {
+	Transaction,
+	TransactionManager,
+} from "@solid-imager/core/domain/interfaces/transaction-manager";
+import type { DbInstance } from "./types";
+
+export function createTransactionManager(
+	db: DbInstance,
+): TransactionManager {
+	return {
+		async transaction<T>(
+			callback: (tx: Transaction) => Promise<T>,
+		): Promise<T> {
+			return await db.transaction(async (tx) => {
+				return await callback(tx);
+			});
+		},
+	};
+}

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,0 +1,32 @@
+import type { Transaction } from "@solid-imager/core/domain/interfaces/transaction-manager";
+import type { PgliteDatabase } from "drizzle-orm/pglite";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type * as schema from "./schema";
+
+export type NodePostgresDb = NodePgDatabase<typeof schema>;
+export type PgLiteDb = PgliteDatabase<typeof schema>;
+export type DbInstance = NodePostgresDb | PgLiteDb;
+export type TransactionClient = DbInstance;
+
+export function getClient(
+	db: DbInstance,
+	tx?: Transaction,
+): TransactionClient {
+	return (tx as TransactionClient | undefined) ?? db;
+}
+
+export type DbConfig =
+	| {
+			databaseType: "pglite";
+			pglite: { path?: string; inMemory?: boolean };
+	  }
+	| {
+			databaseType: "docker-compose-postgres";
+			dockerComposePostgres: {
+				host: string;
+				port: number;
+				user: string;
+				password: string;
+				database: string;
+			};
+	  };

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -1,0 +1,16 @@
+export function escapeLikeString(str: string): string {
+	return str.replace(/[%_]/g, "\\$&");
+}
+
+export function paginatedQuery(
+	query: { limit: (n: number) => { offset: (n: number) => unknown } } & { offset: (n: number) => unknown },
+	options: { limit?: number; offset?: number },
+): unknown {
+	if (options.limit !== undefined) {
+		return query.limit(options.limit).offset(options.offset || 0);
+	}
+	if (options.offset !== undefined && options.offset > 0) {
+		return query.offset(options.offset);
+	}
+	return query;
+}

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -2,15 +2,16 @@ export function escapeLikeString(str: string): string {
 	return str.replace(/[%_]/g, "\\$&");
 }
 
-export function paginatedQuery(
-	query: { limit: (n: number) => { offset: (n: number) => unknown } } & { offset: (n: number) => unknown },
+export function paginatedQuery<T>(
+	query: T,
 	options: { limit?: number; offset?: number },
-): unknown {
+): T {
+	const q = query as any;
 	if (options.limit !== undefined) {
-		return query.limit(options.limit).offset(options.offset || 0);
+		return q.limit(options.limit).offset(options.offset || 0) as T;
 	}
 	if (options.offset !== undefined && options.offset > 0) {
-		return query.offset(options.offset);
+		return q.offset(options.offset) as T;
 	}
 	return query;
 }

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["../core/src/*"],
+      "@solid-imager/core": ["../core/src/index.ts"],
+      "@solid-imager/core/*": ["../core/src/*"],
+      "@solid-imager/db": ["./src/index.ts"],
+      "@solid-imager/db/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite-plus";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+	plugins: [tsconfigPaths()],
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -4,5 +4,6 @@ export default defineWorkspace([
   'apps/cli/vitest.config.ts',
   'apps/server/vitest.unit.config.ts',
   'apps/server/vitest.integration.config.ts',
-  'packages/core/vitest.config.ts'
+  'packages/core/vitest.config.ts',
+  'packages/db/vitest.config.ts'
 ]);


### PR DESCRIPTION
## Summary

- Extracted shared DB infrastructure from `apps/server/src/infrastructure/db/` into `packages/db/`
- Moved schema definitions (29 tables, relations, types) to `@solid-imager/db/schema`
- Created `createDbClient(config)` factory with dependency injection in `@solid-imager/db/client`
- Extracted `createTransactionManager(db)` factory in `@solid-imager/db/transaction-manager`
- Added `getClient(db, tx)` helper replacing `(tx as unknown as TransactionClient) || db` pattern
- Added `escapeLikeString()` and `paginatedQuery()` utilities in `@solid-imager/db/utils`
- Added `runPgliteMigrations()` and `createPgliteClient()` in `@solid-imager/db/migrations`
- Updated all server imports from `~/infrastructure/db/schema` to `@solid-imager/db/schema`
- Applied `getClient()` pattern across all repository files

### Test results
- All 136 unit tests pass
- Server builds successfully

fixes #351