### PR TITLE
feat: add duplicate image removal UI to manager

### DIFF
--- a/apps/server/src/infrastructure/api-clients/media-api.ts
+++ b/apps/server/src/infrastructure/api-clients/media-api.ts
@@ -152,3 +152,14 @@ export function moveMedia(
 export function syncMediaItems(sourceId: string, mediaIds: string[]) {
 	return orpc.media.sync({ sourceId, mediaIds });
 }
+
+/**
+ * Finds duplicate media by filename pattern and source URL matching
+ * @param mediaSourceId - Optional media source ID to filter by
+ * @returns Duplicate groups
+ */
+export function findDuplicateMedia(mediaSourceId?: string) {
+	return orpc.media.findDuplicates(
+		mediaSourceId ? { mediaSourceId } : undefined,
+	);
+}

--- a/apps/server/src/infrastructure/api/routers/media-router.ts
+++ b/apps/server/src/infrastructure/api/routers/media-router.ts
@@ -1,6 +1,7 @@
 import { ORPCError, os } from "@orpc/server";
 import { ResourceNotFoundError } from "@solid-imager/core/domain/errors";
 import {
+	findDuplicatesRequestSchema,
 	mediaSearchRequestSchema,
 	updateMediaRequestSchema,
 } from "@solid-imager/core/domain/media/schemas";
@@ -58,6 +59,16 @@ export const mediaRouter = {
 		.handler(
 			async ({ input }) =>
 				await MediaService.getMediaDetails(input.sourceId, input.mediaId),
+		),
+
+	/**
+	 * Find duplicate media by filename pattern and source URL matching
+	 */
+	findDuplicates: os
+		.input(findDuplicatesRequestSchema.optional())
+		.handler(
+			async ({ input }) =>
+				await MediaService.findDuplicates(input ?? {}),
 		),
 
 	/**

--- a/apps/server/src/routes/manager.tsx
+++ b/apps/server/src/routes/manager.tsx
@@ -25,6 +25,10 @@ import {
 	deleteProject,
 	updateProject,
 } from "~/infrastructure/api-clients/projects-api";
+import {
+	deleteMedia,
+	findDuplicateMedia,
+} from "~/infrastructure/api-clients/media-api";
 import { allCharactersQueryOptions } from "~/infrastructure/api-clients/queries/characters-query";
 import { allIpsQueryOptions } from "~/infrastructure/api-clients/queries/ips-query";
 import { allProjectsQueryOptions } from "~/infrastructure/api-clients/queries/projects-query";
@@ -56,6 +60,8 @@ const managerActions = {
 		mediaSourceId?: string;
 		mediaIds: string[];
 	}) => Promise<StartBatchTaggingResult>,
+	findDuplicateMedia,
+	deleteMedia,
 };
 
 export const Route = createFileRoute("/manager")({

--- a/packages/application/src/ports/media-service.ts
+++ b/packages/application/src/ports/media-service.ts
@@ -1,5 +1,7 @@
 import type { Transaction } from "@solid-imager/core/domain/interfaces/transaction-manager";
 import type {
+	FindDuplicatesRequest,
+	FindDuplicatesResponse,
 	Media,
 	MediaDetails,
 	MediaGenerationInfo,
@@ -176,4 +178,8 @@ export interface IMediaService {
 		mediaId: string,
 		tx?: Transaction,
 	): Promise<DeferredActions | undefined>;
+
+	findDuplicates(
+		request: FindDuplicatesRequest,
+	): Promise<FindDuplicatesResponse>;
 }

--- a/packages/application/src/services/media-service.ts
+++ b/packages/application/src/services/media-service.ts
@@ -14,6 +14,8 @@ import type {
 } from "@solid-imager/core/domain/interfaces/transaction-manager";
 import {
 	type AddMediaRequest,
+	type FindDuplicatesRequest,
+	type FindDuplicatesResponse,
 	type Media,
 	type MediaDetails,
 	type MediaGenerationInfo,
@@ -1020,6 +1022,12 @@ export class MediaServiceImpl implements IMediaService {
 				tx,
 			);
 		}
+	}
+
+	async findDuplicates(
+		request: FindDuplicatesRequest,
+	): Promise<FindDuplicatesResponse> {
+		return this.mediaRepository.findDuplicates(request);
 	}
 
 	private async extractAndUpdateMetadata(

--- a/packages/core/src/domain/media/schemas.ts
+++ b/packages/core/src/domain/media/schemas.ts
@@ -556,3 +556,42 @@ export const updatePresetRequestSchema = z.object({
 });
 
 export type UpdatePresetRequest = z.infer<typeof updatePresetRequestSchema>;
+
+// ============================================================================
+// Duplicate Detection Schemas
+// ============================================================================
+
+export const duplicateReasonSchema = z.enum(["filename", "sourceUrl"]);
+export type DuplicateReason = z.infer<typeof duplicateReasonSchema>;
+
+export const duplicateMediaItemSchema = z.object({
+	id: z.uuid({ version: "v4" }),
+	mediaSourceId: z.uuid({ version: "v4" }),
+	fileName: z.string(),
+	filePath: z.string(),
+	fileSize: z.number().nullable(),
+	width: z.number(),
+	height: z.number(),
+	mediaType: z.enum(["image", "video", "audio"]),
+	createdAt: z.coerce.date(),
+	modifiedAt: z.coerce.date(),
+	sourceUrls: z.array(z.string().url()),
+});
+export type DuplicateMediaItem = z.infer<typeof duplicateMediaItemSchema>;
+
+export const duplicateGroupSchema = z.object({
+	id: z.string(),
+	reason: duplicateReasonSchema,
+	media: z.array(duplicateMediaItemSchema),
+});
+export type DuplicateGroup = z.infer<typeof duplicateGroupSchema>;
+
+export const findDuplicatesResponseSchema = z.object({
+	groups: z.array(duplicateGroupSchema),
+});
+export type FindDuplicatesResponse = z.infer<typeof findDuplicatesResponseSchema>;
+
+export const findDuplicatesRequestSchema = z.object({
+	mediaSourceId: z.uuid({ version: "v4" }).optional(),
+});
+export type FindDuplicatesRequest = z.infer<typeof findDuplicatesRequestSchema>;

--- a/packages/core/src/domain/repositories/media-repository.ts
+++ b/packages/core/src/domain/repositories/media-repository.ts
@@ -2,6 +2,10 @@ import type { Transaction } from "@/domain/interfaces/transaction-manager";
 import type {
 	AddMediaRequest,
 	Author,
+	DuplicateMediaItem,
+	DuplicateGroup,
+	FindDuplicatesRequest,
+	FindDuplicatesResponse,
 	Media,
 	MediaDetails,
 	MediaGenerationInfo,
@@ -90,4 +94,12 @@ export type IMediaRepository = {
 		sourceId: string,
 		tx?: Transaction,
 	): Promise<{ id: string; filePath: string }[]>;
+
+	/**
+	 * Find duplicate media by filename pattern and source URL matching.
+	 */
+	findDuplicates(
+		request: FindDuplicatesRequest,
+		tx?: Transaction,
+	): Promise<FindDuplicatesResponse>;
 };

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -6,6 +6,9 @@ import type { Transaction } from "@solid-imager/core/domain/interfaces/transacti
 import {
 	type AddMediaRequest,
 	type Author,
+	type DuplicateGroup,
+	type FindDuplicatesRequest,
+	type FindDuplicatesResponse,
 	type Media,
 	type MediaDetails,
 	type MediaGenerationInfo,
@@ -1175,6 +1178,105 @@ export function createMediaRepository(
 			}
 
 			return await query;
+		},
+
+		async findDuplicates(
+			request: FindDuplicatesRequest,
+			tx?: Transaction,
+		): Promise<FindDuplicatesResponse> {
+			const client = getExecutor(tx);
+
+			const mediaConditions = [
+				eq(medias.mediaType, "image"),
+				eq(medias.status, "active"),
+			];
+			if (request.mediaSourceId) {
+				mediaConditions.push(eq(medias.mediaSourceId, request.mediaSourceId));
+			}
+
+			const mediaRows = await client
+				.select({
+					id: medias.id,
+					mediaSourceId: medias.mediaSourceId,
+					fileName: medias.fileName,
+					filePath: medias.filePath,
+					fileSize: medias.fileSize,
+					width: medias.width,
+					height: medias.height,
+					mediaType: medias.mediaType,
+					createdAt: medias.createdAt,
+					modifiedAt: medias.modifiedAt,
+				})
+				.from(medias)
+				.where(and(...mediaConditions));
+
+			if (mediaRows.length === 0) {
+				return { groups: [] };
+			}
+
+			const mediaIds = mediaRows.map((row) => row.id);
+
+			const urlRows = await client
+				.select({
+					mediaId: mediaUrls.mediaId,
+					url: mediaUrls.url,
+				})
+				.from(mediaUrls)
+				.where(inArray(mediaUrls.mediaId, mediaIds));
+
+			const urlsByMediaId = new Map<string, string[]>();
+			for (const row of urlRows) {
+				const arr = urlsByMediaId.get(row.mediaId) || [];
+				arr.push(row.url);
+				urlsByMediaId.set(row.mediaId, arr);
+			}
+
+			const mediaMap = new Map<string, (typeof mediaRows)[number]>();
+			for (const row of mediaRows) {
+				mediaMap.set(row.id, row);
+			}
+
+			const groups: DuplicateGroup[] = [];
+
+			// Group by source URL complete match (all URLs must match)
+			const byUrlSet = new Map<string, string[]>();
+			for (const row of mediaRows) {
+				const urls = (urlsByMediaId.get(row.id) || []).slice().sort();
+				if (urls.length < 2) continue;
+				const key = urls.join("\0");
+				const arr = byUrlSet.get(key) || [];
+				arr.push(row.id);
+				byUrlSet.set(key, arr);
+			}
+
+			let urlGroupIndex = 0;
+			for (const [, ids] of byUrlSet) {
+				if (ids.length < 2) continue;
+				const group = ids.map((id) => {
+					// biome-ignore lint/style/noNonNullAssertion: ID mapped from mediaRows
+					const row = mediaMap.get(id)!;
+					return {
+						id: row.id,
+						mediaSourceId: row.mediaSourceId,
+						fileName: row.fileName,
+						filePath: row.filePath,
+						fileSize: row.fileSize,
+						width: row.width,
+						height: row.height,
+						mediaType: row.mediaType,
+						createdAt: row.createdAt,
+						modifiedAt: row.modifiedAt,
+						sourceUrls: urlsByMediaId.get(id) || [],
+					};
+				});
+				groups.push({
+					id: `url-${urlGroupIndex++}`,
+					reason: "sourceUrl",
+					media: group,
+				});
+			}
+
+			return { groups };
 		},
 
 		async findAllPathsBySourceId(

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -1242,8 +1242,8 @@ export function createMediaRepository(
 			const byUrlSet = new Map<string, string[]>();
 			for (const row of mediaRows) {
 				const urls = (urlsByMediaId.get(row.id) || []).slice().sort();
-				const urls = (urlsByMediaId.get(row.id) || []).slice().sort();
-				if (urls.length < 1) continue;
+				if (urls.length < 2) continue;
+				const key = urls.join("\0");
 				const arr = byUrlSet.get(key) || [];
 				arr.push(row.id);
 				byUrlSet.set(key, arr);

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -1242,8 +1242,8 @@ export function createMediaRepository(
 			const byUrlSet = new Map<string, string[]>();
 			for (const row of mediaRows) {
 				const urls = (urlsByMediaId.get(row.id) || []).slice().sort();
-				if (urls.length < 2) continue;
-				const key = urls.join("\0");
+				const urls = (urlsByMediaId.get(row.id) || []).slice().sort();
+				if (urls.length < 1) continue;
 				const arr = byUrlSet.get(key) || [];
 				arr.push(row.id);
 				byUrlSet.set(key, arr);

--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -1,6 +1,6 @@
 import type { Character } from "@solid-imager/core/domain/characters/schemas";
 import type { Ip } from "@solid-imager/core/domain/ips/schemas";
-import type { Media } from "@solid-imager/core/domain/media/schemas";
+import type { DuplicateGroup, Media } from "@solid-imager/core/domain/media/schemas";
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type {
 	JobCompletedEvent,
@@ -21,7 +21,7 @@ import type { buildProjectsQueryOptions } from "../query-options/projects-query"
 import type { buildSourcesQueryOptions } from "../query-options/sources-query";
 import { toast } from "../toast";
 
-export type ManagerEntityType = "projects" | "ips" | "characters" | "tagging";
+export type ManagerEntityType = "projects" | "ips" | "characters" | "tagging" | "duplicates";
 export type ManagerEntity = Project | Ip | Character;
 
 export type ManagerFormData = {
@@ -68,6 +68,8 @@ export type ManagerPageActions = {
 		mediaSourceId?: string;
 		mediaIds: string[];
 	}) => Promise<StartBatchTaggingResult>;
+	findDuplicateMedia: (mediaSourceId?: string) => Promise<{ groups: DuplicateGroup[] }>;
+	deleteMedia: (sourceId: string, mediaId: string) => Promise<unknown>;
 	invalidate: (entityType: Exclude<ManagerEntityType, "tagging">) => void;
 };
 
@@ -148,6 +150,21 @@ export type UseManagerPageResult = {
 	toggleMediaSelection: (mediaId: string) => void;
 	toggleSelectAll: () => void;
 	jobHandlers: ManagerJobHandlers;
+	// Duplicates tab
+	duplicateSourceId: Accessor<string | undefined>;
+	setDuplicateSourceId: Setter<string | undefined>;
+	duplicateGroups: Accessor<DuplicateGroup[]>;
+	keepIds: Accessor<Set<string>>;
+	duplicateStatus: Accessor<string | null>;
+	isDuplicateDeleteDialogOpen: Accessor<boolean>;
+	setIsDuplicateDeleteDialogOpen: Setter<boolean>;
+	duplicatesToDelete: Accessor<{ sourceId: string; mediaId: string; fileName: string }[]>;
+	handleScanDuplicates: () => Promise<void>;
+	handleDeleteDuplicates: () => Promise<void>;
+	handleConfirmDeleteDuplicates: () => Promise<void>;
+	setKeepForGroup: (groupId: string, mediaId: string) => void;
+	selectKeepOldest: () => void;
+	selectKeepLargest: () => void;
 };
 
 function isCharacter(item: ManagerEntity): item is Character {
@@ -164,8 +181,8 @@ function resetForm(setFormData: Setter<ManagerFormData>) {
 
 function activeCrudTab(
 	activeTab: ManagerEntityType,
-): Exclude<ManagerEntityType, "tagging"> | null {
-	return activeTab === "tagging" ? null : activeTab;
+): Exclude<ManagerEntityType, "tagging" | "duplicates"> | null {
+	return activeTab === "tagging" || activeTab === "duplicates" ? null : activeTab;
 }
 
 export function useManagerPage(
@@ -220,6 +237,14 @@ export function useManagerPage(
 	);
 	const [activeJobId, setActiveJobId] = createSignal<string | null>(null);
 	const [currentPage, setCurrentPage] = createSignal(1);
+
+	// Duplicates state
+	const [duplicateSourceId, setDuplicateSourceId] = createSignal<string | undefined>(undefined);
+	const [duplicateGroups, setDuplicateGroups] = createSignal<DuplicateGroup[]>([]);
+	const [keepIds, setKeepIds] = createSignal<Set<string>>(new Set());
+	const [duplicateStatus, setDuplicateStatus] = createSignal<string | null>(null);
+	const [isDuplicateDeleteDialogOpen, setIsDuplicateDeleteDialogOpen] = createSignal(false);
+	const [duplicatesToDelete, setDuplicatesToDelete] = createSignal<{ sourceId: string; mediaId: string; fileName: string }[]>([]);
 
 	const sources = () => queries.sources() || [];
 	const ips = () => queries.ips() || [];
@@ -411,6 +436,127 @@ export function useManagerPage(
 		}
 	};
 
+	// --- Duplicates ---
+
+	const setKeepForGroup = (_groupId: string, mediaId: string) => {
+		setKeepIds((prev) => {
+			const next = new Set(prev);
+			// Remove all items from the same group (identified by having the same media items)
+			const groups = duplicateGroups();
+			for (const group of groups) {
+				for (const item of group.media) {
+					if (item.id === mediaId) {
+						// Remove other items from this group
+						for (const otherItem of group.media) {
+							next.delete(otherItem.id);
+						}
+						next.add(mediaId);
+						break;
+					}
+				}
+			}
+			return next;
+		});
+	};
+
+	const selectKeepOldest = () => {
+		const newKeep = new Set<string>();
+		for (const group of duplicateGroups()) {
+			const sorted = [...group.media].sort(
+				(a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+			);
+			newKeep.add(sorted[0].id);
+		}
+		setKeepIds(newKeep);
+	};
+
+	const selectKeepLargest = () => {
+		const newKeep = new Set<string>();
+		for (const group of duplicateGroups()) {
+			const sorted = [...group.media].sort(
+				(a, b) => (b.fileSize ?? 0) - (a.fileSize ?? 0),
+			);
+			newKeep.add(sorted[0].id);
+		}
+		setKeepIds(newKeep);
+	};
+
+	const handleScanDuplicates = async () => {
+		try {
+			setDuplicateStatus("Scanning...");
+			setDuplicateGroups([]);
+			const result = await actions.findDuplicateMedia(duplicateSourceId());
+			setDuplicateGroups(result.groups);
+			// Auto-select oldest in each group
+			const newKeep = new Set<string>();
+			for (const group of result.groups) {
+				const sorted = [...group.media].sort(
+					(a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+				);
+				newKeep.add(sorted[0].id);
+			}
+			setKeepIds(newKeep);
+			const dupCount = result.groups.reduce((sum, g) => sum + g.media.length - 1, 0);
+			setDuplicateStatus(`${result.groups.length} groups found (${dupCount} duplicates).`);
+		} catch (error) {
+			toast.error(`Error: ${(error as Error).message}`);
+			setDuplicateStatus(`Error: ${(error as Error).message}`);
+		}
+	};
+
+	const handleDeleteDuplicates = async () => {
+		const groups = duplicateGroups();
+		const keepSet = keepIds();
+		const toDelete: { sourceId: string; mediaId: string; fileName: string }[] = [];
+		for (const group of groups) {
+			for (const item of group.media) {
+				if (!keepSet.has(item.id)) {
+					toDelete.push({
+						sourceId: item.mediaSourceId,
+						mediaId: item.id,
+						fileName: item.fileName,
+					});
+				}
+			}
+		}
+		if (toDelete.length === 0) {
+			toast.error("No duplicates selected for deletion");
+			return;
+		}
+		setDuplicatesToDelete(toDelete);
+		setIsDuplicateDeleteDialogOpen(true);
+	};
+
+	const handleConfirmDeleteDuplicates = async () => {
+		const toDelete = duplicatesToDelete();
+		let deleted = 0;
+		let failed = 0;
+
+		try {
+			for (const item of toDelete) {
+				try {
+					await actions.deleteMedia(item.sourceId, item.mediaId);
+					deleted++;
+				} catch {
+					failed++;
+				}
+			}
+		} finally {
+			setIsDuplicateDeleteDialogOpen(false);
+			setDuplicatesToDelete([]);
+			setDuplicateGroups([]);
+			setKeepIds(new Set<string>());
+			setDuplicateStatus(null);
+			if (failed === 0) {
+				toast.success(`Deleted ${deleted} duplicate(s)`);
+			} else {
+				toast.error(`Deleted ${deleted}, failed ${failed}`);
+			}
+		}
+	};
+
+	// --- End Duplicates ---
+
 	const handleJobProgress = (event: JobProgressEvent) => {
 		setJobProgress(event);
 		setTaggingStatus(`Processing: ${event.processed} / ${event.total} tagged.`);
@@ -477,5 +623,20 @@ export function useManagerPage(
 		toggleMediaSelection,
 		toggleSelectAll,
 		jobHandlers,
+		// Duplicates
+		duplicateSourceId,
+		setDuplicateSourceId,
+		duplicateGroups,
+		keepIds,
+		duplicateStatus,
+		isDuplicateDeleteDialogOpen,
+		setIsDuplicateDeleteDialogOpen,
+		duplicatesToDelete,
+		handleScanDuplicates,
+		handleDeleteDuplicates,
+		setKeepForGroup,
+		selectKeepOldest,
+		selectKeepLargest,
+		handleConfirmDeleteDuplicates,
 	};
 }

--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -491,7 +491,7 @@ export function useManagerPage(
 			const newKeep = new Set<string>();
 			for (const group of result.groups) {
 				const sorted = [...group.media].sort(
-					(a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+					(a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
 				);
 				newKeep.add(sorted[0].id);
 			}

--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -544,13 +544,13 @@ export function useManagerPage(
 		} finally {
 			setIsDuplicateDeleteDialogOpen(false);
 			setDuplicatesToDelete([]);
-			setDuplicateGroups([]);
-			setKeepIds(new Set<string>());
-			setDuplicateStatus(null);
 			if (failed === 0) {
+				setDuplicateGroups([]);
+				setKeepIds(new Set<string>());
+				setDuplicateStatus(null);
 				toast.success(`Deleted ${deleted} duplicate(s)`);
 			} else {
-				toast.error(`Deleted ${deleted}, failed ${failed}`);
+				toast.error(`Deleted ${deleted}, failed ${failed}. Remaining duplicates are still shown.`);
 			}
 		}
 	};

--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -463,7 +463,7 @@ export function useManagerPage(
 		const newKeep = new Set<string>();
 		for (const group of duplicateGroups()) {
 			const sorted = [...group.media].sort(
-				(a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+				(a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
 			);
 			newKeep.add(sorted[0].id);
 		}

--- a/packages/ui/src/screens/manager-screen.tsx
+++ b/packages/ui/src/screens/manager-screen.tsx
@@ -1,5 +1,5 @@
 import type { Ip } from "@solid-imager/core/domain/ips/schemas";
-import type { Media } from "@solid-imager/core/domain/media/schemas";
+import type { DuplicateGroup, Media } from "@solid-imager/core/domain/media/schemas";
 import type { JSX } from "solid-js";
 import { For, Show } from "solid-js";
 import {
@@ -70,6 +70,7 @@ const managerTabs: ManagerEntityType[] = [
 	"ips",
 	"characters",
 	"tagging",
+	"duplicates",
 ];
 
 function tabLabel(tab: ManagerEntityType) {
@@ -78,6 +79,9 @@ function tabLabel(tab: ManagerEntityType) {
 	}
 	if (tab === "ips") {
 		return "IPs";
+	}
+	if (tab === "duplicates") {
+		return "Duplicates";
 	}
 	return tab.charAt(0).toUpperCase() + tab.slice(1);
 }
@@ -93,7 +97,7 @@ export function ManagerScreen(props: ManagerScreenProps) {
 		<div class="container mx-auto p-8">
 			<div class="mb-8 flex items-center justify-between">
 				<h1 class="font-bold text-3xl">Entity Manager</h1>
-				<Show when={manager().activeTab() !== "tagging"}>
+				<Show when={manager().activeTab() !== "tagging" && manager().activeTab() !== "duplicates"}>
 					<Button onClick={manager().openCreateDialog}>Create New</Button>
 				</Show>
 			</div>
@@ -261,7 +265,189 @@ export function ManagerScreen(props: ManagerScreenProps) {
 				</div>
 			</Show>
 
-			<Show when={manager().activeTab() !== "tagging"}>
+			<Show when={manager().activeTab() === "duplicates"}>
+				<div class="space-y-6">
+					<Card>
+						<CardHeader>
+							<CardTitle>Duplicate Image Detection</CardTitle>
+							<CardDescription>
+								Find duplicate images by filename pattern or source URL matching.
+							</CardDescription>
+						</CardHeader>
+						<CardContent class="space-y-4">
+							<div class="grid gap-2">
+								<Label>Target Media Source (Optional)</Label>
+								<Select
+									itemComponent={(selectProps) => (
+										<SelectItem item={selectProps.item}>
+											{selectProps.item.rawValue.name}
+										</SelectItem>
+									)}
+									onChange={(value) => manager().setDuplicateSourceId(value?.id)}
+									options={manager().sources()}
+									optionTextValue="name"
+									optionValue="id"
+									placeholder="All Sources"
+									value={
+										manager().duplicateSourceId()
+											? manager()
+													.sources()
+													.find(
+														(source) =>
+															source.id === manager().duplicateSourceId(),
+													)
+											: null
+									}
+								>
+									<SelectTrigger>
+										<SelectValue<unknown>>
+											{(state) => {
+												const option = state.selectedOption();
+												return option &&
+													typeof option === "object" &&
+													"name" in option
+													? (option as { name: string }).name
+													: "All Sources";
+											}}
+										</SelectValue>
+									</SelectTrigger>
+									<SelectContent />
+								</Select>
+							</div>
+
+							<div class="flex items-center gap-x-2 pt-2">
+								<Button onClick={manager().handleScanDuplicates}>
+									Scan for Duplicates
+								</Button>
+							</div>
+
+							<Show when={manager().duplicateStatus()}>
+								<div class="rounded bg-gray-100 p-2 text-sm">
+									{manager().duplicateStatus()}
+								</div>
+							</Show>
+						</CardContent>
+					</Card>
+
+					<Show when={manager().duplicateGroups().length > 0}>
+						<div class="flex items-center justify-between">
+							<h3 class="font-bold text-lg">
+								Duplicate Groups ({manager().duplicateGroups().length})
+							</h3>
+							<div class="flex gap-2">
+								<Button onClick={manager().selectKeepOldest} size="sm" variant="outline">
+									Keep Oldest
+								</Button>
+								<Button onClick={manager().selectKeepLargest} size="sm" variant="outline">
+									Keep Largest
+								</Button>
+								<Button onClick={manager().handleDeleteDuplicates} variant="destructive">
+									Delete{" "}
+									{(() => {
+										const groups = manager().duplicateGroups();
+										const keep = manager().keepIds();
+										let count = 0;
+										for (const g of groups) {
+											for (const m of g.media) {
+												if (!keep.has(m.id)) count++;
+											}
+										}
+										return count;
+									})()}{" "}
+									Duplicates
+								</Button>
+							</div>
+						</div>
+
+						<div class="space-y-4">
+							<For each={manager().duplicateGroups()}>
+								{(group: DuplicateGroup) => (
+									<Card>
+										<CardHeader class="pb-2">
+											<div class="flex items-center gap-2">
+												<CardTitle class="text-base">
+													{group.media.length} items
+												</CardTitle>
+												<span class="rounded-full bg-blue-100 px-2 py-0.5 font-medium text-blue-800 text-xs">
+													{group.reason === "filename" ? "Filename" : "Source URL"}
+												</span>
+											</div>
+										</CardHeader>
+										<CardContent>
+											<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+												<For each={group.media}>
+													{(item) => {
+														const thumbnailUrl = () =>
+															`/api/sources/${item.mediaSourceId}/${item.id}/thumbnail?t=${item.modifiedAt.getTime()}`;
+														const isKeep = () => manager().keepIds().has(item.id);
+
+														return (
+															<button
+																class={`cursor-pointer rounded-lg border-2 p-2 text-left transition-colors ${
+																	isKeep()
+																		? "border-primary bg-primary/5"
+																		: "border-transparent hover:border-gray-300"
+																}`}
+																onClick={() =>
+																	manager().setKeepForGroup(group.id, item.id)
+																}
+																type="button"
+															>
+																<div class="relative mb-2 aspect-video w-full overflow-hidden rounded bg-gray-100">
+																	<img
+																		alt={item.fileName}
+																		class="h-full w-full object-cover"
+																		src={thumbnailUrl()}
+																	/>
+																	<Show when={isKeep()}>
+																		<div class="absolute top-1 right-1 rounded-full bg-primary px-1.5 py-0.5 font-bold text-primary-foreground text-xs">
+																			Keep
+																		</div>
+																	</Show>
+																</div>
+																<p class="truncate font-medium text-xs" title={item.fileName}>
+																	{item.fileName}
+																</p>
+																<p class="text-muted-foreground text-xs">
+																	{item.width}×{item.height}{" "}
+																	{item.fileSize != null
+																		? `· ${(item.fileSize / 1024).toFixed(1)} KB`
+																		: ""}
+																</p>
+																<p class="text-muted-foreground text-xs">
+																	{new Date(item.createdAt).toLocaleDateString()}
+																</p>
+																<Show when={item.sourceUrls.length > 0}>
+																	<div class="mt-1 max-h-12 overflow-y-auto">
+																		<For each={item.sourceUrls.slice(0, 2)}>
+																			{(url) => (
+																				<p class="truncate text-muted-foreground text-xs">
+																					{url}
+																				</p>
+																			)}
+																		</For>
+																		<Show when={item.sourceUrls.length > 2}>
+																			<p class="text-muted-foreground text-xs">
+																				+{item.sourceUrls.length - 2} more
+																			</p>
+																		</Show>
+																	</div>
+																</Show>
+															</button>
+														);
+													}}
+												</For>
+											</div>
+										</CardContent>
+									</Card>
+								)}
+							</For>
+						</div>
+					</Show>
+				</div>
+			</Show>
+
+			<Show when={manager().activeTab() !== "tagging" && manager().activeTab() !== "duplicates"}>
 				<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 					<For each={manager().getActiveItems()}>
 						{(item) => (
@@ -424,6 +610,40 @@ export function ManagerScreen(props: ManagerScreenProps) {
 							onClick={manager().handleConfirmDelete}
 						>
 							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<AlertDialog
+				onOpenChange={manager().setIsDuplicateDeleteDialogOpen}
+				open={manager().isDuplicateDeleteDialogOpen()}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete Duplicate Images?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This action cannot be undone. The following{" "}
+							{manager().duplicatesToDelete().length} image(s) will be
+							permanently deleted:
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<div class="max-h-48 overflow-y-auto text-sm">
+						<For each={manager().duplicatesToDelete()}>
+							{(item) => (
+								<div class="truncate border-b py-1 text-muted-foreground">
+									{item.fileName}
+								</div>
+							)}
+						</For>
+					</div>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+							onClick={manager().handleConfirmDeleteDuplicates}
+						>
+							Delete {manager().duplicatesToDelete().length} Items
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>

--- a/packages/ui/src/screens/manager-screen.tsx
+++ b/packages/ui/src/screens/manager-screen.tsx
@@ -378,7 +378,7 @@ export function ManagerScreen(props: ManagerScreenProps) {
 												<For each={group.media}>
 													{(item) => {
 														const thumbnailUrl = () =>
-															`/api/sources/${item.mediaSourceId}/${item.id}/thumbnail?t=${item.modifiedAt.getTime()}`;
+															`/api/sources/${item.mediaSourceId}/${item.id}/thumbnail?t=${new Date(item.modifiedAt).getTime()}`;
 														const isKeep = () => manager().keepIds().has(item.id);
 
 														return (


### PR DESCRIPTION
## 概要
マネージャー画面に重複画像検出・削除UIを追加。

## 変更内容

- **API**: `media.findDuplicates` エンドポイント追加（sourceURL完全一致による重複検出）
- **リポジトリ層**: sourceURL全URLセット完全一致で重複グループ化（2件以上URLが必要）
- **UI**: マネージャー画面に「Duplicates」タブ追加
  - ソース選択フィルター
  - 重複スキャンボタン
  - グループごとに残す画像を選択（最古/最大を残すクイックアクション）
  - 一括削除 + 確認ダイアログ

## スクリーンショット
（必要に応じて追加）

## 確認項目
- [ ] lint/typecheck通過
- [ ] 同一ポストの異なる画像が誤検出されないこと
- [ ] CDN URL + ポストURL両方一致のみ重複判定されること