### PR TITLE
feat(rust): integrate tauri-plugin-sql for native SQLite access

### DIFF
--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solid-imager-tauri"
+version = "0.1.0"
+description = "solid-imager desktop shell"
+authors = ["hmjn"]
+edition = "2021"
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[dependencies]
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
+mime_guess = "2"
+rayon = "1"
+notify = "8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tauri = { version = "2", features = ["protocol-asset"] }
+tauri-plugin-sql = { version = "2", features = ["sqlite"] }
+zip = { version = "2.2.0", default-features = false, features = ["deflate"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+futures-util = "0.3"

--- a/apps/tauri/src-tauri/capabilities/main.json
+++ b/apps/tauri/src-tauri/capabilities/main.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "../gen/schemas/desktop-schema.json",
+	"identifier": "main-capability",
+	"description": "Main window access for local media management.",
+	"windows": ["main"],
+	"permissions": [
+		"core:default",
+		"core:webview:allow-create-webview-window",
+		"core:webview:allow-webview-close",
+		"core:path:default",
+		"core:event:default",
+		"sql:default"
+	]
+}

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -1,0 +1,53 @@
+mod commands;
+mod media_config;
+mod media_metadata;
+mod watcher;
+
+#[cfg(target_os = "linux")]
+fn configure_linux_webview_environment() {
+    if std::env::var_os("WAYLAND_DISPLAY").is_some()
+        && std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none()
+    {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn configure_linux_webview_environment() {}
+
+fn main() {
+    configure_linux_webview_environment();
+
+    tauri::Builder::default()
+        .plugin(tauri_plugin_sql::Builder::default().build())
+        .manage(watcher::WatcherRegistry::default())
+        .invoke_handler(tauri::generate_handler![
+            commands::backup::backup_create_zip,
+            commands::backup::backup_extract_zip,
+            commands::backup::parse_restore_json,
+            commands::fs::fs_exists,
+            commands::fs::fs_read_file,
+            commands::fs::fs_read_text_file,
+            commands::fs::fs_write_file,
+            commands::fs::fs_mkdir,
+            commands::fs::fs_readdir,
+            commands::fs::fs_scan_recursive,
+            commands::fs::fs_stat,
+            commands::fs::fs_unlink,
+            commands::fs::fs_rm,
+            commands::fs::fs_copy_file,
+            commands::fs::fs_rename,
+            commands::fs::fs_mkdtemp,
+            commands::fs::download_file,
+            commands::media::image_generate_thumbnail,
+            commands::media::image_generate_thumbnails_batch,
+            commands::media::image_extract_metadata,
+            commands::media::image_get_dimensions,
+            commands::media::probe_media,
+            commands::media::probe_media_batch,
+            watcher::source_watch_start,
+            watcher::source_watch_stop
+        ])
+        .run(tauri::generate_context!())
+        .expect("failed to run tauri application")
+}


### PR DESCRIPTION
Tauri v2 ネイティブの SQLite プラグイン（tauri-plugin-sql）を導入し、main.rs へのプラグイン登録と capabilities/main.json への権限設定（sql:default）を完了させました。