### PR TITLE
fix(tauri): TauriアプリでSSEが動作しない問題を修正

### DIFF
--- a/apps/tauri/src/hooks/use-batch-job-events.ts
+++ b/apps/tauri/src/hooks/use-batch-job-events.ts
@@ -1,10 +1,66 @@
-import { createSignal } from "solid-js";
+import type { Accessor } from "solid-js";
+import { createEffect, onCleanup } from "solid-js";
+import type { ManagerJobHandlers } from "@solid-imager/ui/hooks/use-manager-page";
 
-export function useBatchJobEvents() {
-	const [activeJobs, _setActiveJobs] = createSignal<
-		{ id: string; type: string; progress: number; total: number }[]
-	>([]);
+const isDev = import.meta.env.DEV;
+const API_BASE = isDev
+	? window.location.origin
+	: import.meta.env.VITE_API_URL || "http://192.168.1.150:3000";
 
-	// No-op for remote server mode - events come from SSE
-	return { activeJobs };
+export function useBatchJobEvents(
+	activeJobId: Accessor<string | null>,
+	handlers: ManagerJobHandlers,
+) {
+	createEffect(() => {
+		const jobId = activeJobId();
+		if (!jobId) {
+			return;
+		}
+
+		const eventSource = new EventSource(`${API_BASE}/api/events`);
+
+		const onProgress = (event: MessageEvent) => {
+			try {
+				const data = JSON.parse(event.data);
+				if (data.jobId === jobId) {
+					handlers.handleJobProgress(data);
+				}
+			} catch {
+				// ignore parse errors
+			}
+		};
+
+		const onCompleted = (event: MessageEvent) => {
+			try {
+				const data = JSON.parse(event.data);
+				if (data.jobId === jobId) {
+					handlers.handleJobCompleted(data);
+				}
+			} catch {
+				// ignore parse errors
+			}
+		};
+
+		const onFailed = (event: MessageEvent) => {
+			try {
+				const data = JSON.parse(event.data);
+				if (data.jobId === jobId) {
+					handlers.handleJobFailed(data);
+				}
+			} catch {
+				// ignore parse errors
+			}
+		};
+
+		eventSource.addEventListener("job-progress", onProgress);
+		eventSource.addEventListener("job-completed", onCompleted);
+		eventSource.addEventListener("job-failed", onFailed);
+
+		onCleanup(() => {
+			eventSource.removeEventListener("job-progress", onProgress);
+			eventSource.removeEventListener("job-completed", onCompleted);
+			eventSource.removeEventListener("job-failed", onFailed);
+			eventSource.close();
+		});
+	});
 }

--- a/apps/tauri/src/hooks/use-media-source-events.ts
+++ b/apps/tauri/src/hooks/use-media-source-events.ts
@@ -4,6 +4,7 @@ import {
 	useMediaSourceEvents as useMediaSourceEventsShared,
 } from "@solid-imager/ui/hooks/use-media-source-events";
 import type { Accessor } from "solid-js";
+import { orpc as rawOrpc } from "~/infrastructure/api-clients/orpc-client";
 
 export type {
 	AllJobsCompletedEvent,
@@ -19,45 +20,87 @@ export type {
 
 type MediaSourceEventsOptions = Omit<UseMediaSourceEventsOptions, "transport">;
 
-export function createSseTransport(
+const MAX_RETRY_DELAY = 30_000;
+const INITIAL_RETRY_DELAY = 1_000;
+
+/**
+ * oRPC client with events subscription support.
+ * The contract doesn't include `events` (it's an async generator subscription),
+ * so we cast to access the router's events method directly.
+ */
+const orpc = rawOrpc as unknown as {
+	sources: {
+		events: (
+			input: { id: string },
+			opts?: { signal?: AbortSignal },
+		) => Promise<AsyncIterable<{ event: string; data: unknown }>>;
+	};
+};
+
+export function createOrpcTransport(
 	mediaSourceId: Accessor<string | undefined>,
 ): MediaSourceEventTransport {
 	return {
 		listen(handler) {
-			const id = mediaSourceId();
-			if (!id) {
-				return () => {
-					/* no-op */
-				};
-			}
+			const ac = new AbortController();
 
-			const eventSource = new EventSource(`/api/sources/${id}/events`);
+			const startListening = async () => {
+				const id = mediaSourceId();
+				if (!id) {
+					return;
+				}
 
-			const EVENT_NAMES = [
-				"media-added",
-				"media-deleted",
-				"media-changed",
-				"media-copied",
-				"media-moved",
-				"thumbnail-generated",
-				"all-jobs-completed",
-				"watcher-error",
-				"job-progress",
-			] as const;
+				let retryCount = 0;
 
-			for (const eventName of EVENT_NAMES) {
-				eventSource.addEventListener(eventName, (event) => {
+				while (!ac.signal.aborted) {
 					try {
-						const data = JSON.parse((event as MessageEvent).data);
-						handler(eventName, data);
-					} catch {
-						// ignore parse errors
+						const events = await orpc.sources.events(
+							{ id },
+							{ signal: ac.signal },
+						);
+
+						retryCount = 0;
+
+						for await (const msg of events) {
+							if (ac.signal.aborted) {
+								break;
+							}
+
+							if (msg.event === "connected") {
+								continue;
+							}
+
+							handler(msg.event, msg.data);
+						}
+					} catch (err) {
+						if (ac.signal.aborted) {
+							break;
+						}
+
+						retryCount++;
+						const delay = Math.min(
+							INITIAL_RETRY_DELAY * 2 ** (retryCount - 1),
+							MAX_RETRY_DELAY,
+						);
+						await new Promise<void>((resolve) => {
+							const timer = setTimeout(resolve, delay);
+							ac.signal.addEventListener(
+								"abort",
+								() => {
+									clearTimeout(timer);
+									resolve();
+								},
+								{ once: true },
+							);
+						});
 					}
-				});
-			}
+				}
+			};
+
+			startListening();
 
 			return () => {
-				eventSource.close();
+				ac.abort();
 			};
 		},
 	};
@@ -67,7 +110,7 @@ export function useMediaSourceEvents(
 	mediaSourceId: Accessor<string | undefined>,
 	options: MediaSourceEventsOptions = {},
 ): void {
-	const transport = createSseTransport(mediaSourceId);
+	const transport = createOrpcTransport(mediaSourceId);
 
 	useMediaSourceEventsShared({
 		...options,
@@ -75,4 +118,4 @@ export function useMediaSourceEvents(
 	});
 }
 
-export const createTauriTransport = createSseTransport;
+export const createTauriTransport = createOrpcTransport;


### PR DESCRIPTION
## 概要

Tauriアプリで通知とメディア追加の即時反映が行われない問題を修正しました。

## 修正内容

### 1. メディアソースイベントのoRPC subscription化
- 
- ブラウザ標準の（相対URL）からoRPC clientのsubscriptionに切り替え
- 指数バックオフ付きの再接続ロジックを追加

### 2. バッチジョブイベントの実装
- 
- no-op stubをREST SSEエンドポイントへの接続に変更
- 絶対URLを使用して相対URL問題を回避

## 修正した根本原因

| 問題 | 修正 |
|------|------|
| EventSourceの相対URLがTauriで機能しない | oRPC client経由に切り替え |
| バッチジョブイベントがno-op | REST SSEで実装 |

## テスト
- TypeScript型チェック: 通過