### PR TITLE
feat(db): SQLite接続基盤とスキーマ定義(Phase 1-B)の実装

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,6 +138,22 @@
         "zod": "^4.3.5",
       },
     },
+    "packages/db": {
+      "name": "@solid-imager/db",
+      "version": "0.0.0",
+      "dependencies": {
+        "@solid-imager/core": "workspace:*",
+        "@tauri-apps/plugin-sql": "^2.2.0",
+        "better-sqlite3": "^11.8.0",
+        "drizzle-orm": "^0.44.7",
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.12",
+        "typescript": "^5.9.3",
+        "vite-plus": "latest",
+        "vite-tsconfig-paths": "^5.1.4",
+      },
+    },
     "packages/ui": {
       "name": "@solid-imager/ui",
       "version": "0.0.0",
@@ -639,6 +655,8 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.63.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA=="],
 
+    "@oxlint/plugins": ["@oxlint/plugins@1.61.0", "", {}, "sha512-nkOyZEF1vH527CkdQtOp1HMrVFEM4ResURvI2JFeGoup+h+43J/k/FgdOR9b9Isxg+Yae7qVDa7y3nssE8b3TQ=="],
+
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
@@ -710,6 +728,8 @@
     "@solid-imager/cli": ["@solid-imager/cli@workspace:apps/cli"],
 
     "@solid-imager/core": ["@solid-imager/core@workspace:packages/core"],
+
+    "@solid-imager/db": ["@solid-imager/db@workspace:packages/db"],
 
     "@solid-imager/server": ["@solid-imager/server@workspace:apps/server"],
 
@@ -859,6 +879,10 @@
 
     "@tanstack/zod-form-adapter": ["@tanstack/zod-form-adapter@0.42.1", "", { "dependencies": { "@tanstack/form-core": "0.42.1" }, "peerDependencies": { "zod": "^3.x" } }, "sha512-hPRM0lawVKP64yurW4c6KHZH6altMo2MQN14hfi+GMBTKjO9S7bW1x5LPZ5cayoJE3mBvdlahpSGT5rYZtSbXQ=="],
 
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/plugin-sql": ["@tauri-apps/plugin-sql@2.4.0", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-SIICc5JlnK6OrBZzOw7MmhXHPlmASpt5zLWIu10WW4kLr5cDYOXHdV2MoCgYQkgZLQfyBYgF3SQa5XCisUiQkw=="],
+
     "@toon-format/toon": ["@toon-format/toon@2.1.0", "", {}, "sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg=="],
 
     "@trpc/server": ["@trpc/server@11.13.4", "", { "peerDependencies": { "typescript": ">=5.7.2" } }, "sha512-SZmLwi43KSp1D3jp2aPuzqhC644gIy87hgFuD9xWCTwFspH9Pr5DO2/JmpWjCqybTG2fTuKYzxFYLUGjTY5LGg=="],
@@ -874,6 +898,8 @@
     "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -1001,11 +1027,17 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.30", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg=="],
 
