### PR TITLE
perf: APIルーターの並列化 #377

### DIFF
--- a/apps/server/src/infrastructure/api/routers/media-router.ts
+++ b/apps/server/src/infrastructure/api/routers/media-router.ts
@@ -133,14 +133,26 @@ export const mediaRouter = {
 		)
 		.handler(async ({ input }) => {
 			const results: { id: string; success: boolean; error?: string }[] = [];
-			for (const mediaId of input.mediaIds) {
-				try {
-					await MediaService.reprocessMetadata(input.sourceId, mediaId);
+
+			async function processMedia(mediaId: string) {
+				await MediaService.reprocessMetadata(input.sourceId, mediaId);
+			}
+
+			const poolResults = await asyncPool(input.mediaIds, 5, processMedia);
+
+			for (const [index, pr] of poolResults.entries()) {
+				const mediaId = input.mediaIds[index];
+				if (pr.status === "fulfilled") {
 					results.push({ id: mediaId, success: true });
-				} catch (error) {
-					results.push({ id: mediaId, success: false, error: String(error) });
+				} else {
+					results.push({
+						id: mediaId,
+						success: false,
+						error: String(pr.reason),
+					});
 				}
 			}
+
 			return { results };
 		}),
 
@@ -218,3 +230,35 @@ export const mediaRouter = {
 				}),
 		),
 };
+
+/**
+ * Process items with a concurrency limit.
+ * Returns per-item results via Promise.allSettled-style entries.
+ */
+async function asyncPool<T, R = void>(
+	items: T[],
+	limit: number,
+	fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+	const results: PromiseSettledResult<R>[] = new Array(items.length);
+	let index = 0;
+
+	async function worker() {
+		while (true) {
+			const i = index++;
+			if (i >= items.length) break;
+			try {
+				const value = await fn(items[i]);
+				results[i] = { status: "fulfilled" as const, value };
+			} catch (reason) {
+				results[i] = { status: "rejected" as const, reason };
+			}
+		}
+	}
+
+	const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
+		worker(),
+	);
+	await Promise.all(workers);
+	return results;
+}

--- a/apps/server/src/infrastructure/api/routers/media-router.ts
+++ b/apps/server/src/infrastructure/api/routers/media-router.ts
@@ -6,6 +6,7 @@ import {
 } from "@solid-imager/core/domain/media/schemas";
 import { z } from "zod";
 import { MediaService } from "~/application/services/media-service";
+import { asyncPool } from "~/utils/async-pool";
 
 /**
  * Media Router Implementation
@@ -230,35 +231,3 @@ export const mediaRouter = {
 				}),
 		),
 };
-
-/**
- * Process items with a concurrency limit.
- * Returns per-item results via Promise.allSettled-style entries.
- */
-async function asyncPool<T, R = void>(
-	items: T[],
-	limit: number,
-	fn: (item: T) => Promise<R>,
-): Promise<PromiseSettledResult<R>[]> {
-	const results: PromiseSettledResult<R>[] = new Array(items.length);
-	let index = 0;
-
-	async function worker() {
-		while (true) {
-			const i = index++;
-			if (i >= items.length) break;
-			try {
-				const value = await fn(items[i]);
-				results[i] = { status: "fulfilled" as const, value };
-			} catch (reason) {
-				results[i] = { status: "rejected" as const, reason };
-			}
-		}
-	}
-
-	const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
-		worker(),
-	);
-	await Promise.all(workers);
-	return results;
-}

