### PR TITLE
perf: コアドメインのアルゴリズム改善 #378

### DIFF
--- a/packages/core/src/domain/config/config-schema.ts
+++ b/packages/core/src/domain/config/config-schema.ts
@@ -18,7 +18,13 @@ export const JobsConfigSchema = z.object({
 		.default(DEFAULT_JOBS_POLL_INTERVAL),
 	enableAutoTagging: z.boolean().default(DEFAULT_AUTO_TAGGING),
 });
-const defaultJobsConfig = JobsConfigSchema.parse({});
+
+const DEFAULT_JOBS_CONFIG = {
+	concurrency: DEFAULT_JOBS_CONCURRENCY,
+	aiConcurrency: 1,
+	pollIntervalMs: DEFAULT_JOBS_POLL_INTERVAL,
+	enableAutoTagging: DEFAULT_AUTO_TAGGING,
+} as const;
 
 const DEFAULT_AI_BASE_URL = "http://localhost:8000";
 const DEFAULT_AI_TIMEOUT = 120_000;
@@ -28,7 +34,11 @@ export const AiConfigSchema = z.object({
 	baseUrl: z.string().default(DEFAULT_AI_BASE_URL),
 	timeoutMs: z.number().min(MIN_AI_TIMEOUT).default(DEFAULT_AI_TIMEOUT),
 });
-const defaultAiConfig = AiConfigSchema.parse({});
+
+const DEFAULT_AI_CONFIG = {
+	baseUrl: DEFAULT_AI_BASE_URL,
+	timeoutMs: DEFAULT_AI_TIMEOUT,
+} as const;
 
 const DEFAULT_DOWNLOAD_RATE_LIMIT_ENABLED = true;
 const DEFAULT_DOWNLOAD_REQUEST_INTERVAL_MS = 1_000;
@@ -42,7 +52,11 @@ export const DownloadsConfigSchema = z.object({
 		.max(MAX_DOWNLOAD_REQUEST_INTERVAL_MS)
 		.default(DEFAULT_DOWNLOAD_REQUEST_INTERVAL_MS),
 });
-const defaultDownloadsConfig = DownloadsConfigSchema.parse({});
+
+const DEFAULT_DOWNLOADS_CONFIG = {
+	rateLimitEnabled: DEFAULT_DOWNLOAD_RATE_LIMIT_ENABLED,
+	requestIntervalMs: DEFAULT_DOWNLOAD_REQUEST_INTERVAL_MS,
+} as const;
 
 const DEFAULT_THUMB_DIR = ".cache/thumbnails";
 const DEFAULT_THUMB_SIZE = 512;
@@ -65,7 +79,12 @@ export const StorageConfigSchema = z.object({
 		.max(MAX_THUMB_QUALITY)
 		.default(DEFAULT_THUMB_QUALITY),
 });