+    "better-sqlite3": ["better-sqlite3@11.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ=="],
+
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "binary-version": ["binary-version@7.1.0", "", { "dependencies": { "execa": "^8.0.1", "find-versions": "^6.0.0" } }, "sha512-Iy//vPc3ANPNlIWd242Npqc8MK0a/i4kVcHDlDA6HNMv5zMxz4ulIFhOSYJVKw/8AbHdHy0CnGYEt1QqSXxPsw=="],
 
     "binary-version-check": ["binary-version-check@6.1.0", "", { "dependencies": { "binary-version": "^7.1.0", "semver": "^7.6.0", "semver-truncate": "^3.0.0" } }, "sha512-REKdLKmuViV2WrtWXvNSiPX04KbIjfUV3Cy8batUeOg+FtmowavzJorfFhWq95cVJzINnL/44ixP26TrdJZACA=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -1046,6 +1078,8 @@
     "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
@@ -1118,6 +1152,10 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "debug-logfmt": ["debug-logfmt@1.4.8", "", { "dependencies": { "@kikobeats/time-span": "~1.0.5", "null-prototype-object": "~1.2.2", "pretty-ms": "~7.0.1" } }, "sha512-tdHndIqcBCy5vEjDBCcyv9FnCkn38QrPRP0Q5B5qi+0S2Lgc6JOPjy2ozsLt00qslzJVbxoO2W05PXNYNB0IMQ=="],
+
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
@@ -1201,6 +1239,8 @@
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
@@ -1229,6 +1269,8 @@
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
     "filelist": ["filelist@1.0.6", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -1249,6 +1291,8 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
@@ -1266,6 +1310,8 @@
     "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob": ["glob@7.1.6", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.0.4", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA=="],
 
@@ -1326,6 +1372,8 @@
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -1477,11 +1525,15 @@
 
     "mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
 
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
@@ -1489,11 +1541,15 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "nf3": ["nf3@0.3.17", "", {}, "sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ=="],
 
     "nitro": ["nitro-nightly@3.0.1-20260518-130639-31265391", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.5", "db0": "^0.3.4", "env-runner": "^0.1.7", "h3": "^2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.4", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.0.0", "srvx": "^0.11.15", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.1.6", "dotenv": "*", "giget": "*", "jiti": "^2.6.1", "rollup": "^4.60.3", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-JhmqcyNdah1zLNeHzAIeNcTqNT1GW5UveEdK39hGB776K4ydPlijTsm821MTDNZjdEmSTs8Pzxzr+xmi7lBgdw=="],
+
+    "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
 
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
@@ -1617,6 +1673,8 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "pretty-ms": ["pretty-ms@7.0.1", "", { "dependencies": { "parse-ms": "^2.1.0" } }, "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q=="],
@@ -1646,6 +1704,8 @@
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
@@ -1714,6 +1774,10 @@
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
@@ -1785,6 +1849,8 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
     "tar-stream": ["tar-stream@3.1.8", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ=="],
 
     "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
@@ -1832,6 +1898,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.22.0", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
@@ -1961,7 +2029,13 @@
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
+    "@solid-imager/core/vite-plus": ["vite-plus@0.1.22", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@oxlint/plugins": "=1.61.0", "@voidzero-dev/vite-plus-core": "0.1.22", "@voidzero-dev/vite-plus-test": "0.1.22", "oxfmt": "=0.48.0", "oxlint": "=1.63.0", "oxlint-tsgolint": "=0.22.1" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.22", "@voidzero-dev/vite-plus-darwin-x64": "0.1.22", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.22", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.22", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.22", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.22", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.22", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.22" }, "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-fCCmEKjI+Hv74PdL/MKcrBkdYPHFNcqD5568KxwN0sa4SGxtcbs55i/577LxKs0w5zIjuLRZZ0zQPu9MO+9itg=="],
+
+    "@solid-imager/core/vitest": ["@voidzero-dev/vite-plus-test@0.1.22", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.22", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-6VKDNXH+ygDyTXpBYn+g+2a9j3zuAZRlP2ZSx0RcjPMdGUMpX6Mox4CmdK8SkZUvi+f6a1siX50ZnCOcQoTgmQ=="],
+
     "@solid-imager/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@solid-imager/db/vite-plus": ["vite-plus@0.1.22", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@oxlint/plugins": "=1.61.0", "@voidzero-dev/vite-plus-core": "0.1.22", "@voidzero-dev/vite-plus-test": "0.1.22", "oxfmt": "=0.48.0", "oxlint": "=1.63.0", "oxlint-tsgolint": "=0.22.1" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.22", "@voidzero-dev/vite-plus-darwin-x64": "0.1.22", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.22", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.22", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.22", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.22", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.22", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.22" }, "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-fCCmEKjI+Hv74PdL/MKcrBkdYPHFNcqD5568KxwN0sa4SGxtcbs55i/577LxKs0w5zIjuLRZZ0zQPu9MO+9itg=="],
 
     "@solid-imager/server/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -2020,6 +2094,10 @@
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
     "binary-version/execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
+
+    "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.8", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ=="],
 
@@ -2083,6 +2161,8 @@
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
     "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "rimraf/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
@@ -2102,6 +2182,8 @@
     "swagger-jsdoc/commander": ["commander@6.2.0", "", {}, "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="],
 
     "swagger-jsdoc/yaml": ["yaml@2.0.0-1", "", {}, "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ=="],
+
+    "tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
@@ -2194,6 +2276,50 @@
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack/@jsonjoy.com/json-pointer": ["@jsonjoy.com/json-pointer@17.67.0", "", { "dependencies": { "@jsonjoy.com/util": "17.67.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA=="],
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util/@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.22", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-OC7tChagbJCoY7YKzD5MuyxJO1km5IF42B3ltZoQ9Twc8UuPrMuWZrVoP984tJKYd/gFJuQFM/lrbNtBm9kyDg=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.22", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+6sRVGCAQSpO96WC0EZtSLJ01VzNiZL/eQUQ8NLVl1oH+0+KgHF2UXyqUXGCGf/JCu34egEwBEjDU3WUwN2mxg=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.22", "", { "os": "darwin", "cpu": "x64" }, "sha512-rqsCW/Brt2froW7VhLE+gVHKtGniyLdHlfcmTLfuM5vnd5skdQlymibRw/lviJU+mSl0x8pGcXZbvA4TLHbCoA=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.22", "", { "os": "linux", "cpu": "arm64" }, "sha512-OL/WT6pvJpFS1L+hWe8g2LCEHCJfEBSgxV0vbSoQDdfTuilUJaVK8rljVWgtIVjUQSjIx8jKfPsl/I8iEBh0GQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.22", "", { "os": "linux", "cpu": "arm64" }, "sha512-SdZLL2aXm9XlbNfygsIifxhTjnRa2gI5oXNCh9QmLmXN36yhXt816I5Tl5IQ5DJwxhnG1+5Uqp2D6tHaT5g6nQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.22", "", { "os": "linux", "cpu": "x64" }, "sha512-Qn6WPTn61A47ZBCPm+v8kCrMgXlI5p10pllKYkce2PFeCotN6v1bqu2GBZIkLVSi534ywGqdkiG1kaesM9e1vw=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.22", "", { "os": "linux", "cpu": "x64" }, "sha512-DsVE09IgvYBR2PY2Bohd08tScYDa8K8KJkIGc8Y6uRXR14NEldoufmWJdCmEsGLA8puRv5HV3ZheWFFjmw5Liw=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.22", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.22", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-6VKDNXH+ygDyTXpBYn+g+2a9j3zuAZRlP2ZSx0RcjPMdGUMpX6Mox4CmdK8SkZUvi+f6a1siX50ZnCOcQoTgmQ=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.22", "", { "os": "win32", "cpu": "arm64" }, "sha512-/1JDhTu7SAIjpqJVAN3D3zmN/O8cCRwdn63Qs0ep5GzNYh3+TtVyw3xdUY7YHeyuSypgKlqnr6IPeMlNijOG/Q=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.22", "", { "os": "win32", "cpu": "x64" }, "sha512-GITqtIWeTaWZ7mo1799sIB6XhhSAL1TmuJvrtBz8e3SAUpjDsIYACDYumUDhowPdIHRO3rasyJg9jJZA82BjKQ=="],
+
+    "@solid-imager/core/vitest/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.22", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-OC7tChagbJCoY7YKzD5MuyxJO1km5IF42B3ltZoQ9Twc8UuPrMuWZrVoP984tJKYd/gFJuQFM/lrbNtBm9kyDg=="],
+
+    "@solid-imager/core/vitest/vite": ["@voidzero-dev/vite-plus-core@0.1.22", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-OC7tChagbJCoY7YKzD5MuyxJO1km5IF42B3ltZoQ9Twc8UuPrMuWZrVoP984tJKYd/gFJuQFM/lrbNtBm9kyDg=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.22", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-OC7tChagbJCoY7YKzD5MuyxJO1km5IF42B3ltZoQ9Twc8UuPrMuWZrVoP984tJKYd/gFJuQFM/lrbNtBm9kyDg=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.22", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+6sRVGCAQSpO96WC0EZtSLJ01VzNiZL/eQUQ8NLVl1oH+0+KgHF2UXyqUXGCGf/JCu34egEwBEjDU3WUwN2mxg=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.22", "", { "os": "darwin", "cpu": "x64" }, "sha512-rqsCW/Brt2froW7VhLE+gVHKtGniyLdHlfcmTLfuM5vnd5skdQlymibRw/lviJU+mSl0x8pGcXZbvA4TLHbCoA=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.22", "", { "os": "linux", "cpu": "arm64" }, "sha512-OL/WT6pvJpFS1L+hWe8g2LCEHCJfEBSgxV0vbSoQDdfTuilUJaVK8rljVWgtIVjUQSjIx8jKfPsl/I8iEBh0GQ=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.22", "", { "os": "linux", "cpu": "arm64" }, "sha512-SdZLL2aXm9XlbNfygsIifxhTjnRa2gI5oXNCh9QmLmXN36yhXt816I5Tl5IQ5DJwxhnG1+5Uqp2D6tHaT5g6nQ=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.22", "", { "os": "linux", "cpu": "x64" }, "sha512-Qn6WPTn61A47ZBCPm+v8kCrMgXlI5p10pllKYkce2PFeCotN6v1bqu2GBZIkLVSi534ywGqdkiG1kaesM9e1vw=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.22", "", { "os": "linux", "cpu": "x64" }, "sha512-DsVE09IgvYBR2PY2Bohd08tScYDa8K8KJkIGc8Y6uRXR14NEldoufmWJdCmEsGLA8puRv5HV3ZheWFFjmw5Liw=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.22", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.22", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-6VKDNXH+ygDyTXpBYn+g+2a9j3zuAZRlP2ZSx0RcjPMdGUMpX6Mox4CmdK8SkZUvi+f6a1siX50ZnCOcQoTgmQ=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.22", "", { "os": "win32", "cpu": "arm64" }, "sha512-/1JDhTu7SAIjpqJVAN3D3zmN/O8cCRwdn63Qs0ep5GzNYh3+TtVyw3xdUY7YHeyuSypgKlqnr6IPeMlNijOG/Q=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.22", "", { "os": "win32", "cpu": "x64" }, "sha512-GITqtIWeTaWZ7mo1799sIB6XhhSAL1TmuJvrtBz8e3SAUpjDsIYACDYumUDhowPdIHRO3rasyJg9jJZA82BjKQ=="],
 
     "@tanstack/cli/chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -2296,6 +2422,8 @@
     "rimraf/glob/path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -2421,6 +2549,18 @@
 
     "xtracter/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-test/vite": ["@voidzero-dev/vite-plus-core@0.1.22", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-OC7tChagbJCoY7YKzD5MuyxJO1km5IF42B3ltZoQ9Twc8UuPrMuWZrVoP984tJKYd/gFJuQFM/lrbNtBm9kyDg=="],
+
+    "@solid-imager/core/vitest/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/core/vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-test/vite": ["@voidzero-dev/vite-plus-core@0.1.22", "", { "dependencies": { "@oxc-project/runtime": "=0.129.0", "@oxc-project/types": "=0.129.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-OC7tChagbJCoY7YKzD5MuyxJO1km5IF42B3ltZoQ9Twc8UuPrMuWZrVoP984tJKYd/gFJuQFM/lrbNtBm9kyDg=="],
+
     "@tanstack/cli/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -2516,6 +2656,10 @@
     "ultracite/vitest/vite/@oxc-project/types": ["@oxc-project/types@0.115.0", "", {}, "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="],
 
     "ultracite/vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/core/vite-plus/@voidzero-dev/vite-plus-test/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@solid-imager/db/vite-plus/@voidzero-dev/vite-plus-test/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "@solid-imager/db",
+	"version": "0.0.0",
+	"type": "module",
+	"main": "src/index.ts",
+	"exports": {
+		".": "./src/index.ts",
+		"./schema": "./src/schema.ts",
+		"./migrations": "./src/migrations.ts",
+		"./types": "./src/types.ts",
+		"./sqlite/schema": "./src/sqlite/schema.ts",
+		"./sqlite/client": "./src/sqlite/client.ts",
+		"./sqlite/client.mock": "./src/sqlite/client.mock.ts",
+		"./sqlite/migrations": "./src/sqlite/migrations.ts",
+		"./repositories/author-repository": "./src/repositories/author-repository.ts",
+		"./repositories/character-repository": "./src/repositories/character-repository.ts",
+		"./repositories/ip-repository": "./src/repositories/ip-repository.ts",
+		"./repositories/preset-repository": "./src/repositories/preset-repository.ts",
+		"./repositories/project-repository": "./src/repositories/project-repository.ts",
+		"./repositories/source-repository": "./src/repositories/source-repository.ts",
+		"./repositories/tag-repository": "./src/repositories/tag-repository.ts",
+		"./repositories/*": "./src/repositories/*.ts",
+		"./backup": "./src/backup.ts"
+	},
+	"scripts": {
+		"lint": "biome lint ./src",
+		"format": "biome format --fix ./src",
+		"check": "biome check --fix --unsafe ./src",
+		"typecheck": "sh -c 'tsc --noEmit'"
+	},
+	"dependencies": {
+		"@solid-imager/core": "workspace:*",
+		"@tauri-apps/plugin-sql": "^2.2.0",
+		"better-sqlite3": "^11.8.0",
+		"drizzle-orm": "^0.44.7"
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^7.6.12",
+		"typescript": "^5.9.3",
+		"vite-plus": "latest",
+		"vite-tsconfig-paths": "^5.1.4"
+	}
+}

--- a/packages/db/src/backup.ts
+++ b/packages/db/src/backup.ts
@@ -1,0 +1,935 @@
+import type { MediaDumpItem } from "@solid-imager/core/domain/media/schemas";
+import { mediaDumpItemSchema } from "@solid-imager/core/domain/media/schemas";
+import type { SourceRepository } from "@solid-imager/core/domain/repositories/source-repository";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import {
+	authors,
+	characterIps,
+	characters,
+	ips,
+	mediaAuthors,
+	mediaCharacters,
+	mediaGenerationInfo,
+	mediaIps,
+	mediaProjects,
+	medias,
+	mediaTags,
+	mediaUrls,
+	projects,
+	tags,
+} from "./schema";
+import type { DrizzleExecutor } from "./types";
+
+export type BackupExecutorProvider = (tx?: unknown) => DrizzleExecutor;
+
+export type BackupSource = {
+	id?: string;
+	type: string;
+	connectionInfo: unknown;
+};
+
+export type BackupServiceDeps = {
+	getExecutor: BackupExecutorProvider;
+	sourceRepository: SourceRepository;
+	resolvePath: (basePath: string, filePath: string) => string;
+	pathExists: (fullPath: string) => Promise<boolean>;
+	runTransaction?: <T>(
+		callback: (executor: DrizzleExecutor) => Promise<T>,
+	) => Promise<T>;
+	onRestoreComplete?: (params: {
+		source: BackupSource;
+		mediaIds: string[];
+		rootPath: string;
+	}) => Promise<void> | void;
+};
+
+type MediaDumpQueryRow = Awaited<ReturnType<typeof loadMediaDumpItems>>[number];
+
+type RestoreMasterDataResult = {
+	tagMap: Map<string, string>;
+	authorMap: Map<string, string>;
+	projectMap: Map<string, string>;
+	ipMap: Map<string, string>;
+	charMap: Map<string, string>;
+};
+
+type ValidItemsResult = {
+	validItems: MediaDumpItem[];
+	skippedCount: number;
+	errorMessages: string[];
+};
+
+type SimpleMasterDataTable =
+	| typeof tags
+	| typeof projects
+	| typeof ips
+	| typeof characters;
+
+type SimpleMasterDataNameColumn =
+	| typeof tags.name
+	| typeof projects.name
+	| typeof ips.name
+	| typeof characters.name;
+
+const MASTER_DATA_CHUNK_SIZE = 1000;
+const AUTHOR_UPDATE_CHUNK_SIZE = 500;
+const MEDIA_QUERY_CHUNK_SIZE = 1000;
+const RESTORE_BATCH_SIZE = 500;
+const PATH_EXISTS_CONCURRENCY = 50;
+
+function isMediaSourcePath(pathValue: string): boolean {
+	return /^(?:[A-Za-z]:[\\/]|\/)/.test(pathValue);
+}
+
+export function validateRelativePath(filePath: string): void {
+	if (!filePath) {
+		return;
+	}
+
+	const normalized = filePath.replace(/\\/g, "/");
+	if (
+		isMediaSourcePath(filePath) ||
+		normalized.startsWith("/") ||
+		normalized.split("/").some((segment) => segment === "..")
+	) {
+		throw new Error(`Invalid path in backup: ${filePath}`);
+	}
+}
+
+async function loadMediaDumpItems(
+	getExecutor: BackupExecutorProvider,
+	mediaSourceId: string,
+	offset = 0,
+	limit = MEDIA_QUERY_CHUNK_SIZE,
+) {
+	return await getExecutor().query.medias.findMany({
+		where: eq(medias.mediaSourceId, mediaSourceId),
+		orderBy: (table, { asc }) => [asc(table.id)],
+		limit,
+		offset,
+		with: {
+			generationInfo: true,
+			urls: true,
+			tags: { with: { tag: true } },
+			authors: { with: { author: true } },
+			characters: {
+				with: { character: { with: { ips: { with: { ip: true } } } } },
+			},
+			ips: { with: { ip: true } },
+			projects: { with: { project: true } },
+		},
+	});
+}
+
+async function* iterateMediaDumpItems(
+	getExecutor: BackupExecutorProvider,
+	mediaSourceId: string,
+): AsyncGenerator<MediaDumpItem, void, void> {
+	let offset = 0;
+
+	while (true) {
+		const batch = await loadMediaDumpItems(getExecutor, mediaSourceId, offset);
+		if (batch.length === 0) {
+			break;
+		}
+
+		for (const item of transformMediaList(batch)) {
+			yield item;
+		}
+
+		if (batch.length < MEDIA_QUERY_CHUNK_SIZE) {
+			break;
+		}
+
+		offset += MEDIA_QUERY_CHUNK_SIZE;
+	}
+}
+
+function transformMediaList(mediaList: MediaDumpQueryRow[]): MediaDumpItem[] {
+	return mediaList.map((media) => ({
+		id: media.id,
+		filePath: media.filePath,
+		fileName: media.fileName,
+		description: media.description,
+		width: media.width,
+		height: media.height,
+		fileSize: media.fileSize ?? undefined,
+		mediaType: media.mediaType,
+		createdAt: media.createdAt,
+		modifiedAt: media.modifiedAt,
+		sourceUrls: media.urls.map((item) => item.url),
+		generationInfo: media.generationInfo
+			? {
+					prompt: media.generationInfo.prompt,
+					negativePrompt: media.generationInfo.negativePrompt,
+					modelName: media.generationInfo.modelName ?? undefined,
+					seed: media.generationInfo.seed ?? undefined,
+					steps: media.generationInfo.steps ?? undefined,
+					cfgScale: media.generationInfo.cfgScale ?? undefined,
+					aiGenerated: media.generationInfo.aiGenerated ?? undefined,
+					workflow: media.generationInfo.workflow,
+					metadata: media.generationInfo.metadata,
+				}
+			: null,
+		tags: media.tags.map((item) => ({
+			name: item.tag.name,
+			type: item.tagType,
+			confidence: item.confidence,
+			source: item.source,
+		})),
+		authors: media.authors.map((item) => ({
+			name: item.author.name,
+			accountId: item.author.accountId,
+		})),
+		characters: media.characters.map((item) => ({
+			name: item.character.name,
+			description: item.character.description,
+			confidence: item.confidence,
+			linkedIps: item.character.ips.map((link) => link.ip.name),
+			source: item.source,
+		})),
+		ips: media.ips.map((item) => ({
+			name: item.ip.name,
+			description: item.ip.description,
+			confidence: item.confidence,
+			source: item.source,
+		})),
+		projects: media.projects.map((item) => ({
+			name: item.project.name,
+			description: item.project.description,
+		})),
+	}));
+}
+
+async function ensureMasterData(
+	executor: DrizzleExecutor,
+	table: SimpleMasterDataTable,
+	nameColumn: SimpleMasterDataNameColumn,
+	names: Set<string>,
+	defaults: Record<string, string | null>,
+): Promise<Map<string, string>> {
+	const nameList = Array.from(names);
+	if (nameList.length === 0) {
+		return new Map();
+	}
+
+	const result = new Map<string, string>();
+	for (
+		let index = 0;
+		index < nameList.length;
+		index += MASTER_DATA_CHUNK_SIZE
+	) {
+		const chunk = nameList.slice(index, index + MASTER_DATA_CHUNK_SIZE);
+		await executor
+			.insert(table)
+			.values(chunk.map((name) => ({ name, ...defaults })))
+			.onConflictDoNothing();
+
+		const rows = await executor
+			.select({
+				id: table.id,
+				name: nameColumn,
+			})
+			.from(table)
+			.where(inArray(nameColumn, chunk));
+
+		for (const row of rows) {
+			result.set(row.name, row.id);
+		}
+	}
+
+	return result;
+}
+
+async function ensureAuthors(
+	executor: DrizzleExecutor,
+	authorData: Map<string, { accountId?: string | null }>,
+): Promise<Map<string, string>> {
+	if (authorData.size === 0) {
+		return new Map();
+	}
+
+	const entries = Array.from(authorData.entries());
+	const nameList = entries.map(([name]) => name);
+	const existingByName = new Map<
+		string,
+		{ id: string; accountId: string | null }
+	>();
+	for (
+		let index = 0;
+		index < nameList.length;
+		index += MASTER_DATA_CHUNK_SIZE
+	) {
+		const chunk = nameList.slice(index, index + MASTER_DATA_CHUNK_SIZE);
+		const existingRecords = await executor
+			.select({
+				id: authors.id,
+				name: authors.name,
+				accountId: authors.accountId,
+			})
+			.from(authors)
+			.where(inArray(authors.name, chunk));
+
+		for (const row of existingRecords) {
+			const current = existingByName.get(row.name);
+			if (!current || (!current.accountId && row.accountId)) {
+				existingByName.set(row.name, {
+					id: row.id,
+					accountId: row.accountId,
+				});
+			}
+		}
+	}
+
+	const updates = entries.filter(([name, data]) => {
+		const current = existingByName.get(name);
+		return Boolean(
+			current && data.accountId && current.accountId !== data.accountId,
+		);
+	});
+
+	if (updates.length > 0) {
+		for (
+			let index = 0;
+			index < updates.length;
+			index += AUTHOR_UPDATE_CHUNK_SIZE
+		) {
+			const chunk = updates.slice(index, index + AUTHOR_UPDATE_CHUNK_SIZE);
+			const accountIdCase = sql.join(
+				chunk.map(
+					([name, data]) => sql`when ${name} then ${data.accountId ?? null}`,
+				),
+				sql.raw(" "),
+			);
+			await executor
+				.update(authors)
+				.set({
+					accountId: sql`case ${authors.name} ${accountIdCase} else ${authors.accountId} end`,
+					updatedAt: new Date(),
+				})
+				.where(
+					inArray(
+						authors.name,
+						chunk.map(([name]) => name),
+					),
+				);
+		}
+	}
+
+	const missing = entries.filter(([name]) => !existingByName.has(name));
+	if (missing.length > 0) {
+		for (
+			let index = 0;
+			index < missing.length;
+			index += MASTER_DATA_CHUNK_SIZE
+		) {
+			const chunk = missing.slice(index, index + MASTER_DATA_CHUNK_SIZE);
+			const created = await executor
+				.insert(authors)
+				.values(
+					chunk.map(([name, data]) => ({
+						name,
+						accountId: data.accountId ?? null,
+					})),
+				)
+				.returning();
+
+			for (const row of created) {
+				existingByName.set(row.name, { id: row.id, accountId: null });
+			}
+		}
+	}
+
+	return new Map(
+		Array.from(existingByName.entries()).map(([name, row]) => [name, row.id]),
+	);
+}
+
+async function restoreMasterData(
+	executor: DrizzleExecutor,
+	items: MediaDumpItem[],
+): Promise<RestoreMasterDataResult> {
+	const tagNames = new Set<string>();
+	const authorData = new Map<string, { accountId?: string | null }>();
+	const projectNames = new Set<string>();
+	const charNames = new Set<string>();
+	const ipNames = new Set<string>();
+
+	for (const item of items) {
+		for (const tag of item.tags ?? []) {
+			if (tag.name) {
+				tagNames.add(tag.name);
+			}
+		}
+
+		for (const author of item.authors ?? []) {
+			if (author.name && (!authorData.has(author.name) || author.accountId)) {
+				authorData.set(author.name, { accountId: author.accountId });
+			}
+		}
+
+		for (const project of item.projects ?? []) {
+			if (project.name) {
+				projectNames.add(project.name);
+			}
+		}
+
+		for (const character of item.characters ?? []) {
+			if (character.name) {
+				charNames.add(character.name);
+			}
+			for (const linkedIp of character.linkedIps ?? []) {
+				if (linkedIp) {
+					ipNames.add(linkedIp);
+				}
+			}
+		}
+
+		for (const ip of item.ips ?? []) {
+			if (ip.name) {
+				ipNames.add(ip.name);
+			}
+		}
+	}
+
+	const [tagMap, authorMap, projectMap, ipMap, charMap] = await Promise.all([
+		ensureMasterData(executor, tags, tags.name, tagNames, {
+			source: "restored",
+		}),
+		ensureAuthors(executor, authorData),
+		ensureMasterData(executor, projects, projects.name, projectNames, {
+			description: "",
+		}),
+		ensureMasterData(executor, ips, ips.name, ipNames, {
+			description: "",
+			source: "restored",
+		}),
+		ensureMasterData(executor, characters, characters.name, charNames, {
+			description: "",
+			source: "restored",
+		}),
+	]);
+
+	return { tagMap, authorMap, projectMap, ipMap, charMap };
+}
+
+async function restoreMediaRecords(
+	executor: DrizzleExecutor,
+	mediaSourceId: string,
+	items: MediaDumpItem[],
+) {
+	const mediaValues = items.map((item) => ({
+		mediaSourceId,
+		filePath: item.filePath ?? "",
+		fileName: item.fileName ?? "",
+		description: item.description ?? null,
+		width: item.width ?? 0,
+		height: item.height ?? 0,
+		fileSize: item.fileSize ?? 0,
+		mediaType:
+			item.mediaType === "image" || item.mediaType === "video"
+				? item.mediaType
+				: "image",
+		createdAt: item.createdAt ? new Date(item.createdAt) : new Date(),
+		modifiedAt: item.modifiedAt ? new Date(item.modifiedAt) : new Date(),
+		indexedAt: new Date(),
+		status: "active" as const,
+	}));
+
+	const chunkSize = 1000;
+	for (let index = 0; index < mediaValues.length; index += chunkSize) {
+		await executor
+			.insert(medias)
+			.values(mediaValues.slice(index, index + chunkSize))
+			.onConflictDoUpdate({
+				target: [medias.mediaSourceId, medias.filePath],
+				set: {
+					description: sql`excluded.description`,
+					modifiedAt: sql`excluded.modified_at`,
+					createdAt: sql`excluded.created_at`,
+					width: sql`excluded.width`,
+					height: sql`excluded.height`,
+					fileSize: sql`excluded.file_size`,
+					fileName: sql`excluded.file_name`,
+					mediaType: sql`excluded.media_type`,
+				},
+			});
+	}
+}
+
+async function mapMediaPathsToIds(
+	getExecutor: BackupExecutorProvider,
+	mediaSourceId: string,
+	items: MediaDumpItem[],
+): Promise<Map<string, string>> {
+	const filePaths = items.flatMap((item) =>
+		item.filePath ? [item.filePath] : [],
+	);
+	if (filePaths.length === 0) {
+		return new Map();
+	}
+
+	const rows: Array<{ id: string; filePath: string }> = [];
+	const chunkSize = 10_000;
+	for (let index = 0; index < filePaths.length; index += chunkSize) {
+		rows.push(
+			...(await getExecutor().query.medias.findMany({
+				where: and(
+					eq(medias.mediaSourceId, mediaSourceId),
+					inArray(medias.filePath, filePaths.slice(index, index + chunkSize)),
+				),
+				columns: {
+					id: true,
+					filePath: true,
+				},
+			})),
+		);
+	}
+
+	return new Map(rows.map((row) => [row.filePath, row.id]));
+}
+
+async function restoreRelations(
+	executor: DrizzleExecutor,
+	params: {
+		items: MediaDumpItem[];
+		mediaPathToId: Map<string, string>;
+		tagMap: Map<string, string>;
+		authorMap: Map<string, string>;
+		projectMap: Map<string, string>;
+		ipMap: Map<string, string>;
+		charMap: Map<string, string>;
+	},
+) {
+	const mediaTagsData: Array<typeof mediaTags.$inferInsert> = [];
+	const mediaAuthorsData: Array<typeof mediaAuthors.$inferInsert> = [];
+	const mediaProjectsData: Array<typeof mediaProjects.$inferInsert> = [];
+	const mediaCharactersData: Array<typeof mediaCharacters.$inferInsert> = [];
+	const characterIpsData: Array<typeof characterIps.$inferInsert> = [];
+	const mediaIpsData: Array<typeof mediaIps.$inferInsert> = [];
+	const mediaUrlsData: Array<typeof mediaUrls.$inferInsert> = [];
+	const mediaGenerationInfoData: Array<
+		typeof mediaGenerationInfo.$inferInsert
+	> = [];
+	const seenMediaIps = new Set<string>();
+
+	for (const item of params.items) {
+		if (!item.filePath) {
+			continue;
+		}
+		const mediaId = params.mediaPathToId.get(item.filePath);
+		if (!mediaId) {
+			continue;
+		}
+
+		for (const tag of item.tags ?? []) {
+			const tagId = tag.name ? params.tagMap.get(tag.name) : undefined;
+			if (tagId) {
+				mediaTagsData.push({
+					mediaId,
+					tagId,
+					tagType:
+						tag.type === "positive" || tag.type === "negative"
+							? tag.type
+							: "positive",
+					confidence: tag.confidence ?? null,
+					source: tag.source ?? "restored",
+				});
+			}
+		}
+
+		for (const author of item.authors ?? []) {
+			const authorId = author.name
+				? params.authorMap.get(author.name)
+				: undefined;
+			if (authorId) {
+				mediaAuthorsData.push({ mediaId, authorId });
+			}
+		}
+
+		for (const project of item.projects ?? []) {
+			const projectId = project.name
+				? params.projectMap.get(project.name)
+				: undefined;
+			if (projectId) {
+				mediaProjectsData.push({ mediaId, projectId });
+			}
+		}
+
+		const mediaIpNames =
+			item.ips?.flatMap((ip) => (ip.name ? [ip.name] : [])) ?? [];
+
+		for (const character of item.characters ?? []) {
+			const characterId = character.name
+				? params.charMap.get(character.name)
+				: undefined;
+			if (!characterId) {
+				continue;
+			}
+
+			mediaCharactersData.push({
+				mediaId,
+				characterId,
+				confidence: character.confidence ?? null,
+				source: character.source ?? "restored",
+			});
+
+			const ipNamesToLink =
+				character.linkedIps &&
+				Array.isArray(character.linkedIps) &&
+				character.linkedIps.length > 0
+					? character.linkedIps
+					: mediaIpNames;
+
+			for (const ipName of ipNamesToLink) {
+				const ipId = params.ipMap.get(ipName);
+				if (!ipId) {
+					continue;
+				}
+
+				characterIpsData.push({
+					characterId,
+					ipId,
+					source: "restored",
+				});
+			}
+		}
+
+		for (const ip of item.ips ?? []) {
+			const ipId = ip.name ? params.ipMap.get(ip.name) : undefined;
+			if (!ipId) {
+				continue;
+			}
+
+			const mediaIpKey = `${mediaId}:${ipId}`;
+			if (!seenMediaIps.has(mediaIpKey)) {
+				mediaIpsData.push({
+					mediaId,
+					ipId,
+					confidence: ip.confidence ?? null,
+					source: ip.source ?? "restored",
+				});
+				seenMediaIps.add(mediaIpKey);
+			}
+		}
+
+		for (const url of item.sourceUrls ?? []) {
+			mediaUrlsData.push({ mediaId, url });
+		}
+
+		if (item.generationInfo) {
+			mediaGenerationInfoData.push({
+				mediaId,
+				...item.generationInfo,
+			});
+		}
+	}
+
+	const chunkSize = 1000;
+	for (let index = 0; index < mediaTagsData.length; index += chunkSize) {
+		await executor
+			.insert(mediaTags)
+			.values(mediaTagsData.slice(index, index + chunkSize))
+			.onConflictDoNothing();
+	}
+	for (let index = 0; index < mediaAuthorsData.length; index += chunkSize) {
+		await executor
+			.insert(mediaAuthors)
+			.values(mediaAuthorsData.slice(index, index + chunkSize))
+			.onConflictDoNothing();
+	}
+	for (let index = 0; index < mediaProjectsData.length; index += chunkSize) {
+		await executor
+			.insert(mediaProjects)
+			.values(mediaProjectsData.slice(index, index + chunkSize))
+			.onConflictDoNothing();
+	}
+	for (let index = 0; index < mediaCharactersData.length; index += chunkSize) {
+		await executor
+			.insert(mediaCharacters)
+			.values(mediaCharactersData.slice(index, index + chunkSize))
+			.onConflictDoNothing();
+	}
+	for (let index = 0; index < characterIpsData.length; index += chunkSize) {
+		await executor
+			.insert(characterIps)
+			.values(characterIpsData.slice(index, index + chunkSize))
+			.onConflictDoNothing();
+	}
+	for (let index = 0; index < mediaIpsData.length; index += chunkSize) {
+		await executor
+			.insert(mediaIps)
+			.values(mediaIpsData.slice(index, index + chunkSize))
+			.onConflictDoNothing();
+	}
+	for (let index = 0; index < mediaUrlsData.length; index += chunkSize) {
+		await executor
+			.insert(mediaUrls)
+			.values(mediaUrlsData.slice(index, index + chunkSize))
+			.onConflictDoNothing();
+	}
+	for (
+		let index = 0;
+		index < mediaGenerationInfoData.length;
+		index += chunkSize
+	) {
+		await executor
+			.insert(mediaGenerationInfo)
+			.values(mediaGenerationInfoData.slice(index, index + chunkSize))
+			.onConflictDoNothing();
+	}
+}
+
+async function pathExistsParallel(
+	checks: Array<{ item: MediaDumpItem; fullPath: string }>,
+	pathExists: (fullPath: string) => Promise<boolean>,
+): Promise<{ existing: MediaDumpItem[]; skipped: number }> {
+	const existing: MediaDumpItem[] = [];
+	let skipped = 0;
+
+	for (let index = 0; index < checks.length; index += PATH_EXISTS_CONCURRENCY) {
+		const chunk = checks.slice(index, index + PATH_EXISTS_CONCURRENCY);
+		const results = await Promise.allSettled(
+			chunk.map(async ({ item, fullPath }) => {
+				const exists = await pathExists(fullPath);
+				return { item, exists };
+			}),
+		);
+
+		for (const result of results) {
+			if (result.status === "fulfilled" && result.value.exists) {
+				existing.push(result.value.item);
+			} else {
+				skipped += 1;
+			}
+		}
+	}
+
+	return { existing, skipped };
+}
+
+export async function filterValidItems(
+	items: unknown[],
+	mediaSource: BackupSource,
+	pathExists: (fullPath: string) => Promise<boolean>,
+	resolvePath: (basePath: string, filePath: string) => string,
+): Promise<ValidItemsResult> {
+	const connectionInfo = mediaSource.connectionInfo as { path?: string };
+	const basePath = connectionInfo.path ?? "";
+	const isLocal = mediaSource.type === "local";
+
+	const preValidated: MediaDumpItem[] = [];
+	const pathChecks: Array<{ item: MediaDumpItem; fullPath: string }> = [];
+	const errorMessages: string[] = [];
+	let skippedCount = 0;
+
+	for (const item of items) {
+		const parsed = mediaDumpItemSchema.safeParse(item);
+		if (!parsed.success) {
+			skippedCount += 1;
+			errorMessages.push(`Validation failed: ${parsed.error.message}`);
+			continue;
+		}
+
+		const validItem = parsed.data;
+		if (!(validItem.filePath && validItem.fileName)) {
+			skippedCount += 1;
+			continue;
+		}
+
+		try {
+			validateRelativePath(validItem.filePath);
+		} catch (error) {
+			skippedCount += 1;
+			errorMessages.push((error as Error).message);
+			continue;
+		}
+
+		if (isLocal) {
+			const fullPath = resolvePath(basePath, validItem.filePath);
+			pathChecks.push({ item: validItem, fullPath });
+		} else {
+			preValidated.push(validItem);
+		}
+	}
+
+	if (pathChecks.length > 0) {
+		const { existing, skipped } = await pathExistsParallel(
+			pathChecks,
+			pathExists,
+		);
+		preValidated.push(...existing);
+		skippedCount += skipped;
+	}
+
+	return { validItems: preValidated, skippedCount, errorMessages };
+}
+
+export function createBackupService(deps: BackupServiceDeps) {
+	async function findMediaSourceForFile(
+		filePath: string,
+	): Promise<string | null> {
+		try {
+			validateRelativePath(filePath);
+		} catch {
+			return null;
+		}
+
+		const sources = await deps.sourceRepository.findAll();
+		for (const source of sources) {
+			if (source.type !== "local") {
+				continue;
+			}
+
+			const connectionInfo = source.connectionInfo as { path?: string };
+			if (!connectionInfo.path) {
+				continue;
+			}
+
+			const fullPath = deps.resolvePath(connectionInfo.path, filePath);
+			try {
+				if (await deps.pathExists(fullPath)) {
+					return source.id ?? null;
+				}
+			} catch {
+				// Continue scanning other sources.
+			}
+		}
+
+		return null;
+	}
+
+	async function createDumpItems(
+		mediaSourceId: string,
+	): Promise<MediaDumpItem[]> {
+		const source = await deps.sourceRepository.findById(mediaSourceId);
+		if (!source) {
+			throw new Error("Media source not found");
+		}
+
+		const mediaList: MediaDumpItem[] = [];
+		for await (const media of iterateMediaDumpItems(
+			deps.getExecutor,
+			mediaSourceId,
+		)) {
+			mediaList.push(media);
+		}
+		return mediaList;
+	}
+
+	async function restoreSource(
+		mediaSourceId: string,
+		items: unknown[],
+		opts?: {
+			signal?: AbortSignal;
+			onProgress?: (done: number, total: number) => void;
+		},
+	): Promise<{
+		processed: number;
+		skipped: number;
+		errors: string[];
+		cancelled?: boolean;
+	}> {
+		const source = await deps.sourceRepository.findById(mediaSourceId);
+		if (!source) {
+			throw new Error("Media source not found");
+		}
+
+		const totalItems = items.length;
+		let totalProcessed = 0;
+		let totalSkipped = 0;
+		const allErrors: string[] = [];
+
+		const runTransaction =
+			deps.runTransaction ??
+			(async <T>(callback: (executor: DrizzleExecutor) => Promise<T>) =>
+				await callback(deps.getExecutor()));
+
+		const rootPath = (source.connectionInfo as { path?: string }).path ?? "";
+
+		for (let offset = 0; offset < items.length; offset += RESTORE_BATCH_SIZE) {
+			if (opts?.signal?.aborted) {
+				return {
+					processed: totalProcessed,
+					skipped: totalSkipped,
+					errors: allErrors,
+					cancelled: true,
+				};
+			}
+
+			const batch = items.slice(offset, offset + RESTORE_BATCH_SIZE);
+			const { validItems, skippedCount, errorMessages } =
+				await filterValidItems(
+					batch,
+					source,
+					deps.pathExists,
+					deps.resolvePath,
+				);
+			totalSkipped += skippedCount;
+			allErrors.push(...errorMessages);
+
+			if (validItems.length > 0) {
+				const { mediaPathToId } = await runTransaction(async (executor) => {
+					const { tagMap, authorMap, projectMap, ipMap, charMap } =
+						await restoreMasterData(executor, validItems);
+
+					await restoreMediaRecords(executor, mediaSourceId, validItems);
+					const nextMediaPathToId = await mapMediaPathsToIds(
+						() => executor,
+						mediaSourceId,
+						validItems,
+					);
+
+					await restoreRelations(executor, {
+						items: validItems,
+						mediaPathToId: nextMediaPathToId,
+						tagMap,
+						authorMap,
+						projectMap,
+						ipMap,
+						charMap,
+					});
+
+					return {
+						mediaPathToId: nextMediaPathToId,
+					};
+				});
+
+				totalProcessed += validItems.length;
+
+				const mediaIds = Array.from(mediaPathToId.values());
+				if (deps.onRestoreComplete && mediaIds.length > 0) {
+					await deps.onRestoreComplete({
+						source,
+						mediaIds,
+						rootPath,
+					});
+				}
+			}
+
+			opts?.onProgress?.(totalProcessed + totalSkipped, totalItems);
+		}
+
+		return {
+			processed: totalProcessed,
+			skipped: totalSkipped,
+			errors: allErrors,
+		};
+	}
+
+	return {
+		findMediaSourceForFile,
+		createDumpItems,
+		iterateDumpItems: (mediaSourceId: string) =>
+			iterateMediaDumpItems(deps.getExecutor, mediaSourceId),
+		restoreSource,
+		filterValidItems: (items: unknown[], mediaSource: BackupSource) =>
+			filterValidItems(items, mediaSource, deps.pathExists, deps.resolvePath),
+		transformMediaList,
+		restoreMasterData,
+		restoreMediaRecords,
+		mapMediaPathsToIds,
+		restoreRelations,
+		validateRelativePath,
+	};
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./backup";
+export * from "./migrations";
+export * from "./schema";

--- a/packages/db/src/migrations.ts
+++ b/packages/db/src/migrations.ts
@@ -1,0 +1,55 @@
+import { sql } from "drizzle-orm";
+import type { MigrationMeta } from "drizzle-orm/migrator";
+import type { drizzle } from "drizzle-orm/pglite";
+import type * as schema from "./schema";
+
+export type SharedPgliteDb = ReturnType<typeof drizzle<typeof schema>>;
+
+export async function applyPgMigrations(
+	db: SharedPgliteDb,
+	migrations: MigrationMeta[],
+) {
+	await db.execute(sql`CREATE SCHEMA IF NOT EXISTS "drizzle"`);
+	await db.execute(sql`
+		CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
+			id SERIAL PRIMARY KEY,
+			hash text NOT NULL,
+			created_at bigint
+		)
+	`);
+
+	const result = await db.execute<{
+		id: number;
+		hash: string;
+		created_at: string | number | null;
+	}>(
+		sql`select id, hash, created_at from "drizzle"."__drizzle_migrations" order by created_at desc limit 1`,
+	);
+	const lastMigration = result.rows[0];
+	const sortedMigrations = [...migrations].sort(
+		(a, b) => a.folderMillis - b.folderMillis,
+	);
+
+	await db.transaction(async (tx) => {
+		for (const migration of sortedMigrations) {
+			if (
+				lastMigration &&
+				Number(lastMigration.created_at) >= migration.folderMillis
+			) {
+				continue;
+			}
+
+			for (const statement of migration.sql) {
+				if (statement.trim().length === 0) {
+					continue;
+				}
+				await tx.execute(sql.raw(statement));
+			}
+
+			await tx.execute(sql`
+				insert into "drizzle"."__drizzle_migrations" ("hash", "created_at")
+				values (${migration.hash}, ${migration.folderMillis})
+			`);
+		}
+	});
+}

--- a/packages/db/src/repositories/author-repository.ts
+++ b/packages/db/src/repositories/author-repository.ts
@@ -1,0 +1,203 @@
+import {
+	ResourceConflictError,
+	ResourceNotFoundError,
+} from "@solid-imager/core/domain/errors";
+import type {
+	Author,
+	NewAuthor,
+} from "@solid-imager/core/domain/media/schemas";
+import { authorSchema } from "@solid-imager/core/domain/media/schemas";
+import type { IAuthorRepository } from "@solid-imager/core/domain/repositories/author-repository";
+import { and, asc, eq } from "drizzle-orm";
+import { authors, mediaAuthors } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+type DbAuthor = typeof authors.$inferSelect;
+
+export type AuthorRepositoryExecutorProvider = (
+	tx?: unknown,
+) => DrizzleExecutor;
+
+type CreateAuthorRepositoryOptions = {
+	orderByName?: boolean;
+};
+
+function isUniqueViolation(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === "23505"
+	);
+}
+
+function mapToAuthor(row: DbAuthor): Author {
+	return authorSchema.parse({
+		id: row.id,
+		name: row.name,
+		accountId: row.accountId,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+	});
+}
+
+export function createAuthorRepository(
+	getExecutor: AuthorRepositoryExecutorProvider,
+	options: CreateAuthorRepositoryOptions = {},
+): IAuthorRepository {
+	return {
+		async findAll(): Promise<Author[]> {
+			const query = getExecutor().select().from(authors);
+			const rows = await (options.orderByName
+				? query.orderBy(asc(authors.name))
+				: query);
+			return rows.map((row) => mapToAuthor(row));
+		},
+
+		async findById(id: string): Promise<Author | null> {
+			const rows = await getExecutor()
+				.select()
+				.from(authors)
+				.where(eq(authors.id, id))
+				.limit(1);
+			return rows[0] ? mapToAuthor(rows[0]) : null;
+		},
+
+		async findByName(name: string, tx?: unknown): Promise<Author | null> {
+			const rows = await getExecutor(tx)
+				.select()
+				.from(authors)
+				.where(eq(authors.name, name))
+				.limit(1);
+			return rows[0] ? mapToAuthor(rows[0]) : null;
+		},
+
+		async findByAccountId(accountId: string): Promise<Author | null> {
+			const rows = await getExecutor()
+				.select()
+				.from(authors)
+				.where(eq(authors.accountId, accountId))
+				.limit(1);
+			return rows[0] ? mapToAuthor(rows[0]) : null;
+		},
+
+		async create(input: NewAuthor, tx?: unknown): Promise<Author> {
+			const client = getExecutor(tx);
+			const condition = input.accountId
+				? eq(authors.accountId, input.accountId)
+				: eq(authors.name, input.name);
+
+			const existing = await client
+				.select()
+				.from(authors)
+				.where(condition)
+				.limit(1);
+
+			if (existing[0]) {
+				return mapToAuthor(existing[0]);
+			}
+
+			const rows = await client
+				.insert(authors)
+				.values({
+					name: input.name,
+					accountId: input.accountId ?? null,
+				})
+				.returning();
+			return mapToAuthor(rows[0]);
+		},
+
+		async update(
+			id: string,
+			input: Partial<NewAuthor>,
+			tx?: unknown,
+		): Promise<Author> {
+			try {
+				const rows = await getExecutor(tx)
+					.update(authors)
+					.set({
+						...(input.name !== undefined ? { name: input.name } : {}),
+						...(input.accountId !== undefined
+							? { accountId: input.accountId }
+							: {}),
+						updatedAt: new Date(),
+					})
+					.where(eq(authors.id, id))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("Author", id);
+				}
+
+				return mapToAuthor(rows[0]);
+			} catch (error) {
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						`Author with name "${input.name}" already exists`,
+					);
+				}
+				throw error;
+			}
+		},
+
+		async delete(id: string, tx?: unknown): Promise<void> {
+			await getExecutor(tx).delete(authors).where(eq(authors.id, id));
+		},
+
+		async findByMediaId(mediaId: string, tx?: unknown): Promise<Author[]> {
+			const rows = await getExecutor(tx)
+				.select({
+					id: authors.id,
+					name: authors.name,
+					accountId: authors.accountId,
+					createdAt: authors.createdAt,
+					updatedAt: authors.updatedAt,
+				})
+				.from(mediaAuthors)
+				.innerJoin(authors, eq(mediaAuthors.authorId, authors.id))
+				.where(eq(mediaAuthors.mediaId, mediaId));
+			return rows.map((row) => mapToAuthor(row));
+		},
+
+		async addMedia(
+			mediaId: string,
+			authorId: string,
+			tx?: unknown,
+		): Promise<void> {
+			await getExecutor(tx)
+				.insert(mediaAuthors)
+				.values({ mediaId, authorId })
+				.onConflictDoNothing();
+		},
+
+		async addMediaBulk(
+			mediaId: string,
+			authorIds: string[],
+			tx?: unknown,
+		): Promise<void> {
+			if (authorIds.length === 0) {
+				return;
+			}
+
+			await getExecutor(tx)
+				.insert(mediaAuthors)
+				.values(authorIds.map((authorId) => ({ mediaId, authorId })))
+				.onConflictDoNothing();
+		},
+
+		async removeMedia(
+			mediaId: string,
+			authorId: string,
+			tx?: unknown,
+		): Promise<void> {
+			await getExecutor(tx)
+				.delete(mediaAuthors)
+				.where(
+					and(
+						eq(mediaAuthors.mediaId, mediaId),
+						eq(mediaAuthors.authorId, authorId),
+					),
+				);
+		},
+	};
+}

--- a/packages/db/src/repositories/category-repository.ts
+++ b/packages/db/src/repositories/category-repository.ts
@@ -1,0 +1,153 @@
+import {
+	categorySchema,
+	type NewCategory,
+	type UpdateCategory,
+} from "@solid-imager/core/domain/categories/schemas";
+import {
+	ResourceNotFoundError,
+	UnexpectedError,
+} from "@solid-imager/core/domain/errors";
+import type {
+	Category,
+	CategoryRepository,
+} from "@solid-imager/core/domain/repositories/category-repository";
+import { asc, eq } from "drizzle-orm";
+import { categories } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+type DbCategory = typeof categories.$inferSelect;
+
+export type CategoryRepositoryExecutorProvider = (
+	tx?: unknown,
+) => DrizzleExecutor;
+
+type CreateCategoryRepositoryOptions = {
+	orderByName?: boolean;
+};
+
+function mapToCategory(row: DbCategory): Category | null {
+	const result = categorySchema.safeParse({
+		id: row.id,
+		name: row.name,
+		description: row.description ?? null,
+		color: row.color ?? null,
+		parentId: row.parentId ?? null,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+	});
+	return result.success ? result.data : null;
+}
+
+export function createCategoryRepository(
+	getExecutor: CategoryRepositoryExecutorProvider,
+	options: CreateCategoryRepositoryOptions = {},
+): CategoryRepository {
+	return {
+		async findAll(): Promise<Category[]> {
+			try {
+				const query = getExecutor().select().from(categories);
+				const rows = await (options.orderByName
+					? query.orderBy(asc(categories.name))
+					: query);
+				return rows.flatMap((row) => {
+					const mapped = mapToCategory(row);
+					return mapped ? [mapped] : [];
+				});
+			} catch (error) {
+				throw new UnexpectedError("Failed to select categories", error);
+			}
+		},
+
+		async findById(id: string, tx?: unknown): Promise<Category | null> {
+			try {
+				const rows = await getExecutor(tx)
+					.select()
+					.from(categories)
+					.where(eq(categories.id, id))
+					.limit(1);
+				return rows[0] ? mapToCategory(rows[0]) : null;
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select category by ID: ${id}`,
+					error,
+				);
+			}
+		},
+
+		async create(category: NewCategory, tx?: unknown): Promise<Category> {
+			try {
+				const rows = await getExecutor(tx)
+					.insert(categories)
+					.values({
+						...category,
+						description: category.description ?? "",
+						color: category.color ?? "#808080",
+					})
+					.returning();
+				const mapped = mapToCategory(rows[0]);
+				if (!mapped) {
+					throw new UnexpectedError("Failed to parse created category");
+				}
+				return mapped;
+			} catch (error) {
+				if (error instanceof UnexpectedError) throw error;
+				throw new UnexpectedError("Failed to insert category", error);
+			}
+		},
+
+		async update(
+			id: string,
+			category: UpdateCategory,
+			tx?: unknown,
+		): Promise<Category> {
+			try {
+				const rows = await getExecutor(tx)
+					.update(categories)
+					.set(category)
+					.where(eq(categories.id, id))
+					.returning();
+
+				if (rows.length === 0) {
+					throw new ResourceNotFoundError("Category", id);
+				}
+				const mapped = mapToCategory(rows[0]);
+				if (!mapped) {
+					throw new UnexpectedError("Failed to parse updated category");
+				}
+				return mapped;
+			} catch (error) {
+				if (
+					error instanceof ResourceNotFoundError ||
+					error instanceof UnexpectedError
+				) {
+					throw error;
+				}
+				throw new UnexpectedError(
+					`Failed to update category with ID: ${id}`,
+					error,
+				);
+			}
+		},
+
+		async delete(id: string, tx?: unknown): Promise<void> {
+			try {
+				const rows = await getExecutor(tx)
+					.delete(categories)
+					.where(eq(categories.id, id))
+					.returning();
+
+				if (rows.length === 0) {
+					throw new ResourceNotFoundError("Category", id);
+				}
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				throw new UnexpectedError(
+					`Failed to delete category with ID: ${id}`,
+					error,
+				);
+			}
+		},
+	};
+}

--- a/packages/db/src/repositories/character-repository.ts
+++ b/packages/db/src/repositories/character-repository.ts
@@ -1,0 +1,482 @@
+import type {
+	Character,
+	NewCharacter,
+	UpdateCharacter,
+} from "@solid-imager/core/domain/characters/schemas";
+import { characterSchema } from "@solid-imager/core/domain/characters/schemas";
+import {
+	ResourceConflictError,
+	ResourceNotFoundError,
+	UnexpectedError,
+} from "@solid-imager/core/domain/errors";
+import type { CharacterRepository } from "@solid-imager/core/domain/repositories/character-repository";
+import { and, eq, sql } from "drizzle-orm";
+import { characterIps, characters, mediaCharacters } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+export type CharacterRepositoryExecutorProvider = (
+	tx?: unknown,
+) => DrizzleExecutor;
+export type CharacterRepositoryTransactionRunner = <T>(
+	callback: (tx: unknown) => Promise<T>,
+) => Promise<T>;
+
+type CreateCharacterRepositoryOptions = {
+	orderByName?: boolean;
+	throwOnMissingRemove?: boolean;
+	transaction?: CharacterRepositoryTransactionRunner;
+};
+
+type CharacterWithIpsRow = typeof characters.$inferSelect & {
+	ips: Array<{
+		ip: {
+			id: string;
+			name: string;
+		};
+	}>;
+};
+
+type CharacterWithAssociation = Character & {
+	confidence: number | null;
+	associationSource: string;
+};
+
+function isUniqueViolation(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === "23505"
+	);
+}
+
+function mapToCharacter(row: CharacterWithIpsRow): Character {
+	return characterSchema.parse({
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+		ips: row.ips.map((item) => ({
+			id: item.ip.id,
+			name: item.ip.name,
+		})),
+	});
+}
+
+function mediaCharacterConflictSet(source: string) {
+	let sourceUpdateSql = sql`excluded.source`;
+	let confidenceUpdateSql = sql`excluded.confidence`;
+
+	if (source === "AI") {
+		sourceUpdateSql = sql`CASE WHEN media_characters.source = 'AI' THEN excluded.source ELSE media_characters.source END`;
+		confidenceUpdateSql = sql`CASE WHEN media_characters.source = 'AI' THEN excluded.confidence ELSE media_characters.confidence END`;
+	} else if (source === "manual") {
+		sourceUpdateSql = sql`CASE WHEN media_characters.source IN ('AI', 'manual') THEN excluded.source ELSE media_characters.source END`;
+		confidenceUpdateSql = sql`CASE WHEN media_characters.source IN ('AI', 'manual') THEN excluded.confidence ELSE media_characters.confidence END`;
+	}
+
+	return {
+		source: sourceUpdateSql,
+		confidence: confidenceUpdateSql,
+	};
+}
+
+export function createCharacterRepository(
+	getExecutor: CharacterRepositoryExecutorProvider,
+	options: CreateCharacterRepositoryOptions = {},
+): CharacterRepository {
+	async function findCharacterWithIps(
+		id: string,
+		tx?: unknown,
+	): Promise<Character | null> {
+		const row = await getExecutor(tx).query.characters.findFirst({
+			where: eq(characters.id, id),
+			with: {
+				ips: {
+					with: {
+						ip: true,
+					},
+				},
+			},
+		});
+
+		return row ? mapToCharacter(row) : null;
+	}
+
+	async function runWithTransaction<T>(
+		tx: unknown | undefined,
+		callback: (tx?: unknown) => Promise<T>,
+	): Promise<T> {
+		if (tx) {
+			return await callback(tx);
+		}
+		if (options.transaction) {
+			return await options.transaction(callback);
+		}
+		return await callback();
+	}
+
+	return {
+		async findAll(): Promise<Character[]> {
+			try {
+				const rows = await getExecutor().query.characters.findMany({
+					...(options.orderByName
+						? { orderBy: (characters, { asc }) => [asc(characters.name)] }
+						: {}),
+					with: {
+						ips: {
+							with: {
+								ip: true,
+							},
+						},
+					},
+				});
+				return rows.map(mapToCharacter);
+			} catch (error) {
+				throw new UnexpectedError("Failed to select characters", error);
+			}
+		},
+
+		async findById(id: string, tx?: unknown): Promise<Character | null> {
+			try {
+				return await findCharacterWithIps(id, tx);
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select character by ID: ${id}`,
+					error,
+				);
+			}
+		},
+
+		async findByName(name: string, tx?: unknown): Promise<Character | null> {
+			try {
+				const row = await getExecutor(tx).query.characters.findFirst({
+					where: eq(characters.name, name),
+					with: {
+						ips: {
+							with: {
+								ip: true,
+							},
+						},
+					},
+				});
+				return row ? mapToCharacter(row) : null;
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select character by name: ${name}`,
+					error,
+				);
+			}
+		},
+
+		async create(input: NewCharacter, tx?: unknown): Promise<Character> {
+			try {
+				return await runWithTransaction(tx, async (innerTx) => {
+					const client = getExecutor(innerTx);
+					const { ipIds, ...characterData } = input;
+					const rows = await client
+						.insert(characters)
+						.values({
+							name: characterData.name,
+							description: characterData.description ?? "",
+							source: characterData.source ?? "manual",
+						})
+						.returning();
+					const created = rows[0];
+
+					if (ipIds && ipIds.length > 0) {
+						await client.insert(characterIps).values(
+							ipIds.map((ipId) => ({
+								characterId: created.id,
+								ipId,
+								source: input.source ?? "manual",
+							})),
+						);
+					}
+
+					const result = await findCharacterWithIps(created.id, innerTx);
+					if (!result) {
+						throw new UnexpectedError(
+							"Created character could not be reloaded",
+						);
+					}
+					return result;
+				});
+			} catch (error) {
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						"Character with this name already exists",
+					);
+				}
+				if (error instanceof UnexpectedError) {
+					throw error;
+				}
+				throw new UnexpectedError("Failed to insert character", error);
+			}
+		},
+
+		async update(
+			id: string,
+			input: UpdateCharacter,
+			tx?: unknown,
+		): Promise<Character> {
+			try {
+				return await runWithTransaction(tx, async (innerTx) => {
+					const client = getExecutor(innerTx);
+					const { ipIds, ...characterData } = input;
+
+					if (
+						characterData.name !== undefined ||
+						characterData.description !== undefined ||
+						characterData.source !== undefined
+					) {
+						const rows = await client
+							.update(characters)
+							.set({
+								...(characterData.name !== undefined
+									? { name: characterData.name }
+									: {}),
+								...(characterData.description !== undefined
+									? { description: characterData.description ?? "" }
+									: {}),
+								...(characterData.source !== undefined
+									? { source: characterData.source }
+									: {}),
+								updatedAt: new Date(),
+							})
+							.where(eq(characters.id, id))
+							.returning();
+
+						if (!rows[0]) {
+							throw new ResourceNotFoundError("Character", id);
+						}
+					} else {
+						const existing = await findCharacterWithIps(id, innerTx);
+						if (!existing) {
+							throw new ResourceNotFoundError("Character", id);
+						}
+					}
+
+					if (ipIds !== undefined) {
+						await client
+							.delete(characterIps)
+							.where(eq(characterIps.characterId, id));
+
+						if (ipIds.length > 0) {
+							await client.insert(characterIps).values(
+								ipIds.map((ipId) => ({
+									characterId: id,
+									ipId,
+									source: input.source ?? "manual",
+								})),
+							);
+						}
+					}
+
+					const result = await findCharacterWithIps(id, innerTx);
+					if (!result) {
+						throw new ResourceNotFoundError("Character", id);
+					}
+					return result;
+				});
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						"Character with this name already exists",
+					);
+				}
+				throw new UnexpectedError(
+					`Failed to update character with ID: ${id}`,
+					error,
+				);
+			}
+		},
+
+		async delete(id: string, tx?: unknown): Promise<void> {
+			try {
+				const rows = await getExecutor(tx)
+					.delete(characters)
+					.where(eq(characters.id, id))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("Character", id);
+				}
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				throw new UnexpectedError(
+					`Failed to delete character with ID: ${id}`,
+					error,
+				);
+			}
+		},
+
+		async findByMediaId(mediaId: string, tx?: unknown): Promise<Character[]> {
+			try {
+				const rows = await getExecutor(tx).query.mediaCharacters.findMany({
+					...(options.orderByName
+						? {
+								orderBy: (mediaCharacters, { asc }) => [
+									asc(mediaCharacters.characterId),
+								],
+							}
+						: {}),
+					where: eq(mediaCharacters.mediaId, mediaId),
+					with: {
+						character: {
+							with: {
+								ips: {
+									with: {
+										ip: true,
+									},
+								},
+							},
+						},
+					},
+				});
+
+				return rows.map((row) => mapToCharacter(row.character));
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to find characters for media: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async getMediaCharacters(
+			mediaId: string,
+			tx?: unknown,
+		): Promise<CharacterWithAssociation[]> {
+			try {
+				const rows = await getExecutor(tx).query.mediaCharacters.findMany({
+					where: eq(mediaCharacters.mediaId, mediaId),
+					with: {
+						character: {
+							with: {
+								ips: {
+									with: {
+										ip: true,
+									},
+								},
+							},
+						},
+					},
+				});
+
+				return rows.map((row) => ({
+					...mapToCharacter(row.character),
+					confidence: row.confidence,
+					associationSource: row.source,
+				}));
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to find media characters for media: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async addToMedia(
+			mediaId: string,
+			characterId: string,
+			confidence?: number,
+			source = "manual",
+			tx?: unknown,
+		): Promise<void> {
+			try {
+				await getExecutor(tx)
+					.insert(mediaCharacters)
+					.values({
+						mediaId,
+						characterId,
+						confidence: confidence ?? null,
+						source,
+					})
+					.onConflictDoUpdate({
+						target: [mediaCharacters.mediaId, mediaCharacters.characterId],
+						set: mediaCharacterConflictSet(source),
+					});
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to add character ${characterId} to media ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async removeFromMedia(
+			mediaId: string,
+			characterId: string,
+			tx?: unknown,
+		): Promise<void> {
+			try {
+				const query = getExecutor(tx)
+					.delete(mediaCharacters)
+					.where(
+						and(
+							eq(mediaCharacters.mediaId, mediaId),
+							eq(mediaCharacters.characterId, characterId),
+						),
+					);
+
+				if (options.throwOnMissingRemove) {
+					const rows = await query.returning();
+					if (!rows[0]) {
+						throw new ResourceNotFoundError("MediaCharacter association");
+					}
+					return;
+				}
+
+				await query;
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				throw new UnexpectedError(
+					`Failed to remove character ${characterId} from media ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async addToMediaBulk(
+			mediaId: string,
+			charactersData: { id: string; confidence?: number }[],
+			source = "manual",
+			tx?: unknown,
+		): Promise<void> {
+			if (charactersData.length === 0) {
+				return;
+			}
+
+			try {
+				await getExecutor(tx)
+					.insert(mediaCharacters)
+					.values(
+						charactersData.map((character) => ({
+							mediaId,
+							characterId: character.id,
+							confidence: character.confidence ?? null,
+							source,
+						})),
+					)
+					.onConflictDoUpdate({
+						target: [mediaCharacters.mediaId, mediaCharacters.characterId],
+						set: mediaCharacterConflictSet(source),
+					});
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to bulk add characters to media ${mediaId}`,
+					error,
+				);
+			}
+		},
+	};
+}

--- a/packages/db/src/repositories/collection-repository.ts
+++ b/packages/db/src/repositories/collection-repository.ts
@@ -1,0 +1,223 @@
+import type {
+	Collection,
+	NewCollection,
+	NewCollectionItem,
+	UpdateCollection,
+} from "@solid-imager/core/domain/collections/schemas";
+import { collectionSchema } from "@solid-imager/core/domain/collections/schemas";
+import {
+	ResourceConflictError,
+	ResourceNotFoundError,
+	UnexpectedError,
+} from "@solid-imager/core/domain/errors";
+import type { ICollectionRepository } from "@solid-imager/core/domain/repositories/collection-repository";
+import { and, asc, eq } from "drizzle-orm";
+import { collections, mediaCollections } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+type DbCollection = typeof collections.$inferSelect;
+
+export type CollectionRepositoryExecutorProvider = (
+	tx?: unknown,
+) => DrizzleExecutor;
+
+type CreateCollectionRepositoryOptions = {
+	orderByName?: boolean;
+};
+
+function isUniqueViolation(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === "23505"
+	);
+}
+
+function mapToCollection(row: DbCollection): Collection | null {
+	const result = collectionSchema.safeParse({
+		id: row.id,
+		userId: row.userId,
+		name: row.name,
+		description: row.description,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+	});
+	return result.success ? result.data : null;
+}
+
+export function createCollectionRepository(
+	getExecutor: CollectionRepositoryExecutorProvider,
+	options: CreateCollectionRepositoryOptions = {},
+): ICollectionRepository {
+	return {
+		async findAll(): Promise<Collection[]> {
+			try {
+				const query = getExecutor().select().from(collections);
+				const rows = await (options.orderByName
+					? query.orderBy(asc(collections.name))
+					: query);
+				return rows.flatMap((row) => {
+					const mapped = mapToCollection(row);
+					return mapped ? [mapped] : [];
+				});
+			} catch (error) {
+				throw new UnexpectedError("Failed to select collections", error);
+			}
+		},
+
+		async findById(id: string, tx?: unknown): Promise<Collection | null> {
+			try {
+				const rows = await getExecutor(tx)
+					.select()
+					.from(collections)
+					.where(eq(collections.id, id))
+					.limit(1);
+				return rows[0] ? mapToCollection(rows[0]) : null;
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select collection by ID: ${id}`,
+					error,
+				);
+			}
+		},
+
+		async create(collection: NewCollection, tx?: unknown): Promise<Collection> {
+			try {
+				const rows = await getExecutor(tx)
+					.insert(collections)
+					.values({
+						name: collection.name,
+						userId: collection.userId,
+						description: collection.description ?? "",
+					})
+					.returning();
+				const mapped = mapToCollection(rows[0]);
+				if (!mapped) {
+					throw new UnexpectedError("Failed to parse created collection");
+				}
+				return mapped;
+			} catch (error) {
+				if (error instanceof UnexpectedError) throw error;
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						"Collection with this name already exists",
+					);
+				}
+				throw new UnexpectedError("Failed to create collection", error);
+			}
+		},
+
+		async update(
+			id: string,
+			updates: UpdateCollection,
+			tx?: unknown,
+		): Promise<Collection> {
+			try {
+				const rows = await getExecutor(tx)
+					.update(collections)
+					.set({
+						...(updates.name !== undefined ? { name: updates.name } : {}),
+						...(updates.description !== undefined
+							? { description: updates.description }
+							: {}),
+						updatedAt: new Date(),
+					})
+					.where(eq(collections.id, id))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("Collection", id);
+				}
+				const mapped = mapToCollection(rows[0]);
+				if (!mapped) {
+					throw new UnexpectedError("Failed to parse updated collection");
+				}
+				return mapped;
+			} catch (error) {
+				if (
+					error instanceof ResourceNotFoundError ||
+					error instanceof UnexpectedError
+				) {
+					throw error;
+				}
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						"Collection with this name already exists",
+					);
+				}
+				throw new UnexpectedError("Failed to update collection", error);
+			}
+		},
+
+		async delete(id: string, tx?: unknown): Promise<void> {
+			try {
+				const rows = await getExecutor(tx)
+					.delete(collections)
+					.where(eq(collections.id, id))
+					.returning();
+
+				if (rows.length === 0) {
+					throw new ResourceNotFoundError("Collection", id);
+				}
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) throw error;
+				throw new UnexpectedError(
+					`Failed to delete collection with ID: ${id}`,
+					error,
+				);
+			}
+		},
+
+		async addItem(
+			collectionId: string,
+			item: NewCollectionItem,
+			tx?: unknown,
+		): Promise<void> {
+			try {
+				await getExecutor(tx)
+					.insert(mediaCollections)
+					.values({
+						collectionId,
+						mediaId: item.mediaId,
+						displayOrder: item.displayOrder ?? null,
+					});
+			} catch (error) {
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						"Media already exists in this collection",
+					);
+				}
+				throw new UnexpectedError("Failed to add item to collection", error);
+			}
+		},
+
+		async removeItem(
+			collectionId: string,
+			mediaId: string,
+			tx?: unknown,
+		): Promise<void> {
+			try {
+				const rows = await getExecutor(tx)
+					.delete(mediaCollections)
+					.where(
+						and(
+							eq(mediaCollections.collectionId, collectionId),
+							eq(mediaCollections.mediaId, mediaId),
+						),
+					)
+					.returning();
+
+				if (rows.length === 0) {
+					throw new ResourceNotFoundError("CollectionItem association");
+				}
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) throw error;
+				throw new UnexpectedError(
+					"Failed to remove item from collection",
+					error,
+				);
+			}
+		},
+	};
+}