--- a/apps/server/src/infrastructure/api/routers/sources-router.ts
+++ b/apps/server/src/infrastructure/api/routers/sources-router.ts
@@ -222,16 +222,23 @@ export const sourcesRouter = {
 		)
 		.handler(async ({ input }) => {
 			const results: Record<string, unknown>[] = [];
-			for (const id of input.ids) {
-				try {
-					const result = await DirectorySyncService.syncMediaSource(id);
-					results.push({ id, success: true, ...result });
-				} catch (error) {
+			const poolResults = await asyncPool(input.ids, 3, (id: string) =>
+				DirectorySyncService.syncMediaSource(id),
+			);
+			for (const [index, pr] of poolResults.entries()) {
+				const id = input.ids[index];
+				if (pr.status === "fulfilled") {
+					results.push({
+						id,
+						success: true,
+						...(pr.value as Record<string, unknown>),
+					});
+				} else {
 					logger.error(
-						{ err: error, sourceId: id },
+						{ err: pr.reason, sourceId: id },
 						"Failed to sync media source",
 					);
-					results.push({ id, success: false, error: String(error) });
+					results.push({ id, success: false, error: String(pr.reason) });
 				}
 			}
 			return { results };
@@ -370,8 +377,9 @@ export const sourcesRouter = {
 			// Yield initial connection event
 			yield { event: "connected", data: "connected" };
 
-			// Queue for events
+			// Queue for events — use pointer index instead of shift()
 			const queue: { event: string; data: any }[] = [];
+			let head = 0;
 			let resolve: (() => void) | null = null;
 
 			const onEvent = (payload: { event: string; data: any }) => {
@@ -387,7 +395,7 @@ export const sourcesRouter = {
 
 			try {
 				while (!signal?.aborted) {
-					if (queue.length === 0) {
+					if (head >= queue.length) {
 						await new Promise<void>((r) => {
 							const onAbort = () => {
 								r();
@@ -404,11 +412,8 @@ export const sourcesRouter = {
 						});
 					}
 
-					while (queue.length > 0) {
-						const item = queue.shift();
-						if (item) {
-							yield item;
-						}
+					while (head < queue.length) {
+						yield queue[head++];
 					}
 				}
 			} finally {
@@ -416,3 +421,35 @@ export const sourcesRouter = {
 			}
 		}),
 };
+
+/**
+ * Process items with a concurrency limit.
+ * Returns per-item results via Promise.allSettled-style entries.
+ */
+async function asyncPool<T, R = void>(
+	items: T[],
+	limit: number,
+	fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+	const results: PromiseSettledResult<R>[] = new Array(items.length);
+	let index = 0;
+
+	async function worker() {
+		while (true) {
+			const i = index++;
+			if (i >= items.length) break;
+			try {
+				const value = await fn(items[i]);
+				results[i] = { status: "fulfilled" as const, value };
+			} catch (reason) {
+				results[i] = { status: "rejected" as const, reason };
+			}
+		}
+	}
+
+	const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
+		worker(),
+	);
+	await Promise.all(workers);
+	return results;
+}

--- a/apps/server/src/infrastructure/api/routers/sources-router.ts
+++ b/apps/server/src/infrastructure/api/routers/sources-router.ts
@@ -12,6 +12,7 @@ import { MediaService } from "~/application/services/media-service";
 import { MediaSourceService } from "~/application/services/media-source-service";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
 import { logger } from "~/infrastructure/logger";
+import { asyncPool } from "~/utils/async-pool";
 
 /**
  * 機密情報を除外した安全な MediaSource に変換
@@ -415,41 +416,15 @@ export const sourcesRouter = {
 					while (head < queue.length) {
 						yield queue[head++];
 					}
+
+					// Periodically trim stale entries to prevent memory leak
+					if (head > 1000) {
+						queue.splice(0, head);
+						head = 0;
+					}
 				}
 			} finally {
 				SseManager.emitter.off(eventName, onEvent);
 			}
 		}),
 };
-
-/**
- * Process items with a concurrency limit.
- * Returns per-item results via Promise.allSettled-style entries.
- */
-async function asyncPool<T, R = void>(
-	items: T[],
-	limit: number,
-	fn: (item: T) => Promise<R>,
-): Promise<PromiseSettledResult<R>[]> {
-	const results: PromiseSettledResult<R>[] = new Array(items.length);
-	let index = 0;
-
-	async function worker() {
-		while (true) {
-			const i = index++;
-			if (i >= items.length) break;
-			try {
-				const value = await fn(items[i]);
-				results[i] = { status: "fulfilled" as const, value };
-			} catch (reason) {
-				results[i] = { status: "rejected" as const, reason };
-			}
-		}
-	}
-
-	const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
-		worker(),
-	);
-	await Promise.all(workers);
-	return results;
-}

--- a/apps/server/src/utils/async-pool.ts
+++ b/apps/server/src/utils/async-pool.ts
@@ -1,0 +1,31 @@
+/**
+ * Process items with a concurrency limit.
+ * Returns per-item results via Promise.allSettled-style entries.
+ */
+export async function asyncPool<T, R = void>(
+	items: T[],
+	limit: number,
+	fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+	const results: PromiseSettledResult<R>[] = new Array(items.length);
+	let index = 0;
+
+	async function worker() {
+		while (true) {
+			const i = index++;
+			if (i >= items.length) break;
+			try {
+				const value = await fn(items[i]);
+				results[i] = { status: "fulfilled" as const, value };
+			} catch (reason) {
+				results[i] = { status: "rejected" as const, reason };
+			}
+		}
+	}
+
+	const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
+		worker(),
+	);
+	await Promise.all(workers);
+	return results;
+}


### PR DESCRIPTION
## 概要

Issue #377 APIルーターの並列化

## 変更点

- **media-router.ts**: メディア同期（reprocessMetadata）を Promise.allSettled + 並列数制限（5）に変更。for...of の逐次処理を並列化し、処理時間を短縮。
- **sources-router.ts**: ソース同期（syncMediaSource）を同様に並列化。並列数制限は3。
- **sources-router.ts**: SSE キュー内の array.shift()（O(n)）をインデックス方式（O(1)）に最適化。

## 技術詳細

並列制御には asyncPool 関数を実装。ワーカーベースのシンプルな実装で p-limit 相当の機能を提供。各アイテムの成否は PromiseSettledResult で個別管理し、部分的な失敗にも対応。

fixes #377
