### PR TITLE
fix(search): fix case sensitivity and full-text search scope in serve…

### DIFF
--- a/apps/server/src/tests/unit/domain/search-mode-transition.test.ts
+++ b/apps/server/src/tests/unit/domain/search-mode-transition.test.ts
@@ -66,7 +66,7 @@ describe("calculateNextModeState - Pro to Simple transition", () => {
 			children: [
 				{
 					type: "criterion",
-					target: "fileName",
+					target: "keyword",
 					operator: "contains",
 					value: "test",
 				},
@@ -110,7 +110,7 @@ describe("calculateNextModeState - Simple to Pro transition", () => {
 			children: [
 				{
 					type: "criterion",
-					target: "fileName",
+					target: "keyword",
 					operator: "contains",
 					value: "test",
 				},

--- a/packages/core/src/domain/search/logic.ts
+++ b/packages/core/src/domain/search/logic.ts
@@ -87,7 +87,7 @@ const applyCriterionToState = (
 ): boolean => {
 	const { target, operator, value, negate } = criterion;
 
-	if (target === "fileName" && operator === "contains" && !negate) {
+	if (target === "keyword" && operator === "contains" && !negate) {
 		if (typeof value === "string") {
 			state.searchQuery = value;
 			return true;
@@ -129,11 +129,11 @@ export const getSearchConditionFromState = (
 	// Simple Mode Construction
 	const conditions: SearchGroup["children"] = [];
 
-	// Keyword (File name)
+	// Keyword (File name, description, prompt, etc.)
 	if (state.searchQuery.trim()) {
 		conditions.push({
 			type: "criterion",
-			target: "fileName",
+			target: "keyword",
 			operator: "contains",
 			value: state.searchQuery.trim(),
 		});

--- a/packages/db/src/repositories/media-repository-utils.ts
+++ b/packages/db/src/repositories/media-repository-utils.ts
@@ -7,7 +7,7 @@ import {
   eq,
   type InferSelectModel,
   inArray,
-  like,
+  ilike,
   notInArray,
   or,
   type SQL,
@@ -56,8 +56,8 @@ function buildWhereClause(
     const escapedQuery = escapeLikeString(options.query);
     conditions.push(
       or(
-        like(medias.fileName, `%${escapedQuery}%`),
-        like(medias.description, `%${escapedQuery}%`),
+        ilike(medias.fileName, `%${escapedQuery}%`),
+        ilike(medias.description, `%${escapedQuery}%`),
       ),
     );
   }
@@ -184,15 +184,15 @@ export function createMediaSearchFunctions(
         const executor = getExecutor();
         const conditions: (SQL | undefined)[] = [
           eq(medias.mediaSourceId, mediaSourceId),
-          like(medias.filePath, `${escapeLikeString(directoryPath)}%`),
+          ilike(medias.filePath, `${escapeLikeString(directoryPath)}%`),
         ];
 
         if (searchOptions.query) {
           const escapedQuery = escapeLikeString(searchOptions.query);
           conditions.push(
             or(
-              like(medias.fileName, `%${escapedQuery}%`),
-              like(medias.description, `%${escapedQuery}%`),
+              ilike(medias.fileName, `%${escapedQuery}%`),
+              ilike(medias.description, `%${escapedQuery}%`),
             ),
           );
         }

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -36,7 +36,7 @@ import {
 	inArray,
 	isNotNull,
 	isNull,
-	like,
+	ilike,
 	lt,
 	lte,
 	not,
@@ -223,11 +223,11 @@ function buildValueCondition(
 		case "equals":
 			return eq(column, value);
 		case "contains":
-			return like(column, `%${escapeLikePattern(String(value))}%`);
+			return ilike(column, `%${escapeLikePattern(String(value))}%`);
 		case "startsWith":
-			return like(column, `${escapeLikePattern(String(value))}%`);
+			return ilike(column, `${escapeLikePattern(String(value))}%`);
 		case "endsWith":
-			return like(column, `%${escapeLikePattern(String(value))}`);
+			return ilike(column, `%${escapeLikePattern(String(value))}`);
 		case "gt":
 			return gt(column, value);
 		case "gte":
@@ -253,9 +253,9 @@ function makeBuildKeywordCondition(getExecutor: (tx?: unknown) => DrizzleExecuto
 	return (node: SearchCriterion): SQL | undefined => {
 		const pattern = `%${escapeLikePattern(String(node.value))}%`;
 		const condition = or(
-			like(medias.fileName, pattern),
-			like(medias.filePath, pattern),
-			like(medias.description, pattern),
+			ilike(medias.fileName, pattern),
+			ilike(medias.filePath, pattern),
+			ilike(medias.description, pattern),
 			exists(
 				getExecutor()
 					.select({ id: mediaGenerationInfo.mediaId })
@@ -263,7 +263,7 @@ function makeBuildKeywordCondition(getExecutor: (tx?: unknown) => DrizzleExecuto
 					.where(
 						and(
 							eq(mediaGenerationInfo.mediaId, medias.id),
-							like(mediaGenerationInfo.prompt, pattern),
+							ilike(mediaGenerationInfo.prompt, pattern),
 						),
 					),
 			),
@@ -464,7 +464,7 @@ function makeBuildCriterionQuery(getExecutor: (tx?: unknown) => DrizzleExecutor)
 			}
 			const folderPath = node.value.endsWith("/") ? node.value : `${node.value}/`;
 			const pattern = `${escapeLikePattern(folderPath)}%`;
-			const condition = like(medias.filePath, pattern);
+			const condition = ilike(medias.filePath, pattern);
 			return node.negate ? not(condition) : condition;
 		}
 
@@ -1132,7 +1132,7 @@ export function createMediaRepository(
 			const pattern = `${directoryPath.endsWith("/") ? directoryPath : `${directoryPath}/`}%`;
 			const conditions: import("drizzle-orm").SQL[] = [
 				eq(medias.mediaSourceId, mediaSourceId),
-				like(medias.filePath, pattern),
+				ilike(medias.filePath, pattern),
 			];
 			const results = await client
 				.select()


### PR DESCRIPTION
…r search

This commit addresses the issue where search was not matching properly on the server side:
- Replaced Postgres strict 'like' with case-insensitive 'ilike' in media repositories to match user expectations (e.g., 'test' now matches 'Test').
- Reverted the 'fileName' search target back to 'keyword' in search logic so that metadata like descriptions and AI prompts are included in the search results again.
- Updated related search mode transition unit tests to match the new 'keyword' target behavior.