--- a/packages/db/src/repositories/ip-repository.ts
+++ b/packages/db/src/repositories/ip-repository.ts
@@ -1,0 +1,280 @@
+import {
+	ResourceConflictError,
+	ResourceNotFoundError,
+	UnexpectedError,
+} from "@solid-imager/core/domain/errors";
+import type {
+	Ip,
+	NewIp,
+	UpdateIp,
+} from "@solid-imager/core/domain/ips/schemas";
+import { ipSchema } from "@solid-imager/core/domain/ips/schemas";
+import type { IIpRepository } from "@solid-imager/core/domain/repositories/ip-repository";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { ips, mediaIps } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+export type IpRepositoryExecutorProvider = (tx?: unknown) => DrizzleExecutor;
+
+type IpWithAssociation = Ip & {
+	confidence: number | null;
+	associationSource: string;
+};
+
+type CreateIpRepositoryOptions = {
+	orderByName?: boolean;
+};
+
+function isUniqueViolation(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === "23505"
+	);
+}
+
+function mapToIp(row: typeof ips.$inferSelect): Ip {
+	return ipSchema.parse({
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		source: row.source,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+	});
+}
+
+function mediaIpConflictSet(source: string) {
+	let sourceUpdateSql = sql`excluded.source`;
+	let confidenceUpdateSql = sql`excluded.confidence`;
+
+	if (source === "AI") {
+		sourceUpdateSql = sql`CASE WHEN media_ips.source = 'AI' THEN excluded.source ELSE media_ips.source END`;
+		confidenceUpdateSql = sql`CASE WHEN media_ips.source = 'AI' THEN excluded.confidence ELSE media_ips.confidence END`;
+	} else if (source === "manual") {
+		sourceUpdateSql = sql`CASE WHEN media_ips.source IN ('AI', 'manual') THEN excluded.source ELSE media_ips.source END`;
+		confidenceUpdateSql = sql`CASE WHEN media_ips.source IN ('AI', 'manual') THEN excluded.confidence ELSE media_ips.confidence END`;
+	}
+
+	return {
+		source: sourceUpdateSql,
+		confidence: confidenceUpdateSql,
+	};
+}
+
+export function createIpRepository(
+	getExecutor: IpRepositoryExecutorProvider,
+	options: CreateIpRepositoryOptions = {},
+): IIpRepository {
+	return {
+		async findAll(): Promise<Ip[]> {
+			const query = getExecutor().select().from(ips);
+			const rows = options.orderByName
+				? await query.orderBy(asc(ips.name))
+				: await query;
+			return rows.map(mapToIp);
+		},
+
+		async findById(id: string, tx?: unknown): Promise<Ip | null> {
+			const rows = await getExecutor(tx)
+				.select()
+				.from(ips)
+				.where(eq(ips.id, id))
+				.limit(1);
+			return rows[0] ? mapToIp(rows[0]) : null;
+		},
+
+		async findByName(name: string, tx?: unknown): Promise<Ip | null> {
+			const rows = await getExecutor(tx)
+				.select()
+				.from(ips)
+				.where(eq(ips.name, name))
+				.limit(1);
+			return rows[0] ? mapToIp(rows[0]) : null;
+		},
+
+		async findByNames(names: string[], tx?: unknown): Promise<Ip[]> {
+			if (names.length === 0) {
+				return [];
+			}
+			const query = getExecutor(tx)
+				.select()
+				.from(ips)
+				.where(inArray(ips.name, names));
+			const rows = options.orderByName
+				? await query.orderBy(asc(ips.name))
+				: await query;
+			return rows.map(mapToIp);
+		},
+
+		async create(input: NewIp, tx?: unknown): Promise<Ip> {
+			try {
+				const rows = await getExecutor(tx)
+					.insert(ips)
+					.values({
+						name: input.name,
+						description: input.description ?? null,
+						source: input.source ?? "manual",
+					})
+					.returning();
+				return mapToIp(rows[0]);
+			} catch (error) {
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError("IP with this name already exists");
+				}
+				throw error;
+			}
+		},
+
+		async update(id: string, input: UpdateIp, tx?: unknown): Promise<Ip> {
+			try {
+				const rows = await getExecutor(tx)
+					.update(ips)
+					.set({
+						...(input.name !== undefined ? { name: input.name } : {}),
+						...(input.description !== undefined
+							? { description: input.description ?? null }
+							: {}),
+						...(input.source !== undefined ? { source: input.source } : {}),
+						updatedAt: new Date(),
+					})
+					.where(eq(ips.id, id))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("IP", id);
+				}
+				return mapToIp(rows[0]);
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError("IP with this name already exists");
+				}
+				throw new UnexpectedError("Failed to update IP", error);
+			}
+		},
+
+		async delete(id: string, tx?: unknown): Promise<void> {
+			const rows = await getExecutor(tx)
+				.delete(ips)
+				.where(eq(ips.id, id))
+				.returning();
+			if (!rows[0]) {
+				throw new ResourceNotFoundError("IP", id);
+			}
+		},
+
+		async findByMediaId(mediaId: string, tx?: unknown): Promise<Ip[]> {
+			const query = getExecutor(tx)
+				.select({
+					id: ips.id,
+					name: ips.name,
+					description: ips.description,
+					source: ips.source,
+					createdAt: ips.createdAt,
+					updatedAt: ips.updatedAt,
+				})
+				.from(ips)
+				.innerJoin(mediaIps, eq(ips.id, mediaIps.ipId))
+				.where(eq(mediaIps.mediaId, mediaId));
+			const rows = options.orderByName
+				? await query.orderBy(asc(ips.name))
+				: await query;
+			return rows.map(mapToIp);
+		},
+
+		async getMediaIps(
+			mediaId: string,
+			tx?: unknown,
+		): Promise<IpWithAssociation[]> {
+			const query = getExecutor(tx)
+				.select({
+					id: ips.id,
+					name: ips.name,
+					description: ips.description,
+					source: ips.source,
+					createdAt: ips.createdAt,
+					updatedAt: ips.updatedAt,
+					confidence: mediaIps.confidence,
+					associationSource: mediaIps.source,
+				})
+				.from(ips)
+				.innerJoin(mediaIps, eq(ips.id, mediaIps.ipId))
+				.where(eq(mediaIps.mediaId, mediaId));
+			const rows = options.orderByName
+				? await query.orderBy(asc(ips.name))
+				: await query;
+
+			return rows.map((row) => ({
+				...mapToIp(row),
+				confidence: row.confidence,
+				associationSource: row.associationSource,
+			}));
+		},
+
+		async addMedia(
+			mediaId: string,
+			ipId: string,
+			confidence?: number,
+			source = "manual",
+			tx?: unknown,
+		): Promise<void> {
+			await getExecutor(tx)
+				.insert(mediaIps)
+				.values({
+					mediaId,
+					ipId,
+					confidence: confidence ?? null,
+					source,
+				})
+				.onConflictDoUpdate({
+					target: [mediaIps.mediaId, mediaIps.ipId],
+					set: mediaIpConflictSet(source),
+				});
+		},
+
+		async removeMedia(
+			mediaId: string,
+			ipId: string,
+			tx?: unknown,
+		): Promise<void> {
+			const rows = await getExecutor(tx)
+				.delete(mediaIps)
+				.where(and(eq(mediaIps.mediaId, mediaId), eq(mediaIps.ipId, ipId)))
+				.returning();
+
+			if (!rows[0]) {
+				throw new ResourceNotFoundError("MediaIP association");
+			}
+		},
+
+		async addMediaBulk(
+			mediaId: string,
+			ipsData: { id: string; confidence?: number }[],
+			source = "manual",
+			tx?: unknown,
+		): Promise<void> {
+			if (ipsData.length === 0) {
+				return;
+			}
+
+			await getExecutor(tx)
+				.insert(mediaIps)
+				.values(
+					ipsData.map((data) => ({
+						mediaId,
+						ipId: data.id,
+						confidence: data.confidence ?? null,
+						source,
+					})),
+				)
+				.onConflictDoUpdate({
+					target: [mediaIps.mediaId, mediaIps.ipId],
+					set: mediaIpConflictSet(source),
+				});
+		},
+	};
+}

