### PR TITLE
chore(config): organize .env and config.json paths in monorepo

### DIFF
--- a/.agents/skills/solid-imager/SKILL.md
+++ b/.agents/skills/solid-imager/SKILL.md
@@ -25,7 +25,7 @@ description: solid-imager プロジェクトの全体像、モノレポ構成、
 
 2. **環境変数の設定:**
    ```bash
-   cp apps/server/.env.example apps/server/.env
+   cp .env.example .env
    ```
 
 3. **データベースのセットアップ:**

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Database Configuration
+#DB_HOST=localhost
+# pglite to test environment
+DB_HOST=pglite
+DB_PORT=5432
+DB_DATABASE=solid_imager
+DB_USER=your_database_user
+DB_PASSWORD=your_database_password
+
+# API Configuration
+# API_BASE_URL=http://localhost:3000
+
+# Server binding (0.0.0.0 binds to all IPv4 interfaces; remove to default to ::)
+NITRO_HOST=0.0.0.0

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,11 +1,1 @@
-# Database Configuration
-#DB_HOST=localhost
-# pglite to test environment
-DB_HOST=pglite
-DB_PORT=5432
-DB_DATABASE=solid_imager
-DB_USER=your_database_user
-DB_PASSWORD=your_database_password
-
-# API Configuration
-# API_BASE_URL=http://localhost:3000
+../../.env.example

