### PR TITLE
fix: update test expectations to match actual error messages and mock references

### DIFF
--- a/apps/server/src/tests/unit/application/services/character-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/character-service.test.ts
@@ -87,7 +87,9 @@ describe("CharacterService", () => {
 
 			await expect(
 				CharacterService.addCharacterToMedia(mediaId, charId),
-			).rejects.toThrow(`Character not found: ${charId}`);
+			).rejects.toThrow(
+				`Character with identifier ${charId} was not found.`,
+			);
 		});
 	});
 });

--- a/apps/server/src/tests/unit/media/copy-media-job.test.ts
+++ b/apps/server/src/tests/unit/media/copy-media-job.test.ts
@@ -204,7 +204,7 @@ describe("Reproduction: Copy Media Job Type", () => {
 				video: [".mp4", ".webm", ".mov"],
 				audio: [".mp3", ".wav"],
 			},
-			generateThumbnail: vi.fn() as any,
+			generateThumbnail: generateThumbnail as any,
 			sseSendEvent: vi.fn() as any,
 		});
 		services.registerMediaProcessingService(mediaProcessingService);


### PR DESCRIPTION
## Summary

Fixed 2 failing unit tests:

1. **character-service.test.ts** — Updated expected error message from `Character not found: char-1` to `Character with identifier char-1 was not found.` to match the actual `ResourceNotFoundError` format.

2. **copy-media-job.test.ts** — Changed the `generateThumbnail` dependency injection from a local `vi.fn()` to the mocked import, so the assertion correctly verifies the function is called.