--- a/packages/db/src/repositories/job-repository.ts
+++ b/packages/db/src/repositories/job-repository.ts
@@ -1,0 +1,389 @@
+import type {
+	FindPendingJobsOptions,
+	JobRecord,
+	JobRepositoryPort,
+	NewJobRecord,
+} from "@solid-imager/application/ports/job-repository";
+import { and, asc, eq, inArray, ne, notInArray, sql } from "drizzle-orm";
+import { jobs } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+export type JobRepositoryExecutorProvider = () => DrizzleExecutor;
+
+const DEFAULT_INSERT_CHUNK_SIZE = 500;
+const ACTIVE_JOB_STATUSES = ["pending", "in_progress"] as const;
+const UNIQUE_JOB_LOCK_KEY = 0x4a4f4253;
+
+function mapToJobRecord(row: typeof jobs.$inferSelect): JobRecord {
+	return {
+		id: row.id,
+		type: row.type,
+		mediaSourceId: row.mediaSourceId,
+		status: row.status,
+		payload: row.payload,
+		result: row.result,
+		error: row.error,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+		parentId: row.parentId,
+	};
+}
+
+function hasMediaIdPayload(value: unknown): value is { mediaId: string } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"mediaId" in value &&
+		typeof value.mediaId === "string"
+	);
+}
+
+function toInsertValue(job: NewJobRecord): typeof jobs.$inferInsert {
+	return {
+		...(job.id !== undefined ? { id: job.id } : {}),
+		type: job.type,
+		...(job.mediaSourceId !== undefined
+			? { mediaSourceId: job.mediaSourceId }
+			: {}),
+		...(job.status !== undefined ? { status: job.status } : {}),
+		...(job.payload !== undefined ? { payload: job.payload } : {}),
+		...(job.result !== undefined ? { result: job.result } : {}),
+		...(job.error !== undefined ? { error: job.error } : {}),
+		...(job.createdAt !== undefined ? { createdAt: job.createdAt } : {}),
+		...(job.updatedAt !== undefined ? { updatedAt: job.updatedAt } : {}),
+		...(job.parentId !== undefined ? { parentId: job.parentId } : {}),
+	};
+}
+
+function toUpdateValue(
+	job: Partial<JobRecord>,
+): Partial<typeof jobs.$inferInsert> {
+	return {
+		...(job.type !== undefined ? { type: job.type } : {}),
+		...(job.mediaSourceId !== undefined
+			? { mediaSourceId: job.mediaSourceId }
+			: {}),
+		...(job.status !== undefined ? { status: job.status } : {}),
+		...(job.payload !== undefined ? { payload: job.payload } : {}),
+		...(job.result !== undefined ? { result: job.result } : {}),
+		...(job.error !== undefined ? { error: job.error } : {}),
+		...(job.createdAt !== undefined ? { createdAt: job.createdAt } : {}),
+		...(job.updatedAt !== undefined ? { updatedAt: job.updatedAt } : {}),
+		...(job.parentId !== undefined ? { parentId: job.parentId } : {}),
+	};
+}
+
+async function insertJob(
+	executor: DrizzleExecutor,
+	job: NewJobRecord,
+): Promise<JobRecord> {
+	const [created] = await executor
+		.insert(jobs)
+		.values(toInsertValue(job))
+		.returning();
+	return mapToJobRecord(created);
+}
+
+function getUniqueJobKey(job: NewJobRecord): string | null {
+	const payload = job.payload;
+	if (
+		typeof payload !== "object" ||
+		payload === null ||
+		!("mediaId" in payload) ||
+		typeof payload.mediaId !== "string"
+	) {
+		return null;
+	}
+	return `${job.type}:${payload.mediaId}`;
+}
+
+function getUniqueMediaId(job: NewJobRecord): string | null {
+	const payload = job.payload;
+	if (
+		typeof payload !== "object" ||
+		payload === null ||
+		!("mediaId" in payload) ||
+		typeof payload.mediaId !== "string"
+	) {
+		return null;
+	}
+	return payload.mediaId;
+}
+
+async function withUniqueJobLock<T>(
+	executor: DrizzleExecutor,
+	key: string,
+	action: (executor: DrizzleExecutor) => Promise<T>,
+): Promise<T> {
+	if (hasTransaction(executor)) {
+		return await executor.transaction(async (tx) => {
+			await tx.execute(
+				sql`SELECT pg_advisory_xact_lock(${UNIQUE_JOB_LOCK_KEY}, hashtext(${key}))`,
+			);
+			return await action(tx);
+		});
+	}
+
+	const sqlExecutor: unknown = executor;
+	if (!hasExecute(sqlExecutor)) {
+		throw new Error("Drizzle executor does not support execute()");
+	}
+
+	await sqlExecutor.execute(
+		sql`SELECT pg_advisory_xact_lock(${UNIQUE_JOB_LOCK_KEY}, hashtext(${key}))`,
+	);
+	return await action(executor);
+}
+
+function hasTransaction(
+	executor: DrizzleExecutor,
+): executor is Extract<
+	DrizzleExecutor,
+	{ transaction: (...args: any[]) => any }
+> {
+	return "transaction" in executor;
+}
+
+function hasExecute(
+	executor: unknown,
+): executor is { execute: (query: unknown) => Promise<unknown> } {
+	return (
+		typeof executor === "object" &&
+		executor !== null &&
+		"execute" in executor &&
+		typeof executor.execute === "function"
+	);
+}
+
+export function createJobRepository(
+	getExecutor: JobRepositoryExecutorProvider,
+	options: { insertChunkSize?: number } = {},
+): JobRepositoryPort {
+	const insertChunkSize = options.insertChunkSize ?? DEFAULT_INSERT_CHUNK_SIZE;
+
+	return {
+		async create(job: NewJobRecord): Promise<JobRecord> {
+			return await insertJob(getExecutor(), job);
+		},
+
+		async createMany(newJobs: NewJobRecord[]): Promise<JobRecord[]> {
+			if (newJobs.length === 0) {
+				return [];
+			}
+
+			const rows: JobRecord[] = [];
+			for (let i = 0; i < newJobs.length; i += insertChunkSize) {
+				const chunk = newJobs.slice(i, i + insertChunkSize);
+				const inserted = await getExecutor()
+					.insert(jobs)
+					.values(chunk.map(toInsertValue))
+					.returning();
+				rows.push(...inserted.map(mapToJobRecord));
+			}
+			return rows;
+		},
+
+		async createIfUnique(job: NewJobRecord): Promise<JobRecord | null> {
+			const uniqueKey = getUniqueJobKey(job);
+			if (!uniqueKey) {
+				return await insertJob(getExecutor(), job);
+			}
+
+			const mediaId = getUniqueMediaId(job);
+			const executor = getExecutor();
+			return await withUniqueJobLock(executor, uniqueKey, async (tx) => {
+				const activeRows = await tx
+					.select()
+					.from(jobs)
+					.where(
+						and(
+							eq(jobs.type, job.type),
+							inArray(jobs.status, [...ACTIVE_JOB_STATUSES]),
+						),
+					);
+				const existing = activeRows.find(
+					(row) =>
+						hasMediaIdPayload(row.payload) && row.payload.mediaId === mediaId,
+				);
+				if (existing) {
+					return null;
+				}
+
+				return await insertJob(tx, job);
+			});
+		},
+
+		async findById(id: string): Promise<JobRecord | null> {
+			const rows = await getExecutor()
+				.select()
+				.from(jobs)
+				.where(eq(jobs.id, id))
+				.limit(1);
+			return rows[0] ? mapToJobRecord(rows[0]) : null;
+		},
+
+		async findPendingImportRequests(): Promise<JobRecord[]> {
+			const rows = await getExecutor()
+				.select()
+				.from(jobs)
+				.where(and(eq(jobs.type, "import_request"), eq(jobs.status, "pending")))
+				.orderBy(sql`${jobs.createdAt} desc`);
+			return rows.map(mapToJobRecord);
+		},
+
+		async findImportRequestsByIds(jobIds: string[]): Promise<JobRecord[]> {
+			if (jobIds.length === 0) {
+				return [];
+			}
+
+			const rows = await getExecutor()
+				.select()
+				.from(jobs)
+				.where(and(inArray(jobs.id, jobIds), eq(jobs.type, "import_request")));
+			return rows.map(mapToJobRecord);
+		},
+
+		async findPending(
+			limit: number,
+			options: FindPendingJobsOptions = {},
+		): Promise<JobRecord[]> {
+			if (options.excludeTypes?.length && options.includeTypes?.length) {
+				throw new Error(
+					"Cannot use excludeTypes and includeTypes simultaneously.",
+				);
+			}
+
+			const conditions = [
+				eq(jobs.status, "pending"),
+				ne(jobs.type, "import_request"),
+				ne(jobs.type, "bulk_tagging_parent"),
+			];
+
+			if (options.excludeTypes?.length) {
+				conditions.push(notInArray(jobs.type, options.excludeTypes));
+			}
+
+			if (options.includeTypes?.length) {
+				conditions.push(inArray(jobs.type, options.includeTypes));
+			}
+
+			const rows = await getExecutor()
+				.select()
+				.from(jobs)
+				.where(and(...conditions))
+				.orderBy(asc(jobs.createdAt))
+				.limit(limit);
+			return rows.map(mapToJobRecord);
+		},
+
+		async resetInProgressToPending(
+			resetOptions: { includeTypes?: string[] } = {},
+		): Promise<void> {
+			const conditions = [eq(jobs.status, "in_progress")];
+			if (resetOptions.includeTypes?.length) {
+				conditions.push(inArray(jobs.type, resetOptions.includeTypes));
+			} else {
+				conditions.push(ne(jobs.type, "import_request"));
+				conditions.push(ne(jobs.type, "bulk_tagging_parent"));
+			}
+
+			await getExecutor()
+				.update(jobs)
+				.set({
+					status: "pending",
+					updatedAt: new Date(),
+				})
+				.where(and(...conditions));
+		},
+
+		async markImportRequestsCompleted(jobIds: string[]): Promise<void> {
+			if (jobIds.length === 0) {
+				return;
+			}
+
+			await getExecutor()
+				.update(jobs)
+				.set({
+					status: "completed",
+					error: null,
+					updatedAt: new Date(),
+				})
+				.where(and(inArray(jobs.id, jobIds), eq(jobs.type, "import_request")));
+		},
+
+		async markImportRequestsFailed(
+			jobIds: string[],
+			error: string,
+		): Promise<void> {
+			if (jobIds.length === 0) {
+				return;
+			}
+
+			await getExecutor()
+				.update(jobs)
+				.set({
+					status: "failed",
+					error,
+					updatedAt: new Date(),
+				})
+				.where(and(inArray(jobs.id, jobIds), eq(jobs.type, "import_request")));
+		},
+
+		async deleteImportRequests(jobIds: string[]): Promise<void> {
+			if (jobIds.length === 0) {
+				return;
+			}
+
+			await getExecutor()
+				.delete(jobs)
+				.where(and(inArray(jobs.id, jobIds), eq(jobs.type, "import_request")));
+		},
+
+		async markAsInProgress(id: string): Promise<void> {
+			await getExecutor()
+				.update(jobs)
+				.set({
+					status: "in_progress",
+					error: null,
+					updatedAt: new Date(),
+				})
+				.where(eq(jobs.id, id));
+		},
+
+		async markAsCompleted(id: string, result?: unknown): Promise<void> {
+			await getExecutor()
+				.update(jobs)
+				.set({
+					status: "completed",
+					result,
+					error: null,
+					updatedAt: new Date(),
+				})
+				.where(eq(jobs.id, id));
+		},
+
+		async markAsFailed(id: string, error: string): Promise<void> {
+			await getExecutor()
+				.update(jobs)
+				.set({
+					status: "failed",
+					error,
+					updatedAt: new Date(),
+				})
+				.where(eq(jobs.id, id));
+		},
+
+		async update(id: string, data: Partial<JobRecord>): Promise<void> {
+			await getExecutor()
+				.update(jobs)
+				.set(toUpdateValue(data))
+				.where(eq(jobs.id, id));
+		},
+
+		async incrementProgress(id: string): Promise<void> {
+			await getExecutor().execute(
+				sql`UPDATE ${jobs} SET payload = jsonb_set(payload, '{processed}', (COALESCE(payload->>'processed', '0')::int + 1)::text::jsonb) WHERE id = ${id}`,
+			);
+		},
+	};
+}

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -1,0 +1,802 @@
+import {
+	ResourceNotFoundError,
+	UnexpectedError,
+} from "@solid-imager/core/domain/errors";
+import type {
+	AddMediaRequest,
+	Author,
+	Media,
+	MediaDetails,
+	MediaGenerationInfo,
+	MediaSearchRequest,
+	MediaSearchResponse,
+	MediaTag,
+	MediaUrl,
+	UpdateMediaRequest,
+} from "@solid-imager/core/domain/media/schemas";
+import {
+	authorSchema,
+	mediaDetailsSchema,
+	mediaGenerationInfoSchema,
+	mediaSchema,
+	mediaUrlSchema,
+	tagSchema,
+} from "@solid-imager/core/domain/media/schemas";
+import type { IMediaRepository } from "@solid-imager/core/domain/repositories/media-repository";
+import { and, asc, eq, inArray, isNull, like, or, sql } from "drizzle-orm";
+import {
+	authors,
+	type characters,
+	type ips,
+	mediaAuthors,
+	type mediaCharacters,
+	mediaGenerationInfo,
+	type mediaIps,
+	medias,
+	mediaTags,
+	mediaUrls,
+	type NewMedia,
+	tags,
+} from "../schema";
+import type { DrizzleExecutor } from "../types";
+import {
+	executeMediaSearch,
+	executeMediaSearchInDirectory,
+} from "./media-search";
+
+export type MediaRepositoryExecutorProvider = (tx?: unknown) => DrizzleExecutor;
+
+export type UpsertMediaInput = {
+	mediaSourceId: string;
+	filePath: string;
+	fileName: string;
+	mediaType: "image" | "video" | "audio";
+	width: number;
+	height: number;
+	fileSize: number | null;
+	description: string | null;
+	createdAt: Date;
+	modifiedAt: Date;
+};
+
+export type MediaRepository = IMediaRepository & {
+	batchUpsert(
+		inputs: UpsertMediaInput[],
+		tx?: unknown,
+	): Promise<
+		Array<{
+			id: string;
+			filePath: string;
+			fileSize: number | null;
+			modifiedAt: Date | null;
+		}>
+	>;
+	deleteBySourceIdAndPathPrefix(
+		sourceId: string,
+		folderPath: string,
+		tx?: unknown,
+	): Promise<
+		Array<{
+			id: string;
+			filePath: string;
+			fileSize: number | null;
+			modifiedAt: Date | null;
+		}>
+	>;
+};
+
+function mapToMedia(row: typeof medias.$inferSelect): Media {
+	return mediaSchema.parse(row);
+}
+
+function mapToMediaUrl(row: typeof mediaUrls.$inferSelect): MediaUrl {
+	return mediaUrlSchema.parse(row);
+}
+
+function mapToMediaGenerationInfo(
+	row: typeof mediaGenerationInfo.$inferSelect,
+): MediaGenerationInfo {
+	return mediaGenerationInfoSchema.parse({
+		...row,
+		aiGenerated: row.aiGenerated ?? false,
+		modelName: row.modelName ?? "",
+		seed: row.seed ?? -1,
+		cfgScale: row.cfgScale ?? 0,
+		steps: row.steps ?? 0,
+	});
+}
+
+type MediaWithRelations = typeof medias.$inferSelect & {
+	tags: Array<
+		typeof mediaTags.$inferSelect & {
+			tag: typeof tags.$inferSelect;
+		}
+	>;
+	generationInfo: typeof mediaGenerationInfo.$inferSelect | null;
+	authors: Array<
+		typeof mediaAuthors.$inferSelect & {
+			author: typeof authors.$inferSelect;
+		}
+	>;
+	urls: Array<typeof mediaUrls.$inferSelect>;
+	characters: Array<
+		typeof mediaCharacters.$inferSelect & {
+			character: typeof characters.$inferSelect;
+		}
+	>;
+	ips: Array<
+		typeof mediaIps.$inferSelect & {
+			ip: typeof ips.$inferSelect;
+		}
+	>;
+};
+
+function mapToMediaDetails(row: MediaWithRelations): MediaDetails {
+	return mediaDetailsSchema.parse({
+		...mapToMedia(row),
+		tags: row.tags.map((item) => ({
+			...item.tag,
+			type: item.tagType,
+			source: item.source,
+			confidence: item.confidence,
+		})),
+		generationInfo: row.generationInfo
+			? mapToMediaGenerationInfo(row.generationInfo)
+			: null,
+		authors: row.authors.map((item) => item.author),
+		urls: row.urls.map(mapToMediaUrl),
+		characters: row.characters.map((item) => ({
+			...item.character,
+			confidence: item.confidence,
+			linkSource: item.source,
+		})),
+		ips: row.ips.map((item) => ({
+			...item.ip,
+			confidence: item.confidence,
+			linkSource: item.source,
+		})),
+	});
+}
+
+function escapeLikePattern(value: string): string {
+	return value.replace(/[%_\\]/g, (char) => `\\${char}`);
+}
+
+function getExecutor(
+	getExecutorFn: MediaRepositoryExecutorProvider,
+	tx?: unknown,
+) {
+	return getExecutorFn(tx);
+}
+
+async function selectMediaDetails(
+	client: DrizzleExecutor,
+	mediaId: string,
+): Promise<MediaDetails | null> {
+	const row = await client.query.medias.findFirst({
+		where: eq(medias.id, mediaId),
+		with: {
+			tags: {
+				with: {
+					tag: true,
+				},
+			},
+			generationInfo: true,
+			authors: {
+				with: {
+					author: true,
+				},
+			},
+			urls: true,
+			characters: {
+				with: {
+					character: true,
+				},
+			},
+			ips: {
+				with: {
+					ip: true,
+				},
+			},
+		},
+	});
+
+	return row ? mapToMediaDetails(row as MediaWithRelations) : null;
+}
+
+export function createMediaRepository(
+	getExecutorFn: MediaRepositoryExecutorProvider,
+): MediaRepository {
+	return {
+		async findById(mediaId: string, tx?: unknown): Promise<Media | null> {
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.select()
+					.from(medias)
+					.where(eq(medias.id, mediaId))
+					.limit(1);
+				return rows[0] ? mapToMedia(rows[0]) : null;
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select media by ID: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async findByPath(
+			sourceId: string,
+			filePath: string,
+			tx?: unknown,
+		): Promise<Media | null> {
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.select()
+					.from(medias)
+					.where(
+						and(
+							eq(medias.mediaSourceId, sourceId),
+							eq(medias.filePath, filePath),
+						),
+					)
+					.limit(1);
+				return rows[0] ? mapToMedia(rows[0]) : null;
+			} catch (error) {
+				throw new UnexpectedError(
+					"Failed to select media by source ID and file path",
+					error,
+				);
+			}
+		},
+
+		async create(media: AddMediaRequest, tx?: unknown): Promise<Media> {
+			try {
+				const newMedia: NewMedia = {
+					...media,
+					status: "active",
+					indexedAt: new Date(),
+				};
+				const rows = await getExecutor(getExecutorFn, tx)
+					.insert(medias)
+					.values(newMedia)
+					.returning();
+				return mapToMedia(rows[0]);
+			} catch (error) {
+				throw new UnexpectedError("Failed to insert media", error);
+			}
+		},
+
+		async upsert(media: AddMediaRequest, tx?: unknown): Promise<Media> {
+			try {
+				const newMedia: NewMedia = {
+					...media,
+					status: "active",
+					indexedAt: new Date(),
+				};
+				const rows = await getExecutor(getExecutorFn, tx)
+					.insert(medias)
+					.values(newMedia)
+					.onConflictDoUpdate({
+						target: [medias.mediaSourceId, medias.filePath],
+						set: {
+							fileName: newMedia.fileName,
+							mediaType: newMedia.mediaType,
+							width: newMedia.width,
+							height: newMedia.height,
+							fileSize: newMedia.fileSize,
+							description: newMedia.description,
+							createdAt: newMedia.createdAt,
+							modifiedAt: newMedia.modifiedAt,
+							indexedAt: newMedia.indexedAt,
+							status: newMedia.status,
+						},
+					})
+					.returning();
+				return mapToMedia(rows[0]);
+			} catch (error) {
+				throw new UnexpectedError("Failed to upsert media", error);
+			}
+		},
+
+		async update(
+			mediaId: string,
+			updates: UpdateMediaRequest,
+			tx?: unknown,
+		): Promise<Media> {
+			try {
+				const dbUpdates: Partial<NewMedia> = {};
+				if (updates.filePath !== undefined) {
+					dbUpdates.filePath = updates.filePath;
+				}
+				if (updates.fileName !== undefined) {
+					dbUpdates.fileName = updates.fileName;
+				}
+				if (updates.fileSize !== undefined) {
+					dbUpdates.fileSize = updates.fileSize;
+				}
+				if (updates.mediaType !== undefined) {
+					dbUpdates.mediaType = updates.mediaType;
+				}
+				if (updates.width !== undefined) {
+					dbUpdates.width = updates.width;
+				}
+				if (updates.height !== undefined) {
+					dbUpdates.height = updates.height;
+				}
+				if (updates.description !== undefined) {
+					dbUpdates.description = updates.description;
+				}
+				if (updates.createdAt !== undefined) {
+					dbUpdates.createdAt = updates.createdAt;
+				}
+				dbUpdates.modifiedAt = updates.modifiedAt ?? new Date();
+
+				const rows = await getExecutor(getExecutorFn, tx)
+					.update(medias)
+					.set(dbUpdates)
+					.where(eq(medias.id, mediaId))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("Media", mediaId);
+				}
+				return mapToMedia(rows[0]);
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				throw new UnexpectedError(
+					`Failed to update media with ID: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async delete(mediaId: string, tx?: unknown): Promise<void> {
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.delete(medias)
+					.where(eq(medias.id, mediaId))
+					.returning();
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("Media", mediaId);
+				}
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				throw new UnexpectedError(
+					`Failed to delete media with ID: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		search(
+			mediaSourceId: string,
+			params: MediaSearchRequest,
+			tx?: unknown,
+		): Promise<MediaSearchResponse> {
+			return executeMediaSearch({
+				client: getExecutor(getExecutorFn, tx),
+				params,
+				mediaSourceId,
+				mapMedia: mapToMedia,
+			});
+		},
+
+		globalSearch(
+			params: MediaSearchRequest,
+			tx?: unknown,
+		): Promise<MediaSearchResponse> {
+			return executeMediaSearch({
+				client: getExecutor(getExecutorFn, tx),
+				params,
+				mapMedia: mapToMedia,
+			});
+		},
+
+		async getDetails(
+			mediaId: string,
+			tx?: unknown,
+		): Promise<MediaDetails | null> {
+			try {
+				return await selectMediaDetails(
+					getExecutor(getExecutorFn, tx),
+					mediaId,
+				);
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to get media details for mediaId: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async getTags(mediaId: string, tx?: unknown): Promise<MediaTag[]> {
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.select({
+						id: tags.id,
+						name: tags.name,
+						description: tags.description,
+						attribute: tags.attribute,
+						color: tags.color,
+						source: mediaTags.source,
+						authorId: tags.authorId,
+						createdAt: tags.createdAt,
+						updatedAt: tags.updatedAt,
+						type: mediaTags.tagType,
+						confidence: mediaTags.confidence,
+					})
+					.from(mediaTags)
+					.innerJoin(tags, eq(mediaTags.tagId, tags.id))
+					.where(eq(mediaTags.mediaId, mediaId))
+					.orderBy(asc(tags.name));
+				return rows.map((row) => tagSchema.parse(row));
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to retrieve tags for media ID: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async getGenerationInfo(
+			mediaId: string,
+			tx?: unknown,
+		): Promise<MediaGenerationInfo | null> {
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.select()
+					.from(mediaGenerationInfo)
+					.where(eq(mediaGenerationInfo.mediaId, mediaId))
+					.limit(1);
+				return rows[0] ? mapToMediaGenerationInfo(rows[0]) : null;
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select media generation info for mediaId: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async upsertGenerationInfo(
+			mediaId: string,
+			prompt: string | null,
+			workflow: unknown,
+			tx?: unknown,
+		): Promise<MediaGenerationInfo> {
+			try {
+				const values = {
+					mediaId,
+					prompt,
+					workflow,
+					metadata: { prompt },
+					aiGenerated: Boolean(prompt || workflow),
+				};
+				const rows = await getExecutor(getExecutorFn, tx)
+					.insert(mediaGenerationInfo)
+					.values(values)
+					.onConflictDoUpdate({
+						target: mediaGenerationInfo.mediaId,
+						set: values,
+					})
+					.returning();
+				return mapToMediaGenerationInfo(rows[0]);
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to upsert media generation info for mediaId: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async getAuthors(mediaId: string, tx?: unknown): Promise<Author[]> {
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.select({
+						id: authors.id,
+						name: authors.name,
+						accountId: authors.accountId,
+						createdAt: authors.createdAt,
+						updatedAt: authors.updatedAt,
+					})
+					.from(mediaAuthors)
+					.innerJoin(authors, eq(mediaAuthors.authorId, authors.id))
+					.where(eq(mediaAuthors.mediaId, mediaId))
+					.orderBy(asc(authors.name));
+				return rows.map((row) => authorSchema.parse(row));
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to retrieve authors for media ID: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async getUrls(mediaId: string, tx?: unknown): Promise<MediaUrl[]> {
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.select()
+					.from(mediaUrls)
+					.where(eq(mediaUrls.mediaId, mediaId));
+				return rows.map(mapToMediaUrl);
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select media URLs for mediaId: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async addUrls(
+			mediaId: string,
+			urls: string[],
+			tx?: unknown,
+		): Promise<MediaUrl[]> {
+			if (urls.length === 0) {
+				return [];
+			}
+
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.insert(mediaUrls)
+					.values(urls.map((url) => ({ mediaId, url })))
+					.onConflictDoNothing({
+						target: [mediaUrls.mediaId, mediaUrls.url],
+					})
+					.returning();
+				return rows.map(mapToMediaUrl);
+			} catch (error) {
+				throw new UnexpectedError("Failed to insert media URLs", error);
+			}
+		},
+
+		async findExistingUrls(urls: string[], tx?: unknown): Promise<string[]> {
+			if (urls.length === 0) {
+				return [];
+			}
+
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.select({ url: mediaUrls.url })
+					.from(mediaUrls)
+					.where(inArray(mediaUrls.url, urls));
+				return rows.map((row) => row.url);
+			} catch (error) {
+				throw new UnexpectedError("Failed to check existing URLs", error);
+			}
+		},
+
+		async findAllBySourceId(
+			mediaSourceId: string,
+			limit = 100,
+			offset = 0,
+			tx?: unknown,
+		): Promise<Media[]> {
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.select()
+					.from(medias)
+					.where(eq(medias.mediaSourceId, mediaSourceId))
+					.limit(limit)
+					.offset(offset);
+				return rows.map(mapToMedia);
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select medias by source ID: ${mediaSourceId}`,
+					error,
+				);
+			}
+		},
+
+		async searchInDirectory(
+			mediaSourceId: string,
+			directoryPath: string,
+			params: { query?: string; tags?: string[] },
+			tx?: unknown,
+		): Promise<Media[]> {
+			return await executeMediaSearchInDirectory({
+				client: getExecutor(getExecutorFn, tx),
+				mediaSourceId,
+				directoryPath,
+				params,
+				mapMedia: mapToMedia,
+			});
+		},
+
+		async findIdsWithMissingGenerationInfo(
+			tx?: unknown,
+		): Promise<Array<{ id: string; mediaSourceId: string; filePath: string }>> {
+			try {
+				return await getExecutor(getExecutorFn, tx)
+					.select({
+						id: medias.id,
+						mediaSourceId: medias.mediaSourceId,
+						filePath: medias.filePath,
+					})
+					.from(medias)
+					.leftJoin(
+						mediaGenerationInfo,
+						eq(medias.id, mediaGenerationInfo.mediaId),
+					)
+					.where(
+						and(
+							eq(medias.status, "active"),
+							isNull(mediaGenerationInfo.mediaId),
+						),
+					);
+			} catch (error) {
+				throw new UnexpectedError(
+					"Failed to select media IDs with missing generation info",
+					error,
+				);
+			}
+		},
+
+		async findAllMediaIndices(
+			tx?: unknown,
+			options?: { limit?: number; offset?: number },
+		): Promise<Array<{ id: string; mediaSourceId: string; filePath: string }>> {
+			try {
+				let query: any = getExecutor(getExecutorFn, tx)
+					.select({
+						id: medias.id,
+						mediaSourceId: medias.mediaSourceId,
+						filePath: medias.filePath,
+					})
+					.from(medias)
+					.where(eq(medias.status, "active"))
+					.$dynamic();
+
+				if (options?.limit !== undefined) {
+					query = query.limit(options.limit);
+				}
+				if (options?.offset !== undefined) {
+					query = query.offset(options.offset);
+				}
+
+				return await query;
+			} catch (error) {
+				throw new UnexpectedError("Failed to select media indices", error);
+			}
+		},
+
+		async findAllPathsBySourceId(
+			mediaSourceId: string,
+			tx?: unknown,
+		): Promise<
+			Array<{
+				id: string;
+				filePath: string;
+				fileSize: number | null;
+				modifiedAt: Date | null;
+			}>
+		> {
+			try {
+				return await getExecutor(getExecutorFn, tx)
+					.select({
+						id: medias.id,
+						filePath: medias.filePath,
+						fileSize: medias.fileSize,
+						modifiedAt: medias.modifiedAt,
+					})
+					.from(medias)
+					.where(eq(medias.mediaSourceId, mediaSourceId));
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select media paths by source ID: ${mediaSourceId}`,
+					error,
+				);
+			}
+		},
+
+		async batchUpsert(
+			inputs: UpsertMediaInput[],
+			tx?: unknown,
+		): Promise<
+			Array<{
+				id: string;
+				filePath: string;
+				fileSize: number | null;
+				modifiedAt: Date | null;
+			}>
+		> {
+			if (inputs.length === 0) {
+				return [];
+			}
+
+			const now = new Date();
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.insert(medias)
+					.values(
+						inputs.map((input) => ({
+							mediaSourceId: input.mediaSourceId,
+							filePath: input.filePath,
+							fileName: input.fileName,
+							mediaType: input.mediaType,
+							width: input.width,
+							height: input.height,
+							fileSize: input.fileSize,
+							description: input.description,
+							createdAt: input.createdAt,
+							modifiedAt: input.modifiedAt,
+							indexedAt: now,
+							status: "active" as const,
+						})),
+					)
+					.onConflictDoUpdate({
+						target: [medias.mediaSourceId, medias.filePath],
+						set: {
+							fileName: sql`excluded.file_name`,
+							mediaType: sql`excluded.media_type`,
+							width: sql`excluded.width`,
+							height: sql`excluded.height`,
+							fileSize: sql`excluded.file_size`,
+							description: sql`COALESCE(excluded.description, ${medias.description})`,
+							createdAt: sql`excluded.created_at`,
+							modifiedAt: sql`excluded.modified_at`,
+							indexedAt: sql`${now}`,
+							status: sql`excluded.status`,
+						},
+					})
+					.returning();
+				return rows.map((row) => ({
+					id: row.id,
+					filePath: row.filePath,
+					fileSize: row.fileSize,
+					modifiedAt: row.modifiedAt,
+				}));
+			} catch (error) {
+				throw new UnexpectedError("Failed to batch upsert media", error);
+			}
+		},
+
+		async deleteBySourceIdAndPathPrefix(
+			sourceId: string,
+			folderPath: string,
+			tx?: unknown,
+		): Promise<
+			Array<{
+				id: string;
+				filePath: string;
+				fileSize: number | null;
+				modifiedAt: Date | null;
+			}>
+		> {
+			const normalizedFolderPath = folderPath.replace(/[\\/]+$/, "");
+			if (!normalizedFolderPath) {
+				return [];
+			}
+
+			const prefixPattern = `${escapeLikePattern(normalizedFolderPath)}/`;
+			try {
+				const rows = await getExecutor(getExecutorFn, tx)
+					.delete(medias)
+					.where(
+						and(
+							eq(medias.mediaSourceId, sourceId),
+							or(
+								eq(medias.filePath, normalizedFolderPath),
+								like(medias.filePath, `${prefixPattern}%`),
+							),
+						),
+					)
+					.returning();
+				return rows.map((row) => ({
+					id: row.id,
+					filePath: row.filePath,
+					fileSize: row.fileSize,
+					modifiedAt: row.modifiedAt,
+				}));
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to delete media by source ID and path prefix: ${sourceId}`,
+					error,
+				);
+			}
+		},
+	};
+}

--- a/packages/db/src/repositories/media-search.ts
+++ b/packages/db/src/repositories/media-search.ts
@@ -1,0 +1,740 @@
+import { UnexpectedError } from "@solid-imager/core/domain/errors";
+import type {
+	Media,
+	MediaSearchRequest,
+	MediaSearchResponse,
+	SearchCriterion,
+	SearchGroup,
+} from "@solid-imager/core/domain/media/schemas";
+import { mediaSearchResponseSchema } from "@solid-imager/core/domain/media/schemas";
+import type { AnyColumn, SQL } from "drizzle-orm";
+import {
+	and,
+	asc,
+	desc,
+	eq,
+	exists,
+	gt,
+	gte,
+	inArray,
+	isNotNull,
+	isNull,
+	like,
+	lt,
+	lte,
+	not,
+	notInArray,
+	or,
+	sql,
+} from "drizzle-orm";
+import {
+	authors,
+	characters,
+	ips,
+	mediaAuthors,
+	mediaCharacters,
+	mediaDetails,
+	mediaGenerationInfo,
+	mediaIps,
+	mediaProjects,
+	medias,
+	mediaTags,
+	projects,
+	tags,
+} from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+type CriterionValue = SearchCriterion["value"];
+
+export type ExecuteMediaSearchOptions = {
+	client: DrizzleExecutor;
+	params: MediaSearchRequest;
+	mediaSourceId?: string;
+	mapMedia: (row: typeof medias.$inferSelect) => Media;
+	defaultLimit?: number;
+	defaultOffset?: number;
+};
+
+export type ExecuteMediaSearchInDirectoryOptions = {
+	client: DrizzleExecutor;
+	mediaSourceId: string;
+	directoryPath: string;
+	params: {
+		query?: string;
+		tags?: string[];
+	};
+	mapMedia: (row: typeof medias.$inferSelect) => Media;
+};
+
+function escapeLikePattern(value: string): string {
+	return value.replace(/[%_\\]/g, (char) => `\\${char}`);
+}
+
+function isUuid(value: string): boolean {
+	return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+		value,
+	);
+}
+
+function isUuidArray(value: unknown): value is string[] {
+	return (
+		Array.isArray(value) &&
+		value.length > 0 &&
+		value.every((v) => typeof v === "string" && isUuid(v))
+	);
+}
+
+function getColumnForTarget(target: string): AnyColumn | undefined {
+	switch (target) {
+		case "fileName":
+			return medias.fileName;
+		case "filePath":
+			return medias.filePath;
+		case "description":
+			return medias.description;
+		case "mediaType":
+			return medias.mediaType;
+		case "width":
+			return medias.width;
+		case "height":
+			return medias.height;
+		case "fileSize":
+			return medias.fileSize;
+		case "createdAt":
+			return medias.createdAt;
+		case "rating":
+			return mediaDetails.rating;
+		case "favorite":
+			return mediaDetails.favorite;
+		case "viewCount":
+			return mediaDetails.viewCount;
+		case "aiGenerated":
+			return mediaGenerationInfo.aiGenerated;
+		default:
+			return;
+	}
+}
+
+function buildValueCondition(
+	column: AnyColumn,
+	operator: string,
+	value: CriterionValue,
+): SQL | undefined {
+	if (value === null && operator === "equals") {
+		return isNull(column);
+	}
+	if (value === null && operator !== "isEmpty" && operator !== "isNotEmpty") {
+		return;
+	}
+
+	switch (operator) {
+		case "equals":
+			return eq(column, value);
+		case "contains":
+			return like(column, `%${escapeLikePattern(String(value))}%`);
+		case "startsWith":
+			return like(column, `${escapeLikePattern(String(value))}%`);
+		case "endsWith":
+			return like(column, `%${escapeLikePattern(String(value))}`);
+		case "gt":
+			return gt(column, value);
+		case "gte":
+			return gte(column, value);
+		case "lt":
+			return lt(column, value);
+		case "lte":
+			return lte(column, value);
+		case "in":
+			return Array.isArray(value) ? inArray(column, value) : undefined;
+		case "notIn":
+			return Array.isArray(value) ? notInArray(column, value) : undefined;
+		case "isEmpty":
+			return isNull(column);
+		case "isNotEmpty":
+			return isNotNull(column);
+		default:
+			return;
+	}
+}
+
+function buildKeywordCondition(
+	client: DrizzleExecutor,
+	node: SearchCriterion,
+): SQL | undefined {
+	const pattern = `%${escapeLikePattern(String(node.value))}%`;
+	const condition = or(
+		like(medias.fileName, pattern),
+		like(medias.filePath, pattern),
+		like(medias.description, pattern),
+		exists(
+			client
+				.select({ id: mediaGenerationInfo.mediaId })
+				.from(mediaGenerationInfo)
+				.where(
+					and(
+						eq(mediaGenerationInfo.mediaId, medias.id),
+						like(mediaGenerationInfo.prompt, pattern),
+					),
+				),
+		),
+	);
+	if (!condition) {
+		return;
+	}
+	return node.negate ? not(condition) : condition;
+}
+
+function getRelationColumn(
+	target: "tag" | "project" | "ip" | "character" | "author",
+	value: string | number | boolean,
+): AnyColumn {
+	switch (target) {
+		case "tag":
+			return tags.name;
+		case "project":
+			return isUuid(String(value)) || isUuidArray(value)
+				? projects.id
+				: projects.name;
+		case "ip":
+			return isUuid(String(value)) || isUuidArray(value) ? ips.id : ips.name;
+		case "character":
+			return isUuid(String(value)) || isUuidArray(value)
+				? characters.id
+				: characters.name;
+		case "author":
+			return authors.name;
+	}
+}
+
+function buildRelationQuery(
+	client: DrizzleExecutor,
+	target: "tag" | "project" | "ip" | "character" | "author",
+	operator: SearchCriterion["operator"],
+	value: string | number | boolean,
+	negate: boolean,
+): SQL | undefined {
+	let subquery: SQL | undefined;
+
+	switch (target) {
+		case "tag":
+			subquery = exists(
+				client
+					.select({ id: mediaTags.mediaId })
+					.from(mediaTags)
+					.innerJoin(tags, eq(mediaTags.tagId, tags.id))
+					.where(
+						and(
+							eq(mediaTags.mediaId, medias.id),
+							buildValueCondition(tags.name, operator, value),
+						),
+					),
+			);
+			break;
+		case "project":
+			subquery = exists(
+				client
+					.select({ id: mediaProjects.mediaId })
+					.from(mediaProjects)
+					.innerJoin(projects, eq(mediaProjects.projectId, projects.id))
+					.where(
+						and(
+							eq(mediaProjects.mediaId, medias.id),
+							buildValueCondition(
+								getRelationColumn(target, value),
+								operator,
+								value,
+							),
+						),
+					),
+			);
+			break;
+		case "ip":
+			subquery = exists(
+				client
+					.select({ id: mediaIps.mediaId })
+					.from(mediaIps)
+					.innerJoin(ips, eq(mediaIps.ipId, ips.id))
+					.where(
+						and(
+							eq(mediaIps.mediaId, medias.id),
+							buildValueCondition(
+								getRelationColumn(target, value),
+								operator,
+								value,
+							),
+						),
+					),
+			);
+			break;
+		case "character":
+			subquery = exists(
+				client
+					.select({ id: mediaCharacters.mediaId })
+					.from(mediaCharacters)
+					.innerJoin(characters, eq(mediaCharacters.characterId, characters.id))
+					.where(
+						and(
+							eq(mediaCharacters.mediaId, medias.id),
+							buildValueCondition(
+								getRelationColumn(target, value),
+								operator,
+								value,
+							),
+						),
+					),
+			);
+			break;
+		case "author":
+			subquery = exists(
+				client
+					.select({ id: mediaAuthors.mediaId })
+					.from(mediaAuthors)
+					.innerJoin(authors, eq(mediaAuthors.authorId, authors.id))
+					.where(
+						and(
+							eq(mediaAuthors.mediaId, medias.id),
+							buildValueCondition(authors.name, operator, value),
+						),
+					),
+			);
+			break;
+		default:
+			return;
+	}
+
+	if (!subquery) {
+		return;
+	}
+	return negate ? not(subquery) : subquery;
+}
+
+function buildRelationCondition(
+	client: DrizzleExecutor,
+	node: SearchCriterion,
+): SQL | undefined {
+	return buildRelationQuery(
+		client,
+		node.target as "tag" | "project" | "ip" | "character" | "author",
+		node.operator,
+		node.value as string | number | boolean,
+		node.negate ?? false,
+	);
+}
+
+function buildFolderCondition(node: SearchCriterion): SQL | undefined {
+	if (typeof node.value !== "string") {
+		return;
+	}
+	const folderPath = node.value.endsWith("/") ? node.value : `${node.value}/`;
+	const pattern = `${escapeLikePattern(folderPath)}%`;
+	const condition = like(medias.filePath, pattern);
+	return node.negate ? not(condition) : condition;
+}
+
+function buildDetailsQuery(
+	client: DrizzleExecutor,
+	target: string,
+	operator: string,
+	value: CriterionValue,
+	negate?: boolean,
+): SQL | undefined {
+	let column: AnyColumn | undefined;
+	if (target === "rating") {
+		column = mediaDetails.rating;
+	}
+	if (target === "favorite") {
+		column = mediaDetails.favorite;
+	}
+	if (target === "viewCount") {
+		column = mediaDetails.viewCount;
+	}
+	if (!column) {
+		return;
+	}
+
+	const condition = exists(
+		client
+			.select({ one: sql`1` })
+			.from(mediaDetails)
+			.where(
+				and(
+					eq(mediaDetails.mediaId, medias.id),
+					buildValueCondition(column, operator, value),
+				),
+			),
+	);
+	if (!condition) {
+		return;
+	}
+	return negate ? not(condition) : condition;
+}
+
+function buildGenerationInfoQuery(
+	client: DrizzleExecutor,
+	operator: string,
+	value: CriterionValue,
+	negate?: boolean,
+): SQL | undefined {
+	const condition = exists(
+		client
+			.select({ one: sql`1` })
+			.from(mediaGenerationInfo)
+			.where(
+				and(
+					eq(mediaGenerationInfo.mediaId, medias.id),
+					buildValueCondition(mediaGenerationInfo.aiGenerated, operator, value),
+				),
+			),
+	);
+	if (!condition) {
+		return;
+	}
+	return negate ? not(condition) : condition;
+}
+
+function buildStandardQuery(
+	target: string,
+	operator: string,
+	value: CriterionValue,
+	negate?: boolean,
+): SQL | undefined {
+	const column = getColumnForTarget(target);
+	if (!column) {
+		return;
+	}
+	const condition = buildValueCondition(column, operator, value);
+	if (!condition) {
+		return;
+	}
+	return negate ? not(condition) : condition;
+}
+
+function buildCriterionQuery(
+	client: DrizzleExecutor,
+	node: SearchCriterion,
+): SQL | undefined {
+	if (node.target === "keyword") {
+		return buildKeywordCondition(client, node);
+	}
+	if (["tag", "project", "ip", "character", "author"].includes(node.target)) {
+		return buildRelationCondition(client, node);
+	}
+	if (node.target === "folder") {
+		return buildFolderCondition(node);
+	}
+	if (["rating", "favorite", "viewCount"].includes(node.target)) {
+		return buildDetailsQuery(
+			client,
+			node.target,
+			node.operator,
+			node.value,
+			node.negate ?? false,
+		);
+	}
+	if (node.target === "aiGenerated") {
+		return buildGenerationInfoQuery(
+			client,
+			node.operator,
+			node.value,
+			node.negate ?? false,
+		);
+	}
+	return buildStandardQuery(
+		node.target,
+		node.operator,
+		node.value,
+		node.negate ?? false,
+	);
+}
+
+function buildSearchQuery(
+	client: DrizzleExecutor,
+	node: SearchGroup | SearchCriterion,
+	depth = 0,
+): SQL | undefined {
+	const maxDepth = 10;
+	if (depth > maxDepth) {
+		throw new Error(`Search condition nesting too deep (max ${maxDepth})`);
+	}
+
+	if (node.type === "group") {
+		const conditions = node.children
+			.map((child) => buildSearchQuery(client, child, depth + 1))
+			.filter((value): value is SQL => value !== undefined);
+		if (conditions.length === 0) {
+			return;
+		}
+		const combined =
+			node.operator === "and" ? and(...conditions) : or(...conditions);
+		if (!combined) {
+			return;
+		}
+		return node.negate ? not(combined) : combined;
+	}
+
+	return buildCriterionQuery(client, node);
+}
+
+function getOrderByClause(sort: string | undefined, order: "asc" | "desc") {
+	const direction = order === "asc" ? asc : desc;
+
+	switch (sort) {
+		case "name":
+			return direction(medias.fileName);
+		case "size":
+			return direction(medias.fileSize);
+		case "date":
+			return direction(medias.createdAt);
+		case "rating":
+			return direction(mediaDetails.rating);
+		case "viewCount":
+			return direction(mediaDetails.viewCount);
+		default:
+			return direction(medias.createdAt);
+	}
+}
+
+export async function executeMediaSearch({
+	client,
+	params,
+	mediaSourceId,
+	mapMedia,
+	defaultLimit = 100,
+	defaultOffset = 0,
+}: ExecuteMediaSearchOptions): Promise<MediaSearchResponse> {
+	const conditions: SQL[] = [];
+	if (mediaSourceId) {
+		conditions.push(eq(medias.mediaSourceId, mediaSourceId));
+	}
+	if (params.condition) {
+		const searchCondition = buildSearchQuery(client, params.condition);
+		if (searchCondition) {
+			conditions.push(searchCondition);
+		}
+	}
+
+	const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+	const needsDetailsJoin = ["rating", "viewCount"].includes(params.sort ?? "");
+	const orderBy = getOrderByClause(params.sort, params.order);
+	const limit = params.limit ?? defaultLimit;
+	const offset = params.offset ?? defaultOffset;
+
+	const rows = needsDetailsJoin
+		? await client
+				.select({ media: medias })
+				.from(medias)
+				.leftJoin(mediaDetails, eq(mediaDetails.mediaId, medias.id))
+				.where(whereClause)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(orderBy)
+		: await client
+				.select({ media: medias })
+				.from(medias)
+				.where(whereClause)
+				.limit(limit)
+				.offset(offset)
+				.orderBy(orderBy);
+
+	const countRows = await client
+		.select({ count: sql<number>`count(*)` })
+		.from(medias)
+		.where(whereClause);
+
+	return mediaSearchResponseSchema.parse({
+		media: rows.map((row) => mapMedia(row.media)),
+		total: Number(countRows[0]?.count ?? 0),
+	});
+}
+
+export type SearchOptions = {
+	query?: string;
+	tags?: string[];
+	tagMode?: "and" | "or";
+	excludeTags?: string[];
+	projects?: string[];
+	ips?: string[];
+	characters?: string[];
+	sort?: "date" | "name" | "size";
+	order?: "asc" | "desc";
+	limit?: number;
+	offset?: number;
+};
+
+function buildSearchRequestFromOptions(
+	options: SearchOptions,
+): MediaSearchRequest {
+	const children: (SearchCriterion | SearchGroup)[] = [];
+
+	if (options.query) {
+		children.push({
+			type: "criterion",
+			target: "keyword",
+			operator: "contains",
+			value: options.query,
+		});
+	}
+
+	if (options.tags && options.tags.length > 0) {
+		if (options.tagMode === "and") {
+			children.push({
+				type: "group",
+				operator: "and",
+				children: options.tags.map((tag) => ({
+					type: "criterion" as const,
+					target: "tag" as const,
+					operator: "equals" as const,
+					value: tag,
+				})),
+			});
+		} else {
+			children.push({
+				type: "criterion",
+				target: "tag",
+				operator: "in",
+				value: options.tags,
+			});
+		}
+	}
+
+	if (options.excludeTags && options.excludeTags.length > 0) {
+		children.push({
+			type: "criterion" as const,
+			target: "tag" as const,
+			operator: "in" as const,
+			value: options.excludeTags,
+			negate: true,
+		});
+	}
+
+	if (options.projects && options.projects.length > 0) {
+		children.push({
+			type: "criterion" as const,
+			target: "project" as const,
+			operator: "in" as const,
+			value: options.projects,
+		});
+	}
+
+	if (options.ips && options.ips.length > 0) {
+		children.push({
+			type: "criterion" as const,
+			target: "ip" as const,
+			operator: "in" as const,
+			value: options.ips,
+		});
+	}
+
+	if (options.characters && options.characters.length > 0) {
+		children.push({
+			type: "criterion" as const,
+			target: "character" as const,
+			operator: "in" as const,
+			value: options.characters,
+		});
+	}
+
+	return {
+		condition:
+			children.length > 0
+				? { type: "group", operator: "and", children }
+				: undefined,
+		sort: options.sort,
+		order: options.order ?? "desc",
+		limit: options.limit,
+		offset: options.offset ?? 0,
+	};
+}
+
+export const searchMedia = async (
+	mediaSourceId: string,
+	searchOptions: SearchOptions,
+	client: DrizzleExecutor,
+) => {
+	return executeMediaSearch({
+		client,
+		mediaSourceId,
+		params: buildSearchRequestFromOptions(searchOptions),
+		mapMedia: (row) => row,
+		defaultLimit: searchOptions.limit,
+		defaultOffset: searchOptions.offset,
+	});
+};
+
+export const globalSearchMedia = async (
+	searchOptions: SearchOptions,
+	client: DrizzleExecutor,
+) => {
+	return executeMediaSearch({
+		client,
+		params: buildSearchRequestFromOptions(searchOptions),
+		mapMedia: (row) => row,
+		defaultLimit: searchOptions.limit,
+		defaultOffset: searchOptions.offset,
+	});
+};
+
+export const searchMediaInDirectory = async (
+	mediaSourceId: string,
+	directoryPath: string,
+	searchOptions: { query?: string; tags?: string[] },
+	client: DrizzleExecutor,
+) => {
+	return executeMediaSearchInDirectory({
+		client,
+		mediaSourceId,
+		directoryPath,
+		params: searchOptions,
+		mapMedia: (row) => row as Media,
+	});
+};
+
+export async function executeMediaSearchInDirectory({
+	client,
+	mediaSourceId,
+	directoryPath,
+	params,
+	mapMedia,
+}: ExecuteMediaSearchInDirectoryOptions): Promise<Media[]> {
+	try {
+		const normalizedPath = directoryPath.replace(/[\\/]+$/, "");
+		const prefixPattern = `${escapeLikePattern(normalizedPath)}/`;
+		const conditions: (SQL | undefined)[] = [
+			eq(medias.mediaSourceId, mediaSourceId),
+			or(
+				eq(medias.filePath, normalizedPath),
+				like(medias.filePath, `${prefixPattern}%`),
+			),
+		];
+
+		if (params.query) {
+			const escapedQuery = escapeLikePattern(params.query);
+			conditions.push(
+				or(
+					like(medias.fileName, `%${escapedQuery}%`),
+					like(medias.description, `%${escapedQuery}%`),
+				),
+			);
+		}
+
+		if (params.tags && params.tags.length > 0) {
+			const mediaIdsWithTags = client
+				.select({ mediaId: mediaTags.mediaId })
+				.from(mediaTags)
+				.innerJoin(tags, eq(mediaTags.tagId, tags.id))
+				.where(inArray(tags.name, params.tags));
+			conditions.push(inArray(medias.id, mediaIdsWithTags));
+		}
+
+		const rows = await client
+			.select()
+			.from(medias)
+			.where(and(...conditions));
+		return rows.map((row) => mapMedia(row));
+	} catch (error) {
+		throw new UnexpectedError(
+			`Failed to search media in directory ${directoryPath} for source ID: ${mediaSourceId}`,
+			error,
+		);
+	}
+}

--- a/packages/db/src/repositories/preset-repository.ts
+++ b/packages/db/src/repositories/preset-repository.ts
@@ -1,0 +1,113 @@
+import type {
+	CreatePresetRequest,
+	Preset,
+	SearchGroup,
+	UpdatePresetRequest,
+} from "@solid-imager/core/domain/media/schemas";
+import { presetSchema } from "@solid-imager/core/domain/media/schemas";
+import type { PresetRepository } from "@solid-imager/core/domain/repositories/preset-repository";
+import { eq } from "drizzle-orm";
+import { presets } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+export type PresetRepositoryExecutorProvider = (
+	tx?: unknown,
+) => DrizzleExecutor;
+
+const validSorts = new Set(["date", "name", "size", "rating", "viewCount"]);
+const validOrders = new Set(["asc", "desc"]);
+const validModes = new Set(["simple", "pro"]);
+
+function normalizeOptionalEnum<T extends string>(
+	value: string | null,
+	validValues: Set<T>,
+): T | undefined {
+	if (!value || !validValues.has(value as T)) {
+		return;
+	}
+	return value as T;
+}
+
+function mapToPreset(row: typeof presets.$inferSelect): Preset {
+	return presetSchema.parse({
+		id: row.id,
+		name: row.name,
+		value: row.value as SearchGroup,
+		sort: normalizeOptionalEnum(row.sort, validSorts),
+		order: normalizeOptionalEnum(row.order, validOrders),
+		mode: normalizeOptionalEnum(row.mode, validModes),
+		createdAt: row.createdAt,
+	});
+}
+
+export function createPresetRepository(
+	getExecutor: PresetRepositoryExecutorProvider,
+): PresetRepository {
+	return {
+		async list(): Promise<Preset[]> {
+			const rows = await getExecutor()
+				.select()
+				.from(presets)
+				.orderBy(presets.id);
+			return rows.map(mapToPreset);
+		},
+
+		async get(id: number): Promise<Preset | null> {
+			const rows = await getExecutor()
+				.select()
+				.from(presets)
+				.where(eq(presets.id, id))
+				.limit(1);
+			return rows[0] ? mapToPreset(rows[0]) : null;
+		},
+
+		async getByName(name: string): Promise<Preset | null> {
+			const rows = await getExecutor()
+				.select()
+				.from(presets)
+				.where(eq(presets.name, name))
+				.limit(1);
+			return rows[0] ? mapToPreset(rows[0]) : null;
+		},
+
+		async create(input: CreatePresetRequest): Promise<Preset> {
+			const rows = await getExecutor()
+				.insert(presets)
+				.values({
+					name: input.name,
+					value: input.value,
+					sort: input.sort,
+					order: input.order,
+					mode: input.mode,
+				})
+				.returning();
+			return mapToPreset(rows[0]);
+		},
+
+		async update(
+			id: number,
+			input: UpdatePresetRequest,
+		): Promise<Preset | null> {
+			const rows = await getExecutor()
+				.update(presets)
+				.set({
+					...(input.name !== undefined ? { name: input.name } : {}),
+					...(input.value !== undefined ? { value: input.value } : {}),
+					...(input.sort !== undefined ? { sort: input.sort } : {}),
+					...(input.order !== undefined ? { order: input.order } : {}),
+					...(input.mode !== undefined ? { mode: input.mode } : {}),
+				})
+				.where(eq(presets.id, id))
+				.returning();
+			return rows[0] ? mapToPreset(rows[0]) : null;
+		},
+
+		async delete(id: number): Promise<boolean> {
+			const rows = await getExecutor()
+				.delete(presets)
+				.where(eq(presets.id, id))
+				.returning();
+			return rows.length > 0;
+		},
+	};
+}

--- a/packages/db/src/repositories/project-repository.ts
+++ b/packages/db/src/repositories/project-repository.ts
@@ -1,0 +1,176 @@
+import { ResourceNotFoundError } from "@solid-imager/core/domain/errors";
+import type {
+	NewProject,
+	Project,
+	UpdateProject,
+} from "@solid-imager/core/domain/projects/schemas";
+import { projectSchema } from "@solid-imager/core/domain/projects/schemas";
+import type { IProjectRepository } from "@solid-imager/core/domain/repositories/project-repository";
+import { and, asc, eq } from "drizzle-orm";
+import { mediaProjects, projects } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+export type ProjectRepositoryExecutorProvider = (
+	tx?: unknown,
+) => DrizzleExecutor;
+
+type CreateProjectRepositoryOptions = {
+	orderByName?: boolean;
+};
+
+function mapToProject(row: typeof projects.$inferSelect): Project {
+	return projectSchema.parse({
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+		archivedAt: row.archivedAt,
+	});
+}
+
+export function createProjectRepository(
+	getExecutor: ProjectRepositoryExecutorProvider,
+	options: CreateProjectRepositoryOptions = {},
+): IProjectRepository {
+	return {
+		async findAll(): Promise<Project[]> {
+			const query = getExecutor().select().from(projects);
+			const rows = options.orderByName
+				? await query.orderBy(asc(projects.name))
+				: await query;
+			return rows.map(mapToProject);
+		},
+
+		async findById(id: string, tx?: unknown): Promise<Project | null> {
+			const rows = await getExecutor(tx)
+				.select()
+				.from(projects)
+				.where(eq(projects.id, id))
+				.limit(1);
+			return rows[0] ? mapToProject(rows[0]) : null;
+		},
+
+		async findByName(name: string, tx?: unknown): Promise<Project | null> {
+			const rows = await getExecutor(tx)
+				.select()
+				.from(projects)
+				.where(eq(projects.name, name))
+				.limit(1);
+			return rows[0] ? mapToProject(rows[0]) : null;
+		},
+
+		async create(input: NewProject, tx?: unknown): Promise<Project> {
+			const rows = await getExecutor(tx)
+				.insert(projects)
+				.values({
+					name: input.name,
+					description: input.description ?? null,
+				})
+				.returning();
+			return mapToProject(rows[0]);
+		},
+
+		async update(
+			id: string,
+			input: UpdateProject,
+			tx?: unknown,
+		): Promise<Project> {
+			const rows = await getExecutor(tx)
+				.update(projects)
+				.set({
+					...(input.name !== undefined ? { name: input.name } : {}),
+					...(input.description !== undefined
+						? { description: input.description ?? null }
+						: {}),
+					...(input.archivedAt !== undefined
+						? { archivedAt: input.archivedAt }
+						: {}),
+					updatedAt: new Date(),
+				})
+				.where(eq(projects.id, id))
+				.returning();
+
+			if (!rows[0]) {
+				throw new ResourceNotFoundError("Project", id);
+			}
+			return mapToProject(rows[0]);
+		},
+
+		async delete(id: string, tx?: unknown): Promise<void> {
+			const rows = await getExecutor(tx)
+				.delete(projects)
+				.where(eq(projects.id, id))
+				.returning();
+
+			if (!rows[0]) {
+				throw new ResourceNotFoundError("Project", id);
+			}
+		},
+
+		async findByMediaId(mediaId: string, tx?: unknown): Promise<Project[]> {
+			const query = getExecutor(tx)
+				.select({
+					id: projects.id,
+					name: projects.name,
+					description: projects.description,
+					createdAt: projects.createdAt,
+					updatedAt: projects.updatedAt,
+					archivedAt: projects.archivedAt,
+				})
+				.from(projects)
+				.innerJoin(mediaProjects, eq(projects.id, mediaProjects.projectId))
+				.where(eq(mediaProjects.mediaId, mediaId));
+			const rows = options.orderByName
+				? await query.orderBy(asc(projects.name))
+				: await query;
+			return rows.map(mapToProject);
+		},
+
+		async addMedia(
+			mediaId: string,
+			projectId: string,
+			tx?: unknown,
+		): Promise<void> {
+			await getExecutor(tx)
+				.insert(mediaProjects)
+				.values({ mediaId, projectId })
+				.onConflictDoNothing();
+		},
+
+		async removeMedia(
+			mediaId: string,
+			projectId: string,
+			tx?: unknown,
+		): Promise<void> {
+			const rows = await getExecutor(tx)
+				.delete(mediaProjects)
+				.where(
+					and(
+						eq(mediaProjects.mediaId, mediaId),
+						eq(mediaProjects.projectId, projectId),
+					),
+				)
+				.returning();
+
+			if (!rows[0]) {
+				throw new ResourceNotFoundError("MediaProject association");
+			}
+		},
+
+		async addMediaBulk(
+			mediaId: string,
+			projectIds: string[],
+			tx?: unknown,
+		): Promise<void> {
+			if (projectIds.length === 0) {
+				return;
+			}
+
+			await getExecutor(tx)
+				.insert(mediaProjects)
+				.values(projectIds.map((projectId) => ({ mediaId, projectId })))
+				.onConflictDoNothing();
+		},
+	};
+}

--- a/packages/db/src/repositories/source-repository.ts
+++ b/packages/db/src/repositories/source-repository.ts
@@ -1,0 +1,162 @@
+import {
+	ResourceConflictError,
+	ResourceNotFoundError,
+	UnexpectedError,
+} from "@solid-imager/core/domain/errors";
+import type {
+	MediaSource,
+	NewMediaSource,
+	SourceRepository,
+} from "@solid-imager/core/domain/repositories/source-repository";
+import { asc, eq } from "drizzle-orm";
+import { mediaSources } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+export type SourceRepositoryExecutorProvider = (
+	tx?: unknown,
+) => DrizzleExecutor;
+
+type CreateSourceRepositoryOptions = {
+	orderByName?: boolean;
+};
+
+function isUniqueViolation(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === "23505"
+	);
+}
+
+function mapToMediaSource(row: typeof mediaSources.$inferSelect): MediaSource {
+	return {
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		type: row.type,
+		connectionInfo: row.connectionInfo as MediaSource["connectionInfo"],
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+	};
+}
+
+export function createSourceRepository(
+	getExecutor: SourceRepositoryExecutorProvider,
+	options: CreateSourceRepositoryOptions = {},
+): SourceRepository {
+	return {
+		async findAll(): Promise<MediaSource[]> {
+			try {
+				const query = getExecutor().select().from(mediaSources);
+				const rows = options.orderByName
+					? await query.orderBy(asc(mediaSources.name))
+					: await query;
+				return rows.map(mapToMediaSource);
+			} catch (error) {
+				throw new UnexpectedError("Failed to select media sources", error);
+			}
+		},
+
+		async findById(id: string, tx?: unknown): Promise<MediaSource | null> {
+			try {
+				const rows = await getExecutor(tx)
+					.select()
+					.from(mediaSources)
+					.where(eq(mediaSources.id, id))
+					.limit(1);
+				return rows[0] ? mapToMediaSource(rows[0]) : null;
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select media source by ID: ${id}`,
+					error,
+				);
+			}
+		},
+
+		async create(input: NewMediaSource, tx?: unknown): Promise<MediaSource> {
+			try {
+				const rows = await getExecutor(tx)
+					.insert(mediaSources)
+					.values({
+						name: input.name,
+						description: input.description,
+						type: input.type,
+						connectionInfo: input.connectionInfo,
+					})
+					.returning();
+				return mapToMediaSource(rows[0]);
+			} catch (error) {
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						"Media source with this name or ID already exists",
+					);
+				}
+				throw new UnexpectedError("Failed to insert media source", error);
+			}
+		},
+
+		async update(
+			id: string,
+			input: Partial<MediaSource>,
+			tx?: unknown,
+		): Promise<MediaSource> {
+			try {
+				const rows = await getExecutor(tx)
+					.update(mediaSources)
+					.set({
+						...(input.name !== undefined ? { name: input.name } : {}),
+						...(input.description !== undefined
+							? { description: input.description }
+							: {}),
+						...(input.type !== undefined ? { type: input.type } : {}),
+						...(input.connectionInfo !== undefined
+							? { connectionInfo: input.connectionInfo }
+							: {}),
+						updatedAt: new Date(),
+					})
+					.where(eq(mediaSources.id, id))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("Media source", id);
+				}
+				return mapToMediaSource(rows[0]);
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						"Media source with this name or ID already exists",
+					);
+				}
+				throw new UnexpectedError(
+					`Failed to update media source with ID: ${id}`,
+					error,
+				);
+			}
+		},
+
+		async delete(id: string, tx?: unknown): Promise<void> {
+			try {
+				const rows = await getExecutor(tx)
+					.delete(mediaSources)
+					.where(eq(mediaSources.id, id))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("Media source", id);
+				}
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				throw new UnexpectedError(
+					`Failed to delete media source with ID: ${id}`,
+					error,
+				);
+			}
+		},
+	};
+}