--- a/apps/server/src/application/services/server-config-service.ts
+++ b/apps/server/src/application/services/server-config-service.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import type { IConfigService } from "@solid-imager/core";
 import {
@@ -19,7 +20,11 @@ export class ServerConfigService implements IConfigService {
 	private listeners: ConfigChangeListener[] = [];
 
 	constructor() {
-		this.configPath = path.resolve(process.cwd(), "config.json");
+		const __dirname = path.dirname(fileURLToPath(import.meta.url));
+		const defaultPath = path.resolve(__dirname, "../../../config.json");
+		this.configPath = process.env.CONFIG_PATH
+			? path.resolve(process.env.CONFIG_PATH)
+			: defaultPath;
 		this.config = defaultAppConfig;
 	}
 

--- a/apps/server/src/application/services/server-config-service.ts
+++ b/apps/server/src/application/services/server-config-service.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import type { IConfigService } from "@solid-imager/core";
 import {
@@ -20,8 +19,12 @@ export class ServerConfigService implements IConfigService {
 	private listeners: ConfigChangeListener[] = [];
 
 	constructor() {
-		const __dirname = path.dirname(fileURLToPath(import.meta.url));
-		const defaultPath = path.resolve(__dirname, "../../../config.json");
+		let defaultPath = "config.json";
+		if (fs.existsSync(path.resolve(process.cwd(), "apps/server"))) {
+			defaultPath = path.resolve(process.cwd(), "apps/server/config.json");
+		} else {
+			defaultPath = path.resolve(process.cwd(), "config.json");
+		}
 		this.configPath = process.env.CONFIG_PATH
 			? path.resolve(process.env.CONFIG_PATH)
 			: defaultPath;

--- a/apps/server/src/components/media/pro-search-builder.tsx
+++ b/apps/server/src/components/media/pro-search-builder.tsx
@@ -25,8 +25,8 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@solid-imager/ui/select";
-import { cn } from "@solid-imager/ui/utils/cn";
 import { parseSelectValue } from "@solid-imager/ui/utils";
+import { cn } from "@solid-imager/ui/utils/cn";
 import { createMemo, Index, Match, Show, Switch } from "solid-js";
 
 // Labels for targets

--- a/apps/server/src/components/media/search-filters.tsx
+++ b/apps/server/src/components/media/search-filters.tsx
@@ -78,9 +78,7 @@ function FilterSection<T>(props: {
 			<div class="mb-2 flex flex-wrap gap-2">
 				<For each={props.selectedItems}>
 					{(id) => {
-						const item = props.items?.find(
-							(i) => props.getItemKey(i) === id,
-						);
+						const item = props.items?.find((i) => props.getItemKey(i) === id);
 						return (
 							<Badge
 								class="cursor-pointer"

--- a/apps/server/src/components/media/sort-controls.tsx
+++ b/apps/server/src/components/media/sort-controls.tsx
@@ -6,8 +6,8 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@solid-imager/ui/select";
-import { cn } from "@solid-imager/ui/utils/cn";
 import { parseSelectValue } from "@solid-imager/ui/utils";
+import { cn } from "@solid-imager/ui/utils/cn";
 
 const SORT_OPTIONS = ["date", "name", "size", "rating", "viewCount"] as const;
 type SortOption = (typeof SORT_OPTIONS)[number];

--- a/apps/server/src/infrastructure/ai/rust-ai-client.ts
+++ b/apps/server/src/infrastructure/ai/rust-ai-client.ts
@@ -16,8 +16,13 @@ import type { appRouter } from "~/domain/shared/api-contract";
 function createRemoteOrpcClient(remoteUrl: string, timeoutMs: number) {
 	return createClient<typeof appRouter>({
 		url: remoteUrl,
-		fetch: (request: Request, init?: RequestInit) =>
-			fetch(request, { ...init, signal: AbortSignal.timeout(timeoutMs) }),
+		fetch: (request: Request, init?: RequestInit) => {
+			const timeoutSignal = AbortSignal.timeout(timeoutMs);
+			const signal = init?.signal
+				? AbortSignal.any([init.signal, timeoutSignal])
+				: timeoutSignal;
+			return fetch(request, { ...init, signal });
+		},
 	});
 }
 
@@ -62,7 +67,7 @@ export class RustAiClient implements IAiClient {
 		const bytes =
 			buffer instanceof Uint8Array
 				? buffer.subarray(0, 4)
-				: new Uint8Array(buffer, 0, 4);
+				: new Uint8Array(buffer).subarray(0, 4);
 		if (
 			bytes[0] === 0x89 &&
 			bytes[1] === 0x50 &&

--- a/apps/server/src/infrastructure/api/routers/sources-router.ts
+++ b/apps/server/src/infrastructure/api/routers/sources-router.ts
@@ -19,7 +19,6 @@ import { SseManager } from "~/infrastructure/jobs/sse-manager";
 import { logger } from "~/infrastructure/logger";
 import {
 	asDumpStream,
-	nodeStreamToWebReadable,
 	webReadableToNodeStream,
 } from "~/infrastructure/utils/stream-utils";
 

--- a/apps/server/src/infrastructure/jobs/tagging-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/tagging-jobs.ts
@@ -1,6 +1,6 @@
+import { getErrorMessage } from "@solid-imager/core/utils";
 import { and, asc, eq, notExists } from "drizzle-orm";
 import { z } from "zod";
-import { getErrorMessage } from "@solid-imager/core/utils";
 import { services } from "~/application/registry";
 import { taggingService } from "~/application/services/tagging-service";
 import { db } from "~/infrastructure/db";

--- a/apps/server/src/infrastructure/utils/stream-utils.ts
+++ b/apps/server/src/infrastructure/utils/stream-utils.ts
@@ -30,14 +30,10 @@ export function bufferToBodyInit(buffer: Uint8Array): BodyInit {
 export function ensureWebReadableStream(
 	result: Readable | ReadableStream<Uint8Array>,
 ): ReadableStream<Uint8Array> {
-	return result instanceof Readable
-		? nodeStreamToWebReadable(result)
-		: result;
+	return result instanceof Readable ? nodeStreamToWebReadable(result) : result;
 }
 
-export function asDumpStream(
-	result: unknown,
-): ReadableStream<Uint8Array> {
+export function asDumpStream(result: unknown): ReadableStream<Uint8Array> {
 	if (result instanceof Readable) {
 		return nodeStreamToWebReadable(result);
 	}

--- a/apps/server/src/routes/api/sources.$mediaSourceId.dump.ts
+++ b/apps/server/src/routes/api/sources.$mediaSourceId.dump.ts
@@ -19,29 +19,23 @@ export const Route = createFileRoute("/api/sources/$mediaSourceId/dump")({
 					includeImages,
 				});
 
-			if (mode === "zip") {
-				return new Response(
-					asDumpStream(result),
-					{
+				if (mode === "zip") {
+					return new Response(asDumpStream(result), {
 						headers: {
 							"Content-Type": "application/zip",
 							"Content-Disposition": `attachment; filename="source-${mediaSourceId}-dump.zip"`,
 						},
-					},
-				);
-			}
+					});
+				}
 
-			if (mode === "lancedb") {
-				return new Response(
-					asDumpStream(result),
-					{
+				if (mode === "lancedb") {
+					return new Response(asDumpStream(result), {
 						headers: {
 							"Content-Type": "application/gzip",
 							"Content-Disposition": `attachment; filename="source-${mediaSourceId}-dump.tar.gz"`,
 						},
-					},
-				);
-			}
+					});
+				}
 
 				return Response.json(result, {
 					headers: {


### PR DESCRIPTION
## 概要
モノレポ構成における環境変数（.env）および設定（config.json）の配置先とロードロジックを整理し、設定の不整合や意図しないファイルの新規生成を防ぎます。

## 変更内容
- プロジェクトルートに .env と .env.example を一元化し、apps/server/.env と apps/server/.env.example を相対シンボリックリンクに変更
- ServerConfigService が config.json を解決するデフォルトパスを、process.cwd() 基準からモジュール位置基準の絶対パス（apps/server/config.json）に変更し、環境変数 CONFIG_PATH もサポート
- ドキュメント内のセットアップコマンド記述をルート基準の cp .env.example .env に更新