-const defaultStorageConfig = StorageConfigSchema.parse({});
+
+const DEFAULT_STORAGE_CONFIG = {
+	thumbnailDir: DEFAULT_THUMB_DIR,
+	thumbnailSize: DEFAULT_THUMB_SIZE,
+	thumbnailQuality: DEFAULT_THUMB_QUALITY,
+} as const;
 
 export const ComfyUiTagExtractionSchema = z.object({
 	positiveNodeTypes: z
@@ -74,17 +93,29 @@ export const ComfyUiTagExtractionSchema = z.object({
 	negativeKeywords: z.array(z.string()).default(["negative"]),
 	negativeTags: z.array(z.string()).default(["lowres"]),
 });
-const defaultComfyUiTagExtraction = ComfyUiTagExtractionSchema.parse({});
+
+const DEFAULT_COMFYUI_TAG_EXTRACTION = {
+	positiveNodeTypes: ["CLIPTextEncode", "CR Combine Prompt"],
+	negativeKeywords: ["negative"],
+	negativeTags: ["lowres"],
+};
 
 export const TagExtractionConfigSchema = z.object({
-	comfyui: ComfyUiTagExtractionSchema.default(defaultComfyUiTagExtraction),
+	comfyui: ComfyUiTagExtractionSchema.default(DEFAULT_COMFYUI_TAG_EXTRACTION),
 });
-const defaultTagExtractionConfig = TagExtractionConfigSchema.parse({});
 
 const DEFAULT_EXTENSIONS = {
 	image: [".jpg", ".jpeg", ".png", ".webp"],
 	video: [".mp4", ".webm", ".mov"],
 	audio: [".mp3", ".wav"],
+};
+
+const DEFAULT_TAG_EXTRACTION_CONFIG = {
+	comfyui: {
+		positiveNodeTypes: ["CLIPTextEncode", "CR Combine Prompt"],
+		negativeKeywords: ["negative"],
+		negativeTags: ["lowres"],
+	},
 };
 
 export const MediaConfigSchema = z.object({
@@ -95,25 +126,44 @@ export const MediaConfigSchema = z.object({
 			audio: z.array(z.string()).default(DEFAULT_EXTENSIONS.audio),
 		})
 		.default(DEFAULT_EXTENSIONS),
-	tagExtraction: TagExtractionConfigSchema.default(defaultTagExtractionConfig),
+	tagExtraction: TagExtractionConfigSchema.default(
+		DEFAULT_TAG_EXTRACTION_CONFIG,
+	),
 });
-const defaultMediaConfig = MediaConfigSchema.parse({});
+
+const DEFAULT_MEDIA_CONFIG = {
+	supportedExtensions: {
+		image: [".jpg", ".jpeg", ".png", ".webp"] as string[],
+		video: [".mp4", ".webm", ".mov"] as string[],
+		audio: [".mp3", ".wav"] as string[],
+	},
+	tagExtraction: {
+		comfyui: {
+			positiveNodeTypes: ["CLIPTextEncode", "CR Combine Prompt"] as string[],
+			negativeKeywords: ["negative"] as string[],
+			negativeTags: ["lowres"] as string[],
+		},
+	},
+};
 
 export const LoggingConfigSchema = z.object({
 	level: z
 		.enum(["trace", "debug", "info", "warn", "error", "fatal"])
 		.default("info"),
 });
-const defaultLoggingConfig = LoggingConfigSchema.parse({});
+
+const DEFAULT_LOGGING_CONFIG = {
+	level: "info",
+} as const;
 
 export const AppConfigSchema = z.object({
 	version: z.string().default("1.0.0"),
-	jobs: JobsConfigSchema.default(defaultJobsConfig),
-	ai: AiConfigSchema.default(defaultAiConfig),
-	downloads: DownloadsConfigSchema.default(defaultDownloadsConfig),
-	storage: StorageConfigSchema.default(defaultStorageConfig),
-	media: MediaConfigSchema.default(defaultMediaConfig),
-	logging: LoggingConfigSchema.default(defaultLoggingConfig),
+	jobs: JobsConfigSchema.default(DEFAULT_JOBS_CONFIG),
+	ai: AiConfigSchema.default(DEFAULT_AI_CONFIG),
+	downloads: DownloadsConfigSchema.default(DEFAULT_DOWNLOADS_CONFIG),
+	storage: StorageConfigSchema.default(DEFAULT_STORAGE_CONFIG),
+	media: MediaConfigSchema.default(DEFAULT_MEDIA_CONFIG),
+	logging: LoggingConfigSchema.default(DEFAULT_LOGGING_CONFIG),
 });
 
 export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/packages/core/src/domain/config/config-schema.ts
+++ b/packages/core/src/domain/config/config-schema.ts
@@ -111,11 +111,7 @@ const DEFAULT_EXTENSIONS = {
 };
 
 const DEFAULT_TAG_EXTRACTION_CONFIG = {
-	comfyui: {
-		positiveNodeTypes: ["CLIPTextEncode", "CR Combine Prompt"],
-		negativeKeywords: ["negative"],
-		negativeTags: ["lowres"],
-	},
+	comfyui: DEFAULT_COMFYUI_TAG_EXTRACTION,
 };
 
 export const MediaConfigSchema = z.object({
@@ -133,16 +129,12 @@ export const MediaConfigSchema = z.object({
 
 const DEFAULT_MEDIA_CONFIG = {
 	supportedExtensions: {
-		image: [".jpg", ".jpeg", ".png", ".webp"] as string[],
-		video: [".mp4", ".webm", ".mov"] as string[],
-		audio: [".mp3", ".wav"] as string[],
+		image: DEFAULT_EXTENSIONS.image,
+		video: DEFAULT_EXTENSIONS.video,
+		audio: DEFAULT_EXTENSIONS.audio,
 	},
 	tagExtraction: {
-		comfyui: {
-			positiveNodeTypes: ["CLIPTextEncode", "CR Combine Prompt"] as string[],
-			negativeKeywords: ["negative"] as string[],
-			negativeTags: ["lowres"] as string[],
-		},
+		comfyui: DEFAULT_COMFYUI_TAG_EXTRACTION,
 	},
 };
 

--- a/packages/core/src/domain/media/schemas.ts
+++ b/packages/core/src/domain/media/schemas.ts
@@ -369,8 +369,7 @@ export const mediaMetadataContextSchema = z.object({
 				Array.isArray(val)
 					? val.filter(
 							(v): v is string =>
-								typeof v === "string" &&
-								(v.startsWith("http://") || v.startsWith("https://")),
+								typeof v === "string" && /^https?:\/\/.+/.test(v),
 						)
 					: val,
 			z.array(z.string().url()),

--- a/packages/core/src/domain/media/schemas.ts
+++ b/packages/core/src/domain/media/schemas.ts
@@ -367,14 +367,11 @@ export const mediaMetadataContextSchema = z.object({
 		.preprocess(
 			(val) =>
 				Array.isArray(val)
-					? val.filter((v) => {
-							try {
-								new URL(v);
-								return true;
-							} catch {
-								return false;
-							}
-						})
+					? val.filter(
+							(v): v is string =>
+								typeof v === "string" &&
+								(v.startsWith("http://") || v.startsWith("https://")),
+						)
 					: val,
 			z.array(z.string().url()),
 		)

--- a/packages/core/src/domain/media/utils/metadata-utils.ts
+++ b/packages/core/src/domain/media/utils/metadata-utils.ts
@@ -90,10 +90,19 @@ export function extractDataFromComments(
 		workflow: null,
 	};
 
+	// Deduplicate during iteration instead of a separate pass
+	const seenTags = new Set<string>();
+
 	for (const chunk of comments) {
 		const processedChunk = processCommentChunk(chunk, options);
 		if (processedChunk.tags) {
-			finalData.tags.push(...processedChunk.tags);
+			for (const tag of processedChunk.tags) {
+				const tagIdentifier = `${tag.name}:${tag.type}`;
+				if (!seenTags.has(tagIdentifier)) {
+					seenTags.add(tagIdentifier);
+					finalData.tags.push(tag);
+				}
+			}
 		}
 		if (processedChunk.prompt) {
 			finalData.prompt = processedChunk.prompt;
@@ -102,18 +111,6 @@ export function extractDataFromComments(
 			finalData.workflow = processedChunk.workflow;
 		}
 	}
-
-	// Deduplicate tags
-	const uniqueTags: ExtractedData["tags"] = [];
-	const seenTags = new Set<string>();
-	for (const tag of finalData.tags) {
-		const tagIdentifier = `${tag.name}:${tag.type}`;
-		if (!seenTags.has(tagIdentifier)) {
-			uniqueTags.push(tag);
-			seenTags.add(tagIdentifier);
-		}
-	}
-	finalData.tags = uniqueTags;
 
 	return finalData;
 }

--- a/packages/core/src/domain/tags/extractor.ts
+++ b/packages/core/src/domain/tags/extractor.ts
@@ -33,13 +33,11 @@ function _extractTagsFromWidgetValue(
 export function processWidgetValueTags(
 	widgetValue: unknown,
 	nodeTitle: string | undefined,
+	negativeTagSet: Set<string>,
 	options?: TagExtractionOptions,
 ): { positiveTags: string[]; negativeTags: string[] } {
 	const negativeKeywords =
 		options?.negativeKeywords ?? DEFAULT_OPTIONS.negativeKeywords;
-	const negativeTagSet = new Set(
-		options?.negativeTags ?? DEFAULT_OPTIONS.negativeTags,
-	);
 
 	const newPositiveTags: string[] = [];
 	const newNegativeTags: string[] = [];
@@ -107,9 +105,12 @@ function processWorkflowNode({
 			valuesToProcess.push(...Object.values(nodeRecord.inputs));
 		}
 
+		const negativeTagSet = new Set(
+			options?.negativeTags ?? DEFAULT_OPTIONS.negativeTags,
+		);
 		for (const widgetValue of valuesToProcess) {
 			const { positiveTags: newPosTags, negativeTags: newNegTags } =
-				processWidgetValueTags(widgetValue, nodeTitle, options);
+				processWidgetValueTags(widgetValue, nodeTitle, negativeTagSet, options);
 			positiveTags.push(
 				...newPosTags.map((tag) => ({
 					name: tag,

--- a/packages/core/src/domain/tags/extractor.ts
+++ b/packages/core/src/domain/tags/extractor.ts
@@ -37,29 +37,36 @@ export function processWidgetValueTags(
 ): { positiveTags: string[]; negativeTags: string[] } {
 	const negativeKeywords =
 		options?.negativeKeywords ?? DEFAULT_OPTIONS.negativeKeywords;
-	const negativeTags = options?.negativeTags ?? DEFAULT_OPTIONS.negativeTags;
+	const negativeTagSet = new Set(
+		options?.negativeTags ?? DEFAULT_OPTIONS.negativeTags,
+	);
 
 	const newPositiveTags: string[] = [];
 	const newNegativeTags: string[] = [];
 
 	if (typeof widgetValue === "string") {
-		const tags = widgetValue
-			.split(",")
-			.map((s) => s.trim())
-			.filter((s) => s.length > 0)
-			.map((s) => s.replace(/ /g, "_"))
-			.map((s) => s.replace(/"/g, ""));
+		const parts = widgetValue.split(",");
+		const processedTags: string[] = [];
 
-		if (tags.length > 0) {
+		for (const part of parts) {
+			const s = part.trim();
+			if (s.length === 0) continue;
+			// Combine replace(/ /g, "_") and replace(/"/g, "") in a single pass
+			processedTags.push(s.replace(/[ "]/g, (ch) => (ch === " " ? "_" : "")));
+		}
+
+		if (processedTags.length > 0) {
 			const isNegativeByTitle = negativeKeywords.some((keyword) =>
 				nodeTitle?.toLowerCase().includes(keyword.toLowerCase()),
 			);
-			const isNegativeByTag = tags.some((tag) => negativeTags.includes(tag));
+			const isNegativeByTag = processedTags.some((tag) =>
+				negativeTagSet.has(tag),
+			);
 
 			if (isNegativeByTitle || isNegativeByTag) {
-				newNegativeTags.push(...tags);
+				newNegativeTags.push(...processedTags);
 			} else {
-				newPositiveTags.push(...tags);
+				newPositiveTags.push(...processedTags);
 			}
 		}
 	}


### PR DESCRIPTION
## 概要

Issue #378 コアドメインのアルゴリズム改善

## 変更点

- extractor.ts: 5連鎖配列操作を1パスに統合
- metadata-utils.ts: ネストループ改善（重複排除をループ内で実施）
- schemas.ts: new URL()+try/catchを単純な文字列チェックに置き換え
- config-schema.ts: 中間Zod parse呼び出しを削除し、プレーンオブジェクトのデフォルト値を使用

fixes #378