--- a/packages/db/src/repositories/tag-repository.ts
+++ b/packages/db/src/repositories/tag-repository.ts
@@ -1,0 +1,336 @@
+import {
+	ResourceConflictError,
+	ResourceNotFoundError,
+	UnexpectedError,
+} from "@solid-imager/core/domain/errors";
+import type { MediaTag } from "@solid-imager/core/domain/media/schemas";
+import type {
+	NewTag,
+	Tag,
+	TagRepository as TagRepositoryDef,
+	UpdateTag,
+} from "@solid-imager/core/domain/repositories/tag-repository";
+import { tagResponseSchema } from "@solid-imager/core/domain/tags/schemas";
+import { asc, eq, inArray, sql } from "drizzle-orm";
+import { mediaTags, tags } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+export type TagRepositoryExecutorProvider = (tx?: unknown) => DrizzleExecutor;
+export type TagRepositoryTransactionRunner = <T>(
+	callback: (tx: unknown) => Promise<T>,
+) => Promise<T>;
+
+type CreateTagRepositoryOptions = {
+	orderByName?: boolean;
+	transaction?: TagRepositoryTransactionRunner;
+};
+
+type MediaTagResult = typeof tags.$inferSelect & {
+	type: "positive" | "negative";
+	confidence: number | null;
+	associationSource: string;
+};
+
+function isUniqueViolation(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === "23505"
+	);
+}
+
+function mapToTag(row: typeof tags.$inferSelect): Tag {
+	return tagResponseSchema.parse({
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		attribute: row.attribute,
+		color: row.color,
+		source: row.source,
+		authorId: row.authorId,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+	});
+}
+
+function mapToMediaTag(row: MediaTagResult): MediaTag {
+	return {
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		attribute: row.attribute,
+		color: row.color,
+		source: row.associationSource,
+		authorId: row.authorId,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+		type: row.type,
+		confidence: row.confidence,
+	};
+}
+
+function mediaTagConflictSet(source: string) {
+	let sourceUpdateSql = sql`excluded.source`;
+	let confidenceUpdateSql = sql`excluded.confidence`;
+
+	if (source === "AI") {
+		sourceUpdateSql = sql`CASE WHEN media_tags.source = 'AI' THEN excluded.source ELSE media_tags.source END`;
+		confidenceUpdateSql = sql`CASE WHEN media_tags.source = 'AI' THEN excluded.confidence ELSE media_tags.confidence END`;
+	} else if (source === "manual") {
+		sourceUpdateSql = sql`CASE WHEN media_tags.source IN ('AI', 'manual') THEN excluded.source ELSE media_tags.source END`;
+		confidenceUpdateSql = sql`CASE WHEN media_tags.source IN ('AI', 'manual') THEN excluded.confidence ELSE media_tags.confidence END`;
+	}
+
+	return {
+		source: sourceUpdateSql,
+		confidence: confidenceUpdateSql,
+	};
+}
+
+export function createTagRepository(
+	getExecutor: TagRepositoryExecutorProvider,
+	options: CreateTagRepositoryOptions = {},
+): TagRepositoryDef {
+	return {
+		async findAll(): Promise<Tag[]> {
+			try {
+				const query = getExecutor().select().from(tags);
+				const rows = options.orderByName
+					? await query.orderBy(asc(tags.name))
+					: await query;
+				return rows.map(mapToTag);
+			} catch (error) {
+				throw new UnexpectedError("Failed to select tags", error);
+			}
+		},
+
+		async findById(id: string): Promise<Tag | null> {
+			try {
+				const rows = await getExecutor()
+					.select()
+					.from(tags)
+					.where(eq(tags.id, id))
+					.limit(1);
+				return rows[0] ? mapToTag(rows[0]) : null;
+			} catch (error) {
+				throw new UnexpectedError(`Failed to select tag by ID: ${id}`, error);
+			}
+		},
+
+		async findByName(name: string): Promise<Tag | null> {
+			try {
+				const rows = await getExecutor()
+					.select()
+					.from(tags)
+					.where(eq(tags.name, name))
+					.limit(1);
+				return rows[0] ? mapToTag(rows[0]) : null;
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select tag by name: ${name}`,
+					error,
+				);
+			}
+		},
+
+		async create(input: NewTag, tx?: unknown): Promise<Tag> {
+			try {
+				const rows = await getExecutor(tx)
+					.insert(tags)
+					.values({
+						name: input.name,
+						description: input.description ?? null,
+						attribute: input.attribute ?? null,
+						color: input.color ?? null,
+						source: input.source ?? "manual",
+					})
+					.returning();
+				return mapToTag(rows[0]);
+			} catch (error) {
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						`Tag with name '${input.name}' already exists`,
+					);
+				}
+				throw new UnexpectedError("Failed to insert tag", error);
+			}
+		},
+
+		async update(id: string, input: UpdateTag, tx?: unknown): Promise<Tag> {
+			try {
+				const rows = await getExecutor(tx)
+					.update(tags)
+					.set({
+						...(input.name !== undefined ? { name: input.name } : {}),
+						...(input.description !== undefined
+							? { description: input.description ?? null }
+							: {}),
+						...(input.attribute !== undefined
+							? { attribute: input.attribute ?? null }
+							: {}),
+						...(input.color !== undefined
+							? { color: input.color ?? null }
+							: {}),
+						...(input.source !== undefined ? { source: input.source } : {}),
+						updatedAt: new Date(),
+					})
+					.where(eq(tags.id, id))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("Tag", id);
+				}
+				return mapToTag(rows[0]);
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						`Tag with name '${input.name}' already exists`,
+					);
+				}
+				throw new UnexpectedError(`Failed to update tag with ID: ${id}`, error);
+			}
+		},
+
+		async delete(id: string, tx?: unknown): Promise<void> {
+			try {
+				const rows = await getExecutor(tx)
+					.delete(tags)
+					.where(eq(tags.id, id))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("Tag", id);
+				}
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				throw new UnexpectedError(`Failed to delete tag with ID: ${id}`, error);
+			}
+		},
+
+		async findByMediaId(mediaId: string, tx?: unknown): Promise<MediaTag[]> {
+			try {
+				const rows = await getExecutor(tx)
+					.select({
+						id: tags.id,
+						name: tags.name,
+						description: tags.description,
+						attribute: tags.attribute,
+						color: tags.color,
+						source: tags.source,
+						authorId: tags.authorId,
+						createdAt: tags.createdAt,
+						updatedAt: tags.updatedAt,
+						type: mediaTags.tagType,
+						confidence: mediaTags.confidence,
+						associationSource: mediaTags.source,
+					})
+					.from(mediaTags)
+					.innerJoin(tags, eq(mediaTags.tagId, tags.id))
+					.where(eq(mediaTags.mediaId, mediaId));
+
+				return rows.map(mapToMediaTag);
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to retrieve tags for media ID: ${mediaId}`,
+					error,
+				);
+			}
+		},
+
+		async addTagsToMedia(
+			mediaId: string,
+			tagsToInsert: {
+				name: string;
+				type: "positive" | "negative";
+				confidence?: number;
+			}[],
+			source = "manual",
+			tx?: unknown,
+		): Promise<void> {
+			try {
+				const execute = async (innerTx?: unknown): Promise<void> => {
+					const client = getExecutor(innerTx);
+					const dedupedInputs = Array.from(
+						new Map(
+							tagsToInsert.map((tag) => [`${tag.name}:${tag.type}`, tag]),
+						).values(),
+					);
+					const uniqueTagNames = Array.from(
+						new Set(dedupedInputs.map((tag) => tag.name)),
+					);
+					if (uniqueTagNames.length === 0) {
+						return;
+					}
+
+					await client
+						.insert(tags)
+						.values(uniqueTagNames.map((name) => ({ name, source })))
+						.onConflictDoNothing();
+
+					const allTags = await client
+						.select()
+						.from(tags)
+						.where(inArray(tags.name, uniqueTagNames));
+
+					const tagMap = new Map(allTags.map((tag) => [tag.name, tag]));
+					const rows = dedupedInputs.flatMap((tagToInsert) => {
+						const foundTag = tagMap.get(tagToInsert.name);
+						if (!foundTag) {
+							console.error(
+								`Tag "${tagToInsert.name}" not found after insertion; skipping`,
+							);
+							return [];
+						}
+						return [
+							{
+								mediaId,
+								tagId: foundTag.id,
+								tagType: tagToInsert.type,
+								confidence: tagToInsert.confidence ?? null,
+								source,
+							},
+						];
+					});
+
+					if (rows.length === 0) {
+						return;
+					}
+
+					await client
+						.insert(mediaTags)
+						.values(rows)
+						.onConflictDoUpdate({
+							target: [mediaTags.mediaId, mediaTags.tagId, mediaTags.tagType],
+							set: mediaTagConflictSet(source),
+						});
+				};
+
+				if (tx) {
+					await execute(tx);
+					return;
+				}
+				if (options.transaction) {
+					await options.transaction(execute);
+					return;
+				}
+				await execute();
+			} catch (error) {
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						"One or more media tags already exist",
+					);
+				}
+				throw new UnexpectedError(
+					`Failed to insert media tags for media ID: ${mediaId}`,
+					error,
+				);
+			}
+		},
+	};
+}

