### PR TITLE
fix(ui): align Tauri shared components with server visual behavior

### DIFF
--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -286,7 +286,6 @@ export function useManagerPage(
 			}
 
 			invalidateActive();
-			toast.success("Created successfully");
 			setIsDialogOpen(false);
 			setEditingItem(null);
 			resetForm(setFormData);
@@ -312,7 +311,6 @@ export function useManagerPage(
 			}
 
 			invalidateActive();
-			toast.success("Updated successfully");
 			setIsDialogOpen(false);
 			setEditingItem(null);
 			resetForm(setFormData);

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -87,7 +87,8 @@ export type SourceMediaPageActions = {
 		sourceId: string,
 		items: DownloadItem[],
 	) => Promise<unknown>;
-	fetchSourceDump: (sourceId: string, mode: "json" | "zip") => Promise<Blob>;
+	fetchSourceDump: (sourceId: string, mode: "json" | "zip" | "lancedb") => Promise<Blob>;
+	lanceDBDump?: (sourceId: string, includeMedia: boolean) => Promise<Blob>;
 	restoreSource: (
 		sourceId: string,
 		data: unknown,
@@ -160,6 +161,7 @@ export type UseSourceMediaPageResult = {
 	handleUpload: (options: UploadOptions) => Promise<void>;
 	handleFileSelect: (e: Event) => Promise<void>;
 	handleDumpDownload: (mode?: "json" | "zip") => Promise<void>;
+	handleLanceDBDump: (includeMedia: boolean) => Promise<void>;
 	handleRestoreSelect: (e: Event) => Promise<void>;
 	handleAddButtonClick: () => void;
 	handleDrop: (e: DragEvent) => void;
@@ -601,6 +603,30 @@ export function useSourceMediaPage(
 		}
 	};
 
+	const handleLanceDBDump = async (includeMedia: boolean) => {
+		const sourceId = id();
+		if (!sourceId) {
+			return;
+		}
+
+		try {
+			const blob = actions.lanceDBDump
+				? await actions.lanceDBDump(sourceId, includeMedia)
+				: await actions.fetchSourceDump(sourceId, "lancedb");
+			const url = window.URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `source-${sourceId}-lancedb.tar.gz`;
+			document.body.appendChild(a);
+			a.click();
+			window.URL.revokeObjectURL(url);
+			document.body.removeChild(a);
+			toast.success("LanceDB dump downloaded successfully");
+		} catch (_error) {
+			toast.error("Failed to download LanceDB dump");
+		}
+	};
+
 	let restoreAbortController: AbortController | null = null;
 
 	const handleRestoreSelect = async (e: Event) => {
@@ -899,6 +925,7 @@ export function useSourceMediaPage(
 		handleUpload,
 		handleFileSelect,
 		handleDumpDownload,
+		handleLanceDBDump,
 		handleRestoreSelect,
 		handleAddButtonClick,
 		handleDrop,

--- a/packages/ui/src/hooks/use-sources-page.ts
+++ b/packages/ui/src/hooks/use-sources-page.ts
@@ -95,10 +95,8 @@ export function useSourcesPage(
 			}
 			invalidate();
 			setShowFormModal(false);
-		} catch (error) {
-			toast.error(
-				`Failed to save source: ${error instanceof Error ? error.message : String(error)}`,
-			);
+		} catch (_error) {
+			// silently fail
 		}
 	};
 
@@ -113,10 +111,8 @@ export function useSourcesPage(
 			invalidate();
 			setShowDeleteModal(false);
 			setDeletingSource(null);
-		} catch (error) {
-			toast.error(
-				`Failed to delete source: ${error instanceof Error ? error.message : String(error)}`,
-			);
+		} catch (_error) {
+			// silently fail
 		}
 	};
 

--- a/packages/ui/src/media-list-actions.tsx
+++ b/packages/ui/src/media-list-actions.tsx
@@ -1,10 +1,12 @@
 import type { ComponentProps } from "solid-js";
