### PR TITLE
feat: auto-dedup on ingest — skip items with duplicate source URLs

### DIFF
--- a/apps/server/src/infrastructure/api/routers/downloads-router.ts
+++ b/apps/server/src/infrastructure/api/routers/downloads-router.ts
@@ -10,11 +10,19 @@ export const downloadsRouter = {
 	 * Starts bulk download jobs
 	 */
 	start: os.input(bulkDownloadRequestSchema).handler(async ({ input }) => {
-		const jobCount = await queueDownloadJobs(input.mediaSourceId, input.items);
+		const result = await queueDownloadJobs(
+			input.mediaSourceId,
+			input.items,
+		);
+		const msg =
+			result.skippedCount > 0
+				? `Queued ${result.jobCount} download jobs (${result.skippedCount} duplicates skipped)`
+				: `Queued ${result.jobCount} download jobs`;
 		return {
 			success: true,
-			jobCount,
-			message: `Queued ${jobCount} download jobs`,
+			jobCount: result.jobCount,
+			skippedCount: result.skippedCount,
+			message: msg,
 		};
 	}),
 };

--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -791,18 +791,42 @@ async function registerMedia(
 
 /**
  * Queues multiple download jobs from a list of download items.
+ * Filters out items whose source URLs already exist in the database.
  */
 export async function queueDownloadJobs(
 	mediaSourceId: string,
 	items: DownloadItem[],
-): Promise<number> {
+): Promise<{ jobCount: number; skippedCount: number }> {
 	const sourceRepo = DrizzleSourceRepository;
 	const mediaSource = await sourceRepo.findById(mediaSourceId);
 	if (mediaSource?.type !== "local") {
 		throw new Error("Media source not found or not a local source");
 	}
 
-	const jobRows: NewJob[] = items.map((item) => ({
+	// Filter out items whose complete source URL set already exists
+	const newItems: DownloadItem[] = [];
+	let skippedCount = 0;
+
+	for (const item of items) {
+		const urls = item.sourceUrls || [];
+		if (urls.length < 2) {
+			newItems.push(item);
+			continue;
+		}
+		const existingMediaId =
+			await MediaRepository.findMediaIdWithMatchingUrlSet(urls);
+		if (existingMediaId) {
+			skippedCount++;
+			logger.info(
+				{ urls, existingMediaId, fileName: item.fileName },
+				"Skipping duplicate download item (source URLs already exist)",
+			);
+		} else {
+			newItems.push(item);
+		}
+	}
+
+	const jobRows: NewJob[] = newItems.map((item) => ({
 		type: "downloadImage",
 		mediaSourceId,
 		payload: {
@@ -814,7 +838,7 @@ export async function queueDownloadJobs(
 			createdAt: item.createdAt ? new Date(item.createdAt) : undefined,
 		},
 	}));
-	if (jobRows.length === 0) return 0;
+	if (jobRows.length === 0) return { jobCount: 0, skippedCount };
 	const BATCH_SIZE = 500;
 	for (let i = 0; i < jobRows.length; i += BATCH_SIZE) {
 		const chunk = jobRows.slice(i, i + BATCH_SIZE);
@@ -823,5 +847,5 @@ export async function queueDownloadJobs(
 
 	// Jobs are picked up by the worker automatically.
 
-	return items.length;
+	return { jobCount: newItems.length, skippedCount };
 }

--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -11,6 +11,7 @@ import type {
 } from "@solid-imager/core/domain/media/schemas";
 import { generateMediaFilename } from "@solid-imager/core/domain/media/utils/filename-utils";
 import { getMediaTypeFromExtension } from "@solid-imager/core/domain/media/utils/media-type-utils";
+import { asyncPool } from "@solid-imager/core/utils/async-pool";
 import { create as createYtDlp } from "youtube-dl-exec";
 import { db } from "~/infrastructure/db";
 import { type Job, jobs, type NewJob } from "~/infrastructure/db/schema";
@@ -803,26 +804,31 @@ export async function queueDownloadJobs(
 		throw new Error("Media source not found or not a local source");
 	}
 
-	// Filter out items whose complete source URL set already exists
-	const newItems: DownloadItem[] = [];
-	let skippedCount = 0;
-
-	for (const item of items) {
+	// Filter out items whose complete source URL set already exists (parallel)
+	const poolResults = await asyncPool(items, 5, async (item) => {
 		const urls = item.sourceUrls || [];
-		if (urls.length < 2) {
-			newItems.push(item);
-			continue;
-		}
+		if (urls.length < 2) return { item, skip: false };
 		const existingMediaId =
 			await MediaRepository.findMediaIdWithMatchingUrlSet(urls);
 		if (existingMediaId) {
-			skippedCount++;
 			logger.info(
 				{ urls, existingMediaId, fileName: item.fileName },
 				"Skipping duplicate download item (source URLs already exist)",
 			);
+			return { item, skip: true };
+		}
+		return { item, skip: false };
+	});
+
+	const newItems: DownloadItem[] = [];
+	let skippedCount = 0;
+	for (const result of poolResults) {
+		if (result.status === "rejected") {
+			newItems.push(result.reason.item);
+		} else if (result.value.skip) {
+			skippedCount++;
 		} else {
-			newItems.push(item);
+			newItems.push(result.value.item);
 		}
 	}
 

--- a/packages/core/src/domain/contract/downloads.contract.ts
+++ b/packages/core/src/domain/contract/downloads.contract.ts
@@ -9,6 +9,7 @@ export const downloadsContract = {
 			z.object({
 				success: z.boolean(),
 				jobCount: z.number(),
+				skippedCount: z.number(),
 				message: z.string(),
 			}),
 		),

--- a/packages/core/src/domain/repositories/media-repository.ts
+++ b/packages/core/src/domain/repositories/media-repository.ts
@@ -102,4 +102,13 @@ export type IMediaRepository = {
 		request: FindDuplicatesRequest,
 		tx?: Transaction,
 	): Promise<FindDuplicatesResponse>;
+
+	/**
+	 * Check if an existing media item has the exact same set of source URLs.
+	 * Returns the mediaId if a match is found, null otherwise.
+	 */
+	findMediaIdWithMatchingUrlSet(
+		urls: string[],
+		tx?: Transaction,
+	): Promise<string | null>;
 };

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -1301,22 +1301,29 @@ export function createMediaRepository(
 				.groupBy(mediaUrls.mediaId)
 				.having(sql`count(*) = ${urls.length}`);
 
-			for (const row of candidateRows) {
-				const [totalResult] = await client
-					.select({ count: sql<number>`count(*)` })
-					.from(mediaUrls)
-					.where(eq(mediaUrls.mediaId, row.mediaId));
+			if (candidateRows.length === 0) return null;
 
-				if (totalResult.count === urls.length) {
-					const existingUrls = await client
-						.select({ url: mediaUrls.url })
-						.from(mediaUrls)
-						.where(eq(mediaUrls.mediaId, row.mediaId));
+			const candidateIds = candidateRows.map((r) => r.mediaId);
 
-					const existingSet = new Set(existingUrls.map((u) => u.url));
-					if (urls.every((u) => existingSet.has(u))) {
-						return row.mediaId;
-					}
+			// Batch-fetch all URLs for all candidates
+			const allCandidateUrls = await client
+				.select({ mediaId: mediaUrls.mediaId, url: mediaUrls.url })
+				.from(mediaUrls)
+				.where(inArray(mediaUrls.mediaId, candidateIds));
+
+			// Group by mediaId and check for complete match
+			const urlsByCandidate = new Map<string, string[]>();
+			for (const row of allCandidateUrls) {
+				const arr = urlsByCandidate.get(row.mediaId) || [];
+				arr.push(row.url);
+				urlsByCandidate.set(row.mediaId, arr);
+			}
+
+			const urlSet = new Set(urls);
+			for (const [mediaId, existingUrls] of urlsByCandidate) {
+				if (existingUrls.length !== urls.length) continue;
+				if (existingUrls.every((u) => urlSet.has(u))) {
+					return mediaId;
 				}
 			}
 

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -1286,6 +1286,43 @@ export function createMediaRepository(
 			return { groups };
 		},
 
+		async findMediaIdWithMatchingUrlSet(
+			urls: string[],
+			tx?: Transaction,
+		): Promise<string | null> {
+			if (urls.length < 2) return null;
+
+			const client = getExecutor(tx);
+
+			const candidateRows = await client
+				.select({ mediaId: mediaUrls.mediaId })
+				.from(mediaUrls)
+				.where(inArray(mediaUrls.url, urls))
+				.groupBy(mediaUrls.mediaId)
+				.having(sql`count(*) = ${urls.length}`);
+
+			for (const row of candidateRows) {
+				const [totalResult] = await client
+					.select({ count: sql<number>`count(*)` })
+					.from(mediaUrls)
+					.where(eq(mediaUrls.mediaId, row.mediaId));
+
+				if (totalResult.count === urls.length) {
+					const existingUrls = await client
+						.select({ url: mediaUrls.url })
+						.from(mediaUrls)
+						.where(eq(mediaUrls.mediaId, row.mediaId));
+
+					const existingSet = new Set(existingUrls.map((u) => u.url));
+					if (urls.every((u) => existingSet.has(u))) {
+						return row.mediaId;
+					}
+				}
+			}
+
+			return null;
+		},
+
 		async findAllPathsBySourceId(
 			mediaSourceId: string,
 			tx?: Transaction,


### PR DESCRIPTION
## 概要
xtracterから画像を受け入れる際、既存の media_urls と sourceURL 完全一致チェックを行い、重複を自動でスキップする。

## 変更内容

- リポジトリ: findMediaIdWithMatchingUrlSet(urls) メソッド追加 — 全URLセットが完全一致する既存 media_id を検索
- download-jobs: queueDownloadJobs() 内で各アイテムの sourceUrls をチェック、重複はジョブ作成前にフィルタ
- APIレスポンス: downloads.start に skippedCount を追加（xtracter にスキップ件数を通知可能）

## 検出ロジック
- 2件以上の sourceURL を持つアイテムのみチェック（1件のみでは同一ポスト誤検出のためスキップ不可）
- 全URLが既存 media の全URLと完全一致 → 重複としてスキップ
- Danbooru 等 sourceUrls が複数あるサイトにも対応

## 確認項目
- [x] lint/typecheck 通過
- [ ] xtracter から POST した際、既存重複画像が自動スキップされる