### PR TITLE
perf: Quick Wins #373

### DIFF
--- a/apps/server/src/infrastructure/storage/server-media-storage.ts
+++ b/apps/server/src/infrastructure/storage/server-media-storage.ts
@@ -133,6 +133,12 @@ export const ServerMediaStorage: IMediaStorage = {
 		while (head < queue.length) {
 			const dir = queue[head++];
 
+			// Periodically clear processed entries to prevent unbounded memory growth
+			if (head > 100) {
+				queue.splice(0, head);
+				head = 0;
+			}
+
 			try {
 				const dirents = await fs.readdir(dir, { withFileTypes: true });
 				for (const dirent of dirents) {

--- a/apps/server/src/infrastructure/storage/server-media-storage.ts
+++ b/apps/server/src/infrastructure/storage/server-media-storage.ts
@@ -128,12 +128,10 @@ export const ServerMediaStorage: IMediaStorage = {
 	async scanDirectory(basePath: string): Promise<string[]> {
 		const files: string[] = [];
 		const queue: string[] = [basePath];
+		let head = 0;
 
-		while (queue.length > 0) {
-			const dir = queue.shift();
-			if (!dir) {
-				continue;
-			}
+		while (head < queue.length) {
+			const dir = queue[head++];
 
 			try {
 				const dirents = await fs.readdir(dir, { withFileTypes: true });

--- a/apps/server/src/utils/deep-equal.ts
+++ b/apps/server/src/utils/deep-equal.ts
@@ -27,8 +27,10 @@ export function deepEqual(a: unknown, b: unknown): boolean {
 		return false;
 	}
 
+	const keysBSet = new Set(keysB);
+
 	for (const key of keysA) {
-		if (!keysB.includes(key)) {
+		if (!keysBSet.has(key)) {
 			return false;
 		}
 		if (

--- a/apps/server/src/utils/deep-equal.ts
+++ b/apps/server/src/utils/deep-equal.ts
@@ -27,10 +27,11 @@ export function deepEqual(a: unknown, b: unknown): boolean {
 		return false;
 	}
 
-	const keysBSet = new Set(keysB);
+	// Only create a Set for larger objects to avoid overhead on small objects
+	const keysBSet = keysB.length > 5 ? new Set(keysB) : null;
 
 	for (const key of keysA) {
-		if (!keysBSet.has(key)) {
+		if (keysBSet ? !keysBSet.has(key) : !keysB.includes(key)) {
 			return false;
 		}
 		if (

--- a/packages/ui/src/checkbox.tsx
+++ b/packages/ui/src/checkbox.tsx
@@ -10,7 +10,7 @@ import {
 } from "@kobalte/core/checkbox";
 import type { PolymorphicProps } from "@kobalte/core/polymorphic";
 import type { ValidComponent } from "solid-js";
-import { Match, Switch, splitProps } from "solid-js";
+import { splitProps } from "solid-js";
 
 import { cn } from "./utils/cn";
 
@@ -35,23 +35,19 @@ const CheckboxControl = <T extends ValidComponent = "div">(
 				{...others}
 			>
 				<CheckboxIndicator class="flex items-center justify-center text-current">
-					<Switch>
-						<Match when={true}>
-							<svg
-								class="h-4 w-4"
-								fill="none"
-								stroke="currentColor"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="2"
-								viewBox="0 0 24 24"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<title>Checked</title>
-								<path d="M5 12l5 5l10 -10" />
-							</svg>
-						</Match>
-					</Switch>
+					<svg
+						class="h-4 w-4"
+						fill="none"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						viewBox="0 0 24 24"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<title>Checked</title>
+						<path d="M5 12l5 5l10 -10" />
+					</svg>
 				</CheckboxIndicator>
 			</CheckboxControlPrimitive>
 		</>


### PR DESCRIPTION
## 概要

Issue #373 Quick Wins: 軽微なパフォーマンス改善

## 変更点

- deep-equal.ts: O(k²) key comparison → O(k) with Set.has()
- checkbox.tsx: 無駄なSwitch/Matchラッパー削除
- server-media-storage.ts: BFSのarray.shift()→インデックス方式でO(D²)→O(D)

fixes #373