-import { Show } from "solid-js";
+import { createSignal, Show } from "solid-js";
 import { isServer, Portal } from "solid-js/web";
 import { Button } from "./button";
 import {
 	Dialog,
 	DialogContent,
+	DialogDescription,
+	DialogFooter,
 	DialogHeader,
 	DialogTitle,
 	DialogTrigger,
@@ -21,9 +23,12 @@ export type MediaListActionsProps = {
 	onDumpDownload: (mode: "json" | "zip") => void;
 	onSearch: () => void;
 	presetClient: SearchControlPanelProps["presetClient"];
+	onLanceDBDump?: (includeMedia: boolean) => void;
 };
 
 export function MediaListActions(props: MediaListActionsProps) {
+	const [isLanceDBDialogOpen, setIsLanceDBDialogOpen] = createSignal(false);
+
 	return (
 		<Show when={!isServer && document.getElementById("nav-actions")}>
 			<Portal mount={document.getElementById("nav-actions") as HTMLElement}>
@@ -76,6 +81,31 @@ export function MediaListActions(props: MediaListActionsProps) {
 						<rect height="5" rx="1" width="20" x="2" y="3" />
 						<path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
 						<path d="M10 12h4" />
+					</svg>
+				</Button>
+				<Button
+					class="mr-2 border-white text-white hover:bg-sky-700"
+					onClick={() => setIsLanceDBDialogOpen(true)}
+					size="icon"
+					title="Download LanceDB Dump"
+					variant="outline"
+				>
+					<svg
+						class="lucide lucide-database"
+						fill="none"
+						height="20"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						viewBox="0 0 24 24"
+						width="20"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<title>Download LanceDB</title>
+						<ellipse cx="12" cy="5" rx="9" ry="3" />
+						<path d="M3 5V19A9 3 0 0 0 21 19V5" />
+						<path d="M3 12A9 3 0 0 0 21 12" />
 					</svg>
 				</Button>
 				<Button
@@ -139,6 +169,41 @@ export function MediaListActions(props: MediaListActionsProps) {
 								presetClient={props.presetClient}
 							/>
 						</div>
+					</DialogContent>
+				</Dialog>
+
+				<Dialog
+					onOpenChange={setIsLanceDBDialogOpen}
+					open={isLanceDBDialogOpen()}
+				>
+					<DialogContent>
+						<DialogHeader>
+							<DialogTitle>LanceDB Dump</DialogTitle>
+							<DialogDescription>
+								Include media file data in the LanceDB dump? Media files will be
+								stored as binary data within the LanceDB table. Excluding them
+								will produce a smaller dump containing only metadata.
+							</DialogDescription>
+						</DialogHeader>
+						<DialogFooter>
+							<Button
+								onClick={() => {
+									props.onLanceDBDump?.(false);
+									setIsLanceDBDialogOpen(false);
+								}}
+								variant="outline"
+							>
+								Metadata only
+							</Button>
+							<Button
+								onClick={() => {
+									props.onLanceDBDump?.(true);
+									setIsLanceDBDialogOpen(false);
+								}}
+							>
+								Include media files
+							</Button>
+						</DialogFooter>
 					</DialogContent>
 				</Dialog>
 			</Portal>

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -2,6 +2,7 @@ import type { Media } from "@solid-imager/core/domain/media/schemas";
 import type { Component, JSX } from "solid-js";
 import { Show } from "solid-js";
 import { Button } from "../button";
+import { Card, CardContent, CardHeader, CardTitle } from "../card";
 import {
 	Dialog,
 	DialogContent,
@@ -88,10 +89,25 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 				})}
 			</Show>
 
+			<div class="mb-4 flex items-center justify-between">
+				<h1 class="font-bold text-2xl">Media in Source: {page().mediaSourceId()}</h1>
+				<Button
+					disabled={
+						page().isSyncingMedia() || !page().mediaQuery.data?.pages.length
+					}
+					onClick={page().handleSyncLoadedMedia}
+					variant="outline"
+				>
+					{page().isSyncingMedia() ? "Syncing..." : "Sync Loaded Media"}
+				</Button>
+			</div>
+
 			<div class="grid gap-6 md:grid-cols-[300px_1fr]">
-				<div class="sticky top-20 hidden h-fit max-h-[calc(100vh-6rem)] overflow-y-auto rounded-lg border bg-card p-4 md:block">
-					<h3 class="mb-4 font-semibold text-lg">検索フィルター</h3>
-					<div class="space-y-4">
+				<Card class="sticky top-20 hidden h-fit max-h-[calc(100vh-6rem)] overflow-y-auto md:block">
+					<CardHeader>
+						<CardTitle>検索フィルター</CardTitle>
+					</CardHeader>
+					<CardContent class="space-y-4">
 						<SearchControlPanel
 							class="w-full"
 							context="source"
@@ -100,8 +116,8 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 							presetClient={page().presetClient}
 							usePopover={false}
 						/>
-					</div>
-				</div>
+					</CardContent>
+				</Card>
 
 				<SourceMediaGrid
 					contextMenuMediaId={page().contextMenuMediaId}
@@ -125,7 +141,7 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 
 			{/* Hidden file inputs */}
 			<input
-				accept=".json,.zip"
+				accept=".json,.zip,.tar.gz"
 				class="hidden"
 				id="restore-input"
 				onChange={page().handleRestoreSelect}

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -50,6 +50,7 @@ type SourceMediaGridProps = {
 	/** Show empty state message. Default: true. */
 	showEmptyState?: boolean;
 	/** Show "Open in New Tab" context menu item. Default: false. */
+	/** Show "Open in New Tab" context menu item. Default: true. */
 	showOpenInNewTab?: boolean;
 	/** Total result count. If omitted, uses mediaResults().length (may not reflect total). */
 	totalCount?: number;
@@ -58,7 +59,7 @@ type SourceMediaGridProps = {
 export function SourceMediaGrid(props: SourceMediaGridProps) {
 	const showResultCount = () => props.showResultCount ?? true;
 	const showEmptyState = () => props.showEmptyState ?? true;
-	const showOpenInNewTab = () => props.showOpenInNewTab ?? false;
+	const showOpenInNewTab = () => props.showOpenInNewTab ?? true;
 	const enableVirtualization = () => props.enableVirtualization ?? false;
 	const disableContextMenu = () => props.disableContextMenu ?? false;
 	const totalCount = () => props.totalCount ?? props.mediaResults().length;
@@ -308,7 +309,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 									if (id) props.onSyncSingleMedia?.(id);
 								}}
 							>
-								Sync Metadata
+								Sync Metadata (Reprocess)
 							</ContextMenuItem>
 						</Show>
 					</ContextMenuContent>

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -79,6 +79,7 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 		<MediaListActions
 			filterData={page.filterData()}
 			onDumpDownload={page.handleDumpDownload}
+			onLanceDBDump={page.handleLanceDBDump}
 			onSearch={page.handleSearch}
 			presetClient={props.presetClient}
 		/>


### PR DESCRIPTION
## 概要

Tauri アプリの見た目を Server に合わせるための共有 UI コンポーネントの修正。

## 変更内容

### 視覚的な一致
- `MediaListActions` に LanceDB ダウンロードボタンとフォーマット選択ダイアログを追加
- `SourceMediaScreen` にページヘッダー（"Media in Source: {name}"）と Sync Loaded Media ボタンを追加
- ソースメディアページのサイドバーを生の div から Card コンポーネントに変更
- リストア用 input の accept に `.tar.gz` を追加
- コンテキストメニュー表記を「Sync Metadata」→「Sync Metadata (Reprocess)」に統一
- `SourceMediaGrid` の `showOpenInNewTab` デフォルトを `true` に変更

### 過剰な toast 通知の削除
- `useManagerPage`: 作成/更新成功時の toast を削除
- `useSourcesPage`: フォーム送信/削除エラー時の toast を削除

### 機能追加
- `useSourceMediaPage` に `handleLanceDBDump` を追加（`fetchSourceDump("lancedb")` へのフォールバック付き）
- `fetchSourceDump` の mode に `"lancedb"` を追加