--- a/packages/db/src/repositories/user-repository.ts
+++ b/packages/db/src/repositories/user-repository.ts
@@ -1,0 +1,184 @@
+import {
+	ResourceConflictError,
+	ResourceNotFoundError,
+	UnexpectedError,
+} from "@solid-imager/core/domain/errors";
+import type {
+	NewUser,
+	UpdateUser,
+	User,
+	UserRepository,
+} from "@solid-imager/core/domain/repositories/user-repository";
+import { userSchema } from "@solid-imager/core/domain/users/schemas";
+import { asc, eq } from "drizzle-orm";
+import { users } from "../schema";
+import type { DrizzleExecutor } from "../types";
+
+type DbUser = typeof users.$inferSelect;
+
+export type UserRepositoryExecutorProvider = (tx?: unknown) => DrizzleExecutor;
+
+type CreateUserRepositoryOptions = {
+	orderByName?: boolean;
+};
+
+function isUniqueViolation(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === "23505"
+	);
+}
+
+function mapToUser(row: DbUser): User | null {
+	const result = userSchema.safeParse({
+		id: row.id,
+		name: row.name,
+		email: row.email,
+		password: row.password,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+	});
+	return result.success ? result.data : null;
+}
+
+export function createUserRepository(
+	getExecutor: UserRepositoryExecutorProvider,
+	options: CreateUserRepositoryOptions = {},
+): UserRepository {
+	return {
+		async findAll(): Promise<User[]> {
+			try {
+				const query = getExecutor().select().from(users);
+				const rows = options.orderByName
+					? await query.orderBy(asc(users.name))
+					: await query;
+				return rows.flatMap((row) => {
+					const mapped = mapToUser(row);
+					return mapped ? [mapped] : [];
+				});
+			} catch (error) {
+				throw new UnexpectedError("Failed to select users", error);
+			}
+		},
+
+		async findById(id: string, tx?: unknown): Promise<User | null> {
+			try {
+				const rows = await getExecutor(tx)
+					.select()
+					.from(users)
+					.where(eq(users.id, id))
+					.limit(1);
+				return rows[0] ? mapToUser(rows[0]) : null;
+			} catch (error) {
+				throw new UnexpectedError(`Failed to select user by ID: ${id}`, error);
+			}
+		},
+
+		async findByEmail(email: string, tx?: unknown): Promise<User | null> {
+			try {
+				const rows = await getExecutor(tx)
+					.select()
+					.from(users)
+					.where(eq(users.email, email))
+					.limit(1);
+				return rows[0] ? mapToUser(rows[0]) : null;
+			} catch (error) {
+				throw new UnexpectedError(
+					`Failed to select user by email: ${email}`,
+					error,
+				);
+			}
+		},
+
+		async create(input: NewUser, tx?: unknown): Promise<User> {
+			try {
+				const rows = await getExecutor(tx)
+					.insert(users)
+					.values({
+						name: input.name,
+						email: input.email,
+						password: input.password,
+					})
+					.returning();
+				const mapped = mapToUser(rows[0]);
+				if (!mapped) {
+					throw new UnexpectedError("Failed to parse created user");
+				}
+				return mapped;
+			} catch (error) {
+				if (error instanceof UnexpectedError) throw error;
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						"User with this email already exists",
+					);
+				}
+				throw new UnexpectedError("Failed to insert user", error);
+			}
+		},
+
+		async update(id: string, input: UpdateUser, tx?: unknown): Promise<User> {
+			try {
+				const rows = await getExecutor(tx)
+					.update(users)
+					.set({
+						...(input.name !== undefined ? { name: input.name } : {}),
+						...(input.email !== undefined ? { email: input.email } : {}),
+						...(input.password !== undefined
+							? { password: input.password }
+							: {}),
+						updatedAt: new Date(),
+					})
+					.where(eq(users.id, id))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("User", id);
+				}
+				const mapped = mapToUser(rows[0]);
+				if (!mapped) {
+					throw new UnexpectedError("Failed to parse updated user");
+				}
+				return mapped;
+			} catch (error) {
+				if (
+					error instanceof ResourceNotFoundError ||
+					error instanceof UnexpectedError
+				) {
+					throw error;
+				}
+				if (isUniqueViolation(error)) {
+					throw new ResourceConflictError(
+						"User with this email already exists",
+					);
+				}
+				throw new UnexpectedError(
+					`Failed to update user with ID: ${id}`,
+					error,
+				);
+			}
+		},
+
+		async delete(id: string, tx?: unknown): Promise<void> {
+			try {
+				const rows = await getExecutor(tx)
+					.delete(users)
+					.where(eq(users.id, id))
+					.returning();
+
+				if (!rows[0]) {
+					throw new ResourceNotFoundError("User", id);
+				}
+			} catch (error) {
+				if (error instanceof ResourceNotFoundError) {
+					throw error;
+				}
+				throw new UnexpectedError(
+					`Failed to delete user with ID: ${id}`,
+					error,
+				);
+			}
+		},
+	};
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,0 +1,1549 @@
+import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
+import {
+	type AnyPgColumn,
+	bigint,
+	boolean,
+	index,
+	integer,
+	jsonb,
+	pgEnum,
+	pgTable,
+	primaryKey,
+	real,
+	serial,
+	text,
+	timestamp,
+	unique,
+	uniqueIndex,
+	uuid,
+} from "drizzle-orm/pg-core";
+
+// 列挙型
+/**
+ * Enum for media source types.
+ * Defines where the media files are stored and how they are managed.
+ */
+export const mediaSourceTypeEnum = pgEnum("media_source_type", [
+	"local",
+	"sftp",
+	"s3",
+]);
+/**
+ * Enum for media organization status.
+ * Defines the lifecycle status of a media item within the system.
+ */
+export const mediaOrganizationStatusEnum = pgEnum("media_organization_status", [
+	"active",
+	"archived",
+	"deleted",
+]);
+/**
+ * Enum for media synchronization status.
+ * Defines the current state of a media item's synchronization with external backups or systems.
+ */
+export const mediaSyncStatusEnum = pgEnum("media_sync_status", [
+	"synced",
+	"pending",
+	"failed",
+]);
+/**
+ * Enum for media types.
+ * Defines the primary content type of a media file.
+ */
+export const mediaTypeEnum = pgEnum("media_type", ["image", "video", "audio"]);
+/**
+ * Enum for job status.
+ * Defines the current state of a background job.
+ */
+export const jobStatusEnum = pgEnum("job_status", [
+	"pending",
+	"in_progress",
+	"completed",
+	"failed",
+]);
+/**
+ * Enum for media relation types.
+ * Defines various ways media items can be related to each other.
+ */
+export const mediaRelationTypeEnum = pgEnum("media_relation_type", [
+	"variant", // 差分・バリエーション
+	"version", // 別バージョン
+	"page", // ページ（漫画等）
+	"derivative", // 派生作品
+	"edit", // 編集版
+	"source", // 元素材
+]);
+
+/**
+ * Enum for tag types.
+ * Defines whether a tag is positive (included) or negative (excluded).
+ */
+export const tagTypeEnum = pgEnum("tag_type", ["positive", "negative"]);
+
+// テーブル
+/**
+ * Schema for the media_sources table.
+ * Stores information about different media sources configured in the system.
+ */
+export const mediaSources = pgTable("media_sources", {
+	id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+	/** 表示されるメディアソースの名前 */
+	name: text("name").notNull(),
+	/** メディアソースの説明 */
+	description: text("description"),
+	/** メディアソースの種類 */
+	type: mediaSourceTypeEnum("type").notNull(),
+	/** 接続情報(JSON) */
+	connectionInfo: jsonb("connection_info").notNull(),
+	/** 作成日時 */
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+	/** 更新日時 */
+	updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+/**
+ * Schema for the media table.
+ * Stores core information about individual media files.
+ */
+export const medias = pgTable(
+	"media",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** どのメディアソースに属しているか */
+		mediaSourceId: uuid("source_id")
+			.notNull()
+			.references(() => mediaSources.id, { onDelete: "cascade" }),
+		/** ソース内の相対パス */
+		filePath: text("file_path").notNull(),
+		/** ファイル名 */
+		fileName: text("file_name").notNull(),
+		/** メディア種別 */
+		mediaType: mediaTypeEnum("media_type").notNull(),
+		/** メディアの幅 */
+		width: integer("width").notNull(),
+		/** メディアの高さ */
+		height: integer("height").notNull(),
+		/** ファイルサイズ(バイト) */
+		fileSize: bigint("file_size", { mode: "number" }),
+		/** メディアの説明(ユーザー入力) */
+		description: text("description"),
+		/** ファイル作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** ファイル更新日時 */
+		modifiedAt: timestamp("modified_at").notNull().defaultNow(),
+		/** DB登録日時 */
+		indexedAt: timestamp("indexed_at").notNull().defaultNow(),
+		/** メディアの状態 */
+		status: mediaOrganizationStatusEnum("status").notNull().default("active"),
+	},
+	(table) => ({
+		mediaSourceIdFilePathUnique: unique("source_id_file_path_unique").on(
+			table.mediaSourceId,
+			table.filePath,
+		),
+		mediaSourceIdIndex: index("idx_media_source_id").on(table.mediaSourceId),
+		fileSizeIndex: index("idx_media_file_size").on(table.fileSize),
+		fileNameIndex: index("idx_media_file_name").on(table.fileName),
+		createdAtIndex: index("idx_media_created_at").on(table.createdAt),
+		descriptionIndex: index("idx_media_description").on(table.description),
+	}),
+);
+
+/**
+ * Schema for the tags table.
+ * Stores information about tags used to categorize media.
+ */
+export const tags = pgTable(
+	"tags",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** タグの名前 (例: "blue eyes") */
+		name: text("name").notNull(),
+		/** タグの詳細な説明 */
+		description: text("description"),
+		/** タグの属性や分類 (例: "style", "clothing") */
+		attribute: text("attribute"),
+		/** UIで表示する際の色 (例: "#808080") */
+		color: text("color"),
+		/** タグの起源 (manual, comfyui_workflow, tagger_program_Aなど) */
+		source: text("source").notNull().default("manual"),
+		/** 関連するAuthor ID */
+		authorId: uuid("author_id").references(() => authors.id, {
+			onDelete: "set null",
+		}),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		nameUnique: unique("tags_name_unique").on(table.name),
+		authorIdIndex: index("idx_tags_author_id").on(table.authorId),
+	}),
+);
+
+/**
+ * Schema for the media_tags join table.
+ * Represents the many-to-many relationship between media items and tags.
+ */
+export const mediaTags = pgTable(
+	"media_tags",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** タグID */
+		tagId: uuid("tag_id")
+			.notNull()
+			.references(() => tags.id, { onDelete: "cascade" }),
+		/** タグのタイプ (positive/negative) */
+		tagType: tagTypeEnum("tag_type").notNull().default("positive"),
+		/** AIがタグを抽出した際の信頼度スコア (0.0-1.0)。手動の場合はNULL */
+		confidence: real("confidence"),
+		/** メディアへのタグ付与の起源 (manual, comfyui_workflow, tagger_program_Aなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.tagId, table.tagType] }),
+		tagIdTagTypeMediaIdIndex: index(
+			"idx_media_tags_tag_id_tag_type_media_id",
+		).on(table.tagId, table.tagType, table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the media_details table.
+ * Stores additional, often user-generated, details about media items.
+ */
+export const mediaDetails = pgTable(
+	"media_details",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.primaryKey()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 評価 (0-5) */
+		rating: integer("rating").default(0),
+		/** お気に入り */
+		favorite: boolean("favorite").default(false),
+		/** 閲覧回数 */
+		viewCount: integer("view_count").default(0),
+		/** 最終閲覧日時 */
+		lastViewedAt: timestamp("last_viewed_at").default(
+			sql`'1970-01-01 00:00:00'`,
+		),
+	},
+	(table) => ({
+		ratingIndex: index("idx_media_details_rating").on(table.rating),
+		favoriteIndex: index("idx_media_details_favorite").on(table.favorite),
+		viewCountIndex: index("idx_media_details_view_count").on(table.viewCount),
+	}),
+);
+
+/**
+ * Schema for the media_generation_info table.
+ * Stores information related to how a media item was generated, especially for AI-generated content.
+ */
+export const mediaGenerationInfo = pgTable(
+	"media_generation_info",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.primaryKey()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** prompt, workflowなどのメタデータ */
+		metadata: jsonb("metadata"),
+		/** プロンプト文字列 */
+		prompt: text("prompt"),
+		/** ネガティブプロンプト */
+		negativePrompt: text("negative_prompt"),
+		/** ComfyUIワークフロー全体 */
+		workflow: jsonb("workflow"),
+		/** LoRA情報 [{"name": "...", "weight": 0.8}] */
+		loras: jsonb("loras"),
+		/** VAE名 */
+		vae: text("vae"),
+		/** Hypernetwork情報 */
+		hypernetworks: jsonb("hypernetworks"),
+		/** Embedding/Textual Inversion情報 */
+		embeddings: jsonb("embeddings"),
+		/** AIによって生成されたかどうか */
+		aiGenerated: boolean("ai_generated").default(false),
+		/** 使用されたモデル名 */
+		modelName: text("model_name").default(""),
+		/** シード値 */
+		seed: bigint("seed", { mode: "number" }).default(-1),
+		/** CFGスケール */
+		cfgScale: real("cfg_scale").default(0),
+		/** ステップ数 */
+		steps: integer("steps").default(0),
+	},
+	(table) => ({
+		metadataIndex: index("idx_media_generation_info_metadata").on(
+			table.metadata,
+		),
+		aiGeneratedIndex: index("idx_media_generation_info_ai_generated").on(
+			table.aiGenerated,
+		),
+		modelNameIndex: index("idx_media_generation_info_model_name").on(
+			table.modelName,
+		),
+	}),
+);
+
+/**
+ * Schema for the categories table.
+ * Organizes media into user-defined categories.
+ */
+export const categories = pgTable(
+	"categories",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** カテゴリ名 */
+		name: text("name").notNull(),
+		/** カテゴリの説明 */
+		description: text("description").default(""),
+		/** UIで表示する際の色 */
+		color: text("color").default("#808080"),
+		/** 親カテゴリID */
+		parentId: uuid("parent_id").references((): AnyPgColumn => categories.id),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** カテゴリの起源 (manual) */
+		source: text("source").notNull().default("manual"),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		nameUnique: unique("categories_name_unique").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the projects table.
+ * Stores information about projects that media items can be associated with.
+ */
+export const projects = pgTable(
+	"projects",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** プロジェクト名 */
+		name: text("name").notNull(),
+		/** プロジェクトの説明 */
+		description: text("description").default(""),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").defaultNow(),
+		/** アーカイブ日時 */
+		archivedAt: timestamp("archived_at"),
+	},
+	(table) => ({
+		nameUnique: unique("projects_name_unique").on(table.name),
+		nameIndex: index("idx_projects_name").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the ips table.
+ * Stores information about Intellectual Properties (IPs) that media items or characters can be associated with.
+ */
+export const ips = pgTable(
+	"ips",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** IP(作品)名 */
+		name: text("name").notNull(),
+		/** IP(作品)の説明 */
+		description: text("description").default(""),
+		/** IPの起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		nameUnique: unique("ips_name_unique").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the characters table.
+ * Stores information about characters, potentially linked to IPs.
+ */
+export const characters = pgTable(
+	"characters",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** キャラクター名 */
+		name: text("name").notNull(),
+		/** キャラクターの説明 */
+		description: text("description").default(""),
+		/** キャラクターの起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+		/** キャラクターの別名（エイリアス）のリスト */
+		aliases: jsonb("aliases"),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		nameUnique: unique("characters_name_unique").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the character_ips join table.
+ * Represents the many-to-many relationship between characters and IPs.
+ */
+export const characterIps = pgTable(
+	"character_ips",
+	{
+		/** キャラクターID */
+		characterId: uuid("character_id")
+			.notNull()
+			.references(() => characters.id, { onDelete: "cascade" }),
+		/** IP(作品)ID */
+		ipId: uuid("ip_id")
+			.notNull()
+			.references(() => ips.id, { onDelete: "cascade" }),
+		/** 起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.characterId, table.ipId] }),
+		ipIdCharacterIdIndex: index("idx_character_ips_ip_id_character_id").on(
+			table.ipId,
+			table.characterId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_characters join table.
+ * Represents the many-to-many relationship between media items and characters.
+ */
+export const mediaCharacters = pgTable(
+	"media_characters",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** キャラクターID */
+		characterId: uuid("character_id")
+			.notNull()
+			.references(() => characters.id, { onDelete: "cascade" }),
+		/** AIがキャラクターを抽出した際の信頼度スコア (0.0-1.0)。手動の場合はNULL */
+		confidence: real("confidence"),
+		/** メディアへのキャラクター付与の起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.characterId] }),
+		characterIdMediaIdIndex: index(
+			"idx_media_characters_character_id_media_id",
+		).on(table.characterId, table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the media_categories join table.
+ * Represents the many-to-many relationship between media items and categories.
+ */
+export const mediaCategories = pgTable(
+	"media_categories",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** カテゴリID */
+		categoryId: uuid("category_id")
+			.notNull()
+			.references(() => categories.id, { onDelete: "cascade" }),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.categoryId] }),
+		categoryIdMediaIdIndex: index(
+			"idx_media_categories_category_id_media_id",
+		).on(table.categoryId, table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the media_projects join table.
+ * Represents the many-to-many relationship between media items and projects.
+ */
+export const mediaProjects = pgTable(
+	"media_projects",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** プロジェクトID */
+		projectId: uuid("project_id")
+			.notNull()
+			.references(() => projects.id, { onDelete: "cascade" }),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.projectId] }),
+		projectIdMediaIdIndex: index("idx_media_projects_project_id_media_id").on(
+			table.projectId,
+			table.mediaId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_ips join table.
+ * Represents the many-to-many relationship between media items and Intellectual Properties (IPs).
+ */
+export const mediaIps = pgTable(
+	"media_ips",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** IP(作品)ID */
+		ipId: uuid("ip_id")
+			.notNull()
+			.references(() => ips.id, { onDelete: "cascade" }),
+		/** AIがIPを抽出した際の信頼度スコア (0.0-1.0)。手動の場合はNULL */
+		confidence: real("confidence"),
+		/** メディアへのIP付与の起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.ipId] }),
+		ipIdMediaIdIndex: index("idx_media_ips_ip_id_media_id").on(
+			table.ipId,
+			table.mediaId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_technical_info table.
+ * Stores technical details about media files, such as color profiles, EXIF data, and video/audio codecs.
+ */
+export const mediaTechnicalInfo = pgTable(
+	"media_technical_info",
+	{
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.primaryKey()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** カラープロファイル */
+		colorProfile: text("color_profile").default(""),
+		/** EXIFデータ */
+		exifData: jsonb("exif_data").default(sql`'{}'`),
+		/** MD5ハッシュ */
+		hashMd5: text("hash_md5").default(""),
+		/** 知覚ハッシュ */
+		hashPerceptual: text("hash_perceptual").default(""),
+
+		// 動画固有
+		/** 再生時間 (秒) */
+		durationSeconds: real("duration_seconds"),
+		/** フレームレート (fps) */
+		frameRate: real("frame_rate"),
+		/** ビットレート (kbps) */
+		bitrateKbps: integer("bitrate_kbps"),
+		/** 動画コーデック (例: H.264) */
+		videoCodec: text("video_codec"),
+		/** 音声コーデック (例: AAC) */
+		audioCodec: text("audio_codec"),
+	},
+	(table) => ({
+		hashMd5Index: index("idx_media_technical_info_hash_md5").on(table.hashMd5),
+	}),
+);
+
+/**
+ * Schema for the media_sync table.
+ * Manages synchronization and backup status for media items.
+ */
+export const mediaSync = pgTable("media_sync", {
+	/** メディアID */
+	mediaId: uuid("media_id")
+		.primaryKey()
+		.references(() => medias.id, { onDelete: "cascade" }),
+	/** 同期ステータス */
+	syncStatus: mediaSyncStatusEnum("sync_status").default("synced"),
+	/** バックアップURL */
+	backupUrls: text("backup_urls").array().default(sql`'{}'`),
+	/** 最後の同期日時 */
+	lastSyncedAt: timestamp("last_synced_at"),
+	/** 同期試行回数 */
+	syncAttempts: integer("sync_attempts").default(0),
+	/** 最後のエラーメッセージ */
+	lastError: text("last_error"),
+});
+
+/**
+ * Schema for the view_history table.
+ * Records user views of media items for analytics and personalized recommendations.
+ */
+export const viewHistory = pgTable("view_history", {
+	id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+	/** メディアID */
+	mediaId: uuid("media_id")
+		.notNull()
+		.references(() => medias.id, { onDelete: "cascade" }),
+	/** 閲覧日時 */
+	viewedAt: timestamp("viewed_at").defaultNow(),
+	/** IPアドレス */
+	ipAddress: text("ip_address"),
+	/** ユーザーエージェント */
+	userAgent: text("user_agent").default(""),
+});
+
+/**
+ * Schema for the similar_media table.
+ * Stores relationships between similar media items, often determined by perceptual hashing.
+ */
+export const similarMedia = pgTable(
+	"similar_media",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** メディア1のID */
+		media1Id: uuid("media1_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** メディア2のID */
+		media2Id: uuid("media2_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 類似度スコア */
+		similarityScore: real("similarity_score").default(0),
+		/** 類似度計算アルゴリズム */
+		algorithm: text("algorithm").default("perceptual"),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").defaultNow(),
+	},
+	(table) => ({
+		media1IdMedia2IdAlgorithmUnique: unique(
+			"media1Id_media2Id_algorithm_unique",
+		).on(table.media1Id, table.media2Id, table.algorithm),
+		similarityScoreIndex: index("idx_similar_media_score").on(
+			table.similarityScore,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_relations table.
+ * Manages relationships between media items, such as variants, versions, or pages in a series.
+ *
+ * @example Variant illustrations
+ * parent: "Character_Standing.png"
+ *   ├─ child (variant): "Character_Standing_Expression1.png"
+ *   ├─ child (variant): "Character_Standing_Expression2.png"
+ *   └─ child (variant): "Character_Standing_Outfit.png"
+ *
+ * @example Manga pages
+ * parent: "Manga_Chapter1"
+ *   ├─ child (page, order: 1): "page_001.png"
+ *   ├─ child (page, order: 2): "page_002.png"
+ *   └─ child (page, order: 3): "page_003.png"
+ */
+export const mediaRelationsTable = pgTable(
+	"media_relations",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** 親メディアID */
+		parentMediaId: uuid("parent_media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 子メディアID */
+		childMediaId: uuid("child_media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 関係の種類 */
+		relationType: mediaRelationTypeEnum("relation_type").notNull(),
+		/** ページ番号等の順序（オプショナル） */
+		orderIndex: integer("order_index"),
+		/** 追加情報（差分内容の説明等）をJSON形式で保存 */
+		metadata: jsonb("metadata"),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		parentChildTypeUnique: unique("parent_child_type_unique").on(
+			table.parentMediaId,
+			table.childMediaId,
+			table.relationType,
+		),
+		childMediaIdIndex: index("idx_media_relations_child").on(
+			table.childMediaId,
+		),
+		relationTypeIndex: index("idx_media_relations_type").on(table.relationType),
+	}),
+);
+
+/**
+ * Schema for the authors table.
+ * Stores information about authors/artists.
+ */
+export const authors = pgTable(
+	"authors",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** 表示名 */
+		name: text("name").notNull(),
+		/** 外部ID (例: Twitter ID, Pixiv ID) */
+		accountId: text("account_id"),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		accountIdIndex: index("idx_authors_account_id").on(table.accountId),
+		nameIndex: index("idx_authors_name").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the media_authors join table.
+ * Many-to-many relationship between media and authors.
+ */
+export const mediaAuthors = pgTable(
+	"media_authors",
+	{
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		authorId: uuid("author_id")
+			.notNull()
+			.references(() => authors.id, { onDelete: "cascade" }),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.authorId] }),
+		authorIdMediaIdIndex: index("idx_media_authors_author_id_media_id").on(
+			table.authorId,
+			table.mediaId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_urls table.
+ * Stores multiple source URLs for a media item.
+ */
+export const mediaUrls = pgTable(
+	"media_urls",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		url: text("url").notNull(),
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		mediaIdIndex: index("idx_media_urls_media_id").on(table.mediaId),
+		urlIndex: index("idx_media_urls_url").on(table.url),
+		mediaIdUrlUnique: uniqueIndex("idx_media_urls_media_id_url_unique").on(
+			table.mediaId,
+			table.url,
+		),
+	}),
+);
+
+/**
+ * Schema for the users table.
+ * Stores user account information.
+ */
+export const users = pgTable(
+	"users",
+	{
+		/** ユーザーID */
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		/** ユーザー名 */
+		name: text("name").notNull(),
+		/** メールアドレス */
+		email: text("email").notNull(),
+		/** パスワード */
+		password: text("password").notNull(),
+		/** 作成日時 */
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		/** 更新日時 */
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		emailUnique: unique("users_email_unique").on(table.email),
+	}),
+);
+
+/**
+ * Schema for the collections table.
+ * Stores user-created collections of media items.
+ */
+export const collections = pgTable("collections", {
+	id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+	/** どのユーザーのコレクションか (ユーザー管理を導入する場合) */
+	userId: uuid("user_id")
+		.notNull()
+		.references(() => users.id, { onDelete: "cascade" }),
+	/** コレクション名 */
+	name: text("name").notNull(),
+	/** コレクションの説明 */
+	description: text("description").default(""),
+	/** 作成日時 */
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+	/** 更新日時 */
+	updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+/**
+ * Schema for the media_collections join table.
+ * Represents the many-to-many relationship between collections and media items.
+ */
+export const mediaCollections = pgTable(
+	"media_collections",
+	{
+		/** コレクションID */
+		collectionId: uuid("collection_id")
+			.notNull()
+			.references(() => collections.id, { onDelete: "cascade" }),
+		/** メディアID */
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** コレクション内での表示順序 */
+		displayOrder: integer("display_order"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.collectionId, table.mediaId] }),
+		mediaIdIndex: index("idx_media_collections_media_id").on(table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the jobs table.
+ * Manages background jobs such as thumbnail generation, metadata extraction, and bulk tagging.
+ * It tracks their progress and results.
+ */
+export const jobs = pgTable("jobs", {
+	id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+	/** ジョブの種類 (例: "thumbnail_generation", "metadata_extraction", "auto_tagging") */
+	type: text("type").notNull(),
+	/** 関連するメディアソースID (オプショナル) */
+	mediaSourceId: uuid("source_id").references(() => mediaSources.id, {
+		onDelete: "cascade",
+	}),
+	/** ジョブのステータス */
+	status: jobStatusEnum("status").notNull().default("pending"),
+	/** ジョブの入力パラメータ (JSON) */
+	payload: jsonb("payload"),
+	/** ジョブの実行結果 (JSON) */
+	result: jsonb("result"),
+	/** エラーメッセージ (失敗時) */
+	error: text("error"),
+	/** ジョブ作成日時 */
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+	/** 最終更新日時 */
+	updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	/** 親ジョブID (バッチ処理用) */
+	parentId: uuid("parent_id").references((): AnyPgColumn => jobs.id, {
+		onDelete: "cascade",
+	}),
+});
+
+/**
+ * Schema for the presets table.
+ * Stores user-defined filter presets for searching media.
+ * @example valueの保存例
+ * ```json
+ * {
+ *   "tags": [1, 5, 12],
+ *   "dateRange": { "from": "2024-01-01", "to": "2024-12-31" },
+ *   "rating": 5,
+ *   "favorite": true,
+ *   "mediaType": "image",
+ *   "characters": [3, 7],
+ *   "ips": [2]
+ * }
+ * ```
+ */
+export const presets = pgTable("presets", {
+	id: serial("id").primaryKey(),
+	/** プリセット名 (例: "お気に入りの高評価画像", "2024年の青い目キャラクター") */
+	name: text("name").notNull().unique(),
+	/** フィルター条件をJSON形式で保存 */
+	value: jsonb("value").notNull(),
+	/** ソート項目 */
+	sort: text("sort"),
+	/** ソート順 */
+	order: text("order"),
+	/** 検索モード ("simple" または "pro") */
+	mode: text("mode"),
+	/** 作成日時 */
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const appConfig = pgTable("app_config", {
+	id: integer("id").primaryKey(),
+	value: jsonb("value").$type<AppConfig>().notNull(),
+	updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+// リレーション
+/**
+ * Defines the relations for the media_sources table.
+ */
+export const mediaSourcesRelations = relations(mediaSources, ({ many }) => ({
+	/** メディアソースに属するメディア */
+	media: many(medias),
+}));
+
+/**
+ * Defines the relations for the medias table.
+ */
+export const mediaRelations = relations(medias, ({ one, many }) => ({
+	/** メディアが属するメディアソース */
+
+	source: one(mediaSources, {
+		fields: [medias.mediaSourceId],
+		references: [mediaSources.id],
+	}),
+	/** メディアに付けられたタグ */
+
+	tags: many(mediaTags),
+	/** メディアの詳細情報 */
+
+	details: one(mediaDetails, {
+		fields: [medias.id],
+		references: [mediaDetails.mediaId],
+	}),
+	/** メディアの生成情報 */
+
+	generationInfo: one(mediaGenerationInfo, {
+		fields: [medias.id],
+		references: [mediaGenerationInfo.mediaId],
+	}),
+	/** メディアが属するカテゴリ */
+
+	categories: many(mediaCategories),
+	/** メディアが属するプロジェクト */
+
+	projects: many(mediaProjects),
+	/** メディアが属するIP */
+
+	ips: many(mediaIps),
+	/** メディアの技術情報 */
+
+	technicalInfo: one(mediaTechnicalInfo, {
+		fields: [medias.id],
+		references: [mediaTechnicalInfo.mediaId],
+	}),
+	/** メディアの同期情報 */
+
+	sync: one(mediaSync, {
+		fields: [medias.id],
+		references: [mediaSync.mediaId],
+	}),
+	/** メディアの閲覧履歴 */
+
+	viewHistory: many(viewHistory),
+	/** 類似メディア (media1) */
+
+	similarMedia1: many(similarMedia, { relationName: "media1" }),
+	/** 類似メディア (media2) */
+
+	similarMedia2: many(similarMedia, { relationName: "media2" }),
+	/** メディアが属するコレクション */
+
+	collections: many(mediaCollections),
+	/** メディアに含まれるキャラクター */
+
+	characters: many(mediaCharacters),
+	/** このメディアを親とする関連メディア */
+
+	childRelations: many(mediaRelationsTable, { relationName: "parent" }),
+	/** このメディアを子とする関連メディア */
+
+	parentRelations: many(mediaRelationsTable, { relationName: "child" }),
+	/** メディアのSource URLリスト */
+
+	urls: many(mediaUrls),
+	/** メディアのAuthorリスト */
+
+	authors: many(mediaAuthors),
+}));
+
+/**
+ * Defines the relations for the tags table.
+ */
+export const tagsRelations = relations(tags, ({ one, many }) => ({
+	/** タグが付与されたメディア */
+	media: many(mediaTags),
+	/** タグに関連するAuthor */
+	author: one(authors, {
+		fields: [tags.authorId],
+		references: [authors.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_tags join table.
+ */
+export const mediaTagsRelations = relations(mediaTags, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+
+	media: one(medias, {
+		fields: [mediaTags.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するタグ */
+
+	tag: one(tags, {
+		fields: [mediaTags.tagId],
+		references: [tags.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the categories table.
+ */
+export const categoriesRelations = relations(categories, ({ one, many }) => ({
+	/** 親カテゴリ */
+
+	parent: one(categories, {
+		fields: [categories.parentId],
+		references: [categories.id],
+		relationName: "parent_category",
+	}),
+	/** 子カテゴリ */
+
+	children: many(categories, {
+		relationName: "parent_category",
+	}),
+	/** カテゴリに属するメディア */
+
+	media: many(mediaCategories),
+}));
+
+/**
+ * Defines the relations for the projects table.
+ */
+export const projectsRelations = relations(projects, ({ many }) => ({
+	/** プロジェクトに属するメディア */
+	media: many(mediaProjects),
+}));
+
+/**
+ * Defines the relations for the ips table.
+ */
+export const ipsRelations = relations(ips, ({ many }) => ({
+	/** IPに属するメディア */
+
+	media: many(mediaIps),
+	/** IPに属するキャラクター (中間テーブル経由) */
+
+	characters: many(characterIps),
+}));
+
+/**
+ * Defines the relations for the characters table.
+ */
+export const charactersRelations = relations(characters, ({ many }) => ({
+	/** キャラクターが属するIP (中間テーブル経由) */
+
+	ips: many(characterIps),
+	/** キャラクターが含まれるメディア */
+
+	media: many(mediaCharacters),
+}));
+
+/**
+ * Defines the relations for the character_ips join table.
+ */
+export const characterIpsRelations = relations(characterIps, ({ one }) => ({
+	/** 中間テーブルが参照するキャラクター */
+	character: one(characters, {
+		fields: [characterIps.characterId],
+		references: [characters.id],
+	}),
+	/** 中間テーブルが参照するIP */
+	ip: one(ips, {
+		fields: [characterIps.ipId],
+		references: [ips.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_characters join table.
+ */
+export const mediaCharactersRelations = relations(
+	mediaCharacters,
+	({ one }) => ({
+		/** 中間テーブルが参照するメディア */
+
+		media: one(medias, {
+			fields: [mediaCharacters.mediaId],
+			references: [medias.id],
+		}),
+		/** 中間テーブルが参照するキャラクター */
+
+		character: one(characters, {
+			fields: [mediaCharacters.characterId],
+			references: [characters.id],
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the media_categories join table.
+ */
+export const mediaCategoriesRelations = relations(
+	mediaCategories,
+	({ one }) => ({
+		/** 中間テーブルが参照するメディア */
+		media: one(medias, {
+			fields: [mediaCategories.mediaId],
+			references: [medias.id],
+		}),
+		/** 中間テーブルが参照するカテゴリ */
+		category: one(categories, {
+			fields: [mediaCategories.categoryId],
+			references: [categories.id],
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the media_projects join table.
+ */
+export const mediaProjectsRelations = relations(mediaProjects, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+	media: one(medias, {
+		fields: [mediaProjects.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するプロジェクト */
+	project: one(projects, {
+		fields: [mediaProjects.projectId],
+		references: [projects.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_ips join table.
+ */
+export const mediaIpsRelations = relations(mediaIps, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+	media: one(medias, {
+		fields: [mediaIps.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するIP */
+	ip: one(ips, {
+		fields: [mediaIps.ipId],
+		references: [ips.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the view_history table.
+ */
+export const viewHistoryRelations = relations(viewHistory, ({ one }) => ({
+	/** 閲覧履歴が参照するメディア */
+	media: one(medias, {
+		fields: [viewHistory.mediaId],
+		references: [medias.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the similar_media table.
+ */
+export const similarMediaRelations = relations(similarMedia, ({ one }) => ({
+	/** 類似メディア1 */
+
+	media1: one(medias, {
+		fields: [similarMedia.media1Id],
+		references: [medias.id],
+		relationName: "media1",
+	}),
+	/** 類似メディア2 */
+
+	media2: one(medias, {
+		fields: [similarMedia.media2Id],
+		references: [medias.id],
+		relationName: "media2",
+	}),
+}));
+
+/**
+ * Defines the relations for the mediaRelationsTable.
+ */
+export const mediaRelationsTableRelations = relations(
+	mediaRelationsTable,
+	({ one }) => ({
+		/** 親メディア */
+		parentMedia: one(medias, {
+			fields: [mediaRelationsTable.parentMediaId],
+			references: [medias.id],
+			relationName: "parent",
+		}),
+		/** 子メディア */
+		childMedia: one(medias, {
+			fields: [mediaRelationsTable.childMediaId],
+			references: [medias.id],
+			relationName: "child",
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the collections table.
+ */
+export const collectionsRelations = relations(collections, ({ one, many }) => ({
+	media: many(mediaCollections),
+	/** どのユーザーのコレクションか */
+	user: one(users, {
+		fields: [collections.userId],
+		references: [users.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_collections join table.
+ */
+export const mediaCollectionsRelations = relations(
+	mediaCollections,
+	({ one }) => ({
+		/** 中間テーブルが参照するコレクション */
+
+		collection: one(collections, {
+			fields: [mediaCollections.collectionId],
+			references: [collections.id],
+		}),
+		/** 中間テーブルが参照するメディア */
+
+		media: one(medias, {
+			fields: [mediaCollections.mediaId],
+			references: [medias.id],
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the authors table.
+ */
+export const authorsRelations = relations(authors, ({ many }) => ({
+	/** Authorに関連するメディア */
+	media: many(mediaAuthors),
+	/** Authorに関連するタグ */
+	tags: many(tags),
+}));
+
+/**
+ * Defines the relations for the media_authors join table.
+ */
+export const mediaAuthorsRelations = relations(mediaAuthors, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+	media: one(medias, {
+		fields: [mediaAuthors.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するAuthor */
+	author: one(authors, {
+		fields: [mediaAuthors.authorId],
+		references: [authors.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_urls table.
+ */
+export const mediaUrlsRelations = relations(mediaUrls, ({ one }) => ({
+	/** URLが属するメディア */
+	media: one(medias, {
+		fields: [mediaUrls.mediaId],
+		references: [medias.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the users table.
+ */
+export const usersRelations = relations(users, ({ many }) => ({
+	/** ユーザーが持つコレクション */
+	collections: many(collections),
+}));
+
+// 型
+/**
+ * Type definition for selecting a media source from the database.
+ */
+export type MediaSource = InferSelectModel<typeof mediaSources>;
+/**
+ * Type definition for inserting a new media source into the database.
+ */
+export type NewMediaSource = InferInsertModel<typeof mediaSources>;
+
+/**
+ * Type definition for selecting a media item from the database.
+ */
+export type Media = InferSelectModel<typeof medias>;
+/**
+ * Type definition for inserting a new media item into the database.
+ */
+export type NewMedia = InferInsertModel<typeof medias>;
+
+/**
+ * Type definition for selecting a tag from the database.
+ */
+export type Tag = InferSelectModel<typeof tags>;
+/**
+ * Type definition for inserting a new tag into the database.
+ */
+export type NewTag = InferInsertModel<typeof tags>;
+
+/**
+ * Type definition for selecting a media tag relationship from the database.
+ */
+export type MediaTag = InferSelectModel<typeof mediaTags>;
+/**
+ * Type definition for inserting a new media tag relationship into the database.
+ */
+export type NewMediaTag = InferInsertModel<typeof mediaTags>;
+
+/**
+ * Type definition for selecting media details from the database.
+ */
+export type MediaDetails = InferSelectModel<typeof mediaDetails>;
+/**
+ * Type definition for inserting new media details into the database.
+ */
+export type NewMediaDetails = InferInsertModel<typeof mediaDetails>;
+
+/**
+ * Type definition for selecting media generation information from the database.
+ */
+export type MediaGenerationInfo = InferSelectModel<typeof mediaGenerationInfo>;
+/**
+ * Type definition for inserting new media generation information into the database.
+ */
+export type NewMediaGenerationInfo = InferInsertModel<
+	typeof mediaGenerationInfo
+>;
+
+/**
+ * Type definition for selecting a category from the database.
+ */
+export type Category = InferSelectModel<typeof categories>;
+/**
+ * Type definition for inserting a new category into the database.
+ */
+export type NewCategory = InferInsertModel<typeof categories>;
+
+/**
+ * Type definition for selecting a project from the database.
+ */
+export type Project = InferSelectModel<typeof projects>;
+/**
+ * Type definition for inserting a new project into the database.
+ */
+export type NewProject = InferInsertModel<typeof projects>;
+
+/**
+ * Type definition for selecting an IP from the database.
+ */
+export type Ip = InferSelectModel<typeof ips>;
+/**
+ * Type definition for inserting a new IP into the database.
+ */
+export type NewIp = InferInsertModel<typeof ips>;
+
+/**
+ * Type definition for selecting a character from the database.
+ */
+export type Character = InferSelectModel<typeof characters>;
+/**
+ * Type definition for inserting a new character into the database.
+ */
+export type NewCharacter = InferInsertModel<typeof characters>;
+
+/**
+ * Type definition for selecting a character IP relationship from the database.
+ */
+export type CharacterIp = InferSelectModel<typeof characterIps>;
+/**
+ * Type definition for inserting a new character IP relationship into the database.
+ */
+export type NewCharacterIp = InferInsertModel<typeof characterIps>;
+
+/**
+ * Type definition for selecting a media character relationship from the database.
+ */
+export type MediaCharacter = InferSelectModel<typeof mediaCharacters>;
+/**
+ * Type definition for inserting a new media character relationship into the database.
+ */
+export type NewMediaCharacter = InferInsertModel<typeof mediaCharacters>;
+
+/**
+ * Type definition for selecting a media category relationship from the database.
+ */
+export type MediaCategory = InferSelectModel<typeof mediaCategories>;
+/**
+ * Type definition for inserting a new media category relationship into the database.
+ */
+export type NewMediaCategory = InferInsertModel<typeof mediaCategories>;
+
+/**
+ * Type definition for selecting a media project relationship from the database.
+ */
+export type MediaProject = InferSelectModel<typeof mediaProjects>;
+/**
+ * Type definition for inserting a new media project relationship into the database.
+ */
+export type NewMediaProject = InferInsertModel<typeof mediaProjects>;
+
+/**
+ * Type definition for selecting a media IP relationship from the database.
+ */
+export type MediaIp = InferSelectModel<typeof mediaIps>;
+/**
+ * Type definition for inserting a new media IP relationship into the database.
+ */
+export type NewMediaIp = InferInsertModel<typeof mediaIps>;
+
+/**
+ * Type definition for selecting media technical information from the database.
+ */
+export type MediaTechnicalInfo = InferSelectModel<typeof mediaTechnicalInfo>;
+/**
+ * Type definition for inserting new media technical information into the database.
+ */
+export type NewMediaTechnicalInfo = InferInsertModel<typeof mediaTechnicalInfo>;
+
+/**
+ * Type definition for selecting media sync information from the database.
+ */
+export type MediaSync = InferSelectModel<typeof mediaSync>;
+/**
+ * Type definition for inserting new media sync information into the database.
+ */
+export type NewMediaSync = InferInsertModel<typeof mediaSync>;
+
+/**
+ * Type definition for selecting a view history entry from the database.
+ */
+export type ViewHistory = InferSelectModel<typeof viewHistory>;
+/**
+ * Type definition for inserting a new view history entry into the database.
+ */
+export type NewViewHistory = InferInsertModel<typeof viewHistory>;
+
+/**
+ * Type definition for selecting similar media relationships from the database.
+ */
+export type SimilarMedia = InferSelectModel<typeof similarMedia>;
+/**
+ * Type definition for inserting new similar media relationships into the database.
+ */
+export type NewSimilarMedia = InferInsertModel<typeof similarMedia>;
+
+/**
+ * Type definition for selecting a collection from the database.
+ */
+export type Collection = InferSelectModel<typeof collections>;
+/**
+ * Type definition for inserting a new collection into the database.
+ */
+export type NewCollection = InferInsertModel<typeof collections>;
+
+/**
+ * Type definition for selecting a media collection relationship from the database.
+ */
+export type MediaCollection = InferSelectModel<typeof mediaCollections>;
+/**
+ * Type definition for inserting a new media collection relationship into the database.
+ */
+export type NewMediaCollection = InferInsertModel<typeof mediaCollections>;
+
+/**
+ * Type definition for selecting a user from the database.
+ */
+export type User = InferSelectModel<typeof users>;
+/**
+ * Type definition for inserting a new user into the database.
+ */
+export type NewUser = InferInsertModel<typeof users>;
+
+/**
+ * Type definition for selecting a job from the database.
+ */
+export type Job = InferSelectModel<typeof jobs>;
+/**
+ * Type definition for inserting a new job into the database.
+ */
+export type NewJob = InferInsertModel<typeof jobs>;
+
+/**
+ * Type definition for selecting a preset from the database.
+ */
+export type Preset = InferSelectModel<typeof presets>;
+/**
+ * Type definition for inserting a new preset into the database.
+ */
+export type NewPreset = InferInsertModel<typeof presets>;
+
+/**
+ * Type definition for selecting the singleton app config row.
+ */
+export type AppConfigRecord = InferSelectModel<typeof appConfig>;
+/**
+ * Type definition for inserting the singleton app config row.
+ */
+export type NewAppConfigRecord = InferInsertModel<typeof appConfig>;
+
+/**
+ * Type definition for selecting a media relation from the database.
+ */
+export type MediaRelation = InferSelectModel<typeof mediaRelationsTable>;
+/**
+ * Type definition for inserting a new media relation into the database.
+ */
+export type NewMediaRelation = InferInsertModel<typeof mediaRelationsTable>;
+
+/**
+ * Type definition for selecting an author from the database.
+ */
+export type Author = InferSelectModel<typeof authors>;
+/**
+ * Type definition for inserting a new author into the database.
+ */
+export type NewAuthor = InferInsertModel<typeof authors>;
+
+/**
+ * Type definition for selecting a media author relationship from the database.
+ */
+export type MediaAuthor = InferSelectModel<typeof mediaAuthors>;
+/**
+ * Type definition for inserting a new media author relationship into the database.
+ */
+export type NewMediaAuthor = InferInsertModel<typeof mediaAuthors>;
+
+/**
+ * Type definition for selecting a media url from the database.
+ */
+export type MediaUrl = InferSelectModel<typeof mediaUrls>;
+/**
+ * Type definition for inserting a new media url into the database.
+ */
+export type NewMediaUrl = InferInsertModel<typeof mediaUrls>;

--- a/packages/db/src/sqlite/client.mock.ts
+++ b/packages/db/src/sqlite/client.mock.ts
@@ -1,0 +1,51 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/sqlite-proxy";
+import * as schema from "./schema";
+
+/**
+ * テスト/CI用の better-sqlite3 を使用したインメモリ SQLite Proxy データベースを生成します。
+ */
+export function createMockSqliteDb() {
+	// インメモリ上にデータベースを新規構築
+	const mockDb = new Database(":memory:");
+
+	// テスト環境でもカスケード削除の挙動を検証するため、外部キー制約を有効化
+	mockDb.exec("PRAGMA foreign_keys = ON;");
+
+	return drizzle(
+		async (sql, params, method) => {
+			try {
+				// better-sqlite3 のステートメントをプリペアドとして準備
+				const stmt = mockDb.prepare(sql);
+
+				// 1. 書き込み系クエリ (run) の処理
+				if (method === "run") {
+					stmt.run(params);
+					return { rows: [] };
+				}
+
+				// 2. カラム値の2次元配列を要求するクエリ (values) の処理
+				if (method === "values") {
+					const rows = stmt.raw(true).all(params) as unknown[][];
+					return { rows };
+				}
+
+				// 3. 単一レコードを要求するクエリ (get) の処理
+				if (method === "get") {
+					const row = stmt.get(params);
+					return { rows: row !== undefined ? [row] : [] };
+				}
+
+				// 4. 通常のクエリ (all) の処理
+				const rows = stmt.all(params);
+				return { rows };
+			} catch (error) {
+				console.error("Mock SQLite Proxy Query Error:", { sql, params, error });
+				throw error;
+			}
+		},
+		{ schema },
+	);
+}
+
+export type MockSqliteDb = ReturnType<typeof createMockSqliteDb>;

--- a/packages/db/src/sqlite/client.ts
+++ b/packages/db/src/sqlite/client.ts
@@ -1,0 +1,54 @@
+import Database from "@tauri-apps/plugin-sql";
+import { drizzle } from "drizzle-orm/sqlite-proxy";
+import * as schema from "./schema";
+
+/**
+ * Tauri のネイティブ SQLite プラグインを使用した Drizzle Proxy データベースを生成します。
+ * @param dbPath データベースファイル名 (デフォルト: "solid_imager.db")
+ */
+export async function createSqliteProxyDb(dbPath = "solid_imager.db") {
+	// Tauri 環境下で動作するネイティブ SQLite ドライバを読み込み
+	const tauriDb = await Database.load(`sqlite:${dbPath}`);
+
+	// カスケード削除や参照整合性を正しく動作させるため、外部キー制約を有効化
+	await tauriDb.execute("PRAGMA foreign_keys = ON;");
+
+	// Drizzle Proxy クライアントの初期化
+	return drizzle(
+		async (sql, params, method) => {
+			try {
+				// 1. 書き込み系クエリ (run) の処理
+				if (method === "run") {
+					await tauriDb.execute(sql, params);
+					return { rows: [] };
+				}
+
+				// クエリを実行して結果セット (オブジェクトの配列) を取得
+				const rows = await tauriDb.select<Record<string, unknown>[]>(
+					sql,
+					params,
+				);
+
+				// 2. カラム値の2次元配列を要求するクエリ (values) の処理
+				if (method === "values") {
+					const values = rows.map((row) => Object.values(row));
+					return { rows: values };
+				}
+
+				// 3. 単一レコードを要求するクエリ (get) の処理
+				if (method === "get") {
+					return { rows: rows.length > 0 ? [rows[0]] : [] };
+				}
+
+				// 4. 通常のクエリ (all) の処理
+				return { rows };
+			} catch (error) {
+				console.error("SQLite Proxy Query Error:", { sql, params, error });
+				throw error;
+			}
+		},
+		{ schema },
+	);
+}
+
+export type SqliteDb = Awaited<ReturnType<typeof createSqliteProxyDb>>;

--- a/packages/db/src/sqlite/migrations.ts
+++ b/packages/db/src/sqlite/migrations.ts
@@ -1,0 +1,97 @@
+/// <reference types="vite/client" />
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import type { SqliteDb } from "./client";
+import type { MockSqliteDb } from "./client.mock";
+
+// マイグレーション履歴管理用の Drizzle スキーマ定義
+const migrationsTable = sqliteTable("__drizzle_migrations", {
+	id: integer("id").primaryKey({ autoIncrement: true }),
+	hash: text("hash").notNull(),
+	createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+});
+
+// Vite のインポート機能を使用して、マイグレーション SQL ファイル群を文字列として事前バンドル
+// 例: /migrations/0000_init.sql, /migrations/0001_add_index.sql
+const migrationsGlob = import.meta.glob("./migrations/*.sql", {
+	query: "?raw",
+	eager: true,
+}) as Record<string, { default: string }>;
+
+/**
+ * 読み込まれた SQL 文字列から、安全に実行可能な単一ステートメント群に分割します。
+ * (注: コメント行の除去や、不要な空行のフィルタリングを行います)
+ */
+function parseSqlStatements(sqlText: string): string[] {
+	return sqlText
+		.split(";")
+		.map((statement) => statement.trim())
+		.filter((statement) => {
+			if (statement.length === 0) return false;
+			// コメント行のみのステートメントを除外
+			if (statement.startsWith("--")) return false;
+			return true;
+		});
+}
+
+/**
+ * SQLite データベースの自動マイグレーションをアプリ起動時に実行します。
+ */
+export async function migrateTauriDb(db: SqliteDb | MockSqliteDb) {
+	// 1. マイグレーション管理用テーブルを生成
+	await db.run(
+		`CREATE TABLE IF NOT EXISTS __drizzle_migrations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );`,
+	);
+
+	// 2. 適用済みのマイグレーションハッシュの一覧を取得
+	const appliedMigrations = await db
+		.select({ hash: migrationsTable.hash })
+		.from(migrationsTable)
+		.execute();
+
+	const appliedHashSet = new Set(appliedMigrations.map((m) => m.hash));
+
+	// 3. バンドルされている SQL ファイルをソートして処理
+	const migrationFiles = Object.keys(migrationsGlob).sort();
+
+	for (const filePath of migrationFiles) {
+		// パス名からハッシュ値（例: "0000_xxxx"）を生成してキーとする
+		const hash = filePath
+			.replace(/^.*\/migrations\//, "")
+			.replace(/\.sql$/, "");
+
+		// すでに適用済みの場合はスキップ
+		if (appliedHashSet.has(hash)) {
+			continue;
+		}
+
+		const sqlContent = migrationsGlob[filePath].default;
+		const statements = parseSqlStatements(sqlContent);
+
+		console.info(`Applying database migration: ${hash}`);
+
+		// Drizzle のトランザクション機能を使用して適用をアトミックに保証
+		await db.transaction(async (tx) => {
+			// マイグレーション中は外部キー制約の競合を防ぐため一時的に無効化
+			await tx.run("PRAGMA foreign_keys = OFF;");
+
+			for (const statement of statements) {
+				await tx.run(`${statement};`);
+			}
+
+			// バージョン管理テーブルに記録
+			await tx.insert(migrationsTable).values({
+				hash,
+				createdAt: new Date(),
+			});
+
+			// マイグレーション完了後に外部キー制約を再有効化
+			await tx.run("PRAGMA foreign_keys = ON;");
+		});
+
+		console.info(`Migration ${hash} successfully applied.`);
+	}
+}

--- a/packages/db/src/sqlite/schema.ts
+++ b/packages/db/src/sqlite/schema.ts
@@ -1,0 +1,1530 @@
+import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
+import {
+	index,
+	integer,
+	primaryKey,
+	real,
+	sqliteTable,
+	text,
+	unique,
+	uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+// テーブル
+/**
+ * Schema for the media_sources table.
+ * Stores information about different media sources configured in the system.
+ */
+export const mediaSources = sqliteTable("media_sources", {
+	id: text("id")
+		.primaryKey()
+		.$defaultFn(() => crypto.randomUUID()),
+	/** 表示されるメディアソースの名前 */
+	name: text("name").notNull(),
+	/** メディアソースの説明 */
+	description: text("description"),
+	/** メディアソースの種類 */
+	type: text("type", { enum: ["local", "sftp", "s3"] }).notNull(),
+	/** 接続情報(JSON) */
+	connectionInfo: text("connection_info", { mode: "json" }).notNull(),
+	/** 作成日時 */
+	createdAt: integer("created_at", { mode: "timestamp_ms" })
+		.notNull()
+		.$defaultFn(() => new Date()),
+	/** 更新日時 */
+	updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+		.notNull()
+		.$defaultFn(() => new Date()),
+});
+
+/**
+ * Schema for the media table.
+ * Stores core information about individual media files.
+ */
+export const medias = sqliteTable(
+	"media",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		/** どのメディアソースに属しているか */
+		mediaSourceId: text("source_id")
+			.notNull()
+			.references(() => mediaSources.id, { onDelete: "cascade" }),
+		/** ソース内の相対パス */
+		filePath: text("file_path").notNull(),
+		/** ファイル名 */
+		fileName: text("file_name").notNull(),
+		/** メディア種別 */
+		mediaType: text("media_type", {
+			enum: ["image", "video", "audio"],
+		}).notNull(),
+		/** メディアの幅 */
+		width: integer("width").notNull(),
+		/** メディアの高さ */
+		height: integer("height").notNull(),
+		/** ファイルサイズ(バイト) */
+		fileSize: integer("file_size"),
+		/** メディアの説明(ユーザー入力) */
+		description: text("description"),
+		/** ファイル作成日時 */
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		/** ファイル更新日時 */
+		modifiedAt: integer("modified_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		/** DB登録日時 */
+		indexedAt: integer("indexed_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		/** メディアの状態 */
+		status: text("status", {
+			enum: ["active", "archived", "deleted"],
+		})
+			.notNull()
+			.default("active"),
+	},
+	(table) => ({
+		mediaSourceIdFilePathUnique: unique("source_id_file_path_unique").on(
+			table.mediaSourceId,
+			table.filePath,
+		),
+		mediaSourceIdIndex: index("idx_media_source_id").on(table.mediaSourceId),
+		fileSizeIndex: index("idx_media_file_size").on(table.fileSize),
+		fileNameIndex: index("idx_media_file_name").on(table.fileName),
+		createdAtIndex: index("idx_media_created_at").on(table.createdAt),
+		descriptionIndex: index("idx_media_description").on(table.description),
+	}),
+);
+
+/**
+ * Schema for the tags table.
+ * Stores information about tags used to categorize media.
+ */
+export const tags = sqliteTable(
+	"tags",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		/** タグの名前 (例: "blue eyes") */
+		name: text("name").notNull(),
+		/** タグの詳細な説明 */
+		description: text("description"),
+		/** タグの属性や分類 (例: "style", "clothing") */
+		attribute: text("attribute"),
+		/** UIで表示する際の色 (例: "#808080") */
+		color: text("color"),
+		/** タグの起源 (manual, comfyui_workflow, tagger_program_Aなど) */
+		source: text("source").notNull().default("manual"),
+		/** 関連するAuthor ID */
+		authorId: text("author_id").references(() => authors.id, {
+			onDelete: "set null",
+		}),
+		/** 作成日時 */
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		/** 更新日時 */
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+	},
+	(table) => ({
+		nameUnique: unique("tags_name_unique").on(table.name),
+		authorIdIndex: index("idx_tags_author_id").on(table.authorId),
+	}),
+);
+
+/**
+ * Schema for the media_tags join table.
+ * Represents the many-to-many relationship between media items and tags.
+ */
+export const mediaTags = sqliteTable(
+	"media_tags",
+	{
+		/** メディアID */
+		mediaId: text("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** タグID */
+		tagId: text("tag_id")
+			.notNull()
+			.references(() => tags.id, { onDelete: "cascade" }),
+		/** タグのタイプ (positive/negative) */
+		tagType: text("tag_type", { enum: ["positive", "negative"] })
+			.notNull()
+			.default("positive"),
+		/** AIがタグを抽出した際の信頼度スコア (0.0-1.0)。手動の場合はNULL */
+		confidence: real("confidence"),
+		/** メディアへのタグ付与の起源 (manual, comfyui_workflow, tagger_program_Aなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.tagId, table.tagType] }),
+		tagIdTagTypeMediaIdIndex: index(
+			"idx_media_tags_tag_id_tag_type_media_id",
+		).on(table.tagId, table.tagType, table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the media_details table.
+ * Stores additional, often user-generated, details about media items.
+ */
+export const mediaDetails = sqliteTable(
+	"media_details",
+	{
+		/** メディアID */
+		mediaId: text("media_id")
+			.primaryKey()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 評価 (0-5) */
+		rating: integer("rating").default(0),
+		/** お気に入り */
+		favorite: integer("favorite", { mode: "boolean" }).default(false),
+		/** 閲覧回数 */
+		viewCount: integer("view_count").default(0),
+		/** 最終閲覧日時 */
+		lastViewedAt: integer("last_viewed_at", { mode: "timestamp_ms" }).default(
+			new Date(0),
+		),
+	},
+	(table) => ({
+		ratingIndex: index("idx_media_details_rating").on(table.rating),
+		favoriteIndex: index("idx_media_details_favorite").on(table.favorite),
+		viewCountIndex: index("idx_media_details_view_count").on(table.viewCount),
+	}),
+);
+
+/**
+ * Schema for the media_generation_info table.
+ * Stores information related to how a media item was generated, especially for AI-generated content.
+ */
+export const mediaGenerationInfo = sqliteTable(
+	"media_generation_info",
+	{
+		/** メディアID */
+		mediaId: text("media_id")
+			.primaryKey()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** prompt, workflowなどのメタデータ */
+		metadata: text("metadata", { mode: "json" }),
+		/** プロンプト文字列 */
+		prompt: text("prompt"),
+		/** ネガティブプロンプト */
+		negativePrompt: text("negative_prompt"),
+		/** ComfyUIワークフロー全体 */
+		workflow: text("workflow", { mode: "json" }),
+		/** LoRA情報 [{"name": "...", "weight": 0.8}] */
+		loras: text("loras", { mode: "json" }),
+		/** VAE名 */
+		vae: text("vae"),
+		/** Hypernetwork情報 */
+		hypernetworks: text("hypernetworks", { mode: "json" }),
+		/** Embedding/Textual Inversion情報 */
+		embeddings: text("embeddings", { mode: "json" }),
+		/** AIによって生成されたかどうか */
+		aiGenerated: integer("ai_generated", { mode: "boolean" }).default(false),
+		/** 使用されたモデル名 */
+		modelName: text("model_name").default(""),
+		/** シード値 */
+		seed: integer("seed").default(-1),
+		/** CFGスケール */
+		cfgScale: real("cfg_scale").default(0),
+		/** ステップ数 */
+		steps: integer("steps").default(0),
+	},
+	(table) => ({
+		metadataIndex: index("idx_media_generation_info_metadata").on(
+			table.metadata,
+		),
+		aiGeneratedIndex: index("idx_media_generation_info_ai_generated").on(
+			table.aiGenerated,
+		),
+		modelNameIndex: index("idx_media_generation_info_model_name").on(
+			table.modelName,
+		),
+	}),
+);
+
+/**
+ * Schema for the categories table.
+ * Organizes media into user-defined categories.
+ */
+export const categories = sqliteTable(
+	"categories",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		/** カテゴリ名 */
+		name: text("name").notNull(),
+		/** カテゴリの説明 */
+		description: text("description").default(""),
+		/** UIで表示する際の色 */
+		color: text("color").default("#808080"),
+		/** 親カテゴリID */
+		parentId: text("parent_id").references((): any => categories.id),
+		/** 作成日時 */
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		/** カテゴリの起源 (manual) */
+		source: text("source").notNull().default("manual"),
+		/** 更新日時 */
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+	},
+	(table) => ({
+		nameUnique: unique("categories_name_unique").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the projects table.
+ * Stores information about projects that media items can be associated with.
+ */
+export const projects = sqliteTable(
+	"projects",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		/** プロジェクト名 */
+		name: text("name").notNull(),
+		/** プロジェクトの説明 */
+		description: text("description").default(""),
+		/** 作成日時 */
+		createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(
+			() => new Date(),
+		),
+		/** 更新日時 */
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" }).$defaultFn(
+			() => new Date(),
+		),
+		/** アーカイブ日時 */
+		archivedAt: integer("archived_at", { mode: "timestamp_ms" }),
+	},
+	(table) => ({
+		nameUnique: unique("projects_name_unique").on(table.name),
+		nameIndex: index("idx_projects_name").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the ips table.
+ * Stores information about Intellectual Properties (IPs) that media items or characters can be associated with.
+ */
+export const ips = sqliteTable(
+	"ips",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		/** IP(作品)名 */
+		name: text("name").notNull(),
+		/** IP(作品)の説明 */
+		description: text("description").default(""),
+		/** IPの起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+		/** 作成日時 */
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		/** 更新日時 */
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+	},
+	(table) => ({
+		nameUnique: unique("ips_name_unique").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the characters table.
+ * Stores information about characters, potentially linked to IPs.
+ */
+export const characters = sqliteTable(
+	"characters",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		/** キャラクター名 */
+		name: text("name").notNull(),
+		/** キャラクターの説明 */
+		description: text("description").default(""),
+		/** キャラクターの起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+		/** キャラクターの別名（エイリアス）のリスト */
+		aliases: text("aliases", { mode: "json" }),
+		/** 作成日時 */
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		/** 更新日時 */
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+	},
+	(table) => ({
+		nameUnique: unique("characters_name_unique").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the character_ips join table.
+ * Represents the many-to-many relationship between characters and IPs.
+ */
+export const characterIps = sqliteTable(
+	"character_ips",
+	{
+		/** キャラクターID */
+		characterId: text("character_id")
+			.notNull()
+			.references(() => characters.id, { onDelete: "cascade" }),
+		/** IP(作品)ID */
+		ipId: text("ip_id")
+			.notNull()
+			.references(() => ips.id, { onDelete: "cascade" }),
+		/** 起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.characterId, table.ipId] }),
+		ipIdCharacterIdIndex: index("idx_character_ips_ip_id_character_id").on(
+			table.ipId,
+			table.characterId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_characters join table.
+ * Represents the many-to-many relationship between media items and characters.
+ */
+export const mediaCharacters = sqliteTable(
+	"media_characters",
+	{
+		/** メディアID */
+		mediaId: text("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** キャラクターID */
+		characterId: text("character_id")
+			.notNull()
+			.references(() => characters.id, { onDelete: "cascade" }),
+		/** AIがキャラクターを抽出した際の信頼度スコア (0.0-1.0)。手動の場合はNULL */
+		confidence: real("confidence"),
+		/** メディアへのキャラクター付与 of 起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.characterId] }),
+		characterIdMediaIdIndex: index(
+			"idx_media_characters_character_id_media_id",
+		).on(table.characterId, table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the media_categories join table.
+ * Represents the many-to-many relationship between media items and categories.
+ */
+export const mediaCategories = sqliteTable(
+	"media_categories",
+	{
+		/** メディアID */
+		mediaId: text("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** カテゴリID */
+		categoryId: text("category_id")
+			.notNull()
+			.references(() => categories.id, { onDelete: "cascade" }),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.categoryId] }),
+		categoryIdMediaIdIndex: index(
+			"idx_media_categories_category_id_media_id",
+		).on(table.categoryId, table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the media_projects join table.
+ * Represents the many-to-many relationship between media items and projects.
+ */
+export const mediaProjects = sqliteTable(
+	"media_projects",
+	{
+		/** メディアID */
+		mediaId: text("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** プロジェクトID */
+		projectId: text("project_id")
+			.notNull()
+			.references(() => projects.id, { onDelete: "cascade" }),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.projectId] }),
+		projectIdMediaIdIndex: index("idx_media_projects_project_id_media_id").on(
+			table.projectId,
+			table.mediaId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_ips join table.
+ * Represents the many-to-many relationship between media items and Intellectual Properties (IPs).
+ */
+export const mediaIps = sqliteTable(
+	"media_ips",
+	{
+		/** メディアID */
+		mediaId: text("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** IP(作品)ID */
+		ipId: text("ip_id")
+			.notNull()
+			.references(() => ips.id, { onDelete: "cascade" }),
+		/** AIがIPを抽出した際の信頼度スコア (0.0-1.0)。手動の場合はNULL */
+		confidence: real("confidence"),
+		/** メディアへのIP付与の起源 (manual, ai_generatedなど) */
+		source: text("source").notNull().default("manual"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.ipId] }),
+		ipIdMediaIdIndex: index("idx_media_ips_ip_id_media_id").on(
+			table.ipId,
+			table.mediaId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_technical_info table.
+ * Stores technical details about media files, such as color profiles, EXIF data, and video/audio codecs.
+ */
+export const mediaTechnicalInfo = sqliteTable(
+	"media_technical_info",
+	{
+		/** メディアID */
+		mediaId: text("media_id")
+			.primaryKey()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** カラープロファイル */
+		colorProfile: text("color_profile").default(""),
+		/** EXIFデータ */
+		exifData: text("exif_data", { mode: "json" }).default(sql`'{}'`),
+		/** MD5ハッシュ */
+		hashMd5: text("hash_md5").default(""),
+		/** 知覚ハッシュ */
+		hashPerceptual: text("hash_perceptual").default(""),
+
+		// 動画固有
+		/** 再生時間 (秒) */
+		durationSeconds: real("duration_seconds"),
+		/** フレームレート (fps) */
+		frameRate: real("frame_rate"),
+		/** ビットレート (kbps) */
+		bitrateKbps: integer("bitrate_kbps"),
+		/** 動画コーデック (例: H.264) */
+		videoCodec: text("video_codec"),
+		/** 音声コーデック (例: AAC) */
+		audioCodec: text("audio_codec"),
+	},
+	(table) => ({
+		hashMd5Index: index("idx_media_technical_info_hash_md5").on(table.hashMd5),
+	}),
+);
+
+/**
+ * Schema for the media_sync table.
+ * Manages synchronization and backup status for media items.
+ */
+export const mediaSync = sqliteTable("media_sync", {
+	/** メディアID */
+	mediaId: text("media_id")
+		.primaryKey()
+		.references(() => medias.id, { onDelete: "cascade" }),
+	/** 同期ステータス */
+	syncStatus: text("sync_status", {
+		enum: ["synced", "pending", "failed"],
+	}).default("synced"),
+	/** バックアップURL */
+	backupUrls: text("backup_urls", { mode: "json" })
+		.$type<string[]>()
+		.default(sql`'[]'`),
+	/** 最後の同期日時 */
+	lastSyncedAt: integer("last_synced_at", { mode: "timestamp_ms" }),
+	/** 同期試行回数 */
+	syncAttempts: integer("sync_attempts").default(0),
+	/** 最後のエラーメッセージ */
+	lastError: text("last_error"),
+});
+
+/**
+ * Schema for the view_history table.
+ * Records user views of media items for analytics and personalized recommendations.
+ */
+export const viewHistory = sqliteTable("view_history", {
+	id: text("id")
+		.primaryKey()
+		.$defaultFn(() => crypto.randomUUID()),
+	/** メディアID */
+	mediaId: text("media_id")
+		.notNull()
+		.references(() => medias.id, { onDelete: "cascade" }),
+	/** 閲覧日時 */
+	viewedAt: integer("viewed_at", { mode: "timestamp_ms" }).$defaultFn(
+		() => new Date(),
+	),
+	/** IPアドレス */
+	ipAddress: text("ip_address"),
+	/** ユーザーエージェント */
+	userAgent: text("user_agent").default(""),
+});
+
+/**
+ * Schema for the similar_media table.
+ * Stores relationships between similar media items, often determined by perceptual hashing.
+ */
+export const similarMedia = sqliteTable(
+	"similar_media",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		/** メディア1のID */
+		media1Id: text("media1_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** メディア2のID */
+		media2Id: text("media2_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 類似度スコア */
+		similarityScore: real("similarity_score").default(0),
+		/** 類似度計算アルゴリズム */
+		algorithm: text("algorithm").default("perceptual"),
+		/** 作成日時 */
+		createdAt: integer("created_at", { mode: "timestamp_ms" }).$defaultFn(
+			() => new Date(),
+		),
+	},
+	(table) => ({
+		media1IdMedia2IdAlgorithmUnique: unique(
+			"media1Id_media2Id_algorithm_unique",
+		).on(table.media1Id, table.media2Id, table.algorithm),
+		similarityScoreIndex: index("idx_similar_media_score").on(
+			table.similarityScore,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_relations table.
+ * Manages relationships between media items, such as variants, versions, or pages in a series.
+ */
+export const mediaRelationsTable = sqliteTable(
+	"media_relations",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		/** 親メディアID */
+		parentMediaId: text("parent_media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 子メディアID */
+		childMediaId: text("child_media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** 関係の種類 */
+		relationType: text("relation_type", {
+			enum: ["variant", "version", "page", "derivative", "edit", "source"],
+		}).notNull(),
+		/** ページ番号等の順序（オプショナル） */
+		orderIndex: integer("order_index"),
+		/** 追加情報（差分内容の説明等）をJSON形式で保存 */
+		metadata: text("metadata", { mode: "json" }),
+		/** 作成日時 */
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+	},
+	(table) => ({
+		parentChildTypeUnique: unique("parent_child_type_unique").on(
+			table.parentMediaId,
+			table.childMediaId,
+			table.relationType,
+		),
+		childMediaIdIndex: index("idx_media_relations_child").on(
+			table.childMediaId,
+		),
+		relationTypeIndex: index("idx_media_relations_type").on(table.relationType),
+	}),
+);
+
+/**
+ * Schema for the authors table.
+ * Stores information about authors/artists.
+ */
+export const authors = sqliteTable(
+	"authors",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		/** 表示名 */
+		name: text("name").notNull(),
+		/** 外部ID (例: Twitter ID, Pixiv ID) */
+		accountId: text("account_id"),
+		/** 作成日時 */
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		/** 更新日時 */
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+	},
+	(table) => ({
+		accountIdIndex: index("idx_authors_account_id").on(table.accountId),
+		nameIndex: index("idx_authors_name").on(table.name),
+	}),
+);
+
+/**
+ * Schema for the media_authors join table.
+ * Many-to-many relationship between media and authors.
+ */
+export const mediaAuthors = sqliteTable(
+	"media_authors",
+	{
+		mediaId: text("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		authorId: text("author_id")
+			.notNull()
+			.references(() => authors.id, { onDelete: "cascade" }),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.mediaId, table.authorId] }),
+		authorIdMediaIdIndex: index("idx_media_authors_author_id_media_id").on(
+			table.authorId,
+			table.mediaId,
+		),
+	}),
+);
+
+/**
+ * Schema for the media_urls table.
+ * Stores multiple source URLs for a media item.
+ */
+export const mediaUrls = sqliteTable(
+	"media_urls",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		mediaId: text("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		url: text("url").notNull(),
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+	},
+	(table) => ({
+		mediaIdIndex: index("idx_media_urls_media_id").on(table.mediaId),
+		urlIndex: index("idx_media_urls_url").on(table.url),
+		mediaIdUrlUnique: uniqueIndex("idx_media_urls_media_id_url_unique").on(
+			table.mediaId,
+			table.url,
+		),
+	}),
+);
+
+/**
+ * Schema for the users table.
+ * Stores user account information.
+ */
+export const users = sqliteTable(
+	"users",
+	{
+		/** ユーザーID */
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		/** ユーザー名 */
+		name: text("name").notNull(),
+		/** メールアドレス */
+		email: text("email").notNull(),
+		/** パスワード */
+		password: text("password").notNull(),
+		/** 作成日時 */
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		/** 更新日時 */
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+	},
+	(table) => ({
+		emailUnique: unique("users_email_unique").on(table.email),
+	}),
+);
+
+/**
+ * Schema for the collections table.
+ * Stores user-created collections of media items.
+ */
+export const collections = sqliteTable("collections", {
+	id: text("id")
+		.primaryKey()
+		.$defaultFn(() => crypto.randomUUID()),
+	/** どのユーザーのコレクションか (ユーザー管理を導入する場合) */
+	userId: text("user_id")
+		.notNull()
+		.references(() => users.id, { onDelete: "cascade" }),
+	/** コレクション名 */
+	name: text("name").notNull(),
+	/** コレクションの説明 */
+	description: text("description").default(""),
+	/** 作成日時 */
+	createdAt: integer("created_at", { mode: "timestamp_ms" })
+		.notNull()
+		.$defaultFn(() => new Date()),
+	/** 更新日時 */
+	updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+		.notNull()
+		.$defaultFn(() => new Date()),
+});
+
+/**
+ * Schema for the media_collections join table.
+ * Represents the many-to-many relationship between collections and media items.
+ */
+export const mediaCollections = sqliteTable(
+	"media_collections",
+	{
+		/** コレクションID */
+		collectionId: text("collection_id")
+			.notNull()
+			.references(() => collections.id, { onDelete: "cascade" }),
+		/** メディアID */
+		mediaId: text("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		/** コレクション内での表示順序 */
+		displayOrder: integer("display_order"),
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.collectionId, table.mediaId] }),
+		mediaIdIndex: index("idx_media_collections_media_id").on(table.mediaId),
+	}),
+);
+
+/**
+ * Schema for the jobs table.
+ * Manages background jobs such as thumbnail generation, metadata extraction, and bulk tagging.
+ * It tracks their progress and results.
+ */
+export const jobs = sqliteTable("jobs", {
+	id: text("id")
+		.primaryKey()
+		.$defaultFn(() => crypto.randomUUID()),
+	/** ジョブの種類 (例: "thumbnail_generation", "metadata_extraction", "auto_tagging") */
+	type: text("type").notNull(),
+	/** 関連するメディアソースID (オプショナル) */
+	mediaSourceId: text("source_id").references(() => mediaSources.id, {
+		onDelete: "cascade",
+	}),
+	/** ジョブのステータス */
+	status: text("status", {
+		enum: ["pending", "in_progress", "completed", "failed"],
+	})
+		.notNull()
+		.default("pending"),
+	/** ジョブの入力パラメータ (JSON) */
+	payload: text("payload", { mode: "json" }),
+	/** ジョブの実行結果 (JSON) */
+	result: text("result", { mode: "json" }),
+	/** エラーメッセージ (失敗時) */
+	error: text("error"),
+	/** ジョブ作成日時 */
+	createdAt: integer("created_at", { mode: "timestamp_ms" })
+		.notNull()
+		.$defaultFn(() => new Date()),
+	/** 最終更新日時 */
+	updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+		.notNull()
+		.$defaultFn(() => new Date()),
+	/** 親ジョブID (バッチ処理用) */
+	parentId: text("parent_id").references((): any => jobs.id, {
+		onDelete: "cascade",
+	}),
+});
+
+/**
+ * Schema for the presets table.
+ * Stores user-defined filter presets for searching media.
+ */
+export const presets = sqliteTable("presets", {
+	id: integer("id").primaryKey({ autoIncrement: true }),
+	/** プリセット名 (例: "お気に入りの高評価画像", "2024年の青い目キャラクター") */
+	name: text("name").notNull().unique(),
+	/** フィルター条件をJSON形式で保存 */
+	value: text("value", { mode: "json" }).notNull(),
+	/** ソート項目 */
+	sort: text("sort"),
+	/** ソート順 */
+	order: text("order"),
+	/** 検索モード ("simple" または "pro") */
+	mode: text("mode"),
+	/** 作成日時 */
+	createdAt: integer("created_at", { mode: "timestamp_ms" })
+		.notNull()
+		.$defaultFn(() => new Date()),
+});
+
+export const appConfig = sqliteTable("app_config", {
+	id: integer("id").primaryKey(),
+	value: text("value", { mode: "json" }).$type<AppConfig>().notNull(),
+	updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+		.notNull()
+		.$defaultFn(() => new Date()),
+});
+
+// リレーション
+/**
+ * Defines the relations for the media_sources table.
+ */
+export const mediaSourcesRelations = relations(mediaSources, ({ many }) => ({
+	/** メディアソースに属するメディア */
+	media: many(medias),
+}));
+
+/**
+ * Defines the relations for the medias table.
+ */
+export const mediaRelations = relations(medias, ({ one, many }) => ({
+	/** メディアが属するメディアソース */
+	source: one(mediaSources, {
+		fields: [medias.mediaSourceId],
+		references: [mediaSources.id],
+	}),
+	/** メディアに付けられたタグ */
+	tags: many(mediaTags),
+	/** メディアの詳細情報 */
+	details: one(mediaDetails, {
+		fields: [medias.id],
+		references: [mediaDetails.mediaId],
+	}),
+	/** メディアの生成情報 */
+	generationInfo: one(mediaGenerationInfo, {
+		fields: [medias.id],
+		references: [mediaGenerationInfo.mediaId],
+	}),
+	/** メディアが属するカテゴリ */
+	categories: many(mediaCategories),
+	/** メディアが属するプロジェクト */
+	projects: many(mediaProjects),
+	/** メディアが属するIP */
+	ips: many(mediaIps),
+	/** メディアの技術情報 */
+	technicalInfo: one(mediaTechnicalInfo, {
+		fields: [medias.id],
+		references: [mediaTechnicalInfo.mediaId],
+	}),
+	/** メディアの同期情報 */
+	sync: one(mediaSync, {
+		fields: [medias.id],
+		references: [mediaSync.mediaId],
+	}),
+	/** メディアの閲覧履歴 */
+	viewHistory: many(viewHistory),
+	/** 類似メディア (media1) */
+	similarMedia1: many(similarMedia, { relationName: "media1" }),
+	/** 類似メディア (media2) */
+	similarMedia2: many(similarMedia, { relationName: "media2" }),
+	/** メディアが属するコレクション */
+	collections: many(mediaCollections),
+	/** メディアに含まれるキャラクター */
+	characters: many(mediaCharacters),
+	/** このメディアを親とする関連メディア */
+	childRelations: many(mediaRelationsTable, { relationName: "parent" }),
+	/** このメディアを子とする関連メディア */
+	parentRelations: many(mediaRelationsTable, { relationName: "child" }),
+	/** メディアのSource URLリスト */
+	urls: many(mediaUrls),
+	/** メディアのAuthorリスト */
+	authors: many(mediaAuthors),
+}));
+
+/**
+ * Defines the relations for the tags table.
+ */
+export const tagsRelations = relations(tags, ({ one, many }) => ({
+	/** タグが付与されたメディア */
+	media: many(mediaTags),
+	/** タグに関連するAuthor */
+	author: one(authors, {
+		fields: [tags.authorId],
+		references: [authors.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_tags join table.
+ */
+export const mediaTagsRelations = relations(mediaTags, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+	media: one(medias, {
+		fields: [mediaTags.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するタグ */
+	tag: one(tags, {
+		fields: [mediaTags.tagId],
+		references: [tags.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the categories table.
+ */
+export const categoriesRelations = relations(categories, ({ one, many }) => ({
+	/** 親カテゴリ */
+	parent: one(categories, {
+		fields: [categories.parentId],
+		references: [categories.id],
+		relationName: "parent_category",
+	}),
+	/** 子カテゴリ */
+	children: many(categories, {
+		relationName: "parent_category",
+	}),
+	/** カテゴリに属するメディア */
+	media: many(mediaCategories),
+}));
+
+/**
+ * Defines the relations for the projects table.
+ */
+export const projectsRelations = relations(projects, ({ many }) => ({
+	/** プロジェクトに属するメディア */
+	media: many(mediaProjects),
+}));
+
+/**
+ * Defines the relations for the ips table.
+ */
+export const ipsRelations = relations(ips, ({ many }) => ({
+	/** IPに属するメディア */
+	media: many(mediaIps),
+	/** IPに属するキャラクター (中間テーブル経由) */
+	characters: many(characterIps),
+}));
+
+/**
+ * Defines the relations for the characters table.
+ */
+export const charactersRelations = relations(characters, ({ many }) => ({
+	/** キャラクターが属するIP (中間テーブル経由) */
+	ips: many(characterIps),
+	/** キャラクターが含まれるメディア */
+	media: many(mediaCharacters),
+}));
+
+/**
+ * Defines the relations for the character_ips join table.
+ */
+export const characterIpsRelations = relations(characterIps, ({ one }) => ({
+	/** 中間テーブルが参照するキャラクター */
+	character: one(characters, {
+		fields: [characterIps.characterId],
+		references: [characters.id],
+	}),
+	/** 中間テーブルが参照するIP */
+	ip: one(ips, {
+		fields: [characterIps.ipId],
+		references: [ips.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_characters join table.
+ */
+export const mediaCharactersRelations = relations(
+	mediaCharacters,
+	({ one }) => ({
+		/** 中間テーブルが参照するメディア */
+		media: one(medias, {
+			fields: [mediaCharacters.mediaId],
+			references: [medias.id],
+		}),
+		/** 中間テーブルが参照するキャラクター */
+		character: one(characters, {
+			fields: [mediaCharacters.characterId],
+			references: [characters.id],
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the media_categories join table.
+ */
+export const mediaCategoriesRelations = relations(
+	mediaCategories,
+	({ one }) => ({
+		/** 中間テーブルが参照するメディア */
+		media: one(medias, {
+			fields: [mediaCategories.mediaId],
+			references: [medias.id],
+		}),
+		/** 中間テーブルが参照するカテゴリ */
+		category: one(categories, {
+			fields: [mediaCategories.categoryId],
+			references: [categories.id],
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the media_projects join table.
+ */
+export const mediaProjectsRelations = relations(mediaProjects, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+	media: one(medias, {
+		fields: [mediaProjects.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するプロジェクト */
+	project: one(projects, {
+		fields: [mediaProjects.projectId],
+		references: [projects.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_ips join table.
+ */
+export const mediaIpsRelations = relations(mediaIps, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+	media: one(medias, {
+		fields: [mediaIps.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するIP */
+	ip: one(ips, {
+		fields: [mediaIps.ipId],
+		references: [ips.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the view_history table.
+ */
+export const viewHistoryRelations = relations(viewHistory, ({ one }) => ({
+	/** 閲覧履歴が参照するメディア */
+	media: one(medias, {
+		fields: [viewHistory.mediaId],
+		references: [medias.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the similar_media table.
+ */
+export const similarMediaRelations = relations(similarMedia, ({ one }) => ({
+	/** 類似メディア1 */
+	media1: one(medias, {
+		fields: [similarMedia.media1Id],
+		references: [medias.id],
+		relationName: "media1",
+	}),
+	/** 類似メディア2 */
+	media2: one(medias, {
+		fields: [similarMedia.media2Id],
+		references: [medias.id],
+		relationName: "media2",
+	}),
+}));
+
+/**
+ * Defines the relations for the mediaRelationsTable.
+ */
+export const mediaRelationsTableRelations = relations(
+	mediaRelationsTable,
+	({ one }) => ({
+		/** 親メディア */
+		parentMedia: one(medias, {
+			fields: [mediaRelationsTable.parentMediaId],
+			references: [medias.id],
+			relationName: "parent",
+		}),
+		/** 子メディア */
+		childMedia: one(medias, {
+			fields: [mediaRelationsTable.childMediaId],
+			references: [medias.id],
+			relationName: "child",
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the collections table.
+ */
+export const collectionsRelations = relations(collections, ({ one, many }) => ({
+	media: many(mediaCollections),
+	/** どのユーザーのコレクションか */
+	user: one(users, {
+		fields: [collections.userId],
+		references: [users.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_collections join table.
+ */
+export const mediaCollectionsRelations = relations(
+	mediaCollections,
+	({ one }) => ({
+		/** 中間テーブルが参照するコレクション */
+		collection: one(collections, {
+			fields: [mediaCollections.collectionId],
+			references: [collections.id],
+		}),
+		/** 中間テーブルが参照するメディア */
+		media: one(medias, {
+			fields: [mediaCollections.mediaId],
+			references: [medias.id],
+		}),
+	}),
+);
+
+/**
+ * Defines the relations for the authors table.
+ */
+export const authorsRelations = relations(authors, ({ many }) => ({
+	/** Authorに関連するメディア */
+	media: many(mediaAuthors),
+	/** Authorに関連するタグ */
+	tags: many(tags),
+}));
+
+/**
+ * Defines the relations for the media_authors join table.
+ */
+export const mediaAuthorsRelations = relations(mediaAuthors, ({ one }) => ({
+	/** 中間テーブルが参照するメディア */
+	media: one(medias, {
+		fields: [mediaAuthors.mediaId],
+		references: [medias.id],
+	}),
+	/** 中間テーブルが参照するAuthor */
+	author: one(authors, {
+		fields: [mediaAuthors.authorId],
+		references: [authors.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the media_urls table.
+ */
+export const mediaUrlsRelations = relations(mediaUrls, ({ one }) => ({
+	/** URLが属するメディア */
+	media: one(medias, {
+		fields: [mediaUrls.mediaId],
+		references: [medias.id],
+	}),
+}));
+
+/**
+ * Defines the relations for the users table.
+ */
+export const usersRelations = relations(users, ({ many }) => ({
+	/** ユーザーが持つコレクション */
+	collections: many(collections),
+}));
+
+// 型
+/**
+ * Type definition for selecting a media source from the database.
+ */
+export type MediaSource = InferSelectModel<typeof mediaSources>;
+/**
+ * Type definition for inserting a new media source into the database.
+ */
+export type NewMediaSource = InferInsertModel<typeof mediaSources>;
+
+/**
+ * Type definition for selecting a media item from the database.
+ */
+export type Media = InferSelectModel<typeof medias>;
+/**
+ * Type definition for inserting a new media item into the database.
+ */
+export type NewMedia = InferInsertModel<typeof medias>;
+
+/**
+ * Type definition for selecting a tag from the database.
+ */
+export type Tag = InferSelectModel<typeof tags>;
+/**
+ * Type definition for inserting a new tag into the database.
+ */
+export type NewTag = InferInsertModel<typeof tags>;
+
+/**
+ * Type definition for selecting a media tag relationship from the database.
+ */
+export type MediaTag = InferSelectModel<typeof mediaTags>;
+/**
+ * Type definition for inserting a new media tag relationship into the database.
+ */
+export type NewMediaTag = InferInsertModel<typeof mediaTags>;
+
+/**
+ * Type definition for selecting media details from the database.
+ */
+export type MediaDetails = InferSelectModel<typeof mediaDetails>;
+/**
+ * Type definition for inserting new media details into the database.
+ */
+export type NewMediaDetails = InferInsertModel<typeof mediaDetails>;
+
+/**
+ * Type definition for selecting media generation information from the database.
+ */
+export type MediaGenerationInfo = InferSelectModel<typeof mediaGenerationInfo>;
+/**
+ * Type definition for inserting new media generation information into the database.
+ */
+export type NewMediaGenerationInfo = InferInsertModel<
+	typeof mediaGenerationInfo
+>;
+
+/**
+ * Type definition for selecting a category from the database.
+ */
+export type Category = InferSelectModel<typeof categories>;
+/**
+ * Type definition for inserting a new category into the database.
+ */
+export type NewCategory = InferInsertModel<typeof categories>;
+
+/**
+ * Type definition for selecting a project from the database.
+ */
+export type Project = InferSelectModel<typeof projects>;
+/**
+ * Type definition for inserting a new project into the database.
+ */
+export type NewProject = InferInsertModel<typeof projects>;
+
+/**
+ * Type definition for selecting an IP from the database.
+ */
+export type Ip = InferSelectModel<typeof ips>;
+/**
+ * Type definition for inserting a new IP into the database.
+ */
+export type NewIp = InferInsertModel<typeof ips>;
+
+/**
+ * Type definition for selecting a character from the database.
+ */
+export type Character = InferSelectModel<typeof characters>;
+/**
+ * Type definition for inserting a new character into the database.
+ */
+export type NewCharacter = InferInsertModel<typeof characters>;
+
+/**
+ * Type definition for selecting a character IP relationship from the database.
+ */
+export type CharacterIp = InferSelectModel<typeof characterIps>;
+/**
+ * Type definition for inserting a new character IP relationship into the database.
+ */
+export type NewCharacterIp = InferInsertModel<typeof characterIps>;
+
+/**
+ * Type definition for selecting a media character relationship from the database.
+ */
+export type MediaCharacter = InferSelectModel<typeof mediaCharacters>;
+/**
+ * Type definition for inserting a new media character relationship into the database.
+ */
+export type NewMediaCharacter = InferInsertModel<typeof mediaCharacters>;
+
+/**
+ * Type definition for selecting a media category relationship from the database.
+ */
+export type MediaCategory = InferSelectModel<typeof mediaCategories>;
+/**
+ * Type definition for inserting a new media category relationship into the database.
+ */
+export type NewMediaCategory = InferInsertModel<typeof mediaCategories>;
+
+/**
+ * Type definition for selecting a media project relationship from the database.
+ */
+export type MediaProject = InferSelectModel<typeof mediaProjects>;
+/**
+ * Type definition for inserting a new media project relationship into the database.
+ */
+export type NewMediaProject = InferInsertModel<typeof mediaProjects>;
+
+/**
+ * Type definition for selecting a media IP relationship from the database.
+ */
+export type MediaIp = InferSelectModel<typeof mediaIps>;
+/**
+ * Type definition for inserting a new media IP relationship into the database.
+ */
+export type NewMediaIp = InferInsertModel<typeof mediaIps>;
+
+/**
+ * Type definition for selecting media technical information from the database.
+ */
+export type MediaTechnicalInfo = InferSelectModel<typeof mediaTechnicalInfo>;
+/**
+ * Type definition for inserting new media technical information into the database.
+ */
+export type NewMediaTechnicalInfo = InferInsertModel<typeof mediaTechnicalInfo>;
+
+/**
+ * Type definition for selecting media sync information from the database.
+ */
+export type MediaSync = InferSelectModel<typeof mediaSync>;
+/**
+ * Type definition for inserting new media sync information into the database.
+ */
+export type NewMediaSync = InferInsertModel<typeof mediaSync>;
+
+/**
+ * Type definition for selecting a view history entry from the database.
+ */
+export type ViewHistory = InferSelectModel<typeof viewHistory>;
+/**
+ * Type definition for inserting a new view history entry into the database.
+ */
+export type NewViewHistory = InferInsertModel<typeof viewHistory>;
+
+/**
+ * Type definition for selecting similar media relationships from the database.
+ */
+export type SimilarMedia = InferSelectModel<typeof similarMedia>;
+/**
+ * Type definition for inserting new similar media relationships into the database.
+ */
+export type NewSimilarMedia = InferInsertModel<typeof similarMedia>;
+
+/**
+ * Type definition for selecting a collection from the database.
+ */
+export type Collection = InferSelectModel<typeof collections>;
+/**
+ * Type definition for inserting a new collection into the database.
+ */
+export type NewCollection = InferInsertModel<typeof collections>;
+
+/**
+ * Type definition for selecting a media collection relationship from the database.
+ */
+export type MediaCollection = InferSelectModel<typeof mediaCollections>;
+/**
+ * Type definition for inserting a new media collection relationship into the database.
+ */
+export type NewMediaCollection = InferInsertModel<typeof mediaCollections>;
+
+/**
+ * Type definition for selecting a user from the database.
+ */
+export type User = InferSelectModel<typeof users>;
+/**
+ * Type definition for inserting a new user into the database.
+ */
+export type NewUser = InferInsertModel<typeof users>;
+
+/**
+ * Type definition for selecting a job from the database.
+ */
+export type Job = InferSelectModel<typeof jobs>;
+/**
+ * Type definition for inserting a new job into the database.
+ */
+export type NewJob = InferInsertModel<typeof jobs>;
+
+/**
+ * Type definition for selecting a preset from the database.
+ */
+export type Preset = InferSelectModel<typeof presets>;
+/**
+ * Type definition for inserting a new preset into the database.
+ */
+export type NewPreset = InferInsertModel<typeof presets>;
+
+/**
+ * Type definition for selecting the singleton app config row.
+ */
+export type AppConfigRecord = InferSelectModel<typeof appConfig>;
+/**
+ * Type definition for inserting the singleton app config row.
+ */
+export type NewAppConfigRecord = InferInsertModel<typeof appConfig>;
+
+/**
+ * Type definition for selecting a media relation from the database.
+ */
+export type MediaRelation = InferSelectModel<typeof mediaRelationsTable>;
+/**
+ * Type definition for inserting a new media relation into the database.
+ */
+export type NewMediaRelation = InferInsertModel<typeof mediaRelationsTable>;
+
+/**
+ * Type definition for selecting an author from the database.
+ */
+export type Author = InferSelectModel<typeof authors>;
+/**
+ * Type definition for inserting a new author into the database.
+ */
+export type NewAuthor = InferInsertModel<typeof authors>;
+
+/**
+ * Type definition for selecting a media author relationship from the database.
+ */
+export type MediaAuthor = InferSelectModel<typeof mediaAuthors>;
+/**
+ * Type definition for inserting a new media author relationship into the database.
+ */
+export type NewMediaAuthor = InferInsertModel<typeof mediaAuthors>;
+
+/**
+ * Type definition for selecting a media url from the database.
+ */
+export type MediaUrl = InferSelectModel<typeof mediaUrls>;
+/**
+ * Type definition for inserting a new media url into the database.
+ */
+export type NewMediaUrl = InferInsertModel<typeof mediaUrls>;

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,0 +1,18 @@
+import type { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
+import type { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import type * as schema from "./schema";
+
+export type NodePostgresDb = ReturnType<
+	typeof drizzleNodePostgres<typeof schema>
+>;
+export type PgLiteDb = ReturnType<typeof drizzlePglite<typeof schema>>;
+export type NodePostgresTransaction = Parameters<
+	Parameters<NodePostgresDb["transaction"]>[0]
+>[0];
+export type PgLiteTransaction = Parameters<
+	Parameters<PgLiteDb["transaction"]>[0]
+>[0];
+export type DrizzleDb = NodePostgresDb | PgLiteDb;
+export type DrizzleTransaction = NodePostgresTransaction | PgLiteTransaction;
+export type DrizzleExecutor = DrizzleDb | DrizzleTransaction;
+export type ExecutorProvider = (tx?: unknown) => DrizzleExecutor;

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"moduleResolution": "bundler",
+		"baseUrl": ".",
+		"paths": {
+			"@solid-imager/core": ["../core/src"],
+			"@solid-imager/core/*": ["../core/src/*"],
+			"@/*": ["../core/src/*"]
+		}
+	},
+	"include": ["src"],
+	"exclude": ["src/repositories"]
+}


### PR DESCRIPTION
## 概要
設計規範書（`docs/design/sqlite-proxy-design.md`）に基づき、`packages/db` パッケージにて SQLite 移行（Drizzle ORM + sqlite-proxy + tauri-plugin-sql）のためのスキーマ定義と接続基盤（Phase 1-B）を実装しました。

## 実装内容
1. **SQLite スキーマ定義 (`packages/db/src/sqlite/schema.ts`)**:
   - PostgreSQL 用スキーマを忠実に SQLite にマッピング（全29テーブル）。
   - UUID 型を `text(id).$defaultFn(() => crypto.randomUUID())` にマッピング。
   - Enum 型を `text(type, { enum: [...] })` でエミュレーション。
   - JSON/JSONB 型を `text(connection_info, { mode: json })` で透過処理。
   - Timestamp 型を `integer(created_at, { mode: timestamp_ms })` に高精度マッピング。
   - Boolean 型を `integer(favorite, { mode: boolean })` でエミュレーション。
2. **SQLite Proxy クライアント (`packages/db/src/sqlite/client.ts`)**:
   - `@tauri-apps/plugin-sql` を用いた `sqlite-proxy` クライアントを構築。
   - コネクション確立時に `PRAGMA foreign_keys = ON;` を強制実行し、カスケード削除の挙動を保証。
   - Drizzle Proxy が要求するメソッド（`run`, `values`, `get`, `all`）に応じた戻り値補正処理を厳密に実装。
3. **Mock コネクタ (`packages/db/src/sqlite/client.mock.ts`)**:
   - テストおよび CI（Vitest）環境下で、`better-sqlite3` を使ってインメモリ動作する SQLite Proxy コネクタを実装。
4. **Vite ?raw マイグレーションランナー (`packages/db/src/sqlite/migrations.ts`)**:
   - Vite の `?raw` 読み込み機能を利用し、マイグレーション用 SQL ファイル群を JavaScript バンドルに埋め込んで起動時に自動実行する軽量ランナーを実装。
   - マイグレーション中は外部キー制約の競合を防ぐため `PRAGMA foreign_keys = OFF;` を設定し、完了後に `ON` に戻すアトミックなトランザクション制御。
   - マイグレーション管理用テーブルを Drizzle で型安全に操作するための `migrationsTable` 定義の導入。
5. **アーキテクチャ規約遵守**:
   - `db` パッケージにおける `application` への依存を排除（逆依存防止）。
   - `index.ts` から repositories を除外し、PostgreSQL と SQLite のスキーマ重複による競合をサブパスエクスポート（`@solid-imager/db/sqlite/...`）で解決。