### PR TITLE
ci: add Dependabot for monorepo dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## 概要

Dependabot を追加し、monorepo 全 workspace の依存関係を自動監視します。

## 設定内容

- **package-ecosystem**: npm
- **directory**: / (root)
- **schedule**: 週次
- **open-pull-requests-limit**: 10
- **groups**: minor/patch 更新をグループ化

## 効果

- 各 workspace (, ) の依存関係を個別に監視
- minor/patch 更新は1つのPRにまとめる
- major 更新は個別PR
-  も自動更新