### PR TITLE
fix: LanceDB OOM in mergeInsert - increase memory pool and reduce image chunk size

### DIFF
--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -357,7 +357,7 @@ export async function writeToLanceDB(
 	await fs.mkdir(tempDir, { recursive: true });
 
 	try {
-		process.env.LANCE_MEM_POOL_SIZE = "2147483648";
+		process.env.LANCE_MEM_POOL_SIZE = LANCE_MEM_POOL_SIZE;
 		const lancedb = await import("@lancedb/lancedb");
 		const db = await lancedb.connect(tempDir);
 		const schema = await createMediaSchema();

--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -5,6 +5,7 @@ import { logger } from "~/infrastructure/logger";
 
 const METADATA_CHUNK_SIZE = 1000;
 const IMAGE_CHUNK_SIZE = 100;
+const LANCE_MEM_POOL_SIZE = "2147483648"; // 2GB
 
 async function createMediaSchema(): Promise<import("apache-arrow").Schema> {
 	const arrow = await import("apache-arrow");

--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -452,7 +452,7 @@ export async function readFromLanceDB(
 	const includeImageData = options.extractImages ?? false;
 
 	while (true) {
-		const rows = await table.query().limit(METADATA_CHUNK_SIZE).offset(offset).toArray();
+		const rows = await table.query().limit(includeImageData ? IMAGE_CHUNK_SIZE : METADATA_CHUNK_SIZE).offset(offset).toArray();
 
 		if (rows.length === 0) {
 			break;

--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -3,7 +3,8 @@ import * as path from "node:path";
 import type { MediaDumpItem } from "@solid-imager/core/domain/media/schemas";
 import { logger } from "~/infrastructure/logger";
 
-const CHUNK_SIZE = 1000;
+const METADATA_CHUNK_SIZE = 1000;
+const IMAGE_CHUNK_SIZE = 100;
 
 async function createMediaSchema(): Promise<import("apache-arrow").Schema> {
 	const arrow = await import("apache-arrow");
@@ -355,6 +356,7 @@ export async function writeToLanceDB(
 	await fs.mkdir(tempDir, { recursive: true });
 
 	try {
+		process.env.LANCE_MEM_POOL_SIZE = "2147483648";
 		const lancedb = await import("@lancedb/lancedb");
 		const db = await lancedb.connect(tempDir);
 		const schema = await createMediaSchema();
@@ -362,8 +364,8 @@ export async function writeToLanceDB(
 		let table: import("@lancedb/lancedb").Table | null = null;
 
 		// Phase 1: Write metadata only (without imageData)
-		for (let i = 0; i < items.length; i += CHUNK_SIZE) {
-			const chunk = items.slice(i, i + CHUNK_SIZE);
+		for (let i = 0; i < items.length; i += METADATA_CHUNK_SIZE) {
+			const chunk = items.slice(i, i + METADATA_CHUNK_SIZE);
 			const rows: Record<string, unknown>[] = [];
 
 			for (const item of chunk) {
@@ -380,15 +382,15 @@ export async function writeToLanceDB(
 			}
 
 			logger.info(
-				{ chunk: Math.floor(i / CHUNK_SIZE) + 1, total: items.length },
+				{ chunk: Math.floor(i / METADATA_CHUNK_SIZE) + 1, total: items.length },
 				"LanceDB metadata chunk written",
 			);
 		}
 
 		// Phase 2: Fetch images concurrently and update via mergeInsert
 		if (options.includeImages && options.getImageBuffer && table) {
-			for (let i = 0; i < items.length; i += CHUNK_SIZE) {
-				const chunk = items.slice(i, i + CHUNK_SIZE);
+			for (let i = 0; i < items.length; i += IMAGE_CHUNK_SIZE) {
+				const chunk = items.slice(i, i + IMAGE_CHUNK_SIZE);
 
 				const imagePromises = chunk.map(async (item) => {
 					if (!item.filePath) return null;
@@ -413,8 +415,8 @@ export async function writeToLanceDB(
 				}
 
 				logger.info(
-					{ chunk: Math.floor(i / CHUNK_SIZE) + 1, total: items.length },
-					"LanceDB image chunk updated",
+				{ chunk: Math.floor(i / IMAGE_CHUNK_SIZE) + 1, total: items.length },
+				"LanceDB image chunk updated",
 				);
 			}
 		}
@@ -439,6 +441,7 @@ export async function readFromLanceDB(
 		onChunk?: (chunk: MediaDumpItemWithImageData[]) => Promise<void>;
 	} = {},
 ): Promise<MediaDumpItemWithImageData[]> {
+	process.env.LANCE_MEM_POOL_SIZE = "2147483648";
 	const lancedb = await import("@lancedb/lancedb");
 	const db = await lancedb.connect(lanceDbDir);
 	const table = await db.openTable("media");
@@ -449,7 +452,7 @@ export async function readFromLanceDB(
 	const includeImageData = options.extractImages ?? false;
 
 	while (true) {
-		const rows = await table.query().limit(CHUNK_SIZE).offset(offset).toArray();
+		const rows = await table.query().limit(METADATA_CHUNK_SIZE).offset(offset).toArray();
 
 		if (rows.length === 0) {
 			break;
@@ -490,7 +493,7 @@ export async function readFromLanceDB(
 			"LanceDB chunk read",
 		);
 
-		if (rows.length < CHUNK_SIZE) {
+		if (rows.length < METADATA_CHUNK_SIZE) {
 			break;
 		}
 

--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -493,7 +493,7 @@ export async function readFromLanceDB(
 			"LanceDB chunk read",
 		);
 
-		if (rows.length < METADATA_CHUNK_SIZE) {
+		if (rows.length < (includeImageData ? IMAGE_CHUNK_SIZE : METADATA_CHUNK_SIZE)) {
 			break;
 		}
 

--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -441,7 +441,7 @@ export async function readFromLanceDB(
 		onChunk?: (chunk: MediaDumpItemWithImageData[]) => Promise<void>;
 	} = {},
 ): Promise<MediaDumpItemWithImageData[]> {
-	process.env.LANCE_MEM_POOL_SIZE = "2147483648";
+	process.env.LANCE_MEM_POOL_SIZE = LANCE_MEM_POOL_SIZE;
 	const lancedb = await import("@lancedb/lancedb");
 	const db = await lancedb.connect(lanceDbDir);
 	const table = await db.openTable("media");


### PR DESCRIPTION
## 原因

LanceDB 内部の DataFusion メモリプールのデフォルト値が 100MB (LANCE_MEM_POOL_SIZE) であり、画像データを含む mergeInsert の外部ソートでメモリ不足が発生していた。

## 対策

1. **LANCE_MEM_POOL_SIZE を 2GB に拡大**
   - dynamic import 直前に process.env に設定（コードから制御、環境変数不要）
   - writeToLanceDB / readFromLanceDB の両方に追加

2. **チャンクサイズを分割**
   - METADATA_CHUNK_SIZE = 1000 (Phase 1: メタデータ書き込み、従来通り)
   - IMAGE_CHUNK_SIZE = 100 (Phase 2: 画像 mergeInsert、従来の1/10)

## 変更ファイル

- `apps/server/src/application/services/lancedb-dump-service.ts`: 13 insertions, 10 deletions