### PR TITLE
fix: enable video thumbnails in Tauri grid/card views

### DIFF
--- a/apps/tauri/src/components/media/media-card-item.tsx
+++ b/apps/tauri/src/components/media/media-card-item.tsx
@@ -13,7 +13,6 @@ type MediaCardItemProps = {
 export function MediaCardItem(props: MediaCardItemProps) {
 	return (
 		<SharedMediaCardItem
-			canRenderThumbnail={(media) => media.mediaType === "image"}
 			checkboxContainerClass="rounded bg-background/90 p-1"
 			isSelected={props.selected}
 			media={props.media}

--- a/apps/tauri/src/components/media/media-grid-item.tsx
+++ b/apps/tauri/src/components/media/media-grid-item.tsx
@@ -14,7 +14,6 @@ type MediaGridItemProps = {
 export function MediaGridItem(props: MediaGridItemProps) {
 	return (
 		<SharedMediaGridItem
-			canRenderThumbnail={(media) => media.mediaType === "image"}
 			linkComponent={(linkProps) => (
 				<Link
 					class={linkProps.class}


### PR DESCRIPTION
Tauri のグリッド/カードビューで動画のサムネイルが表示されない問題を修正。

## 原因
 と  が  で明示的に  と制限していたため、動画のサムネイルがレンダリングされていなかった。サーバー側では ffmpeg で動画サムネイル（.webp）は正常に生成されている。

## 修正
両コンポーネントから  prop を削除し、共有コンポーネントのデフォルト（）にフォールバックさせることで、画像に加えて動画もサムネイル表示できるようにした。