### PR TITLE
perf(ui): Comboboxの仮想化とデバウンス対応

### DIFF
--- a/apps/server/src/components/media/pro-search-builder.tsx
+++ b/apps/server/src/components/media/pro-search-builder.tsx
@@ -11,11 +11,11 @@ import { Button } from "@solid-imager/ui/button";
 import { Card, CardContent } from "@solid-imager/ui/card";
 import {
 	Combobox,
-	ComboboxContent,
 	ComboboxControl,
 	ComboboxInput,
 	ComboboxItem,
 	ComboboxItemLabel,
+	VirtualComboboxContent,
 } from "@solid-imager/ui/combobox";
 import { Input } from "@solid-imager/ui/input";
 import {
@@ -483,7 +483,7 @@ function CriterionBuilder(props: {
 						<ComboboxControl>
 							<ComboboxInput />
 						</ComboboxControl>
-						<ComboboxContent class="max-h-[300px]" />
+						<VirtualComboboxContent class="max-h-[300px]" />
 					</Combobox>
 				</Match>
 

--- a/apps/server/src/components/media/search-filters.tsx
+++ b/apps/server/src/components/media/search-filters.tsx
@@ -7,16 +7,17 @@ import { Badge } from "@solid-imager/ui/badge";
 import { Button } from "@solid-imager/ui/button";
 import {
 	Combobox,
-	ComboboxContent,
 	ComboboxControl,
 	ComboboxInput,
 	ComboboxItem,
 	ComboboxItemLabel,
+	VirtualComboboxContent,
 } from "@solid-imager/ui/combobox";
 import { Input } from "@solid-imager/ui/input";
 import { Label } from "@solid-imager/ui/label";
 import { cn } from "@solid-imager/ui/utils/cn";
-import { createSignal, For } from "solid-js";
+import { createDebouncedSignal } from "@solid-imager/ui/utils/debounce";
+import { createMemo, createSignal, For } from "solid-js";
 import type { SetStoreFunction } from "solid-js/store";
 
 export type SearchFilterState = {
@@ -59,6 +60,17 @@ function FilterSection<T>(props: {
 	badgeVariant?: "default" | "destructive" | "secondary" | "outline";
 }) {
 	const [value, _setValue] = createSignal<T | null>(null);
+	const [filterText, setFilterText] = createDebouncedSignal("", 150);
+
+	const filteredItems = createMemo(() => {
+		const items = props.items;
+		if (!items) return [];
+		const query = filterText().toLowerCase();
+		if (!query) return items;
+		return items.filter((item) =>
+			props.getItemLabel(item).toLowerCase().includes(query),
+		);
+	});
 
 	return (
 		<div class="space-y-2">
@@ -96,11 +108,11 @@ function FilterSection<T>(props: {
 				onChange={(val) => {
 					if (val) {
 						props.onSelect(val);
-						// setValue(null); // Keep the selection visible
 					}
 				}}
+				onInputChange={(text) => setFilterText(text)}
 				optionLabel={props.getItemLabel}
-				options={props.items || []}
+				options={filteredItems()}
 				optionTextValue={props.getItemLabel}
 				optionValue={(item) => props.getItemKey(item)}
 				placeholder={props.placeholder}
@@ -110,7 +122,7 @@ function FilterSection<T>(props: {
 				<ComboboxControl>
 					<ComboboxInput />
 				</ComboboxControl>
-				<ComboboxContent class="max-h-[300px]" />
+				<VirtualComboboxContent class="max-h-[300px]" />
 			</Combobox>
 		</div>
 	);

--- a/apps/server/src/components/media/search-filters.tsx
+++ b/apps/server/src/components/media/search-filters.tsx
@@ -59,7 +59,7 @@ function FilterSection<T>(props: {
 	placeholder?: string;
 	badgeVariant?: "default" | "destructive" | "secondary" | "outline";
 }) {
-	const [value, _setValue] = createSignal<T | null>(null);
+	const [value, setValue] = createSignal<T | null>(null);
 	const [filterText, setFilterText] = createDebouncedSignal("", 150);
 
 	const filteredItems = createMemo(() => {
@@ -108,6 +108,11 @@ function FilterSection<T>(props: {
 				onChange={(val) => {
 					if (val) {
 						props.onSelect(val);
+						setValue(() => val);
+						requestAnimationFrame(() => {
+							setValue(null);
+							setFilterText("");
+						});
 					}
 				}}
 				onInputChange={(text) => setFilterText(text)}

--- a/packages/ui/src/combobox.tsx
+++ b/packages/ui/src/combobox.tsx
@@ -1,7 +1,7 @@
 import * as ComboboxPrimitive from "@kobalte/core/combobox";
 import type { PolymorphicProps } from "@kobalte/core/polymorphic";
 import { createVirtualizer } from "@tanstack/solid-virtual";
-import { createMemo, For, Show, splitProps } from "solid-js";
+import { createEffect, createMemo, For, Show, splitProps } from "solid-js";
 import type { JSX, ValidComponent } from "solid-js";
 
 import { cn } from "./utils/cn";
@@ -232,11 +232,15 @@ const VirtualComboboxContent = <T extends ValidComponent = "div">(
 				>
 					{(items) => {
 						const asArray = createMemo(() => [...items()]);
-						const virtualItems = createMemo(() => {
+
+						createEffect(() => {
 							virtualizer.setOptions({
 								...virtualizer.options,
 								count: asArray().length,
 							});
+						});
+
+						const virtualItems = createMemo(() => {
 							return virtualizer.getVirtualItems();
 						});
 

--- a/packages/ui/src/combobox.tsx
+++ b/packages/ui/src/combobox.tsx
@@ -1,7 +1,8 @@
 import * as ComboboxPrimitive from "@kobalte/core/combobox";
 import type { PolymorphicProps } from "@kobalte/core/polymorphic";
+import { createVirtualizer } from "@tanstack/solid-virtual";
+import { createMemo, For, Show, splitProps } from "solid-js";
 import type { JSX, ValidComponent } from "solid-js";
-import { Show, splitProps } from "solid-js";
 
 import { cn } from "./utils/cn";
 
@@ -192,6 +193,97 @@ const ComboboxContent = <T extends ValidComponent = "div">(
 	);
 };
 
+const ITEM_HEIGHT_PX = 32;
+const VIRTUAL_OVERSCAN = 5;
+
+const VirtualComboboxContent = <T extends ValidComponent = "div">(
+	props: PolymorphicProps<T, ComboboxContentProps<T>>,
+) => {
+	const [local, others] = splitProps(props as ComboboxContentProps, ["class"]);
+	let scrollEl: HTMLUListElement | undefined;
+
+	const virtualizer = createVirtualizer({
+		count: 0,
+		getScrollElement: () => scrollEl ?? null,
+		estimateSize: () => ITEM_HEIGHT_PX,
+		overscan: VIRTUAL_OVERSCAN,
+	});
+
+	return (
+		<ComboboxPrimitive.Portal>
+			<ComboboxPrimitive.Content
+				class={cn(
+					"fade-in-80 relative z-50 min-w-32 animate-in overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+					local.class,
+				)}
+				{...others}
+			>
+				<ComboboxPrimitive.Listbox
+					class="m-0 p-1"
+					ref={(el: Element) => {
+						scrollEl = el as HTMLUListElement;
+					}}
+					scrollToItem={(key) => {
+						const items = virtualizer.getVirtualItems();
+						const idx = items.findIndex((v) => v.key === key);
+						if (idx >= 0) virtualizer.scrollToIndex(idx);
+					}}
+					style={{ overflow: "auto" }}
+				>
+					{(items) => {
+						const asArray = createMemo(() => [...items()]);
+						const virtualItems = createMemo(() => {
+							virtualizer.setOptions({
+								...virtualizer.options,
+								count: asArray().length,
+							});
+							return virtualizer.getVirtualItems();
+						});
+
+						return (
+							<div
+								style={{
+									height: `${virtualizer.getTotalSize()}px`,
+									width: "100%",
+									position: "relative",
+								}}
+							>
+								<For each={virtualItems()}>
+									{(virtualRow) => {
+										const item = asArray()[virtualRow.index];
+										if (!item) return null;
+										return (
+											<div
+												style={{
+													position: "absolute",
+													top: 0,
+													left: 0,
+													width: "100%",
+													height: `${virtualRow.size}px`,
+													transform: `translateY(${virtualRow.start}px)`,
+												}}
+											>
+												<ComboboxPrimitive.Item
+													item={item}
+													class="relative flex cursor-default select-none items-center justify-between rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50"
+												>
+													<ComboboxPrimitive.ItemLabel>
+														{item.textValue}
+													</ComboboxPrimitive.ItemLabel>
+												</ComboboxPrimitive.Item>
+											</div>
+										);
+									}}
+								</For>
+							</div>
+						);
+					}}
+				</ComboboxPrimitive.Listbox>
+			</ComboboxPrimitive.Content>
+		</ComboboxPrimitive.Portal>
+	);
+};
+
 export {
 	Combobox,
 	ComboboxContent,
@@ -203,4 +295,5 @@ export {
 	ComboboxItemLabel,
 	ComboboxSection,
 	ComboboxTrigger,
+	VirtualComboboxContent,
 };

--- a/packages/ui/src/pro-search-builder.tsx
+++ b/packages/ui/src/pro-search-builder.tsx
@@ -12,11 +12,11 @@ import { Button } from "./button";
 import { Card, CardContent } from "./card";
 import {
 	Combobox,
-	ComboboxContent,
 	ComboboxControl,
 	ComboboxInput,
 	ComboboxItem,
 	ComboboxItemLabel,
+	VirtualComboboxContent,
 } from "./combobox";
 import { Input } from "./input";
 import {
@@ -477,7 +477,7 @@ function CriterionBuilder(props: {
 						<ComboboxControl>
 							<ComboboxInput />
 						</ComboboxControl>
-						<ComboboxContent class="max-h-[300px]" />
+						<VirtualComboboxContent class="max-h-[300px]" />
 					</Combobox>
 				</Match>
 

--- a/packages/ui/src/search-filters.tsx
+++ b/packages/ui/src/search-filters.tsx
@@ -4,21 +4,22 @@ import type { Ip } from "@solid-imager/core/domain/ips/schemas";
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type { SearchState } from "@solid-imager/core/domain/search/schema";
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
-import { createSignal, For } from "solid-js";
+import { createMemo, createSignal, For } from "solid-js";
 import type { SetStoreFunction } from "solid-js/store";
 import { Badge } from "./badge";
 import { Button } from "./button";
 import {
 	Combobox,
-	ComboboxContent,
 	ComboboxControl,
 	ComboboxInput,
 	ComboboxItem,
 	ComboboxItemLabel,
+	VirtualComboboxContent,
 } from "./combobox";
 import { Input } from "./input";
 import { Label } from "./label";
 import { cn } from "./utils/cn";
+import { createDebouncedSignal } from "./utils/debounce";
 
 type SearchFiltersProps = {
 	state: SearchState;
@@ -46,6 +47,17 @@ function FilterSection<T>(props: {
 	badgeVariant?: "default" | "destructive" | "secondary" | "outline";
 }) {
 	const [value, _setValue] = createSignal<T | null>(null);
+	const [filterText, setFilterText] = createDebouncedSignal("", 150);
+
+	const filteredItems = createMemo(() => {
+		const items = props.items;
+		if (!items) return [];
+		const query = filterText().toLowerCase();
+		if (!query) return items;
+		return items.filter((item) =>
+			props.getItemLabel(item).toLowerCase().includes(query),
+		);
+	});
 
 	return (
 		<div class="space-y-2">
@@ -85,8 +97,9 @@ function FilterSection<T>(props: {
 						props.onSelect(val);
 					}
 				}}
+				onInputChange={(text) => setFilterText(text)}
 				optionLabel={props.getItemLabel}
-				options={props.items || []}
+				options={filteredItems()}
 				optionTextValue={props.getItemLabel}
 				optionValue={(item) => props.getItemKey(item)}
 				placeholder={props.placeholder}
@@ -96,7 +109,7 @@ function FilterSection<T>(props: {
 				<ComboboxControl>
 					<ComboboxInput />
 				</ComboboxControl>
-				<ComboboxContent class="max-h-[300px]" />
+				<VirtualComboboxContent class="max-h-[300px]" />
 			</Combobox>
 		</div>
 	);

--- a/packages/ui/src/search-filters.tsx
+++ b/packages/ui/src/search-filters.tsx
@@ -46,7 +46,7 @@ function FilterSection<T>(props: {
 	placeholder?: string;
 	badgeVariant?: "default" | "destructive" | "secondary" | "outline";
 }) {
-	const [value, _setValue] = createSignal<T | null>(null);
+	const [value, setValue] = createSignal<T | null>(null);
 	const [filterText, setFilterText] = createDebouncedSignal("", 150);
 
 	const filteredItems = createMemo(() => {
@@ -95,6 +95,11 @@ function FilterSection<T>(props: {
 				onChange={(val) => {
 					if (val) {
 						props.onSelect(val);
+						setValue(() => val);
+						requestAnimationFrame(() => {
+							setValue(null);
+							setFilterText("");
+						});
 					}
 				}}
 				onInputChange={(text) => setFilterText(text)}

--- a/packages/ui/src/utils/debounce.ts
+++ b/packages/ui/src/utils/debounce.ts
@@ -1,0 +1,23 @@
+import { createSignal, onCleanup } from "solid-js";
+
+export function createDebouncedSignal<T>(
+	initialValue: T,
+	delayMs: number,
+): [() => T, (value: T) => void] {
+	const [debounced, setDebounced] = createSignal<T>(initialValue);
+	let timer: ReturnType<typeof setTimeout> | null = null;
+
+	const setter = (newValue: T) => {
+		if (timer) clearTimeout(timer);
+		timer = setTimeout(() => {
+			setDebounced(() => newValue);
+			timer = null;
+		}, delayMs);
+	};
+
+	onCleanup(() => {
+		if (timer) clearTimeout(timer);
+	});
+
+	return [debounced, setter];
+}

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { cn } from "./cn";
+export { createDebouncedSignal } from "./debounce";
 export { parseSelectValue } from "./parse-select-value";


### PR DESCRIPTION
## 概要

候補数が多い検索コンポーネント（タグ、キャラクター、IP等）での入力時のパフォーマンス問題を修正します。

## 変更内容

### パフォーマンス改善
- **VirtualComboboxContent** 追加 - @tanstack/solid-virtual を使用したListbox仮想化。可視範囲のみDOMノードを生成するため、候補1000件でもDOM上には約10件のみ
- **createDebouncedSignal** ユーティリティ追加 - 150msデバウンスでキーストローク毎のフィルタリングを抑制
- **FilterSection** にデバウンス付きフィルタリング統合 - createMemo で事前フィルタリングし、Comboboxに渡す候補数を削減

### バグ修正
- Comboboxで候補を選択後、入力テキストが残る問題を修正。onChange時にvalueを一時設定し、次のフレームでクリア+フィルタテキストをリセット

### 対象コンポーネント
- packages/ui/src/search-filters.tsx - 検索フィルタパネル
- packages/ui/src/pro-search-builder.tsx - 詳細条件ビルダー
- apps/server/src/components/media/ - サーバー側の同等コンポーネント

## 技術詳細

| 最適化 | 効果 |
|---|---|
| 仮想スクロール | DOMノード数を O(n) から O(可視件数) に削減 |
| デバウンス (150ms) | フィルタリング実行頻度を削減 |
| プレフィルタリング | Comboboxに渡す候補数を事前削減 |