### PR TITLE
fix: include filePath in media-added SSE event from download-jobs

### DIFF
--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -762,7 +762,10 @@ async function updateExistingMediaWithMetadata(
 		projects: item.projects,
 	});
 
-	SseManager.sendEvent(mediaSourceId, "media-added", { mediaId });
+	SseManager.sendEvent(mediaSourceId, "media-added", {
+		mediaId,
+		filePath: newMedia.filePath,
+	});
 	logger.info(
 		{ mediaId },
 		"[DownloadJob] Existing media updated with download metadata",


### PR DESCRIPTION
## 問題
download-jobs.ts で既存メディアのメタデータ更新時に送信される  SSE イベントに  が含まれておらず、クライアント側の Zod バリデーションエラーが発生していた。

## 修正
 の呼び出しに  を追加。

## 影響範囲
-  (ファイル監視) と  は元から  を含めていたため影響なし
-  の競合時ハンドリングパスのみ修正