### PR TITLE
feat: TanStack Virtual を検索・ソースメディア画面に導入

### DIFF
--- a/apps/server/src/routes/search.tsx
+++ b/apps/server/src/routes/search.tsx
@@ -78,6 +78,7 @@ function SearchRoute() {
 
 	return (
 		<SearchScreen
+			enableVirtualization
 			filterData={page.filterData}
 			onSelectSource={(id) => setSearchState("selectedSource", id)}
 			page={page}

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -42,6 +42,7 @@ export function SourceMediaPage() {
 
 	return (
 		<SourceMediaPageComponent
+			enableVirtualization
 			mediaSourceId={mediaSourceId}
 			transport={transport}
 			presetClient={PresetClient}

--- a/packages/ui/src/screens/search-screen.tsx
+++ b/packages/ui/src/screens/search-screen.tsx
@@ -106,6 +106,8 @@ export function SearchScreen(props: SearchScreenProps) {
 							isPending={page().searchResultQuery.isLoading}
 							mediaResults={page().searchResults}
 							mediaSourceId={() => undefined}
+							onLoadMore={() => page().searchResultQuery.fetchNextPage()}
+							hasNextPage={page().searchResultQuery.hasNextPage}
 							queryError={
 								page().searchResultQuery.error instanceof Error
 									? page().searchResultQuery.error

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -131,7 +131,9 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 					mediaSourceId={page().mediaSourceId}
 					onCopyMove={page().handleCopyMove}
 					onDelete={page().handleDelete}
+					onLoadMore={() => page().mediaQuery.fetchNextPage()}
 					onSyncSingleMedia={page().handleSyncSingleMedia}
+					hasNextPage={page().mediaQuery.hasNextPage}
 					queryError={page().mediaQuery.error ?? null}
 					renderItem={props.renderItem}
 					setContextMenuMediaId={page().setContextMenuMediaId}

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -36,6 +36,10 @@ type SourceMediaGridProps = {
 	onCopyMove?: (mediaId: string, mode: "copy" | "move") => void;
 	onSyncSingleMedia?: (mediaId: string) => void;
 	setLoadMoreRef: (el: HTMLDivElement) => void;
+	/** Whether there are more pages to load. */
+	hasNextPage?: boolean;
+	/** Called when virtual scroll reaches near the end. */
+	onLoadMore?: () => void;
 	/** Render a single media grid item. */
 	renderItem: (
 		media: Media,
@@ -151,6 +155,21 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 		mediaItemHeight();
 		columnCount();
 		mediaRowVirtualizer.measure();
+	});
+
+	// Virtual scroll-based load more: trigger when user scrolls near the end
+	createEffect(() => {
+		if (!shouldVirtualize()) return;
+		const totalRows = rowCount();
+		const handleScroll = () => {
+			if (!props.hasNextPage || props.isFetchingNextPage) return;
+			const lastItem = mediaRowVirtualizer.getVirtualItems().at(-1);
+			if (lastItem && lastItem.index >= totalRows - 2) {
+				props.onLoadMore?.();
+			}
+		};
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		onCleanup(() => window.removeEventListener("scroll", handleScroll));
 	});
 
 	const contextMenuMediaId = () => props.contextMenuMediaId?.() ?? null;


### PR DESCRIPTION
## 概要
検索画面とソースメディア画面のメディアグリッドにTanStack Virtualによる仮想スクロールを有効化しました。

## 変更内容
- `SearchScreen` と `SourceMediaScreen` に `enableVirtualization` プロパティを追加（100件超で自動有効化）
- 仮想スクロール有効時にwindowのscrollイベントで末尾付近を検知し、次のページを読み込む仕組みを追加（IntersectionObserverの代替）
- 非仮想時は従来のIntersectionObserverベースのsentinelがそのまま動作

## 対象ファイル
- `apps/server/src/routes/search.tsx`
- `apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx`
- `packages/ui/src/screens/search-screen.tsx`
- `packages/ui/src/screens/source-media-screen.tsx`
- `packages/ui/src/source-media-grid.tsx`