### PR TITLE
feat: setup Android build infrastructure for Tauri

### DIFF
--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -5,6 +5,10 @@ description = "solid-imager desktop shell"
 authors = ["hmjn"]
 edition = "2021"
 
+[lib]
+name = "solid_imager_tauri_lib"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+#[tauri::mobile_entry_point]
 pub fn run() {
 	tauri::Builder::default()
 		.plugin(tauri_plugin_http::init())

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -1,0 +1,6 @@
+pub fn run() {
+	tauri::Builder::default()
+		.plugin(tauri_plugin_http::init())
+		.run(tauri::generate_context!())
+		.expect("error while running tauri application");
+}

--- a/apps/tauri/src-tauri/src/main.rs
+++ b/apps/tauri/src-tauri/src/main.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-	tauri::Builder::default()
-		.plugin(tauri_plugin_http::init())
-		.run(tauri::generate_context!())
-		.expect("error while running tauri application");
+	solid_imager_tauri_lib::run()
 }

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "solid-imager",
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"identifier": "dev.hmjn.solid-imager.desktop",
 	"build": {
 		"beforeDevCommand": "bun run dev:web",

--- a/apps/tauri/src/routes/manager.tsx
+++ b/apps/tauri/src/routes/manager.tsx
@@ -1,7 +1,7 @@
 import type { Media } from "@solid-imager/core/domain/media/schemas";
 import {
-	type StartBatchTaggingResult,
 	prefetchManagerPageQueries,
+	type StartBatchTaggingResult,
 	useManagerPage,
 } from "@solid-imager/ui/hooks/use-manager-page";
 import { ManagerScreen } from "@solid-imager/ui/screens/manager-screen";

--- a/mise.toml
+++ b/mise.toml
@@ -3,10 +3,13 @@ run="psql -h ${DB_HOST} -p ${DB_PORT} -U ${DB_USER} ${DB_DATABASE}"
 
 [env]
 _.file = '.env'
+ANDROID_SDK_ROOT = "/home/hmjn/Android/Sdk"
+ANDROID_NDK_HOME = "/home/hmjn/Android/Sdk/ndk/27.3.13750724"
+JAVA_HOME = "/home/hmjn/.local/share/mise/installs/java/21.0.2"
 
 [tools]
 bun = "latest"
-"npm:@upstash/context7-mcp" = "latest"
+java = "21.0.2"
+rust = "latest"
 "npm:chrome-devtools-mcp" = "latest"
-"npm:ultracite" = "latest"
-"pipx:git+https://github.com/oraios/serena.git" = "latest"
+android-sdk = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -3,9 +3,6 @@ run="psql -h ${DB_HOST} -p ${DB_PORT} -U ${DB_USER} ${DB_DATABASE}"
 
 [env]
 _.file = '.env'
-ANDROID_SDK_ROOT = "/home/hmjn/Android/Sdk"
-ANDROID_NDK_HOME = "/home/hmjn/Android/Sdk/ndk/27.3.13750724"
-JAVA_HOME = "/home/hmjn/.local/share/mise/installs/java/21.0.2"
 
 [tools]
 bun = "latest"

--- a/packages/ui/src/thumbnail-image.tsx
+++ b/packages/ui/src/thumbnail-image.tsx
@@ -60,16 +60,6 @@ export function ThumbnailImage(props: ThumbnailImageProps) {
 	const handleError = () => {
 		setError(true);
 		props.source.onError?.();
-		// Re-evaluate URL in case onError updated internal fallback state
-		void (async () => {
-			try {
-				const resolved = await props.source.getUrl();
-				setUrl(resolved);
-				setError(false);
-			} catch {
-				// keep error state
-			}
-		})();
 	};
 
 	return (


### PR DESCRIPTION
- Extract tauri::Builder into library crate (lib.rs) for Android compatibility
- Add Android SDK/NDK/Java toolchain to mise.toml
- Bump app version to 0.0.1
- Remove thumbnail fallback URL retry logic
- Fix manager.tsx import order