### PR TITLE
perf: N+1問題の解消 #376

### DIFF
--- a/apps/server/src/application/services/character-service.ts
+++ b/apps/server/src/application/services/character-service.ts
@@ -91,15 +91,12 @@ export class CharacterServiceImpl {
 		tx?: Transaction,
 	): Promise<void> {
 		if (character.ips && character.ips.length > 0) {
-			for (const ip of character.ips) {
-				await this.ipRepo.addMedia(
-					mediaId,
-					ip.id,
-					undefined,
-					"character_link",
-					tx,
-				);
-			}
+			await this.ipRepo.addMediaBulk(
+				mediaId,
+				character.ips.map((ip) => ({ id: ip.id })),
+				"character_link",
+				tx,
+			);
 		}
 	}
 

--- a/apps/server/src/application/services/media-processing-service.ts
+++ b/apps/server/src/application/services/media-processing-service.ts
@@ -273,22 +273,16 @@ export class MediaProcessingServiceImpl {
 		authors: NonNullable<MediaMetadataContext["authors"]>,
 		tx?: Transaction,
 	): Promise<void> {
-		for (const author of authors) {
-			try {
-				let createdAuthor = await this.authorRepo.findByName(author.name, tx);
-				if (!createdAuthor) {
-					createdAuthor = await this.authorRepo.create(
-						{
-							name: author.name,
-							accountId: author.accountId ?? null,
-						},
-						tx,
-					);
-				}
-				await this.authorRepo.addMedia(mediaId, createdAuthor.id, tx);
-			} catch (e) {
-				logger.warn({ err: e, author }, "Failed to register author");
-			}
+		if (authors.length === 0) {
+			return;
+		}
+		const names = authors.map((a) => a.name);
+		try {
+			const allAuthors = await this.authorRepo.findOrCreateBulk(names, tx);
+			const authorIds = allAuthors.map((a) => a.id);
+			await this.authorRepo.addMediaBulk(mediaId, authorIds, tx);
+		} catch (e) {
+			logger.warn({ err: e }, "Failed to register authors");
 		}
 	}
 
@@ -298,93 +292,135 @@ export class MediaProcessingServiceImpl {
 		currentIpNames?: string[],
 		tx?: Transaction,
 	): Promise<void> {
-		for (const charData of characters) {
-			try {
-				await this._registerSingleCharacter(
-					mediaId,
-					charData,
-					currentIpNames,
-					tx,
-				);
-			} catch (e) {
-				logger.warn(
-					{ err: e, character: charData },
-					"Failed to register character",
-				);
-			}
-		}
-	}
-
-	private async _registerSingleCharacter(
-		mediaId: string,
-		charData: NonNullable<MediaMetadataContext["characters"]>[number],
-		currentIpNames?: string[],
-		tx?: Transaction,
-	): Promise<void> {
-		let character: Character | null = await this.characterService.findByName(
-			charData.name,
-		);
-
-		// Determine which IPs to link to this character
-		// Priority: 1) linkedIps from metadata, 2) infer from media's current IPs
-		const ipNamesToLink =
-			charData.linkedIps && charData.linkedIps.length > 0
-				? charData.linkedIps
-				: currentIpNames;
-
-		const ipIdsToLink = await this._resolveIpIds(ipNamesToLink, tx);
-
-		if (!character) {
-			character = await this.characterService.createCharacter({
-				name: charData.name,
-				description: charData.description ?? "",
-				ipIds: ipIdsToLink,
-			});
-		} else if (ipIdsToLink.length > 0) {
-			character = await this._updateCharacterIps(character, ipIdsToLink);
-		}
-
-		if (!character) {
+		if (characters.length === 0) {
 			return;
 		}
 
-		// Re-link character to media if necessary
-		// We can use characterService.addCharacterToMedia(mediaId, character.id) but it will call linkCharacterIps again.
-		// That's actually fine/safe.
-		// NOTE: CharacterService.addCharacterToMedia now uses internal transactionManager, so we might want to call repo directly if we already have a tx?
-		// But for simplicity and consistent auto-link logic, service call is safer.
-		// If tx is provided, we should probably prefer repo call or update service to accept tx.
-		const charRepo = this.characterService.characterRepo;
-		const confidence = charData.confidence ?? 1;
-		await charRepo.addToMedia(mediaId, character.id, confidence, "manual", tx);
-		await this.characterService.linkCharacterIps(mediaId, character, tx);
-	}
+		try {
+			// Step 1: Collect all unique IP names from character data (linkedIps priority, fallback to currentIpNames)
+			const allIpNamesSet = new Set<string>();
+			for (const charData of characters) {
+				const ipNames =
+					charData.linkedIps && charData.linkedIps.length > 0
+						? charData.linkedIps
+						: currentIpNames ?? [];
+				for (const name of ipNames) {
+					allIpNamesSet.add(name);
+				}
+			}
 
-	private async _resolveIpIds(
-		currentIpNames?: string[],
-		tx?: Transaction,
-	): Promise<string[]> {
-		if (!currentIpNames?.length) {
-			return [];
+			// Resolve all IP IDs in one query
+			const allIpNames = [...allIpNamesSet];
+			const allIpNameIdMap = new Map<string, string>();
+			if (allIpNames.length > 0) {
+				const foundIps = await this.ipRepo.findByNames(allIpNames, tx);
+				for (const ip of foundIps) {
+					allIpNameIdMap.set(ip.name, ip.id);
+				}
+			}
+
+			// Step 2: Map character data to IP IDs and find existing characters
+			const charNameIpIdsMap = new Map<string, string[]>();
+			for (const charData of characters) {
+				const ipNames =
+					charData.linkedIps && charData.linkedIps.length > 0
+						? charData.linkedIps
+						: currentIpNames ?? [];
+				const ipIds: string[] = [];
+				for (const name of ipNames) {
+					const ipId = allIpNameIdMap.get(name);
+					if (ipId) {
+						ipIds.push(ipId);
+					}
+				}
+				charNameIpIdsMap.set(charData.name, ipIds);
+			}
+
+			const charNames = characters.map((c) => c.name);
+			const charRepo = this.characterService.characterRepo;
+			const existingChars: Character[] = await charRepo.findByNames(
+				charNames,
+				tx,
+			);
+			const existingCharMap = new Map(existingChars.map((c) => [c.name, c]));
+
+			// Step 3: Build data for bulk findOrCreateBulk and IP updates
+			const bulkCharData: Array<{ name: string; ipIds: string[] }> = [];
+			const charsToUpdateIps: Array<{
+				id: string;
+				ipIds: string[];
+			}> = [];
+
+			for (const charData of characters) {
+				const ipIds = charNameIpIdsMap.get(charData.name) ?? [];
+				const existing = existingCharMap.get(charData.name);
+
+				if (!existing) {
+					bulkCharData.push({ name: charData.name, ipIds });
+				} else if (ipIds.length > 0) {
+					const existingIpIds = existing.ips?.map((i) => i.id) || [];
+					const mergedIpIds = [
+						...new Set([...existingIpIds, ...ipIds]),
+					];
+					if (mergedIpIds.length > existingIpIds.length) {
+						charsToUpdateIps.push({
+							id: existing.id,
+							ipIds: mergedIpIds,
+						});
+					}
+				}
+			}
+
+			// Step 4: Bulk create new characters
+			const newChars = await charRepo.findOrCreateBulk(
+				bulkCharData,
+				"manual",
+				tx,
+			);
+
+			// Step 5: Update IPs for existing characters
+			for (const { id, ipIds } of charsToUpdateIps) {
+				await this.characterService.updateCharacter(id, { ipIds });
+			}
+
+			// Step 6: Bulk add characters to media
+			const allChars = [...existingChars, ...newChars];
+			const charsToAddMedia = allChars.map((char) => ({
+				id: char.id,
+				confidence:
+					characters.find((c) => c.name === char.name)?.confidence ?? 1,
+			}));
+
+			await charRepo.addToMediaBulk(
+				mediaId,
+				charsToAddMedia,
+				"manual",
+				tx,
+			);
+
+			// Step 7: Bulk link character IPs to media
+			const allIpIdsToLink: { id: string; confidence?: number }[] = [];
+			for (const char of allChars) {
+				if (char.ips && char.ips.length > 0) {
+					for (const ip of char.ips) {
+						if (!allIpIdsToLink.some((i) => i.id === ip.id)) {
+							allIpIdsToLink.push({ id: ip.id });
+						}
+					}
+				}
+			}
+
+			if (allIpIdsToLink.length > 0) {
+				await this.ipRepo.addMediaBulk(
+					mediaId,
+					allIpIdsToLink,
+					"character_link",
+					tx,
+				);
+			}
+		} catch (e) {
+			logger.warn({ err: e }, "Failed to register characters");
 		}
-
-		const foundIps = await this.ipRepo.findByNames(currentIpNames, tx);
-		return foundIps.map((ip) => ip.id);
-	}
-
-	private async _updateCharacterIps(
-		character: Character,
-		ipIdsToLink: string[],
-	): Promise<Character> {
-		const existingIpIds = character.ips?.map((i) => i.id) || [];
-		const newIpIds = [...new Set([...existingIpIds, ...ipIdsToLink])];
-
-		if (newIpIds.length > existingIpIds.length) {
-			return await this.characterService.updateCharacter(character.id, {
-				ipIds: newIpIds,
-			});
-		}
-		return character;
 	}
 
 	private async registerIps(
@@ -392,7 +428,7 @@ export class MediaProcessingServiceImpl {
 		ipsData: NonNullable<MediaMetadataContext["ips"]>,
 		tx?: Transaction,
 	): Promise<void> {
-		// Normalize names and remove duplicates to avoid redundant creation attempts
+		// Normalize names and remove duplicates
 		const normalizedIpsMap = new Map<
 			string,
 			NonNullable<MediaMetadataContext["ips"]>[number]
@@ -404,28 +440,23 @@ export class MediaProcessingServiceImpl {
 			}
 		}
 
-		for (const [name, ipData] of normalizedIpsMap) {
-			try {
-				let created = await this.ipRepo.findByName(name, tx);
-				if (!created) {
-					created = await this.ipRepo.create(
-						{
-							name,
-							description: ipData.description ?? "",
-						},
-						tx,
-					);
-				}
-				await this.ipRepo.addMedia(
-					mediaId,
-					created.id,
-					ipData.confidence ?? undefined,
-					"manual",
-					tx,
-				);
-			} catch (e) {
-				logger.warn({ err: e, ip: ipData }, "Failed to register IP");
-			}
+		if (normalizedIpsMap.size === 0) {
+			return;
+		}
+
+		try {
+			const names = [...normalizedIpsMap.keys()];
+			const allIps = await this.ipRepo.findOrCreateBulk(names, "manual", tx);
+
+			// Build bulk media linkage with confidence from original data
+			const ipsToLink = allIps.map((ip) => ({
+				id: ip.id,
+				confidence: normalizedIpsMap.get(ip.name)?.confidence ?? undefined,
+			}));
+
+			await this.ipRepo.addMediaBulk(mediaId, ipsToLink, "manual", tx);
+		} catch (e) {
+			logger.warn({ err: e }, "Failed to register IPs");
 		}
 	}
 
@@ -434,25 +465,16 @@ export class MediaProcessingServiceImpl {
 		projectsData: NonNullable<MediaMetadataContext["projects"]>,
 		tx?: Transaction,
 	): Promise<void> {
-		for (const projData of projectsData) {
-			try {
-				let created = await this.projectRepo.findByName(projData.name, tx);
-				if (!created) {
-					created = await this.projectRepo.create(
-						{
-							name: projData.name,
-							description: projData.description ?? "",
-						},
-						tx,
-					);
-				}
-				await this.projectRepo.addMedia(mediaId, created.id, tx);
-			} catch (e) {
-				logger.warn(
-					{ err: e, project: projData },
-					"Failed to register project",
-				);
-			}
+		if (projectsData.length === 0) {
+			return;
+		}
+		const names = projectsData.map((p) => p.name);
+		try {
+			const allProjects = await this.projectRepo.findOrCreateBulk(names, tx);
+			const projectIds = allProjects.map((p) => p.id);
+			await this.projectRepo.addMediaBulk(mediaId, projectIds, tx);
+		} catch (e) {
+			logger.warn({ err: e }, "Failed to register projects");
 		}
 	}
 

--- a/apps/server/src/application/services/tagging-service.ts
+++ b/apps/server/src/application/services/tagging-service.ts
@@ -167,29 +167,22 @@ export class TaggingService {
 		);
 		await this.tagRepo.addTagsToMedia(mediaId, tagsToInsert, "AI");
 
-		// 2. IPs
+		// 2. IPs — bulk find-or-create
 		const ipNames = response.ips;
 		const ipNameIdMap = new Map<string, string>();
-		const ipsToLink: { id: string; confidence?: number }[] = [];
 
-		// Process IPs sequentially to handle potential creations (bulk create/find not fully supported by repo yet without refactor)
-		// TODO: Refactor IpRepository to support findOrCreateBulk for true bulk performance
-		for (const ipName of ipNames) {
-			let ip = await this.ipRepo.findByName(ipName);
-			if (!ip) {
-				try {
-					ip = await this.ipRepo.create({ name: ipName, source: "AI" });
-				} catch (e) {
-					if (e instanceof ResourceConflictError) {
-						ip = await this.ipRepo.findByName(ipName);
-					} else {
-						throw e;
-					}
-				}
+		if (ipNames.length > 0) {
+			const allIps = await this.ipRepo.findOrCreateBulk(ipNames, "AI");
+			for (const ip of allIps) {
+				ipNameIdMap.set(ip.name, ip.id);
 			}
-			if (ip) {
-				ipNameIdMap.set(ipName, ip.id);
-				ipsToLink.push({ id: ip.id });
+		}
+
+		const ipsToLink: { id: string; confidence?: number }[] = [];
+		for (const ipName of ipNames) {
+			const ipId = ipNameIdMap.get(ipName);
+			if (ipId) {
+				ipsToLink.push({ id: ipId });
 			}
 		}
 
@@ -198,8 +191,8 @@ export class TaggingService {
 		}
 
 		// 3. Characters
-		// ips_mapping: { charName: [ipName] } - Note: The key is character name, value is list of IP names
-		const charToIpIdsMap = new Map<string, string[]>(); // charName -> ipIds[]
+		// ips_mapping: { charName: [ipName] }
+		const charToIpIdsMap = new Map<string, string[]>();
 
 		for (const [charName, linkedIpNames] of Object.entries(
 			response.ips_mapping,
@@ -216,57 +209,75 @@ export class TaggingService {
 			}
 		}
 
-		const charsToLink: { id: string; confidence: number }[] = [];
+		const charNames = Object.keys(response.character);
 
-		// Process Characters sequentially for creation/update
-		// TODO: Refactor CharacterRepository to support bulk operations
-		for (const [charName, confidence] of Object.entries(response.character)) {
-			const ipIds = charToIpIdsMap.get(charName) ?? [];
-			let char = await this.characterRepo.findByName(charName);
+		// Fetch existing characters in one query
+		const existingChars = await this.characterRepo.findByNames(charNames);
+		const existingCharMap = new Map(existingChars.map((c) => [c.name, c]));
 
-			if (!char) {
-				try {
-					char = await this.characterRepo.create({
-						name: charName,
-						ipIds, // Link to IPs if known
-						source: "AI",
+		// Build full character data for findOrCreateBulk:
+		// For existing chars, merge existing IPs with newly detected IPs
+		const bulkCharData: Array<{ name: string; ipIds: string[] }> = [];
+		const charsNeedingUpdate: Array<{
+			id: string;
+			ipIds: string[];
+		}> = [];
+
+		for (const charName of charNames) {
+			const newIpIds = charToIpIdsMap.get(charName) ?? [];
+			const existing = existingCharMap.get(charName);
+
+			if (!existing) {
+				// New character — will be created by findOrCreateBulk
+				bulkCharData.push({ name: charName, ipIds: newIpIds });
+			} else if (
+				existing.ips.length === 0 &&
+				newIpIds.length > 0
+			) {
+				// Existing character with no IPs — need to link IPs
+				charsNeedingUpdate.push({ id: existing.id, ipIds: newIpIds });
+			} else if (newIpIds.length > 0) {
+				// Existing character with some IPs — append only new ones
+				const existingIpIds = new Set(existing.ips.map((i) => i.id));
+				const appendedIds = newIpIds.filter(
+					(id) => !existingIpIds.has(id),
+				);
+				if (appendedIds.length > 0) {
+					charsNeedingUpdate.push({
+						id: existing.id,
+						ipIds: [...existingIpIds, ...appendedIds],
 					});
-				} catch (e) {
-					if (e instanceof ResourceConflictError) {
-						char = await this.characterRepo.findByName(charName);
-					} else {
-						throw e;
-					}
-				}
-			} else if (char.ips.length === 0 && ipIds.length > 0) {
-				// Link orphaned character (no IPs) to detected IPs
-				try {
-					await this.characterRepo.update(char.id, { ipIds });
-				} catch (e) {
-					if (e instanceof ResourceConflictError) {
-						// Ignore conflict during update
-					} else {
-						throw e;
-					}
-				}
-			} else if (ipIds.length > 0) {
-				// Character has existing IPs. We should check if we need to append new ones.
-				// We only append new ones, never remove existing ones for AI updates on existing chars
-				const existingIpIds = new Set(char.ips.map((i) => i.id));
-				const newIpIds = ipIds.filter((id) => !existingIpIds.has(id));
-
-				if (newIpIds.length > 0) {
-					try {
-						await this.characterRepo.update(char.id, {
-							ipIds: [...existingIpIds, ...newIpIds],
-						});
-					} catch (_e) {
-						// Ignore conflict
-					}
 				}
 			}
+		}
 
-			if (char) {
+		// Bulk create new characters with IP links
+		const newChars = await this.characterRepo.findOrCreateBulk(
+			bulkCharData,
+			"AI",
+		);
+
+		// Bulk IP updates for existing characters
+		for (const { id, ipIds } of charsNeedingUpdate) {
+			try {
+				await this.characterRepo.update(id, { ipIds });
+			} catch (e) {
+				if (!(e instanceof ResourceConflictError)) {
+					throw e;
+				}
+			}
+		}
+
+		// Build character link list for addToMediaBulk
+		const charsToLink: { id: string; confidence: number }[] = [];
+
+		for (const char of existingChars) {
+			const confidence = response.character[char.name];
+			charsToLink.push({ id: char.id, confidence });
+		}
+		for (const char of newChars) {
+			const confidence = response.character[char.name];
+			if (confidence !== undefined) {
 				charsToLink.push({ id: char.id, confidence });
 			}
 		}
@@ -276,7 +287,6 @@ export class TaggingService {
 		}
 
 		// Notify clients of the update
-		// Ensure all consumers (like use-media-source-events.ts) are updated to "media-changed"
 		SseManager.sendEvent(mediaSourceId, "media-changed", {
 			filePath,
 			mediaId,

--- a/apps/server/src/infrastructure/repositories/author-repository.ts
+++ b/apps/server/src/infrastructure/repositories/author-repository.ts
@@ -1,7 +1,7 @@
 import { ResourceNotFoundError } from "@solid-imager/core/domain/errors";
 import type { Transaction } from "@solid-imager/core/domain/interfaces/transaction-manager";
 import type { IAuthorRepository } from "@solid-imager/core/domain/repositories/author-repository";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { db, type TransactionClient } from "~/infrastructure/db/index";
 import {
 	type Author,
@@ -32,6 +32,17 @@ export const AuthorRepository: IAuthorRepository = {
 			.where(eq(authors.name, name))
 			.limit(1);
 		return result[0] || null;
+	},
+
+	async findByNames(names: string[], tx?: Transaction): Promise<Author[]> {
+		if (names.length === 0) {
+			return [];
+		}
+		const client = (tx as unknown as TransactionClient) || db;
+		return await client
+			.select()
+			.from(authors)
+			.where(inArray(authors.name, names));
 	},
 
 	async create(author: NewAuthor, tx?: Transaction): Promise<Author> {
@@ -145,5 +156,36 @@ export const AuthorRepository: IAuthorRepository = {
 				})),
 			)
 			.onConflictDoNothing();
+	},
+
+	async findOrCreateBulk(
+		names: string[],
+		tx?: Transaction,
+	): Promise<Author[]> {
+		if (names.length === 0) {
+			return [];
+		}
+		const uniqueNames = [...new Set(names)];
+		const client = (tx as unknown as TransactionClient) || db;
+
+		// Find existing authors (authors table has no unique constraint on name)
+		const existing = await client
+			.select()
+			.from(authors)
+			.where(inArray(authors.name, uniqueNames));
+
+		const existingNameSet = new Set(existing.map((a) => a.name));
+		const missingNames = uniqueNames.filter((n) => !existingNameSet.has(n));
+
+		// Insert missing authors
+		if (missingNames.length > 0) {
+			const inserted = await client
+				.insert(authors)
+				.values(missingNames.map((name) => ({ name })))
+				.returning();
+			existing.push(...inserted);
+		}
+
+		return existing;
 	},
 };

--- a/apps/server/src/infrastructure/repositories/character-repository.ts
+++ b/apps/server/src/infrastructure/repositories/character-repository.ts
@@ -96,6 +96,37 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 		}
 	}
 
+	async findByNames(
+		names: string[],
+		tx?: Transaction,
+	): Promise<Character[]> {
+		if (names.length === 0) {
+			return [];
+		}
+		try {
+			const client = (tx as unknown as TransactionClient) || db;
+			const results = await client.query.characters.findMany({
+				where: inArray(characters.name, names),
+				with: {
+					ips: {
+						with: {
+							ip: true,
+						},
+					},
+				},
+			});
+			return results.map((r) => ({
+				...r,
+				ips: r.ips.map((i) => i.ip),
+			}));
+		} catch (error) {
+			throw new UnexpectedError(
+				"Failed to select characters by names",
+				error,
+			);
+		}
+	}
+
 	async create(character: NewCharacter, tx?: Transaction): Promise<Character> {
 		try {
 			const client = (tx as unknown as TransactionClient) || db;
@@ -487,5 +518,74 @@ export class DrizzleCharacterRepository implements CharacterRepository {
 				error,
 			);
 		}
+	}
+
+	async findOrCreateBulk(
+		charactersData: Array<{ name: string; ipIds?: string[] }>,
+		source?: string,
+		tx?: Transaction,
+	): Promise<Character[]> {
+		if (charactersData.length === 0) {
+			return [];
+		}
+		const client = (tx as unknown as TransactionClient) || db;
+		const names = [...new Set(charactersData.map((c) => c.name))];
+
+		// Insert missing characters (ON CONFLICT DO NOTHING skips existing ones via unique constraint)
+		await client
+			.insert(characters)
+			.values(
+				names.map((name) => ({
+					name,
+					source: source || "manual",
+					description: "",
+				})),
+			)
+			.onConflictDoNothing({ target: [characters.name] });
+
+		// Fetch all characters with their IPs
+		const results = await client.query.characters.findMany({
+			where: inArray(characters.name, names),
+			with: {
+				ips: {
+					with: {
+						ip: true,
+					},
+				},
+			},
+		});
+
+		// Build IP link insertions in bulk
+		const ipLinks: Array<{
+			characterId: string;
+			ipId: string;
+			source: string;
+		}> = [];
+		for (const charData of charactersData) {
+			if (charData.ipIds && charData.ipIds.length > 0) {
+				const char = results.find((c) => c.name === charData.name);
+				if (char) {
+					for (const ipId of charData.ipIds) {
+						ipLinks.push({
+							characterId: char.id,
+							ipId,
+							source: source || "manual",
+						});
+					}
+				}
+			}
+		}
+
+		if (ipLinks.length > 0) {
+			await client
+				.insert(characterIps)
+				.values(ipLinks)
+				.onConflictDoNothing();
+		}
+
+		return results.map((r) => ({
+			...r,
+			ips: r.ips.map((i) => i.ip),
+		}));
 	}
 }

--- a/apps/server/src/infrastructure/repositories/ip-repository.ts
+++ b/apps/server/src/infrastructure/repositories/ip-repository.ts
@@ -10,7 +10,7 @@ import type {
 	UpdateIp,
 } from "@solid-imager/core/domain/ips/schemas";
 import type { IIpRepository } from "@solid-imager/core/domain/repositories/ip-repository";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { db, type TransactionClient } from "~/infrastructure/db";
 import { ips, mediaIps } from "~/infrastructure/db/schema";
 
@@ -44,12 +44,43 @@ export const IpRepository: IIpRepository = {
 		if (names.length === 0) {
 			return [];
 		}
-		const { inArray } = await import("drizzle-orm");
 		const client = (tx as unknown as TransactionClient) || db;
 		const result = await client
 			.select()
 			.from(ips)
 			.where(inArray(ips.name, names));
+		return result.map(mapToDomain);
+	},
+
+	async findOrCreateBulk(
+		names: string[],
+		source?: string,
+		tx?: Transaction,
+	): Promise<Ip[]> {
+		if (names.length === 0) {
+			return [];
+		}
+		const uniqueNames = [...new Set(names)];
+		const client = (tx as unknown as TransactionClient) || db;
+
+		// Insert missing IPs (ON CONFLICT DO NOTHING skips existing ones via unique constraint)
+		await client
+			.insert(ips)
+			.values(
+				uniqueNames.map((name) => ({
+					name,
+					source: source || "manual",
+					description: "",
+				})),
+			)
+			.onConflictDoNothing({ target: [ips.name] });
+
+		// Fetch all IPs (both pre-existing and newly created)
+		const result = await client
+			.select()
+			.from(ips)
+			.where(inArray(ips.name, uniqueNames));
+
 		return result.map(mapToDomain);
 	},
 

--- a/apps/server/src/infrastructure/repositories/project-repository.ts
+++ b/apps/server/src/infrastructure/repositories/project-repository.ts
@@ -6,7 +6,7 @@ import type {
 	UpdateProject,
 } from "@solid-imager/core/domain/projects/schemas";
 import type { IProjectRepository } from "@solid-imager/core/domain/repositories/project-repository";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { db, type TransactionClient } from "~/infrastructure/db";
 import { mediaProjects, projects } from "~/infrastructure/db/schema";
 
@@ -41,6 +41,18 @@ export const ProjectRepository: IProjectRepository = {
 			.from(projects)
 			.where(eq(projects.name, name));
 		return result[0] ? mapToDomain(result[0]) : null;
+	},
+
+	async findByNames(names: string[], tx?: Transaction): Promise<Project[]> {
+		if (names.length === 0) {
+			return [];
+		}
+		const client = (tx as unknown as TransactionClient) || db;
+		const result = await client
+			.select()
+			.from(projects)
+			.where(inArray(projects.name, names));
+		return result.map(mapToDomain);
 	},
 
 	async create(project: NewProject, tx?: Transaction): Promise<Project> {
@@ -163,5 +175,36 @@ export const ProjectRepository: IProjectRepository = {
 				})),
 			)
 			.onConflictDoNothing();
+	},
+
+	async findOrCreateBulk(
+		names: string[],
+		tx?: Transaction,
+	): Promise<Project[]> {
+		if (names.length === 0) {
+			return [];
+		}
+		const uniqueNames = [...new Set(names)];
+		const client = (tx as unknown as TransactionClient) || db;
+
+		// Find existing projects (projects table has no unique constraint on name)
+		const existing = await client
+			.select()
+			.from(projects)
+			.where(inArray(projects.name, uniqueNames));
+
+		const existingNameSet = new Set(existing.map((p) => p.name));
+		const missingNames = uniqueNames.filter((n) => !existingNameSet.has(n));
+
+		// Insert missing projects
+		if (missingNames.length > 0) {
+			const inserted = await client
+				.insert(projects)
+				.values(missingNames.map((name) => ({ name, description: "" })))
+				.returning();
+			existing.push(...inserted);
+		}
+
+		return existing.map(mapToDomain);
 	},
 };

--- a/apps/server/src/tests/unit/application/services/character-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/character-service.test.ts
@@ -26,6 +26,7 @@ const mockCharacterRepo = {
 
 const mockIpRepo = {
 	addMedia: vi.fn(),
+	addMediaBulk: vi.fn(),
 	findByNames: vi.fn(),
 	findByName: vi.fn(),
 	create: vi.fn(),
@@ -73,10 +74,9 @@ describe("CharacterService", () => {
 				undefined,
 				"mock-tx",
 			);
-			expect(mockIpRepo.addMedia).toHaveBeenCalledWith(
+			expect(mockIpRepo.addMediaBulk).toHaveBeenCalledWith(
 				mediaId,
-				ipId,
-				undefined,
+				[{ id: ipId }],
 				"character_link",
 				"mock-tx",
 			);

--- a/apps/server/src/tests/unit/application/services/tagging-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/tagging-service.test.ts
@@ -66,6 +66,9 @@ describe("TaggingService", () => {
 					name === "ExistingIP" ? { id: "ip-1", name: "ExistingIP" } : null,
 				),
 			),
+			findOrCreateBulk: vi.fn(() =>
+				Promise.resolve([{ id: "ip-vocaloid", name: "Vocaloid" }]),
+			),
 			create: vi.fn((data: { name: string }) =>
 				Promise.resolve({ id: "ip-new", name: data.name }),
 			),
@@ -75,6 +78,19 @@ describe("TaggingService", () => {
 
 		mockCharacterRepo = {
 			findByName: vi.fn(() => Promise.resolve(null)),
+			findByNames: vi.fn(() => Promise.resolve([])),
+			findOrCreateBulk: vi.fn((data: Array<{ name: string; ipIds?: string[] }>) =>
+				Promise.resolve(
+					data.map((d) => ({
+						id: `char-${d.name}`,
+						name: d.name,
+						ips: (d.ipIds ?? []).map((ipId: string) => ({
+							id: ipId,
+							name: ipId,
+						})),
+					})),
+				),
+			),
 			create: vi.fn((data: { name: string; ipId?: string }) =>
 				Promise.resolve({ id: "char-new", name: data.name, ipId: data.ipId }),
 			),
@@ -107,37 +123,37 @@ describe("TaggingService", () => {
 			},
 		});
 
-		// Mock IP repo to return an IP for "Vocaloid"
-		(mockIpRepo.findByName as any).mockImplementation((name: string) => {
-			if (name === "Vocaloid") {
-				return Promise.resolve({ id: "ip-vocaloid", name: "Vocaloid" });
-			}
-			return Promise.resolve(null);
-		});
-
 		await taggingService.getTagsForMedia("source-1", "media-1");
 
-		// Verify IP was looked up/created and linked to media
+		// Verify IPs were bulk-created via findOrCreateBulk
+		expect(mockIpRepo.findOrCreateBulk).toHaveBeenCalledWith(
+			["Vocaloid"],
+			"AI",
+		);
+
+		// Verify IP was linked to media
 		expect(mockIpRepo.addMediaBulk).toHaveBeenCalledWith(
 			"media-1",
 			expect.arrayContaining([expect.objectContaining({ id: "ip-vocaloid" })]),
 			"AI",
 		);
 
-		// Verify character creation included the ipIds
-		expect(mockCharacterRepo.create).toHaveBeenCalledWith(
-			expect.objectContaining({
-				name: "HatsuneMiku",
-				ipIds: ["ip-vocaloid"], // Crucial: Character should be linked to IP
-				source: "AI",
-			}),
+		// Verify characters were bulk-created via findOrCreateBulk with IP ids
+		expect(mockCharacterRepo.findOrCreateBulk).toHaveBeenCalledWith(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: "HatsuneMiku",
+					ipIds: ["ip-vocaloid"],
+				}),
+			]),
+			"AI",
 		);
 
 		// Verify character was linked to media
 		expect(mockCharacterRepo.addToMediaBulk).toHaveBeenCalledWith(
 			"media-1",
 			expect.arrayContaining([
-				expect.objectContaining({ id: "char-new", confidence: 0.95 }),
+				expect.objectContaining({ id: "char-HatsuneMiku", confidence: 0.95 }),
 			]),
 			"AI",
 		);

--- a/packages/core/src/domain/repositories/author-repository.ts
+++ b/packages/core/src/domain/repositories/author-repository.ts
@@ -5,6 +5,7 @@ export type IAuthorRepository = {
 	findAll(): Promise<Author[]>;
 	findById(id: string): Promise<Author | null>;
 	findByName(name: string, tx?: Transaction): Promise<Author | null>;
+	findByNames(names: string[], tx?: Transaction): Promise<Author[]>;
 	// findByAccountId is implementation detail or specific query, usually usually findBy(criteria).
 	// But keeping it simple for now if needed.
 	// Actually, standard repo usually has specific finders.
@@ -35,4 +36,10 @@ export type IAuthorRepository = {
 		authorId: string,
 		tx?: Transaction,
 	): Promise<void>;
+
+	/** Bulk find-or-create authors by name (authors table has no unique constraint on name, so SELECT then INSERT). */
+	findOrCreateBulk(
+		names: string[],
+		tx?: Transaction,
+	): Promise<Author[]>;
 };

--- a/packages/core/src/domain/repositories/character-repository.ts
+++ b/packages/core/src/domain/repositories/character-repository.ts
@@ -15,6 +15,7 @@ export type CharacterRepository = {
 	findAll(): Promise<Character[]>;
 	findById(id: string, tx?: Transaction): Promise<Character | null>;
 	findByName(name: string, tx?: Transaction): Promise<Character | null>;
+	findByNames(names: string[], tx?: Transaction): Promise<Character[]>;
 	create(character: NewCharacter, tx?: Transaction): Promise<Character>;
 	update(
 		id: string,
@@ -47,4 +48,15 @@ export type CharacterRepository = {
 		source?: string,
 		tx?: Transaction,
 	): Promise<void>;
+
+	/**
+	 * Bulk find-or-create: ensures all named characters exist,
+	 * links provided IP IDs via characterIps, and returns all characters
+	 * (existing + newly created) with their current IPs.
+	 */
+	findOrCreateBulk(
+		characters: Array<{ name: string; ipIds?: string[] }>,
+		source?: string,
+		tx?: Transaction,
+	): Promise<Character[]>;
 };

--- a/packages/core/src/domain/repositories/ip-repository.ts
+++ b/packages/core/src/domain/repositories/ip-repository.ts
@@ -30,4 +30,11 @@ export type IIpRepository = {
 		source?: string,
 		tx?: Transaction,
 	): Promise<void>;
+
+	/** Bulk find-or-create: ensures all named IPs exist and returns all of them. */
+	findOrCreateBulk(
+		names: string[],
+		source?: string,
+		tx?: Transaction,
+	): Promise<Ip[]>;
 };

--- a/packages/core/src/domain/repositories/project-repository.ts
+++ b/packages/core/src/domain/repositories/project-repository.ts
@@ -9,6 +9,7 @@ export type IProjectRepository = {
 	findAll(): Promise<Project[]>;
 	findById(id: string, tx?: Transaction): Promise<Project | null>;
 	findByName(name: string, tx?: Transaction): Promise<Project | null>;
+	findByNames(names: string[], tx?: Transaction): Promise<Project[]>;
 	create(project: NewProject, tx?: Transaction): Promise<Project>;
 	update(
 		id: string,
@@ -30,4 +31,10 @@ export type IProjectRepository = {
 		projectIds: string[],
 		tx?: Transaction,
 	): Promise<void>;
+
+	/** Bulk find-or-create projects by name. */
+	findOrCreateBulk(
+		names: string[],
+		tx?: Transaction,
+	): Promise<Project[]>;
 };


### PR DESCRIPTION
## 概要

Issue #376 N+1問題の解消（バルクメソッド導入）

## 変更点

### リポジトリ層（インターフェース + 実装）
- **IP Repository**: `findOrCreateBulk(names, source)` 追加 - PostgreSQL ON CONFLICT DO NOTHING + RETURNING で一括UPSERT
- **Character Repository**: `findOrCreateBulk(characters, source)` + `findByNames(names)` 追加 - キャラクター作成とIPリンクを一括処理
- **Author Repository**: `findOrCreateBulk(names)` + `findByNames(names)` 追加 - SELECT → INSERT パターン
- **Project Repository**: `findOrCreateBulk(names)` + `findByNames(names)` 追加 - 同上

### サービス層N+1解消
- **tagging-service.ts**: `saveTags()` の逐次 findByName→create ループを `findOrCreateBulk` に置換。タグ保存時のIP/Character処理がN+1から定数クエリに改善
- **media-processing-service.ts**: `registerIps()`, `registerCharacters()`, `registerAuthors()`, `registerProjects()` すべての逐次ループをバルクメソッドに置換
- **character-service.ts**: `linkCharacterIps()` のIP単位addMediaループを `addMediaBulk` に置換

### テスト更新
- character-service と tagging-service のテストモックに新メソッド追加、アサーション更新

fixes #376