### PR TITLE
feat(api): remote AI proxy via oRPC + Rust experimental tagger

### DIFF
--- a/apps/server/nitro.config.ts
+++ b/apps/server/nitro.config.ts
@@ -7,7 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineNitroConfig({
   rollupConfig: {
-    external: ["@lancedb/lancedb", "apache-arrow", /^@lancedb\/lancedb-/],
+    external: ["@lancedb/lancedb", "apache-arrow", /^@lancedb\/lancedb-/, "dghs-imgutils-rs"],
   },
   hooks: {
     compiled: (nitro) => {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -44,6 +44,7 @@
     "@solid-imager/core": "workspace:*",
     "@solid-imager/db": "workspace:*",
     "@solid-imager/ui": "workspace:*",
+    "dghs-imgutils-rs": "workspace:*",
     "@tanstack/router-plugin": "^1.168.14",
     "@tanstack/solid-form": "^1.33.0",
     "@tanstack/solid-query": "^5.101.0",

--- a/apps/server/src/components/media/media-sidebar.tsx
+++ b/apps/server/src/components/media/media-sidebar.tsx
@@ -7,6 +7,7 @@ import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { createMemo, createSignal, For, Show } from "solid-js";
 import AiTaggingModal from "~/components/media/ai-tagging-modal";
 import AssociationManager from "~/components/media/association-manager";
+import RustExperimentalModal from "~/components/media/rust-experimental-modal";
 import {
 	addCharacterToMedia,
 	createCharacter,
@@ -78,6 +79,8 @@ export default function MediaSidebar(props: MediaSidebarProps) {
 	const queryClient = useQueryClient();
 	const tags = createMemo(() => props.media.tags || []);
 	const [isAiTaggingModalOpen, setIsAiTaggingModalOpen] = createSignal(false);
+	const [isRustExperimentalModalOpen, setIsRustExperimentalModalOpen] =
+		createSignal(false);
 
 	// Description editing state
 	const [isEditingDescription, setIsEditingDescription] = createSignal(false);
@@ -234,7 +237,7 @@ export default function MediaSidebar(props: MediaSidebarProps) {
 				<p class="text-gray-500 text-sm">{props.media.filePath}</p>
 			</div>
 
-			<div class="flex gap-2">
+			<div class="flex flex-col gap-2">
 				<button
 					class="flex w-full items-center justify-center gap-2 rounded-md bg-purple-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-purple-700"
 					onClick={() => setIsAiTaggingModalOpen(true)}
@@ -243,6 +246,14 @@ export default function MediaSidebar(props: MediaSidebarProps) {
 					<span class="i-lucide-sparkles" />
 					Extract Tags (AI)
 				</button>
+				<button
+					class="flex w-full items-center justify-center gap-2 rounded-md bg-indigo-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-indigo-700"
+					onClick={() => setIsRustExperimentalModalOpen(true)}
+					type="button"
+				>
+					<span class="i-lucide-terminal" />
+					Extract Tags (Rust Experimental)
+				</button>
 			</div>
 
 			<AiTaggingModal
@@ -250,6 +261,12 @@ export default function MediaSidebar(props: MediaSidebarProps) {
 				mediaId={props.media.id}
 				mediaSourceId={props.media.mediaSourceId}
 				onClose={() => setIsAiTaggingModalOpen(false)}
+			/>
+
+			<RustExperimentalModal
+				isOpen={isRustExperimentalModalOpen()}
+				media={props.media}
+				onClose={() => setIsRustExperimentalModalOpen(false)}
 			/>
 
 			<div class="space-y-2">

--- a/apps/server/src/components/media/rust-experimental-modal.tsx
+++ b/apps/server/src/components/media/rust-experimental-modal.tsx
@@ -1,0 +1,409 @@
+import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
+import type { TaggingResponse } from "@solid-imager/core/domain/tagging/schemas";
+import { Badge } from "@solid-imager/ui/badge";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@solid-imager/ui/dialog";
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import { fetchRustExperimentalTags } from "~/infrastructure/api-clients/ai-api";
+
+type RustExperimentalModalProps = {
+	isOpen: boolean;
+	onClose: () => void;
+	media: MediaDetails;
+};
+
+const PERCENTAGE_MULTIPLIER = 100;
+
+interface ComparisonItem {
+	name: string;
+	dbScore: number | null; // null if not in DB
+	rustScore: number | null; // null if not in Rust
+	diff: number | null;
+}
+
+export default function RustExperimentalModal(
+	props: RustExperimentalModalProps,
+) {
+	const [isLoading, setIsLoading] = createSignal(false);
+	const [rustResult, setRustResult] = createSignal<TaggingResponse | null>(
+		null,
+	);
+	const [error, setError] = createSignal<string | null>(null);
+
+	createEffect(() => {
+		if (props.isOpen) {
+			analyzeWithRust();
+		} else {
+			setRustResult(null);
+			setError(null);
+			setIsLoading(false);
+		}
+	});
+
+	const analyzeWithRust = async () => {
+		setIsLoading(true);
+		setError(null);
+		try {
+			const data = await fetchRustExperimentalTags(props.media.id);
+			setRustResult(data);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Unknown error occurred");
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	// 1. General Tags Comparison Logic
+	const tagsComparison = createMemo((): ComparisonItem[] => {
+		const res = rustResult();
+		if (!res) return [];
+
+		const dbTagsMap = new Map<string, number | null>();
+		for (const t of props.media.tags || []) {
+			if (t.type === "positive") {
+				dbTagsMap.set(t.name, t.confidence ?? null);
+			}
+		}
+
+		const rustTagsMap = new Map<string, number>();
+		for (const [name, score] of Object.entries(res.general)) {
+			rustTagsMap.set(name, score);
+		}
+
+		const allNames = new Set([...dbTagsMap.keys(), ...rustTagsMap.keys()]);
+		const comparison: ComparisonItem[] = [];
+
+		for (const name of allNames) {
+			const dbScore = dbTagsMap.has(name)
+				? (dbTagsMap.get(name) ?? null)
+				: null;
+			const rustScore = rustTagsMap.has(name)
+				? (rustTagsMap.get(name) ?? null)
+				: null;
+			let diff: number | null = null;
+			if (dbScore !== null && rustScore !== null) {
+				diff = rustScore - dbScore;
+			}
+			comparison.push({ name, dbScore, rustScore, diff });
+		}
+
+		return comparison.sort((a, b) => {
+			const scoreA = a.rustScore ?? a.dbScore ?? 0;
+			const scoreB = b.rustScore ?? b.dbScore ?? 0;
+			return scoreB - scoreA;
+		});
+	});
+
+	// 2. Characters Comparison Logic
+	const charactersComparison = createMemo((): ComparisonItem[] => {
+		const res = rustResult();
+		if (!res) return [];
+
+		const dbCharsMap = new Map<string, number | null>();
+		for (const c of props.media.characters || []) {
+			dbCharsMap.set(c.name, c.confidence ?? null);
+		}
+
+		const rustCharsMap = new Map<string, number>();
+		for (const [name, score] of Object.entries(res.character)) {
+			rustCharsMap.set(name, score);
+		}
+
+		const allNames = new Set([...dbCharsMap.keys(), ...rustCharsMap.keys()]);
+		const comparison: ComparisonItem[] = [];
+
+		for (const name of allNames) {
+			const dbScore = dbCharsMap.has(name)
+				? (dbCharsMap.get(name) ?? null)
+				: null;
+			const rustScore = rustCharsMap.has(name)
+				? (rustCharsMap.get(name) ?? null)
+				: null;
+			let diff: number | null = null;
+			if (dbScore !== null && rustScore !== null) {
+				diff = rustScore - dbScore;
+			}
+			comparison.push({ name, dbScore, rustScore, diff });
+		}
+
+		return comparison.sort((a, b) => {
+			const scoreA = a.rustScore ?? a.dbScore ?? 0;
+			const scoreB = b.rustScore ?? b.dbScore ?? 0;
+			return scoreB - scoreA;
+		});
+	});
+
+	// 3. IPs Comparison Logic
+	const ipsComparison = createMemo(() => {
+		const res = rustResult();
+		if (!res)
+			return {
+				dbOnly: [] as string[],
+				rustOnly: [] as string[],
+				both: [] as string[],
+			};
+
+		const dbIps = new Set((props.media.ips || []).map((ip) => ip.name));
+		const rustIps = new Set(res.ips);
+
+		const dbOnly = [...dbIps].filter((ip) => !rustIps.has(ip));
+		const rustOnly = [...rustIps].filter((ip) => !dbIps.has(ip));
+		const both = [...dbIps].filter((ip) => rustIps.has(ip));
+
+		return { dbOnly, rustOnly, both };
+	});
+
+	return (
+		<Dialog
+			onOpenChange={(open) => !open && props.onClose()}
+			open={props.isOpen}
+		>
+			<DialogContent class="max-h-[90vh] overflow-y-auto sm:max-w-[800px]">
+				<DialogHeader>
+					<DialogTitle class="flex items-center gap-2">
+						<span class="i-lucide-terminal text-indigo-600" />
+						Rust Tagger Comparison (Experimental)
+					</DialogTitle>
+					<DialogDescription>
+						Compare the results of the experimental Rust tagger
+						(dghs-imgutils-rs) side-by-side with current DB tags (Python
+						version). No changes will be persisted.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div class="py-4">
+					<Show when={isLoading()}>
+						<div class="flex flex-col items-center justify-center py-12">
+							<div class="h-10 w-10 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent" />
+							<span class="mt-4 font-medium text-gray-600 text-sm">
+								Running Rust ONNX Tagger inference...
+							</span>
+						</div>
+					</Show>
+
+					<Show when={error()}>
+						<div class="rounded-md border border-red-200 bg-red-50 p-4 text-red-700">
+							<h4 class="font-semibold">Inference Error</h4>
+							<p class="mt-1 text-sm">{error()}</p>
+						</div>
+					</Show>
+
+					<Show when={rustResult()}>
+						<div class="space-y-8">
+							{/* Characters Section */}
+							<div>
+								<h3 class="mb-3 font-semibold text-gray-800 text-lg border-b pb-1">
+									Characters
+								</h3>
+								<Show
+									fallback={
+										<p class="text-gray-500 text-sm italic">
+											No characters detected by either tagger.
+										</p>
+									}
+									when={charactersComparison().length > 0}
+								>
+									<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+										<For each={charactersComparison()}>
+											{(item) => (
+												<div class="flex items-center justify-between rounded-lg border p-2.5 text-sm hover:bg-gray-50">
+													<span class="font-medium text-gray-800">
+														{item.name}
+													</span>
+													<div class="flex items-center gap-2">
+														<Show
+															fallback={
+																<span class="rounded bg-emerald-50 px-1.5 py-0.5 text-emerald-700 text-xs font-semibold">
+																	Rust Only
+																</span>
+															}
+															when={item.dbScore !== null}
+														>
+															<span class="text-gray-500 text-xs">
+																DB:{" "}
+																{(
+																	item.dbScore! * PERCENTAGE_MULTIPLIER
+																).toFixed(0)}
+																%
+															</span>
+														</Show>
+
+														<Show
+															fallback={
+																<span class="rounded bg-rose-50 px-1.5 py-0.5 text-rose-700 text-xs font-semibold">
+																	DB Only
+																</span>
+															}
+															when={item.rustScore !== null}
+														>
+															<span class="rounded bg-indigo-50 px-2 py-0.5 font-semibold text-indigo-700 text-xs">
+																Rust:{" "}
+																{(
+																	item.rustScore! * PERCENTAGE_MULTIPLIER
+																).toFixed(0)}
+																%
+															</span>
+														</Show>
+
+														<Show when={item.diff !== null}>
+															<span
+																class={`text-xs font-bold ${
+																	item.diff! >= 0
+																		? "text-emerald-600"
+																		: "text-rose-600"
+																}`}
+															>
+																{item.diff! >= 0 ? "+" : ""}
+																{(item.diff! * PERCENTAGE_MULTIPLIER).toFixed(
+																	0,
+																)}
+																%
+															</span>
+														</Show>
+													</div>
+												</div>
+											)}
+										</For>
+									</div>
+								</Show>
+							</div>
+
+							{/* IPs / Series Section */}
+							<div>
+								<h3 class="mb-3 font-semibold text-gray-800 text-lg border-b pb-1">
+									IPs (Copyright/Series)
+								</h3>
+								<div class="flex flex-wrap gap-2">
+									<For each={ipsComparison().both}>
+										{(ip) => (
+											<Badge
+												class="border-indigo-200 bg-indigo-50 text-indigo-800"
+												variant="secondary"
+											>
+												{ip}
+											</Badge>
+										)}
+									</For>
+									<For each={ipsComparison().rustOnly}>
+										{(ip) => (
+											<Badge
+												class="border-emerald-200 bg-emerald-50 text-emerald-800"
+												variant="secondary"
+											>
+												{ip} (Rust Only)
+											</Badge>
+										)}
+									</For>
+									<For each={ipsComparison().dbOnly}>
+										{(ip) => (
+											<Badge
+												class="border-rose-200 bg-rose-50 text-rose-800"
+												variant="secondary"
+											>
+												{ip} (DB Only)
+											</Badge>
+										)}
+									</For>
+									<Show
+										when={
+											ipsComparison().both.length === 0 &&
+											ipsComparison().rustOnly.length === 0 &&
+											ipsComparison().dbOnly.length === 0
+										}
+									>
+										<p class="text-gray-500 text-sm italic">
+											No series IPs detected.
+										</p>
+									</Show>
+								</div>
+							</div>
+
+							{/* General Tags Section */}
+							<div>
+								<h3 class="mb-3 font-semibold text-gray-800 text-lg border-b pb-1">
+									General Tags
+								</h3>
+								<div class="overflow-x-auto rounded-lg border">
+									<table class="w-full text-left border-collapse text-sm">
+										<thead>
+											<tr class="bg-gray-100 border-b">
+												<th class="p-3 font-semibold text-gray-700">
+													Tag Name
+												</th>
+												<th class="p-3 font-semibold text-gray-700 text-right">
+													DB Score (Python)
+												</th>
+												<th class="p-3 font-semibold text-gray-700 text-right">
+													Rust Score
+												</th>
+												<th class="p-3 font-semibold text-gray-700 text-right">
+													Difference
+												</th>
+											</tr>
+										</thead>
+										<tbody>
+											<For each={tagsComparison()}>
+												{(item) => (
+													<tr class="border-b hover:bg-gray-50/50">
+														<td class="p-3 font-medium text-gray-900">
+															{item.name}
+														</td>
+														<td class="p-3 text-right text-gray-600">
+															{item.dbScore !== null ? (
+																`${(item.dbScore * PERCENTAGE_MULTIPLIER).toFixed(1)}%`
+															) : (
+																<span class="text-emerald-600 font-semibold text-xs bg-emerald-50 px-1.5 py-0.5 rounded">
+																	Rust New
+																</span>
+															)}
+														</td>
+														<td class="p-3 text-right text-gray-600">
+															{item.rustScore !== null ? (
+																`${(item.rustScore * PERCENTAGE_MULTIPLIER).toFixed(1)}%`
+															) : (
+																<span class="text-rose-600 font-semibold text-xs bg-rose-50 px-1.5 py-0.5 rounded">
+																	Removed
+																</span>
+															)}
+														</td>
+														<td class="p-3 text-right">
+															<Show
+																fallback={
+																	<span class="text-gray-400 text-xs">—</span>
+																}
+																when={item.diff !== null}
+															>
+																<span
+																	class={`font-semibold ${
+																		item.diff! >= 0
+																			? "text-emerald-600"
+																			: "text-rose-600"
+																	}`}
+																>
+																	{item.diff! >= 0 ? "+" : ""}
+																	{(item.diff! * PERCENTAGE_MULTIPLIER).toFixed(
+																		1,
+																	)}
+																	%
+																</span>
+															</Show>
+														</td>
+													</tr>
+												)}
+											</For>
+										</tbody>
+									</table>
+								</div>
+							</div>
+						</div>
+					</Show>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/server/src/infrastructure/api-clients/ai-api.ts
+++ b/apps/server/src/infrastructure/api-clients/ai-api.ts
@@ -24,3 +24,11 @@ export function fetchAiTags(params: z.infer<typeof tagImageRequestSchema>) {
 export function fetchAiTagsForFile(file: File) {
 	return orpc.ai.tag({ file });
 }
+
+/**
+ * Fetches experimental Rust AI tags for a media item
+ * @param mediaId - The ID of the media item
+ */
+export function fetchRustExperimentalTags(mediaId: string) {
+	return orpc.ai.tagRustExperimental({ mediaId });
+}

--- a/apps/server/src/infrastructure/api/routers/ai-router.ts
+++ b/apps/server/src/infrastructure/api/routers/ai-router.ts
@@ -1,5 +1,7 @@
+import fs from "node:fs";
 import path from "node:path";
 import { ORPCError, os } from "@orpc/server";
+import { createClient } from "@solid-imager/client";
 import {
 	batchTaggingRequestSchema,
 	ccipDifferenceRequestSchema,
@@ -19,15 +21,89 @@ import {
 } from "~/infrastructure/db/schema";
 import { logger } from "~/infrastructure/logger";
 
+function isRemoteServerLocal(url: string): boolean {
+	try {
+		const host = new URL(url).hostname;
+		return (
+			host === "localhost" ||
+			host === "127.0.0.1" ||
+			host === "::1" ||
+			host === "0.0.0.0"
+		);
+	} catch {
+		return true;
+	}
+}
+
+function getRemoteServerUrl(): string | undefined {
+	const config = services.getConfigService().getConfig();
+	const url = config.ai.remoteServerUrl;
+	if (!url || url.trim() === "") return undefined;
+	return url;
+}
+
+async function readFileBuffer(filePath: string): Promise<Buffer> {
+	return fs.promises.readFile(filePath);
+}
+
+async function callRemoteOprc(
+	remoteUrl: string,
+	endpoint: "tag" | "tagRustExperimental",
+	fileBuffer: Buffer,
+	fileName: string,
+	timeoutMs: number,
+): Promise<unknown> {
+	const file = new File([new Uint8Array(fileBuffer)], fileName);
+	const remoteOrpc = createClient({
+		url: remoteUrl,
+		fetch: async (request, init) => {
+			const controller = new AbortController();
+			const t = setTimeout(() => controller.abort(), timeoutMs);
+			try {
+				return await fetch(request, {
+					...init,
+					signal: controller.signal,
+				});
+			} finally {
+				clearTimeout(t);
+			}
+		},
+	}) as any;
+
+	if (endpoint === "tagRustExperimental") {
+		return remoteOrpc.ai.tagRustExperimental({ file });
+	}
+	return remoteOrpc.ai.tag({ file });
+}
+
 export const aiRouter = {
 	tagRustExperimental: os
 		.input(
-			z.object({
-				mediaId: z.string().uuid(),
-			}),
+			z.union([
+				z.object({ mediaId: z.string().uuid() }),
+				z.object({ file: z.instanceof(File) }),
+			]),
 		)
 		.handler(async ({ input }) => {
 			try {
+				if ("file" in input) {
+					const buffer = Buffer.from(await input.file.arrayBuffer());
+					const tmpPath = `/tmp/rust-tag-${Date.now()}-${Math.random().toString(36).slice(2)}.png`;
+					await fs.promises.writeFile(tmpPath, buffer);
+					try {
+						const { getPixaiTags } = await import("dghs-imgutils-rs");
+						const result = await getPixaiTags(tmpPath);
+						return {
+							general: result.general,
+							character: result.character,
+							ips: result.ips,
+							ips_mapping: result.ipsMapping,
+						};
+					} finally {
+						await fs.promises.unlink(tmpPath).catch(() => {});
+					}
+				}
+
 				const { mediaId } = input;
 				const media = await services.getMediaRepository().findById(mediaId);
 				if (!media) {
@@ -45,12 +121,33 @@ export const aiRouter = {
 					);
 				}
 
-const connectionInfo = mediaSource.connectionInfo as Record<string, unknown> | null | undefined;
-if (!connectionInfo || typeof connectionInfo.path !== "string") {
-	console.error("Media source connection path is missing or invalid");
-	return null;
-}
-const fullPath = path.join(connectionInfo.path, media.filePath);
+				const connectionInfo = mediaSource.connectionInfo as
+					| Record<string, unknown>
+					| null
+					| undefined;
+				if (!connectionInfo || typeof connectionInfo.path !== "string") {
+					throw new Error("Media source connection path is missing or invalid");
+				}
+				const fullPath = path.join(connectionInfo.path, media.filePath);
+
+				const remoteUrl = getRemoteServerUrl();
+				const config = services.getConfigService().getConfig();
+				if (remoteUrl && !isRemoteServerLocal(remoteUrl)) {
+					const fileBuffer = await readFileBuffer(fullPath);
+					const result = (await callRemoteOprc(
+						remoteUrl,
+						"tagRustExperimental",
+						fileBuffer,
+						path.basename(fullPath),
+						config.ai.timeoutMs,
+					)) as {
+						general: Record<string, number>;
+						character: Record<string, number>;
+						ips: string[];
+						ips_mapping: Record<string, string[]>;
+					};
+					return result;
+				}
 
 				const { getPixaiTags } = await import("dghs-imgutils-rs");
 				const result = await getPixaiTags(fullPath);
@@ -88,6 +185,41 @@ const fullPath = path.join(connectionInfo.path, media.filePath);
 				const { mediaSourceId, mediaId } = input;
 				if (!(mediaSourceId && mediaId)) {
 					throw new Error("mediaSourceId and mediaId are required");
+				}
+
+				const remoteUrl = getRemoteServerUrl();
+				const config = services.getConfigService().getConfig();
+				if (remoteUrl && !isRemoteServerLocal(remoteUrl)) {
+					const media = await services.getMediaRepository().findById(mediaId);
+					if (!media) {
+						throw new Error("Media not found");
+					}
+					const mediaSource = await services
+						.getSourceRepository()
+						.findById(media.mediaSourceId);
+					if (mediaSource?.type !== "local") {
+						throw new Error(
+							"Only local media sources are supported for remote tagging",
+						);
+					}
+					const connectionInfo = mediaSource.connectionInfo as
+						| Record<string, unknown>
+						| null
+						| undefined;
+					if (!connectionInfo || typeof connectionInfo.path !== "string") {
+						throw new Error(
+							"Media source connection path is missing or invalid",
+						);
+					}
+					const fullPath = path.join(connectionInfo.path, media.filePath);
+					const fileBuffer = await readFileBuffer(fullPath);
+					return (await callRemoteOprc(
+						remoteUrl,
+						"tag",
+						fileBuffer,
+						path.basename(fullPath),
+						config.ai.timeoutMs,
+					)) as import("@solid-imager/core/domain/tagging/schemas").TaggingResponse;
 				}
 
 				return await taggingService.getTagsForMedia(mediaSourceId, mediaId);

--- a/apps/server/src/routes/config.tsx
+++ b/apps/server/src/routes/config.tsx
@@ -224,6 +224,31 @@ function ConfigForm(props: { data: AppConfig }) {
 									</div>
 								)}
 							</form.Field>
+							<form.Field name="ai.remoteServerUrl">
+								{(field) => (
+									<div class="space-y-2">
+										<Label for={field().name}>
+											Remote AI Server URL (oRPC)
+										</Label>
+										<Input
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(e) =>
+												field().handleChange(
+													(e.target.value || undefined) as any,
+												)
+											}
+											placeholder="http://power-machine:3000"
+											value={(field().state.value as string) ?? ""}
+										/>
+										<div class="text-muted-foreground text-xs">
+											外部の solid-imager サーバーの oRPC
+											エンドポイントを指定。AI
+											処理をリモートに委託します。空欄の場合はローカルで処理します。
+										</div>
+									</div>
+								)}
+							</form.Field>
 						</div>
 					</TabsContent>
 

--- a/apps/server/vite.config.ts
+++ b/apps/server/vite.config.ts
@@ -63,7 +63,8 @@ export default defineConfig({
       "fluent-ffmpeg",
       "archiver",
       "@lancedb/lancedb",
-      "apache-arrow"
+      "apache-arrow",
+      "dghs-imgutils-rs"
     ],
   },
 });

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,14 @@
         "vite-plus": "^0.1.24",
       },
     },
+    ".worktree/dghs-imgutils-rs": {
+      "name": "dghs-imgutils-rs",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@napi-rs/cli": "^2.18.4",
+        "typescript": "^5.4.5",
+      },
+    },
     "apps/cli": {
       "name": "@solid-imager/cli",
       "version": "0.1.0",
@@ -62,6 +70,7 @@
         "apache-arrow": "^21.1.0",
         "archiver": "^8.0.0",
         "chokidar": "^5.0.0",
+        "dghs-imgutils-rs": "workspace:*",
         "drizzle-orm": "^0.45.2",
         "fast-glob": "^3.3.3",
         "ffmpeg-static": "^5.3.0",
@@ -529,6 +538,8 @@
     "@lancedb/lancedb-win32-x64-msvc": ["@lancedb/lancedb-win32-x64-msvc@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-XlwiI6CK2Gkqq+FFVAStHojao/XjIJpDPTm7Tb9SpLL64IlwGw3yaT2hnWKTm90W4KlSrpfSldPly+s+y4U7JQ=="],
 
     "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0-alpha.2", "", { "dependencies": { "zod": "^4.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA=="],
+
+    "@napi-rs/cli": ["@napi-rs/cli@2.18.4", "", { "bin": { "napi": "scripts/index.js" } }, "sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -1185,6 +1196,8 @@
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dghs-imgutils-rs": ["dghs-imgutils-rs@workspace:.worktree/dghs-imgutils-rs"],
 
     "diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
 
@@ -1907,6 +1920,8 @@
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
+
+    "dghs-imgutils-rs/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "execa/pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "workspaces": [
     "apps/*",
     "packages/client",
-    "packages/*"
+    "packages/*",
+    ".worktree/dghs-imgutils-rs"
   ],
   "scripts": {
     "dev": "bun --filter @solid-imager/server dev",

--- a/packages/core/src/domain/config/config-schema.ts
+++ b/packages/core/src/domain/config/config-schema.ts
@@ -33,6 +33,7 @@ const MIN_AI_TIMEOUT = 1000;
 export const AiConfigSchema = z.object({
 	baseUrl: z.string().default(DEFAULT_AI_BASE_URL),
 	timeoutMs: z.number().min(MIN_AI_TIMEOUT).default(DEFAULT_AI_TIMEOUT),
+	remoteServerUrl: z.string().optional(),
 });
 
 const DEFAULT_AI_CONFIG = {


### PR DESCRIPTION
## 外容

- tagRustExperimental エンドポイント（Rust ネイティブモジュール直接呼び出し）
- tag/tagRustExperimental のリモートプロキシ対応（remoteServerUrl 設定で外部 solid-imager に委託）
- リモート呼び出しを oRPC クライアント経由に変更（生 fetch+FormData の 400 エラー修正）
- Settings UI に Remote AI Server URL フィールド追加
- dghs-imgutils-rs 依存関係の追加・設定

## 構成

```
[弱いマシン: solid-imager]
  remoteServerUrl → oRPC → [パワーマシン: solid-imager]
                              → tag: PythonClient → REST
                              → tagRustExperimental: dghs-imgutils-rs native
```