### PR TITLE
feat(media): 一括コピー・移動・削除操作のAPIおよびUI追加

### DIFF
--- a/apps/server/public/openapi.json
+++ b/apps/server/public/openapi.json
@@ -823,6 +823,110 @@
         }
       }
     },
+    "/media/bulkEdit": {
+      "post": {
+        "operationId": "media.bulkEdit",
+        "summary": "bulkEdit",
+        "tags": [
+          "Media"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/media/bulkDelete": {
+      "post": {
+        "operationId": "media.bulkDelete",
+        "summary": "bulkDelete",
+        "tags": [
+          "Media"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/media/bulkMove": {
+      "post": {
+        "operationId": "media.bulkMove",
+        "summary": "bulkMove",
+        "tags": [
+          "Media"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/media/bulkTag": {
+      "post": {
+        "operationId": "media.bulkTag",
+        "summary": "bulkTag",
+        "tags": [
+          "Media"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/categories/list": {
       "post": {
         "operationId": "categories.list",

--- a/apps/server/public/openapi.json
+++ b/apps/server/public/openapi.json
@@ -927,6 +927,58 @@
         }
       }
     },
+    "/media/bulkCopyToSource": {
+      "post": {
+        "operationId": "media.bulkCopyToSource",
+        "summary": "bulkCopyToSource",
+        "tags": [
+          "Media"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/media/bulkMoveToSource": {
+      "post": {
+        "operationId": "media.bulkMoveToSource",
+        "summary": "bulkMoveToSource",
+        "tags": [
+          "Media"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/categories/list": {
       "post": {
         "operationId": "categories.list",

--- a/apps/server/src/application/services/bulk-operation-service.ts
+++ b/apps/server/src/application/services/bulk-operation-service.ts
@@ -1,69 +1,164 @@
+import { updateMediaRequestSchema } from "@solid-imager/core/domain/media/schemas";
+import { services } from "~/application/registry";
+import { deleteThumbnail } from "~/infrastructure/jobs/thumbnails";
+import { logger } from "~/infrastructure/logger";
+
 /**
  * BulkOperationService - バルク操作機能
  * Feature 15: バルク操作機能
- */
-/**
-
- * Provides services for performing bulk operations on media files.
  */
 
 export const BulkOperationService = {
 	/**
 	 * Performs a bulk edit on multiple media items within a specific source.
-	 * @param {string} _mediaSourceId - The ID of the media source.
-	 * @param {string[]} _mediaIds - An array of media IDs to be edited.
-	 * @param {unknown} _updates - An object containing the fields to update and their new values.
+	 * @param {string} mediaSourceId - The ID of the media source.
+	 * @param {string[]} mediaIds - An array of media IDs to be edited.
+	 * @param {unknown} updates - An object containing the fields to update and their new values.
 	 */
-	bulkEditMedia(
-		_mediaSourceId: string,
-		_mediaIds: string[],
-		_updates: unknown,
+	async bulkEditMedia(
+		mediaSourceId: string,
+		mediaIds: string[],
+		updates: unknown,
 	) {
-		// TODO: Bulk edit multiple media
-		throw new Error("Not implemented");
+		const parsedUpdates = updateMediaRequestSchema.parse(updates);
+		const mediaRepo = services.getMediaRepository();
+
+		// セキュリティ及び整合性チェック
+		for (const mediaId of mediaIds) {
+			const media = await mediaRepo.findById(mediaId);
+			if (!media || media.mediaSourceId !== mediaSourceId) {
+				throw new Error(
+					`Media with ID ${mediaId} does not belong to source ${mediaSourceId}`,
+				);
+			}
+		}
+
+		await mediaRepo.bulkUpdate(mediaIds, parsedUpdates);
 	},
 
 	/**
 	 * Performs a bulk delete operation on multiple media items within a specific source.
-	 * @param {string} _mediaSourceId - The ID of the media source.
-	 * @param {string[]} _mediaIds - An array of media IDs to be deleted.
+	 * @param {string} mediaSourceId - The ID of the media source.
+	 * @param {string[]} mediaIds - An array of media IDs to be deleted.
 	 */
-	bulkDeleteMedia(_mediaSourceId: string, _mediaIds: string[]) {
-		// TODO: Bulk delete multiple media
-		throw new Error("Not implemented");
+	async bulkDeleteMedia(mediaSourceId: string, mediaIds: string[]) {
+		const mediaRepo = services.getMediaRepository();
+		const mediaStorage = services.getMediaStorage();
+		const sourceRepo = services.getSourceRepository();
+
+		const source = await sourceRepo.findById(mediaSourceId);
+		if (!source) {
+			throw new Error(`Media source not found: ${mediaSourceId}`);
+		}
+		const basePath = (source.connectionInfo as { path: string }).path;
+
+		for (const mediaId of mediaIds) {
+			const media = await mediaRepo.findById(mediaId);
+			if (media && media.mediaSourceId === mediaSourceId) {
+				// 実ファイルの削除
+				try {
+					await mediaStorage.deleteFile(basePath, media.filePath);
+				} catch (e) {
+					logger.warn(
+						{ mediaId, filePath: media.filePath, error: e },
+						"Failed to delete file from storage during bulk delete",
+					);
+				}
+				// サムネイルの削除
+				try {
+					await deleteThumbnail(mediaSourceId, media.id);
+				} catch (e) {
+					logger.warn(
+						{ mediaId, error: e },
+						"Failed to delete thumbnail during bulk delete",
+					);
+				}
+			}
+		}
+
+		await mediaRepo.bulkDelete(mediaIds);
 	},
 
 	/**
 	 * Performs a bulk move operation on multiple media items to a new destination path.
-	 * @param {string} _mediaSourceId - The ID of the media source.
-	 * @param {string[]} _mediaIds - An array of media IDs to be moved.
-	 * @param {string} _destinationPath - The target path where the media items will be moved.
+	 * @param {string} mediaSourceId - The ID of the media source.
+	 * @param {string[]} mediaIds - An array of media IDs to be moved.
+	 * @param {string} destinationPath - The target path where the media items will be moved.
 	 */
-
-	bulkMoveMedia(
-		_mediaSourceId: string,
-		_mediaIds: string[],
-		_destinationPath: string,
+	async bulkMoveMedia(
+		mediaSourceId: string,
+		mediaIds: string[],
+		destinationPath: string,
 	) {
-		// TODO: Bulk move media to destination
-		throw new Error("Not implemented");
+		const mediaRepo = services.getMediaRepository();
+		const mediaStorage = services.getMediaStorage();
+		const sourceRepo = services.getSourceRepository();
+
+		const source = await sourceRepo.findById(mediaSourceId);
+		if (!source) {
+			throw new Error(`Media source not found: ${mediaSourceId}`);
+		}
+		const basePath = (source.connectionInfo as { path: string }).path;
+
+		const pathUpdates: { id: string; filePath: string; fileName: string }[] =
+			[];
+
+		for (const mediaId of mediaIds) {
+			const media = await mediaRepo.findById(mediaId);
+			if (media && media.mediaSourceId === mediaSourceId) {
+				const cleanDestDir = destinationPath.endsWith("/")
+					? destinationPath
+					: `${destinationPath}/`;
+				const newFilePath = `${cleanDestDir}${media.fileName}`;
+
+				if (newFilePath !== media.filePath) {
+					// ファイルを物理的に移動
+					await mediaStorage.moveFile(basePath, media.filePath, newFilePath);
+
+					pathUpdates.push({
+						id: media.id,
+						filePath: newFilePath,
+						fileName: media.fileName,
+					});
+				}
+			}
+		}
+
+		if (pathUpdates.length > 0) {
+			await mediaRepo.bulkUpdatePaths(pathUpdates);
+		}
 	},
 
 	/**
 	 * Performs a bulk tagging operation on multiple media items, adding and/or removing specified tags.
-	 * @param {string} _mediaSourceId - The ID of the media source.
-	 * @param {string[]} _mediaIds - An array of media IDs to be tagged.
-	 * @param {number[]} _tagsToAdd - An array of tag IDs to add to the media items.
-	 * @param {number[]} _tagsToRemove - An array of tag IDs to remove from the media items.
+	 * @param {string} mediaSourceId - The ID of the media source.
+	 * @param {string[]} mediaIds - An array of media IDs to be tagged.
+	 * @param {string[]} tagsToAdd - An array of tag IDs to add to the media items.
+	 * @param {string[]} tagsToRemove - An array of tag IDs to remove from the media items.
 	 */
-
-	bulkTagMedia(
-		_mediaSourceId: string,
-		_mediaIds: string[],
-		_tagsToAdd: number[],
-		_tagsToRemove: number[],
+	async bulkTagMedia(
+		mediaSourceId: string,
+		mediaIds: string[],
+		tagsToAdd: string[],
+		tagsToRemove: string[],
 	) {
-		// TODO: Bulk add/remove tags
-		throw new Error("Not implemented");
+		const mediaRepo = services.getMediaRepository();
+
+		// セキュリティ及び整合性チェック
+		for (const mediaId of mediaIds) {
+			const media = await mediaRepo.findById(mediaId);
+			if (!media || media.mediaSourceId !== mediaSourceId) {
+				throw new Error(
+					`Media with ID ${mediaId} does not belong to source ${mediaSourceId}`,
+				);
+			}
+		}
+
+		if (tagsToRemove.length > 0) {
+			await mediaRepo.bulkRemoveTags(mediaIds, tagsToRemove);
+		}
+		if (tagsToAdd.length > 0) {
+			await mediaRepo.bulkAddTags(mediaIds, tagsToAdd);
+		}
 	},
 };

--- a/apps/server/src/application/services/bulk-operation-service.ts
+++ b/apps/server/src/application/services/bulk-operation-service.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { updateMediaRequestSchema } from "@solid-imager/core/domain/media/schemas";
 import { services } from "~/application/registry";
 import { deleteThumbnail } from "~/infrastructure/jobs/thumbnails";
@@ -105,7 +104,8 @@ export const BulkOperationService = {
 		}
 		const basePath = (source.connectionInfo as { path: string }).path;
 
-		const pathUpdates: { id: string; filePath: string; fileName: string }[] = [];
+		const pathUpdates: { id: string; filePath: string; fileName: string }[] =
+			[];
 
 		for (const mediaId of mediaIds) {
 			const media = await mediaRepo.findById(mediaId);
@@ -181,7 +181,9 @@ export const BulkOperationService = {
 		targetSourceId: string,
 	) {
 		const mediaRepo = services.getMediaRepository();
-		const { MediaService } = await import("~/application/services/media-service");
+		const { MediaService } = await import(
+			"~/application/services/media-service"
+		);
 
 		// セキュリティチェック
 		for (const mediaId of mediaIds) {
@@ -201,7 +203,10 @@ export const BulkOperationService = {
 		const poolResults = await asyncPool(mediaIds, 5, processCopy);
 		const failures = poolResults.filter((r) => r.status === "rejected");
 		if (failures.length > 0) {
-			logger.error({ failures }, "Some copy operations failed during bulk copy");
+			logger.error(
+				{ failures },
+				"Some copy operations failed during bulk copy",
+			);
 			throw new Error(`Failed to copy ${failures.length} media items.`);
 		}
 	},
@@ -215,7 +220,9 @@ export const BulkOperationService = {
 		targetSourceId: string,
 	) {
 		const mediaRepo = services.getMediaRepository();
-		const { MediaService } = await import("~/application/services/media-service");
+		const { MediaService } = await import(
+			"~/application/services/media-service"
+		);
 
 		// セキュリティチェック
 		for (const mediaId of mediaIds) {
@@ -235,7 +242,10 @@ export const BulkOperationService = {
 		const poolResults = await asyncPool(mediaIds, 5, processMove);
 		const failures = poolResults.filter((r) => r.status === "rejected");
 		if (failures.length > 0) {
-			logger.error({ failures }, "Some move operations failed during bulk move");
+			logger.error(
+				{ failures },
+				"Some move operations failed during bulk move",
+			);
 			throw new Error(`Failed to move ${failures.length} media items.`);
 		}
 	},

--- a/apps/server/src/application/services/bulk-operation-service.ts
+++ b/apps/server/src/application/services/bulk-operation-service.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { updateMediaRequestSchema } from "@solid-imager/core/domain/media/schemas";
 import { services } from "~/application/registry";
 import { deleteThumbnail } from "~/infrastructure/jobs/thumbnails";
@@ -100,8 +101,7 @@ export const BulkOperationService = {
 		}
 		const basePath = (source.connectionInfo as { path: string }).path;
 
-		const pathUpdates: { id: string; filePath: string; fileName: string }[] =
-			[];
+		const pathUpdates: { id: string; filePath: string; fileName: string }[] = [];
 
 		for (const mediaId of mediaIds) {
 			const media = await mediaRepo.findById(mediaId);
@@ -159,6 +159,74 @@ export const BulkOperationService = {
 		}
 		if (tagsToAdd.length > 0) {
 			await mediaRepo.bulkAddTags(mediaIds, tagsToAdd);
+		}
+	},
+
+	/**
+	 * Performs a bulk copy operation to copy multiple media items to a target media source.
+	 */
+	async bulkCopyToSource(
+		mediaSourceId: string,
+		mediaIds: string[],
+		targetSourceId: string,
+	) {
+		const mediaRepo = services.getMediaRepository();
+		const { MediaService } = await import("~/application/services/media-service");
+
+		// セキュリティチェック
+		for (const mediaId of mediaIds) {
+			const media = await mediaRepo.findById(mediaId);
+			if (!media || media.mediaSourceId !== mediaSourceId) {
+				throw new Error(
+					`Media with ID ${mediaId} does not belong to source ${mediaSourceId}`,
+				);
+			}
+		}
+
+		const { asyncPool } = await import("@solid-imager/core/utils/async-pool");
+		const processCopy = async (mediaId: string) => {
+			await MediaService.copyMedia(mediaId, targetSourceId);
+		};
+
+		const poolResults = await asyncPool(mediaIds, 5, processCopy);
+		const failures = poolResults.filter((r) => r.status === "rejected");
+		if (failures.length > 0) {
+			logger.error({ failures }, "Some copy operations failed during bulk copy");
+			throw new Error(`Failed to copy ${failures.length} media items.`);
+		}
+	},
+
+	/**
+	 * Performs a bulk move operation to move multiple media items to a target media source.
+	 */
+	async bulkMoveToSource(
+		mediaSourceId: string,
+		mediaIds: string[],
+		targetSourceId: string,
+	) {
+		const mediaRepo = services.getMediaRepository();
+		const { MediaService } = await import("~/application/services/media-service");
+
+		// セキュリティチェック
+		for (const mediaId of mediaIds) {
+			const media = await mediaRepo.findById(mediaId);
+			if (!media || media.mediaSourceId !== mediaSourceId) {
+				throw new Error(
+					`Media with ID ${mediaId} does not belong to source ${mediaSourceId}`,
+				);
+			}
+		}
+
+		const { asyncPool } = await import("@solid-imager/core/utils/async-pool");
+		const processMove = async (mediaId: string) => {
+			await MediaService.moveMedia(mediaId, targetSourceId);
+		};
+
+		const poolResults = await asyncPool(mediaIds, 5, processMove);
+		const failures = poolResults.filter((r) => r.status === "rejected");
+		if (failures.length > 0) {
+			logger.error({ failures }, "Some move operations failed during bulk move");
+			throw new Error(`Failed to move ${failures.length} media items.`);
 		}
 	},
 };

--- a/apps/server/src/application/services/bulk-operation-service.ts
+++ b/apps/server/src/application/services/bulk-operation-service.ts
@@ -53,9 +53,11 @@ export const BulkOperationService = {
 		}
 		const basePath = (source.connectionInfo as { path: string }).path;
 
+		const validMediaIds: string[] = [];
 		for (const mediaId of mediaIds) {
 			const media = await mediaRepo.findById(mediaId);
 			if (media && media.mediaSourceId === mediaSourceId) {
+				validMediaIds.push(mediaId);
 				// 実ファイルの削除
 				try {
 					await mediaStorage.deleteFile(basePath, media.filePath);
@@ -77,7 +79,9 @@ export const BulkOperationService = {
 			}
 		}
 
-		await mediaRepo.bulkDelete(mediaIds);
+		if (validMediaIds.length > 0) {
+			await mediaRepo.bulkDelete(validMediaIds);
+		}
 	},
 
 	/**
@@ -112,14 +116,20 @@ export const BulkOperationService = {
 				const newFilePath = `${cleanDestDir}${media.fileName}`;
 
 				if (newFilePath !== media.filePath) {
-					// ファイルを物理的に移動
-					await mediaStorage.moveFile(basePath, media.filePath, newFilePath);
-
-					pathUpdates.push({
-						id: media.id,
-						filePath: newFilePath,
-						fileName: media.fileName,
-					});
+					try {
+						// ファイルを物理的に移動
+						await mediaStorage.moveFile(basePath, media.filePath, newFilePath);
+						pathUpdates.push({
+							id: media.id,
+							filePath: newFilePath,
+							fileName: media.fileName,
+						});
+					} catch (e) {
+						logger.error(
+							{ mediaId, filePath: media.filePath, newFilePath, error: e },
+							"Failed to move file in storage during bulk move",
+						);
+					}
 				}
 			}
 		}

--- a/apps/server/src/application/services/bulk-operation-service.ts
+++ b/apps/server/src/application/services/bulk-operation-service.ts
@@ -23,9 +23,12 @@ export const BulkOperationService = {
 		const parsedUpdates = updateMediaRequestSchema.parse(updates);
 		const mediaRepo = services.getMediaRepository();
 
-		// セキュリティ及び整合性チェック
+		// 一括取得してセキュリティ及び整合性チェック
+		const mediaList = await mediaRepo.findByIds(mediaIds);
+		const mediaMap = new Map(mediaList.map((m) => [m.id, m]));
+
 		for (const mediaId of mediaIds) {
-			const media = await mediaRepo.findById(mediaId);
+			const media = mediaMap.get(mediaId);
 			if (!media || media.mediaSourceId !== mediaSourceId) {
 				throw new Error(
 					`Media with ID ${mediaId} does not belong to source ${mediaSourceId}`,
@@ -52,9 +55,13 @@ export const BulkOperationService = {
 		}
 		const basePath = (source.connectionInfo as { path: string }).path;
 
+		// 一括取得
+		const mediaList = await mediaRepo.findByIds(mediaIds);
+		const mediaMap = new Map(mediaList.map((m) => [m.id, m]));
+
 		const validMediaIds: string[] = [];
 		for (const mediaId of mediaIds) {
-			const media = await mediaRepo.findById(mediaId);
+			const media = mediaMap.get(mediaId);
 			if (media && media.mediaSourceId === mediaSourceId) {
 				validMediaIds.push(mediaId);
 				// 実ファイルの削除
@@ -104,11 +111,15 @@ export const BulkOperationService = {
 		}
 		const basePath = (source.connectionInfo as { path: string }).path;
 
+		// 一括取得
+		const mediaList = await mediaRepo.findByIds(mediaIds);
+		const mediaMap = new Map(mediaList.map((m) => [m.id, m]));
+
 		const pathUpdates: { id: string; filePath: string; fileName: string }[] =
 			[];
 
 		for (const mediaId of mediaIds) {
-			const media = await mediaRepo.findById(mediaId);
+			const media = mediaMap.get(mediaId);
 			if (media && media.mediaSourceId === mediaSourceId) {
 				const cleanDestDir = destinationPath.endsWith("/")
 					? destinationPath
@@ -154,9 +165,12 @@ export const BulkOperationService = {
 	) {
 		const mediaRepo = services.getMediaRepository();
 
-		// セキュリティ及び整合性チェック
+		// 一括取得してセキュリティ及び整合性チェック
+		const mediaList = await mediaRepo.findByIds(mediaIds);
+		const mediaMap = new Map(mediaList.map((m) => [m.id, m]));
+
 		for (const mediaId of mediaIds) {
-			const media = await mediaRepo.findById(mediaId);
+			const media = mediaMap.get(mediaId);
 			if (!media || media.mediaSourceId !== mediaSourceId) {
 				throw new Error(
 					`Media with ID ${mediaId} does not belong to source ${mediaSourceId}`,
@@ -185,9 +199,12 @@ export const BulkOperationService = {
 			"~/application/services/media-service"
 		);
 
-		// セキュリティチェック
+		// 一括取得してセキュリティチェック
+		const mediaList = await mediaRepo.findByIds(mediaIds);
+		const mediaMap = new Map(mediaList.map((m) => [m.id, m]));
+
 		for (const mediaId of mediaIds) {
-			const media = await mediaRepo.findById(mediaId);
+			const media = mediaMap.get(mediaId);
 			if (!media || media.mediaSourceId !== mediaSourceId) {
 				throw new Error(
 					`Media with ID ${mediaId} does not belong to source ${mediaSourceId}`,
@@ -224,9 +241,12 @@ export const BulkOperationService = {
 			"~/application/services/media-service"
 		);
 
-		// セキュリティチェック
+		// 一括取得してセキュリティチェック
+		const mediaList = await mediaRepo.findByIds(mediaIds);
+		const mediaMap = new Map(mediaList.map((m) => [m.id, m]));
+
 		for (const mediaId of mediaIds) {
-			const media = await mediaRepo.findById(mediaId);
+			const media = mediaMap.get(mediaId);
 			if (!media || media.mediaSourceId !== mediaSourceId) {
 				throw new Error(
 					`Media with ID ${mediaId} does not belong to source ${mediaSourceId}`,

--- a/apps/server/src/application/services/bulk-operation-service.ts
+++ b/apps/server/src/application/services/bulk-operation-service.ts
@@ -53,40 +53,51 @@ export const BulkOperationService = {
 		if (!source) {
 			throw new Error(`Media source not found: ${mediaSourceId}`);
 		}
-		const basePath = (source.connectionInfo as { path: string }).path;
+		const connectionInfo = source.connectionInfo as Record<
+			string,
+			unknown
+		> | null;
+		const basePath = connectionInfo?.path as string | undefined;
+		if (!basePath) {
+			throw new Error(`Base path not found for media source: ${mediaSourceId}`);
+		}
 
-		// 一括取得
+		// 一括取得してセキュリティ及び整合性チェック
 		const mediaList = await mediaRepo.findByIds(mediaIds);
 		const mediaMap = new Map(mediaList.map((m) => [m.id, m]));
 
-		const validMediaIds: string[] = [];
 		for (const mediaId of mediaIds) {
 			const media = mediaMap.get(mediaId);
-			if (media && media.mediaSourceId === mediaSourceId) {
-				validMediaIds.push(mediaId);
-				// 実ファイルの削除
-				try {
-					await mediaStorage.deleteFile(basePath, media.filePath);
-				} catch (e) {
-					logger.warn(
-						{ mediaId, filePath: media.filePath, error: e },
-						"Failed to delete file from storage during bulk delete",
-					);
-				}
-				// サムネイルの削除
-				try {
-					await deleteThumbnail(mediaSourceId, media.id);
-				} catch (e) {
-					logger.warn(
-						{ mediaId, error: e },
-						"Failed to delete thumbnail during bulk delete",
-					);
-				}
+			if (!media || media.mediaSourceId !== mediaSourceId) {
+				throw new Error(
+					`Media with ID ${mediaId} does not belong to source ${mediaSourceId}`,
+				);
 			}
 		}
 
-		if (validMediaIds.length > 0) {
-			await mediaRepo.bulkDelete(validMediaIds);
+		for (const media of mediaList) {
+			// 実ファイルの削除
+			try {
+				await mediaStorage.deleteFile(basePath, media.filePath);
+			} catch (e) {
+				logger.warn(
+					{ mediaId: media.id, filePath: media.filePath, error: e },
+					"Failed to delete file from storage during bulk delete",
+				);
+			}
+			// サムネイルの削除
+			try {
+				await deleteThumbnail(mediaSourceId, media.id);
+			} catch (e) {
+				logger.warn(
+					{ mediaId: media.id, error: e },
+					"Failed to delete thumbnail during bulk delete",
+				);
+			}
+		}
+
+		if (mediaIds.length > 0) {
+			await mediaRepo.bulkDelete(mediaIds);
 		}
 	},
 
@@ -109,38 +120,56 @@ export const BulkOperationService = {
 		if (!source) {
 			throw new Error(`Media source not found: ${mediaSourceId}`);
 		}
-		const basePath = (source.connectionInfo as { path: string }).path;
+		const connectionInfo = source.connectionInfo as Record<
+			string,
+			unknown
+		> | null;
+		const basePath = connectionInfo?.path as string | undefined;
+		if (!basePath) {
+			throw new Error(`Base path not found for media source: ${mediaSourceId}`);
+		}
 
-		// 一括取得
+		// 一括取得してセキュリティ及び整合性チェック
 		const mediaList = await mediaRepo.findByIds(mediaIds);
 		const mediaMap = new Map(mediaList.map((m) => [m.id, m]));
+
+		for (const mediaId of mediaIds) {
+			const media = mediaMap.get(mediaId);
+			if (!media || media.mediaSourceId !== mediaSourceId) {
+				throw new Error(
+					`Media with ID ${mediaId} does not belong to source ${mediaSourceId}`,
+				);
+			}
+		}
 
 		const pathUpdates: { id: string; filePath: string; fileName: string }[] =
 			[];
 
-		for (const mediaId of mediaIds) {
-			const media = mediaMap.get(mediaId);
-			if (media && media.mediaSourceId === mediaSourceId) {
-				const cleanDestDir = destinationPath.endsWith("/")
-					? destinationPath
-					: `${destinationPath}/`;
-				const newFilePath = `${cleanDestDir}${media.fileName}`;
+		for (const media of mediaList) {
+			const cleanDestDir = destinationPath.endsWith("/")
+				? destinationPath
+				: `${destinationPath}/`;
+			const newFilePath = `${cleanDestDir}${media.fileName}`;
 
-				if (newFilePath !== media.filePath) {
-					try {
-						// ファイルを物理的に移動
-						await mediaStorage.moveFile(basePath, media.filePath, newFilePath);
-						pathUpdates.push({
-							id: media.id,
-							filePath: newFilePath,
-							fileName: media.fileName,
-						});
-					} catch (e) {
-						logger.error(
-							{ mediaId, filePath: media.filePath, newFilePath, error: e },
-							"Failed to move file in storage during bulk move",
-						);
-					}
+			if (newFilePath !== media.filePath) {
+				try {
+					// ファイルを物理的に移動
+					await mediaStorage.moveFile(basePath, media.filePath, newFilePath);
+					pathUpdates.push({
+						id: media.id,
+						filePath: newFilePath,
+						fileName: media.fileName,
+					});
+				} catch (e) {
+					logger.error(
+						{
+							mediaId: media.id,
+							filePath: media.filePath,
+							newFilePath,
+							error: e,
+						},
+						"Failed to move file in storage during bulk move",
+					);
 				}
 			}
 		}

--- a/apps/server/src/components/media/bulk-action-dialog.tsx
+++ b/apps/server/src/components/media/bulk-action-dialog.tsx
@@ -1,4 +1,5 @@
 import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import { Button } from "@solid-imager/ui/button";
 import {
 	Dialog,
 	DialogContent,
@@ -7,16 +8,15 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@solid-imager/ui/dialog";
-import { Button } from "@solid-imager/ui/button";
 import { Input } from "@solid-imager/ui/input";
-import { createSignal, createResource, Show, For } from "solid-js";
-import { fetchMediaSources } from "~/infrastructure/api-clients/sources-api";
+import { createResource, createSignal, For, Show } from "solid-js";
 import {
-	bulkDeleteMedia,
 	bulkCopyToSource,
-	bulkMoveToSource,
+	bulkDeleteMedia,
 	bulkMoveMedia,
+	bulkMoveToSource,
 } from "~/infrastructure/api-clients/media-api";
+import { fetchMediaSources } from "~/infrastructure/api-clients/sources-api";
 
 type BulkActionDialogProps = {
 	open: boolean;
@@ -59,17 +59,29 @@ export function BulkActionDialog(props: BulkActionDialogProps) {
 				if (!targetSourceId()) {
 					throw new Error("Target source is required.");
 				}
-				await bulkCopyToSource(props.mediaSourceId, props.mediaIds, targetSourceId());
+				await bulkCopyToSource(
+					props.mediaSourceId,
+					props.mediaIds,
+					targetSourceId(),
+				);
 			} else if (currentAction === "move-source") {
 				if (!targetSourceId()) {
 					throw new Error("Target source is required.");
 				}
-				await bulkMoveToSource(props.mediaSourceId, props.mediaIds, targetSourceId());
+				await bulkMoveToSource(
+					props.mediaSourceId,
+					props.mediaIds,
+					targetSourceId(),
+				);
 			} else if (currentAction === "move-folder") {
 				if (!destinationPath().trim()) {
 					throw new Error("Destination path is required.");
 				}
-				await bulkMoveMedia(props.mediaSourceId, props.mediaIds, destinationPath());
+				await bulkMoveMedia(
+					props.mediaSourceId,
+					props.mediaIds,
+					destinationPath(),
+				);
 			} else if (currentAction === "delete") {
 				await bulkDeleteMedia(props.mediaSourceId, props.mediaIds);
 			}
@@ -88,13 +100,16 @@ export function BulkActionDialog(props: BulkActionDialogProps) {
 				<DialogHeader>
 					<DialogTitle>一括操作を実行</DialogTitle>
 					<DialogDescription>
-						選択された {props.mediaIds.length} 件のメディアに対して一括操作を実行します。
+						選択された {props.mediaIds.length}{" "}
+						件のメディアに対して一括操作を実行します。
 					</DialogDescription>
 				</DialogHeader>
 
 				<div class="grid gap-4 py-4">
 					<div class="flex flex-col gap-2">
-						<label class="text-sm font-medium" for="bulk-action-type">操作を選択</label>
+						<label class="text-sm font-medium" for="bulk-action-type">
+							操作を選択
+						</label>
 						<select
 							id="bulk-action-type"
 							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
@@ -110,7 +125,9 @@ export function BulkActionDialog(props: BulkActionDialogProps) {
 
 					<Show when={action() === "copy-source" || action() === "move-source"}>
 						<div class="flex flex-col gap-2">
-							<label class="text-sm font-medium" for="target-source-id">コピー/移動先のソース</label>
+							<label class="text-sm font-medium" for="target-source-id">
+								コピー/移動先のソース
+							</label>
 							<select
 								id="target-source-id"
 								class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
@@ -119,9 +136,7 @@ export function BulkActionDialog(props: BulkActionDialogProps) {
 							>
 								<option value="">選択してください...</option>
 								<For each={usableSources()}>
-									{(source) => (
-										<option value={source.id}>{source.name}</option>
-									)}
+									{(source) => <option value={source.id}>{source.name}</option>}
 								</For>
 							</select>
 						</div>
@@ -129,7 +144,9 @@ export function BulkActionDialog(props: BulkActionDialogProps) {
 
 					<Show when={action() === "move-folder"}>
 						<div class="flex flex-col gap-2">
-							<label class="text-sm font-medium" for="destination-path">移動先フォルダパス</label>
+							<label class="text-sm font-medium" for="destination-path">
+								移動先フォルダパス
+							</label>
 							<Input
 								id="destination-path"
 								placeholder="e.g. subfolder/new-dir"
@@ -146,9 +163,7 @@ export function BulkActionDialog(props: BulkActionDialogProps) {
 					</Show>
 
 					<Show when={errorMsg()}>
-						<div class="text-sm text-red-500 font-medium">
-							{errorMsg()}
-						</div>
+						<div class="text-sm text-red-500 font-medium">{errorMsg()}</div>
 					</Show>
 				</div>
 
@@ -162,7 +177,11 @@ export function BulkActionDialog(props: BulkActionDialogProps) {
 					</Button>
 					<Button
 						onClick={handleConfirm}
-						disabled={isSubmitting() || (sources.loading && (action() === "copy-source" || action() === "move-source"))}
+						disabled={
+							isSubmitting() ||
+							(sources.loading &&
+								(action() === "copy-source" || action() === "move-source"))
+						}
 						variant={action() === "delete" ? "destructive" : "default"}
 					>
 						{isSubmitting() ? "処理中..." : "確定"}

--- a/apps/server/src/components/media/bulk-action-dialog.tsx
+++ b/apps/server/src/components/media/bulk-action-dialog.tsx
@@ -1,0 +1,174 @@
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@solid-imager/ui/dialog";
+import { Button } from "@solid-imager/ui/button";
+import { Input } from "@solid-imager/ui/input";
+import { createSignal, createResource, Show, For } from "solid-js";
+import { fetchMediaSources } from "~/infrastructure/api-clients/sources-api";
+import {
+	bulkDeleteMedia,
+	bulkCopyToSource,
+	bulkMoveToSource,
+	bulkMoveMedia,
+} from "~/infrastructure/api-clients/media-api";
+
+type BulkActionDialogProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	mediaSourceId: string;
+	mediaIds: string[];
+	onSuccess: () => void;
+};
+
+type ActionType = "copy-source" | "move-source" | "move-folder" | "delete";
+
+export function BulkActionDialog(props: BulkActionDialogProps) {
+	const [action, setAction] = createSignal<ActionType>("copy-source");
+	const [targetSourceId, setTargetSourceId] = createSignal("");
+	const [destinationPath, setDestinationPath] = createSignal("");
+	const [isSubmitting, setIsSubmitting] = createSignal(false);
+	const [errorMsg, setErrorMsg] = createSignal("");
+
+	const [sources] = createResource<SafeMediaSource[], boolean>(
+		() => props.open,
+		async (isOpen) => {
+			if (!isOpen) return [];
+			return await fetchMediaSources();
+		},
+		{ initialValue: [] },
+	);
+
+	const usableSources = () =>
+		(sources() ?? []).filter(
+			(s): s is SafeMediaSource & { id: string } =>
+				!!s.id && s.id !== props.mediaSourceId,
+		);
+
+	const handleConfirm = async () => {
+		setIsSubmitting(true);
+		setErrorMsg("");
+		try {
+			const currentAction = action();
+			if (currentAction === "copy-source") {
+				if (!targetSourceId()) {
+					throw new Error("Target source is required.");
+				}
+				await bulkCopyToSource(props.mediaSourceId, props.mediaIds, targetSourceId());
+			} else if (currentAction === "move-source") {
+				if (!targetSourceId()) {
+					throw new Error("Target source is required.");
+				}
+				await bulkMoveToSource(props.mediaSourceId, props.mediaIds, targetSourceId());
+			} else if (currentAction === "move-folder") {
+				if (!destinationPath().trim()) {
+					throw new Error("Destination path is required.");
+				}
+				await bulkMoveMedia(props.mediaSourceId, props.mediaIds, destinationPath());
+			} else if (currentAction === "delete") {
+				await bulkDeleteMedia(props.mediaSourceId, props.mediaIds);
+			}
+			props.onSuccess();
+			props.onOpenChange(false);
+		} catch (e: any) {
+			setErrorMsg(e.message || "An error occurred.");
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	return (
+		<Dialog open={props.open} onOpenChange={props.onOpenChange}>
+			<DialogContent class="sm:max-w-[425px]">
+				<DialogHeader>
+					<DialogTitle>一括操作を実行</DialogTitle>
+					<DialogDescription>
+						選択された {props.mediaIds.length} 件のメディアに対して一括操作を実行します。
+					</DialogDescription>
+				</DialogHeader>
+
+				<div class="grid gap-4 py-4">
+					<div class="flex flex-col gap-2">
+						<label class="text-sm font-medium" for="bulk-action-type">操作を選択</label>
+						<select
+							id="bulk-action-type"
+							class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+							value={action()}
+							onChange={(e) => setAction(e.target.value as ActionType)}
+						>
+							<option value="copy-source">コピー (別ソースへ)</option>
+							<option value="move-source">移動 (別ソースへ)</option>
+							<option value="move-folder">フォルダ移動 (同一ソース内)</option>
+							<option value="delete">一括削除</option>
+						</select>
+					</div>
+
+					<Show when={action() === "copy-source" || action() === "move-source"}>
+						<div class="flex flex-col gap-2">
+							<label class="text-sm font-medium" for="target-source-id">コピー/移動先のソース</label>
+							<select
+								id="target-source-id"
+								class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+								value={targetSourceId()}
+								onChange={(e) => setTargetSourceId(e.target.value)}
+							>
+								<option value="">選択してください...</option>
+								<For each={usableSources()}>
+									{(source) => (
+										<option value={source.id}>{source.name}</option>
+									)}
+								</For>
+							</select>
+						</div>
+					</Show>
+
+					<Show when={action() === "move-folder"}>
+						<div class="flex flex-col gap-2">
+							<label class="text-sm font-medium" for="destination-path">移動先フォルダパス</label>
+							<Input
+								id="destination-path"
+								placeholder="e.g. subfolder/new-dir"
+								value={destinationPath()}
+								onInput={(e) => setDestinationPath(e.currentTarget.value)}
+							/>
+						</div>
+					</Show>
+
+					<Show when={action() === "delete"}>
+						<div class="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+							警告: この操作は元に戻せません。実ファイルも削除されます。
+						</div>
+					</Show>
+
+					<Show when={errorMsg()}>
+						<div class="text-sm text-red-500 font-medium">
+							{errorMsg()}
+						</div>
+					</Show>
+				</div>
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => props.onOpenChange(false)}
+						disabled={isSubmitting()}
+					>
+						キャンセル
+					</Button>
+					<Button
+						onClick={handleConfirm}
+						disabled={isSubmitting() || (sources.loading && (action() === "copy-source" || action() === "move-source"))}
+						variant={action() === "delete" ? "destructive" : "default"}
+					>
+						{isSubmitting() ? "処理中..." : "確定"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/server/src/components/media/media-grid-item.tsx
+++ b/apps/server/src/components/media/media-grid-item.tsx
@@ -9,25 +9,48 @@ type MediaGridItemProps = {
 	onContextMenu?: (event: MouseEvent) => void;
 	priority?: boolean;
 	sourceRootPath?: string;
+	isBulkSelectMode?: boolean;
+	isSelected?: boolean;
+	onToggleSelect?: () => void;
 };
 
 export function MediaGridItem(props: MediaGridItemProps) {
 	return (
 		<SharedMediaGridItem
-			linkComponent={(linkProps) => (
-				<Link
-					class={linkProps.class}
-					data-media-id={linkProps["data-media-id"]}
-					onContextMenu={linkProps.onContextMenu}
-					params={{
-						mediaId: props.media.id,
-						mediaSourceId: props.media.mediaSourceId,
-					}}
-					to="/sources/$mediaSourceId/$mediaId"
-				>
-					{linkProps.children}
-				</Link>
-			)}
+			isBulkSelectMode={props.isBulkSelectMode}
+			isSelected={props.isSelected}
+			linkComponent={(linkProps) => {
+				if (props.isBulkSelectMode) {
+					return (
+						<button
+							type="button"
+							class={linkProps.class}
+							data-media-id={linkProps["data-media-id"]}
+							onContextMenu={linkProps.onContextMenu}
+							onClick={(e) => {
+								e.preventDefault();
+								props.onToggleSelect?.();
+							}}
+						>
+							{linkProps.children}
+						</button>
+					);
+				}
+				return (
+					<Link
+						class={linkProps.class}
+						data-media-id={linkProps["data-media-id"]}
+						onContextMenu={linkProps.onContextMenu}
+						params={{
+							mediaId: props.media.id,
+							mediaSourceId: props.media.mediaSourceId,
+						}}
+						to="/sources/$mediaSourceId/$mediaId"
+					>
+						{linkProps.children}
+					</Link>
+				);
+			}}
 			linkPrefix={props.linkPrefix}
 			media={props.media}
 			onContextMenu={props.onContextMenu}

--- a/apps/server/src/components/media/media-grid-item.tsx
+++ b/apps/server/src/components/media/media-grid-item.tsx
@@ -1,6 +1,7 @@
 import type { Media } from "@solid-imager/core/domain/media/schemas";
 import { MediaGridItem as SharedMediaGridItem } from "@solid-imager/ui/media-grid-item";
 import { Link } from "@tanstack/solid-router";
+import { Show } from "solid-js";
 import { ThumbnailImage } from "./thumbnail-image";
 
 type MediaGridItemProps = {
@@ -19,38 +20,38 @@ export function MediaGridItem(props: MediaGridItemProps) {
 		<SharedMediaGridItem
 			isBulkSelectMode={props.isBulkSelectMode}
 			isSelected={props.isSelected}
-			linkComponent={(linkProps) => {
-				if (props.isBulkSelectMode) {
-					return (
-						<button
-							type="button"
+			linkComponent={(linkProps) => (
+				<Show
+					fallback={
+						<Link
 							class={linkProps.class}
 							data-media-id={linkProps["data-media-id"]}
 							onContextMenu={linkProps.onContextMenu}
-							onClick={(e) => {
-								e.preventDefault();
-								props.onToggleSelect?.();
+							params={{
+								mediaId: props.media.id,
+								mediaSourceId: props.media.mediaSourceId,
 							}}
+							to="/sources/$mediaSourceId/$mediaId"
 						>
 							{linkProps.children}
-						</button>
-					);
-				}
-				return (
-					<Link
+						</Link>
+					}
+					when={props.isBulkSelectMode}
+				>
+					<button
+						type="button"
 						class={linkProps.class}
 						data-media-id={linkProps["data-media-id"]}
 						onContextMenu={linkProps.onContextMenu}
-						params={{
-							mediaId: props.media.id,
-							mediaSourceId: props.media.mediaSourceId,
+						onClick={(e) => {
+							e.preventDefault();
+							props.onToggleSelect?.();
 						}}
-						to="/sources/$mediaSourceId/$mediaId"
 					>
 						{linkProps.children}
-					</Link>
-				);
-			}}
+					</button>
+				</Show>
+			)}
 			linkPrefix={props.linkPrefix}
 			media={props.media}
 			onContextMenu={props.onContextMenu}

--- a/apps/server/src/infrastructure/api-clients/media-api.ts
+++ b/apps/server/src/infrastructure/api-clients/media-api.ts
@@ -163,3 +163,43 @@ export function findDuplicateMedia(mediaSourceId?: string) {
 		mediaSourceId ? { mediaSourceId } : undefined,
 	);
 }
+
+export function bulkDeleteMedia(sourceId: string, mediaIds: string[]) {
+	return orpc.media.bulkDelete({ mediaSourceId: sourceId, mediaIds });
+}
+
+export function bulkCopyToSource(
+	sourceId: string,
+	mediaIds: string[],
+	targetSourceId: string,
+) {
+	return orpc.media.bulkCopyToSource({
+		mediaSourceId: sourceId,
+		mediaIds,
+		targetSourceId,
+	});
+}
+
+export function bulkMoveToSource(
+	sourceId: string,
+	mediaIds: string[],
+	targetSourceId: string,
+) {
+	return orpc.media.bulkMoveToSource({
+		mediaSourceId: sourceId,
+		mediaIds,
+		targetSourceId,
+	});
+}
+
+export function bulkMoveMedia(
+	sourceId: string,
+	mediaIds: string[],
+	destinationPath: string,
+) {
+	return orpc.media.bulkMove({
+		mediaSourceId: sourceId,
+		mediaIds,
+		destinationPath,
+	});
+}

--- a/apps/server/src/infrastructure/api/routers/media-router.ts
+++ b/apps/server/src/infrastructure/api/routers/media-router.ts
@@ -1,12 +1,17 @@
 import { ORPCError, os } from "@orpc/server";
 import { ResourceNotFoundError } from "@solid-imager/core/domain/errors";
 import {
+	bulkDeleteMediaRequestSchema,
+	bulkEditMediaRequestSchema,
+	bulkMoveMediaRequestSchema,
+	bulkTagMediaRequestSchema,
 	findDuplicatesRequestSchema,
 	mediaSearchRequestSchema,
 	updateMediaRequestSchema,
 } from "@solid-imager/core/domain/media/schemas";
 import { asyncPool } from "@solid-imager/core/utils/async-pool";
 import { z } from "zod";
+import { BulkOperationService } from "~/application/services/bulk-operation-service";
 import { MediaService } from "~/application/services/media-service";
 
 /**
@@ -240,4 +245,54 @@ export const mediaRouter = {
 					autoIncrement: input.autoIncrement === "true",
 				}),
 		),
+
+	/**
+	 * Bulk edit multiple media metadata
+	 */
+	bulkEdit: os.input(bulkEditMediaRequestSchema).handler(async ({ input }) => {
+		await BulkOperationService.bulkEditMedia(
+			input.mediaSourceId,
+			input.mediaIds,
+			input.updates,
+		);
+		return { success: true };
+	}),
+
+	/**
+	 * Bulk delete multiple media items
+	 */
+	bulkDelete: os
+		.input(bulkDeleteMediaRequestSchema)
+		.handler(async ({ input }) => {
+			await BulkOperationService.bulkDeleteMedia(
+				input.mediaSourceId,
+				input.mediaIds,
+			);
+			return { success: true };
+		}),
+
+	/**
+	 * Bulk move multiple media items within the source
+	 */
+	bulkMove: os.input(bulkMoveMediaRequestSchema).handler(async ({ input }) => {
+		await BulkOperationService.bulkMoveMedia(
+			input.mediaSourceId,
+			input.mediaIds,
+			input.destinationPath,
+		);
+		return { success: true };
+	}),
+
+	/**
+	 * Bulk add/remove tags on multiple media items
+	 */
+	bulkTag: os.input(bulkTagMediaRequestSchema).handler(async ({ input }) => {
+		await BulkOperationService.bulkTagMedia(
+			input.mediaSourceId,
+			input.mediaIds,
+			input.tagsToAdd,
+			input.tagsToRemove,
+		);
+		return { success: true };
+	}),
 };

--- a/apps/server/src/infrastructure/api/routers/media-router.ts
+++ b/apps/server/src/infrastructure/api/routers/media-router.ts
@@ -5,6 +5,8 @@ import {
 	bulkEditMediaRequestSchema,
 	bulkMoveMediaRequestSchema,
 	bulkTagMediaRequestSchema,
+	bulkCopyToSourceMediaRequestSchema,
+	bulkMoveToSourceMediaRequestSchema,
 	findDuplicatesRequestSchema,
 	mediaSearchRequestSchema,
 	updateMediaRequestSchema,
@@ -295,4 +297,32 @@ export const mediaRouter = {
 		);
 		return { success: true };
 	}),
+
+	/**
+	 * Bulk copy multiple media items to another source
+	 */
+	bulkCopyToSource: os
+		.input(bulkCopyToSourceMediaRequestSchema)
+		.handler(async ({ input }) => {
+			await BulkOperationService.bulkCopyToSource(
+				input.mediaSourceId,
+				input.mediaIds,
+				input.targetSourceId,
+			);
+			return { success: true };
+		}),
+
+	/**
+	 * Bulk move multiple media items to another source
+	 */
+	bulkMoveToSource: os
+		.input(bulkMoveToSourceMediaRequestSchema)
+		.handler(async ({ input }) => {
+			await BulkOperationService.bulkMoveToSource(
+				input.mediaSourceId,
+				input.mediaIds,
+				input.targetSourceId,
+			);
+			return { success: true };
+		}),
 };

--- a/apps/server/src/infrastructure/api/routers/media-router.ts
+++ b/apps/server/src/infrastructure/api/routers/media-router.ts
@@ -1,12 +1,12 @@
 import { ORPCError, os } from "@orpc/server";
 import { ResourceNotFoundError } from "@solid-imager/core/domain/errors";
 import {
+	bulkCopyToSourceMediaRequestSchema,
 	bulkDeleteMediaRequestSchema,
 	bulkEditMediaRequestSchema,
 	bulkMoveMediaRequestSchema,
-	bulkTagMediaRequestSchema,
-	bulkCopyToSourceMediaRequestSchema,
 	bulkMoveToSourceMediaRequestSchema,
+	bulkTagMediaRequestSchema,
 	findDuplicatesRequestSchema,
 	mediaSearchRequestSchema,
 	updateMediaRequestSchema,

--- a/apps/server/src/infrastructure/storage/server-media-storage.ts
+++ b/apps/server/src/infrastructure/storage/server-media-storage.ts
@@ -370,4 +370,18 @@ export const ServerMediaStorage: IMediaStorage = {
 			throw e;
 		}
 	},
+
+	async moveFile(
+		basePath: string,
+		sourcePath: string,
+		targetPath: string,
+	): Promise<void> {
+		const fullSourcePath = resolveSafePath(basePath, sourcePath);
+		const fullTargetPath = resolveSafePath(basePath, targetPath);
+
+		const targetDir = path.dirname(fullTargetPath);
+		await fs.mkdir(targetDir, { recursive: true });
+
+		await fs.rename(fullSourcePath, fullTargetPath);
+	},
 };

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -1,5 +1,6 @@
 import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { SourceMediaPage as SourceMediaPageComponent } from "@solid-imager/ui/source-media-page";
+import { useQueryClient } from "@tanstack/solid-query";
 import { useParams } from "@tanstack/solid-router";
 import { createSignal, Show } from "solid-js";
 import { MediaGridItem } from "~/components/media/media-grid-item";
@@ -40,6 +41,7 @@ const PresetClient = createPresetClient(rawPresetClient);
 export function SourceMediaPage() {
 	const params = useParams({ from: "/sources/$mediaSourceId/" });
 	const mediaSourceId = () => params().mediaSourceId;
+	const queryClient = useQueryClient();
 
 	const transport = createServerTransport(mediaSourceId);
 
@@ -67,13 +69,9 @@ export function SourceMediaPage() {
 	// 一括操作成功時のコールバック
 	const handleBulkSuccess = () => {
 		handleCancelSelect();
-		// リロードさせるため、transportの通知を利用するか、リフレッシュをトリガーする
-		// ここでは SSE Transport が自動検知するか、またはページ再読込が必要だが、
-		// TanStack Router を介した再読み込みや refetch はクライアントのキャッシュをクリアする。
-		// 一般的には window.location.reload() が確実で手っ取り早いが、
-		// queryClient を使った invalidation の方が洗練されている。
-		// 簡易的に location.reload() で全画面を再読込する
-		window.location.reload();
+		queryClient.invalidateQueries({
+			queryKey: ["media", mediaSourceId()],
+		});
 	};
 
 	return (

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -1,11 +1,12 @@
+import { Button } from "@solid-imager/ui/button";
 import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { SourceMediaPage as SourceMediaPageComponent } from "@solid-imager/ui/source-media-page";
 import { useQueryClient } from "@tanstack/solid-query";
 import { useParams } from "@tanstack/solid-router";
 import { createSignal, Show } from "solid-js";
+import { BulkActionDialog } from "~/components/media/bulk-action-dialog";
 import { MediaGridItem } from "~/components/media/media-grid-item";
 import { MoveCopyMediaDialog } from "~/components/media/move-copy-media-dialog";
-import { BulkActionDialog } from "~/components/media/bulk-action-dialog";
 import { UploadMediaModal } from "~/components/upload-media-modal";
 import { createServerTransport } from "~/hooks/use-media-source-events";
 import { PresetClient as rawPresetClient } from "~/infrastructure/api/clients/preset-client";
@@ -34,7 +35,6 @@ import {
 	getSearchCondition,
 	searchState,
 } from "~/presentation/store/search-store";
-import { Button } from "@solid-imager/ui/button";
 
 const PresetClient = createPresetClient(rawPresetClient);
 
@@ -105,6 +105,9 @@ export function SourceMediaPage() {
 				onToggleSelect={handleToggleSelect}
 				isBulkSelectMode={isBulkSelectMode}
 				isSelected={isSelected}
+				onBulkAction={() => setIsBulkActionOpen(true)}
+				onClearSelection={handleCancelSelect}
+				selectedCount={() => selectedMediaIds().length}
 				renderItem={(media, options) => (
 					<MediaGridItem
 						media={media}
@@ -125,17 +128,10 @@ export function SourceMediaPage() {
 					<span class="font-medium text-sm">
 						{selectedMediaIds().length} 件選択中
 					</span>
-					<Button
-						onClick={() => setIsBulkActionOpen(true)}
-						size="sm"
-					>
+					<Button onClick={() => setIsBulkActionOpen(true)} size="sm">
 						一括操作を実行
 					</Button>
-					<Button
-						onClick={handleCancelSelect}
-						variant="outline"
-						size="sm"
-					>
+					<Button onClick={handleCancelSelect} variant="outline" size="sm">
 						解除
 					</Button>
 				</div>

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -141,7 +141,7 @@ export function SourceMediaPage() {
 			<BulkActionDialog
 				open={isBulkActionOpen()}
 				onOpenChange={setIsBulkActionOpen}
-				mediaSourceId={mediaSourceId() || ""}
+				mediaSourceId={mediaSourceId()}
 				mediaIds={selectedMediaIds()}
 				onSuccess={handleBulkSuccess}
 			/>

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -52,11 +52,15 @@ export function SourceMediaPage() {
 
 	const handleToggleSelect = (mediaId: string) => {
 		setIsBulkSelectMode(true);
-		setSelectedMediaIds((prev) =>
-			prev.includes(mediaId)
+		setSelectedMediaIds((prev) => {
+			const next = prev.includes(mediaId)
 				? prev.filter((id) => id !== mediaId)
-				: [...prev, mediaId],
-		);
+				: [...prev, mediaId];
+			if (next.length === 0) {
+				setIsBulkSelectMode(false);
+			}
+			return next;
+		});
 	};
 
 	const isSelected = (mediaId: string) => selectedMediaIds().includes(mediaId);

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -1,8 +1,10 @@
 import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { SourceMediaPage as SourceMediaPageComponent } from "@solid-imager/ui/source-media-page";
 import { useParams } from "@tanstack/solid-router";
+import { createSignal, Show } from "solid-js";
 import { MediaGridItem } from "~/components/media/media-grid-item";
 import { MoveCopyMediaDialog } from "~/components/media/move-copy-media-dialog";
+import { BulkActionDialog } from "~/components/media/bulk-action-dialog";
 import { UploadMediaModal } from "~/components/upload-media-modal";
 import { createServerTransport } from "~/hooks/use-media-source-events";
 import { PresetClient as rawPresetClient } from "~/infrastructure/api/clients/preset-client";
@@ -31,6 +33,7 @@ import {
 	getSearchCondition,
 	searchState,
 } from "~/presentation/store/search-store";
+import { Button } from "@solid-imager/ui/button";
 
 const PresetClient = createPresetClient(rawPresetClient);
 
@@ -40,39 +43,114 @@ export function SourceMediaPage() {
 
 	const transport = createServerTransport(mediaSourceId);
 
+	// 一括選択用シグナル
+	const [isBulkSelectMode, setIsBulkSelectMode] = createSignal(false);
+	const [selectedMediaIds, setSelectedMediaIds] = createSignal<string[]>([]);
+	const [isBulkActionOpen, setIsBulkActionOpen] = createSignal(false);
+
+	const handleToggleSelect = (mediaId: string) => {
+		setIsBulkSelectMode(true);
+		setSelectedMediaIds((prev) =>
+			prev.includes(mediaId)
+				? prev.filter((id) => id !== mediaId)
+				: [...prev, mediaId],
+		);
+	};
+
+	const isSelected = (mediaId: string) => selectedMediaIds().includes(mediaId);
+
+	const handleCancelSelect = () => {
+		setIsBulkSelectMode(false);
+		setSelectedMediaIds([]);
+	};
+
+	// 一括操作成功時のコールバック
+	const handleBulkSuccess = () => {
+		handleCancelSelect();
+		// リロードさせるため、transportの通知を利用するか、リフレッシュをトリガーする
+		// ここでは SSE Transport が自動検知するか、またはページ再読込が必要だが、
+		// TanStack Router を介した再読み込みや refetch はクライアントのキャッシュをクリアする。
+		// 一般的には window.location.reload() が確実で手っ取り早いが、
+		// queryClient を使った invalidation の方が洗練されている。
+		// 簡易的に location.reload() で全画面を再読込する
+		window.location.reload();
+	};
+
 	return (
-		<SourceMediaPageComponent
-			enableVirtualization
-			mediaSourceId={mediaSourceId}
-			transport={transport}
-			presetClient={PresetClient}
-			actions={{
-				searchMedia,
-				uploadMedia: (sourceId, file, opts) =>
-					uploadMedia(sourceId, file, opts),
-				deleteMedia,
-				copyMedia,
-				moveMedia,
-				syncMediaItems,
-				startDownloadJobs,
-				fetchSourceDump,
-				restoreSource,
-				importSourceZip,
-			}}
-			getSearchCondition={getSearchCondition}
-			sortBy={() => searchState.sortBy}
-			sortOrder={() => searchState.sortOrder}
-			tagsQueryOptions={tagsQueryOptions}
-			projectsQueryOptions={allProjectsQueryOptions}
-			ipsQueryOptions={allIpsQueryOptions}
-			charactersQueryOptions={allCharactersQueryOptions}
-			authorsQueryOptions={allAuthorsQueryOptions}
-			renderItem={(media, { onContextMenu }) => (
-				<MediaGridItem media={media} onContextMenu={onContextMenu} />
-			)}
-			moveCopyDialogComponent={MoveCopyMediaDialog}
-			uploadModalComponent={UploadMediaModal}
-			showOpenInNewTab
-		/>
+		<>
+			<SourceMediaPageComponent
+				enableVirtualization
+				mediaSourceId={mediaSourceId}
+				transport={transport}
+				presetClient={PresetClient}
+				actions={{
+					searchMedia,
+					uploadMedia: (sourceId, file, opts) =>
+						uploadMedia(sourceId, file, opts),
+					deleteMedia,
+					copyMedia,
+					moveMedia,
+					syncMediaItems,
+					startDownloadJobs,
+					fetchSourceDump,
+					restoreSource,
+					importSourceZip,
+				}}
+				getSearchCondition={getSearchCondition}
+				sortBy={() => searchState.sortBy}
+				sortOrder={() => searchState.sortOrder}
+				tagsQueryOptions={tagsQueryOptions}
+				projectsQueryOptions={allProjectsQueryOptions}
+				ipsQueryOptions={allIpsQueryOptions}
+				charactersQueryOptions={allCharactersQueryOptions}
+				authorsQueryOptions={allAuthorsQueryOptions}
+				onToggleSelect={handleToggleSelect}
+				isBulkSelectMode={isBulkSelectMode}
+				isSelected={isSelected}
+				renderItem={(media, options) => (
+					<MediaGridItem
+						media={media}
+						onContextMenu={options.onContextMenu}
+						isBulkSelectMode={options.isBulkSelectMode}
+						isSelected={options.isSelected}
+						onToggleSelect={() => handleToggleSelect(media.id)}
+					/>
+				)}
+				moveCopyDialogComponent={MoveCopyMediaDialog}
+				uploadModalComponent={UploadMediaModal}
+				showOpenInNewTab
+			/>
+
+			{/* 一括選択ツールバー */}
+			<Show when={isBulkSelectMode() && selectedMediaIds().length > 0}>
+				<div class="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-4 border border-primary/20 bg-background/95 px-6 py-3 shadow-lg backdrop-blur rounded-full">
+					<span class="font-medium text-sm">
+						{selectedMediaIds().length} 件選択中
+					</span>
+					<Button
+						onClick={() => setIsBulkActionOpen(true)}
+						size="sm"
+					>
+						一括操作を実行
+					</Button>
+					<Button
+						onClick={handleCancelSelect}
+						variant="outline"
+						size="sm"
+					>
+						解除
+					</Button>
+				</div>
+			</Show>
+
+			{/* 一括操作ダイアログ */}
+			<BulkActionDialog
+				open={isBulkActionOpen()}
+				onOpenChange={setIsBulkActionOpen}
+				mediaSourceId={mediaSourceId() || ""}
+				mediaIds={selectedMediaIds()}
+				onSuccess={handleBulkSuccess}
+			/>
+		</>
 	);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "solid-imager-monorepo",
-      "dependencies": {
-        "@tanstack/solid-query": "5.99.2",
-      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",
         "@tanstack/cli": "^0.69.3",

--- a/packages/core/src/domain/media/schemas.ts
+++ b/packages/core/src/domain/media/schemas.ts
@@ -644,3 +644,26 @@ export const bulkTagMediaRequestSchema = z.object({
 	tagsToRemove: z.array(z.string().uuid("Invalid tag ID format")),
 });
 export type BulkTagMediaRequest = z.infer<typeof bulkTagMediaRequestSchema>;
+
+export const bulkCopyToSourceMediaRequestSchema = z.object({
+	mediaSourceId: z.string().uuid("Invalid source ID format"),
+	mediaIds: z
+		.array(z.string().uuid("Invalid media ID format"))
+		.min(1, "At least one media ID is required"),
+	targetSourceId: z.string().uuid("Invalid target source ID format"),
+});
+export type BulkCopyToSourceMediaRequest = z.infer<
+	typeof bulkCopyToSourceMediaRequestSchema
+>;
+
+export const bulkMoveToSourceMediaRequestSchema = z.object({
+	mediaSourceId: z.string().uuid("Invalid source ID format"),
+	mediaIds: z
+		.array(z.string().uuid("Invalid media ID format"))
+		.min(1, "At least one media ID is required"),
+	targetSourceId: z.string().uuid("Invalid target source ID format"),
+});
+export type BulkMoveToSourceMediaRequest = z.infer<
+	typeof bulkMoveToSourceMediaRequestSchema
+>;
+

--- a/packages/core/src/domain/media/schemas.ts
+++ b/packages/core/src/domain/media/schemas.ts
@@ -598,9 +598,49 @@ export type DuplicateGroup = z.infer<typeof duplicateGroupSchema>;
 export const findDuplicatesResponseSchema = z.object({
 	groups: z.array(duplicateGroupSchema),
 });
-export type FindDuplicatesResponse = z.infer<typeof findDuplicatesResponseSchema>;
+export type FindDuplicatesResponse = z.infer<
+	typeof findDuplicatesResponseSchema
+>;
 
 export const findDuplicatesRequestSchema = z.object({
 	mediaSourceId: z.uuid({ version: "v4" }).optional(),
 });
 export type FindDuplicatesRequest = z.infer<typeof findDuplicatesRequestSchema>;
+
+export const bulkEditMediaRequestSchema = z.object({
+	mediaSourceId: z.string().uuid("Invalid source ID format"),
+	mediaIds: z
+		.array(z.string().uuid("Invalid media ID format"))
+		.min(1, "At least one media ID is required"),
+	updates: updateMediaRequestSchema,
+});
+export type BulkEditMediaRequest = z.infer<typeof bulkEditMediaRequestSchema>;
+
+export const bulkDeleteMediaRequestSchema = z.object({
+	mediaSourceId: z.string().uuid("Invalid source ID format"),
+	mediaIds: z
+		.array(z.string().uuid("Invalid media ID format"))
+		.min(1, "At least one media ID is required"),
+});
+export type BulkDeleteMediaRequest = z.infer<
+	typeof bulkDeleteMediaRequestSchema
+>;
+
+export const bulkMoveMediaRequestSchema = z.object({
+	mediaSourceId: z.string().uuid("Invalid source ID format"),
+	mediaIds: z
+		.array(z.string().uuid("Invalid media ID format"))
+		.min(1, "At least one media ID is required"),
+	destinationPath: z.string().min(1, "Destination path is required"),
+});
+export type BulkMoveMediaRequest = z.infer<typeof bulkMoveMediaRequestSchema>;
+
+export const bulkTagMediaRequestSchema = z.object({
+	mediaSourceId: z.string().uuid("Invalid source ID format"),
+	mediaIds: z
+		.array(z.string().uuid("Invalid media ID format"))
+		.min(1, "At least one media ID is required"),
+	tagsToAdd: z.array(z.string().uuid("Invalid tag ID format")),
+	tagsToRemove: z.array(z.string().uuid("Invalid tag ID format")),
+});
+export type BulkTagMediaRequest = z.infer<typeof bulkTagMediaRequestSchema>;

--- a/packages/core/src/domain/repositories/media-repository.ts
+++ b/packages/core/src/domain/repositories/media-repository.ts
@@ -16,6 +16,7 @@ import type {
 
 export type IMediaRepository = {
 	findById(id: string, tx?: Transaction): Promise<Media | null>;
+	findByIds(ids: string[], tx?: Transaction): Promise<Media[]>;
 	findByPath(
 		sourceId: string,
 		filePath: string,

--- a/packages/core/src/domain/repositories/media-repository.ts
+++ b/packages/core/src/domain/repositories/media-repository.ts
@@ -2,8 +2,6 @@ import type { Transaction } from "@/domain/interfaces/transaction-manager";
 import type {
 	AddMediaRequest,
 	Author,
-	DuplicateMediaItem,
-	DuplicateGroup,
 	FindDuplicatesRequest,
 	FindDuplicatesResponse,
 	Media,
@@ -111,4 +109,25 @@ export type IMediaRepository = {
 		urls: string[],
 		tx?: Transaction,
 	): Promise<string | null>;
+
+	bulkUpdate(
+		mediaIds: string[],
+		updates: UpdateMediaRequest,
+		tx?: Transaction,
+	): Promise<void>;
+	bulkDelete(mediaIds: string[], tx?: Transaction): Promise<void>;
+	bulkUpdatePaths(
+		updates: { id: string; filePath: string; fileName: string }[],
+		tx?: Transaction,
+	): Promise<void>;
+	bulkAddTags(
+		mediaIds: string[],
+		tagIds: string[],
+		tx?: Transaction,
+	): Promise<void>;
+	bulkRemoveTags(
+		mediaIds: string[],
+		tagIds: string[],
+		tx?: Transaction,
+	): Promise<void>;
 };

--- a/packages/core/src/interfaces/media-storage.ts
+++ b/packages/core/src/interfaces/media-storage.ts
@@ -53,4 +53,10 @@ export type IMediaStorage = {
 			autoIncrement?: boolean;
 		},
 	): Promise<MediaStorageResult>;
+
+	moveFile(
+		basePath: string,
+		sourcePath: string,
+		targetPath: string,
+	): Promise<void>;
 };

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -1437,16 +1437,25 @@ export function createMediaRepository(
 		): Promise<void> {
 			if (updates.length === 0) return;
 			try {
-				const client = getExecutor(tx);
-				for (const u of updates) {
-					await client
-						.update(medias)
-						.set({
-							filePath: u.filePath,
-							fileName: u.fileName,
-							modifiedAt: new Date(),
-						})
-						.where(eq(medias.id, u.id));
+				const runUpdates = async (executor: DrizzleExecutor) => {
+					for (const u of updates) {
+						await executor
+							.update(medias)
+							.set({
+								filePath: u.filePath,
+								fileName: u.fileName,
+								modifiedAt: new Date(),
+							})
+							.where(eq(medias.id, u.id));
+					}
+				};
+
+				if (tx) {
+					await runUpdates(getExecutor(tx));
+				} else {
+					await getExecutor().transaction(async (innerTx) => {
+						await runUpdates(innerTx);
+					});
 				}
 			} catch (error) {
 				throw new UnexpectedError("Failed to bulk update media paths", error);

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -1372,5 +1372,139 @@ export function createMediaRepository(
 				);
 			}
 		},
+
+		async bulkUpdate(
+			mediaIds: string[],
+			updates: UpdateMediaRequest,
+			tx?: Transaction,
+		): Promise<void> {
+			if (mediaIds.length === 0) return;
+			try {
+				const client = getExecutor(tx);
+				const dbUpdates: Partial<NewMedia> = {};
+
+				if (updates.filePath !== undefined) {
+					dbUpdates.filePath = updates.filePath;
+				}
+				if (updates.fileName !== undefined) {
+					dbUpdates.fileName = updates.fileName;
+				}
+				if (updates.fileSize !== undefined) {
+					dbUpdates.fileSize = updates.fileSize;
+				}
+				if (updates.mediaType !== undefined) {
+					dbUpdates.mediaType = updates.mediaType;
+				}
+				if (updates.width !== undefined) {
+					dbUpdates.width = updates.width;
+				}
+				if (updates.height !== undefined) {
+					dbUpdates.height = updates.height;
+				}
+				if (updates.description !== undefined) {
+					dbUpdates.description = updates.description;
+				}
+				if (updates.createdAt !== undefined) {
+					dbUpdates.createdAt = updates.createdAt;
+				}
+
+				dbUpdates.modifiedAt = updates.modifiedAt || new Date();
+
+				await client
+					.update(medias)
+					.set(dbUpdates)
+					.where(inArray(medias.id, mediaIds));
+			} catch (error) {
+				throw new UnexpectedError("Failed to bulk update media", error);
+			}
+		},
+
+		async bulkDelete(mediaIds: string[], tx?: Transaction): Promise<void> {
+			if (mediaIds.length === 0) return;
+			try {
+				const client = getExecutor(tx);
+				await client
+					.delete(medias)
+					.where(inArray(medias.id, mediaIds));
+			} catch (error) {
+				throw new UnexpectedError("Failed to bulk delete media", error);
+			}
+		},
+
+		async bulkUpdatePaths(
+			updates: { id: string; filePath: string; fileName: string }[],
+			tx?: Transaction,
+		): Promise<void> {
+			if (updates.length === 0) return;
+			try {
+				const client = getExecutor(tx);
+				for (const u of updates) {
+					await client
+						.update(medias)
+						.set({
+							filePath: u.filePath,
+							fileName: u.fileName,
+							modifiedAt: new Date(),
+						})
+						.where(eq(medias.id, u.id));
+				}
+			} catch (error) {
+				throw new UnexpectedError("Failed to bulk update media paths", error);
+			}
+		},
+
+		async bulkAddTags(
+			mediaIds: string[],
+			tagIds: string[],
+			tx?: Transaction,
+		): Promise<void> {
+			if (mediaIds.length === 0 || tagIds.length === 0) return;
+			try {
+				const client = getExecutor(tx);
+				const values = mediaIds.flatMap((mediaId) =>
+					tagIds.map((tagId) => ({
+						mediaId,
+						tagId,
+						tagType: "positive" as const,
+						confidence: 1.0,
+					})),
+				);
+
+				const CHUNK_SIZE = 500;
+				for (let i = 0; i < values.length; i += CHUNK_SIZE) {
+					const chunk = values.slice(i, i + CHUNK_SIZE);
+					await client
+						.insert(mediaTags)
+						.values(chunk)
+						.onConflictDoNothing({
+							target: [mediaTags.mediaId, mediaTags.tagId],
+						});
+				}
+			} catch (error) {
+				throw new UnexpectedError("Failed to bulk add tags to media", error);
+			}
+		},
+
+		async bulkRemoveTags(
+			mediaIds: string[],
+			tagIds: string[],
+			tx?: Transaction,
+		): Promise<void> {
+			if (mediaIds.length === 0 || tagIds.length === 0) return;
+			try {
+				const client = getExecutor(tx);
+				await client
+					.delete(mediaTags)
+					.where(
+						and(
+							inArray(mediaTags.mediaId, mediaIds),
+							inArray(mediaTags.tagId, tagIds),
+						),
+					);
+			} catch (error) {
+				throw new UnexpectedError("Failed to bulk remove tags from media", error);
+			}
+		},
 	};
 }
+

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -683,6 +683,20 @@ export function createMediaRepository(
 			}
 		},
 
+		async findByIds(mediaIds: string[], tx?: Transaction): Promise<Media[]> {
+			if (mediaIds.length === 0) return [];
+			try {
+				const client = getExecutor(tx);
+				const results = await client
+					.select()
+					.from(medias)
+					.where(inArray(medias.id, mediaIds));
+				return results.map(mapToMedia);
+			} catch (e) {
+				throw new UnexpectedError(`Failed to select media by IDs`, e);
+			}
+		},
+
 		/**
 		 * Retrieves a specific media item by Source ID and File Path.
 		 */
@@ -1438,16 +1452,26 @@ export function createMediaRepository(
 			if (updates.length === 0) return;
 			try {
 				const runUpdates = async (executor: DrizzleExecutor) => {
+					const idList = updates.map((u) => u.id);
+					let filePathSql = sql`case ${medias.id} `;
+					let fileNameSql = sql`case ${medias.id} `;
+
 					for (const u of updates) {
-						await executor
-							.update(medias)
-							.set({
-								filePath: u.filePath,
-								fileName: u.fileName,
-								modifiedAt: new Date(),
-							})
-							.where(eq(medias.id, u.id));
+						filePathSql = sql`${filePathSql} when ${u.id} then ${u.filePath} `;
+						fileNameSql = sql`${fileNameSql} when ${u.id} then ${u.fileName} `;
 					}
+
+					filePathSql = sql`${filePathSql} else ${medias.filePath} end`;
+					fileNameSql = sql`${fileNameSql} else ${medias.fileName} end`;
+
+					await executor
+						.update(medias)
+						.set({
+							filePath: filePathSql,
+							fileName: fileNameSql,
+							modifiedAt: new Date(),
+						})
+						.where(inArray(medias.id, idList));
 				};
 
 				if (tx) {

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -687,10 +687,16 @@ export function createMediaRepository(
 			if (mediaIds.length === 0) return [];
 			try {
 				const client = getExecutor(tx);
-				const results = await client
-					.select()
-					.from(medias)
-					.where(inArray(medias.id, mediaIds));
+				const CHUNK_SIZE = 500;
+				const results: any[] = [];
+				for (let i = 0; i < mediaIds.length; i += CHUNK_SIZE) {
+					const chunk = mediaIds.slice(i, i + CHUNK_SIZE);
+					const chunkResults = await client
+						.select()
+						.from(medias)
+						.where(inArray(medias.id, chunk));
+					results.push(...chunkResults);
+				}
 				return results.map(mapToMedia);
 			} catch (e) {
 				throw new UnexpectedError(`Failed to select media by IDs`, e);
@@ -1424,10 +1430,14 @@ export function createMediaRepository(
 
 				dbUpdates.modifiedAt = updates.modifiedAt || new Date();
 
-				await client
-					.update(medias)
-					.set(dbUpdates)
-					.where(inArray(medias.id, mediaIds));
+				const CHUNK_SIZE = 500;
+				for (let i = 0; i < mediaIds.length; i += CHUNK_SIZE) {
+					const chunk = mediaIds.slice(i, i + CHUNK_SIZE);
+					await client
+						.update(medias)
+						.set(dbUpdates)
+						.where(inArray(medias.id, chunk));
+				}
 			} catch (error) {
 				throw new UnexpectedError("Failed to bulk update media", error);
 			}
@@ -1437,9 +1447,13 @@ export function createMediaRepository(
 			if (mediaIds.length === 0) return;
 			try {
 				const client = getExecutor(tx);
-				await client
-					.delete(medias)
-					.where(inArray(medias.id, mediaIds));
+				const CHUNK_SIZE = 500;
+				for (let i = 0; i < mediaIds.length; i += CHUNK_SIZE) {
+					const chunk = mediaIds.slice(i, i + CHUNK_SIZE);
+					await client
+						.delete(medias)
+						.where(inArray(medias.id, chunk));
+				}
 			} catch (error) {
 				throw new UnexpectedError("Failed to bulk delete media", error);
 			}
@@ -1452,26 +1466,30 @@ export function createMediaRepository(
 			if (updates.length === 0) return;
 			try {
 				const runUpdates = async (executor: DrizzleExecutor) => {
-					const idList = updates.map((u) => u.id);
-					let filePathSql = sql`case ${medias.id} `;
-					let fileNameSql = sql`case ${medias.id} `;
+					const CHUNK_SIZE = 500;
+					for (let i = 0; i < updates.length; i += CHUNK_SIZE) {
+						const chunk = updates.slice(i, i + CHUNK_SIZE);
+						const idList = chunk.map((u) => u.id);
+						let filePathSql = sql`case ${medias.id} `;
+						let fileNameSql = sql`case ${medias.id} `;
 
-					for (const u of updates) {
-						filePathSql = sql`${filePathSql} when ${u.id} then ${u.filePath} `;
-						fileNameSql = sql`${fileNameSql} when ${u.id} then ${u.fileName} `;
+						for (const u of chunk) {
+							filePathSql = sql`${filePathSql} when ${u.id} then ${u.filePath} `;
+							fileNameSql = sql`${fileNameSql} when ${u.id} then ${u.fileName} `;
+						}
+
+						filePathSql = sql`${filePathSql} else ${medias.filePath} end`;
+						fileNameSql = sql`${fileNameSql} else ${medias.fileName} end`;
+
+						await executor
+							.update(medias)
+							.set({
+								filePath: filePathSql,
+								fileName: fileNameSql,
+								modifiedAt: new Date(),
+							})
+							.where(inArray(medias.id, idList));
 					}
-
-					filePathSql = sql`${filePathSql} else ${medias.filePath} end`;
-					fileNameSql = sql`${fileNameSql} else ${medias.fileName} end`;
-
-					await executor
-						.update(medias)
-						.set({
-							filePath: filePathSql,
-							fileName: fileNameSql,
-							modifiedAt: new Date(),
-						})
-						.where(inArray(medias.id, idList));
 				};
 
 				if (tx) {

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -181,12 +181,6 @@ export type UseSourceMediaPageResult = {
 	setFileInputRef: (el: HTMLInputElement) => void;
 	restoreInputRef: HTMLInputElement | undefined;
 	setRestoreInputRef: (el: HTMLInputElement) => void;
-	isBulkSelectMode: () => boolean;
-	setIsBulkSelectMode: (mode: boolean) => void;
-	selectedMediaIds: () => string[];
-	setSelectedMediaIds: (ids: string[]) => void;
-	handleToggleSelect: (mediaId: string) => void;
-	isSelected: (mediaId: string) => boolean;
 };
 
 export function useSourceMediaPage(
@@ -366,21 +360,7 @@ export function useSourceMediaPage(
 	const [jobProgress, setJobProgress] = createSignal<JobProgressEvent | null>(
 		null,
 	);
-	const [isBulkSelectMode, setIsBulkSelectMode] = createSignal(false);
-	const [selectedMediaIds, setSelectedMediaIds] = createSignal<string[]>([]);
 
-	const handleToggleSelect = (mediaId: string) => {
-		setIsBulkSelectMode(true);
-		setSelectedMediaIds((prev) =>
-			prev.includes(mediaId)
-				? prev.filter((id) => id !== mediaId)
-				: [...prev, mediaId],
-		);
-	};
-
-	const isSelected = (mediaId: string) => {
-		return selectedMediaIds().includes(mediaId);
-	};
 
 	let fileInputRef: HTMLInputElement | undefined;
 	const setFileInputRef = (el: HTMLInputElement) => {
@@ -961,11 +941,5 @@ export function useSourceMediaPage(
 		setFileInputRef,
 		restoreInputRef,
 		setRestoreInputRef,
-		isBulkSelectMode,
-		setIsBulkSelectMode,
-		selectedMediaIds,
-		setSelectedMediaIds,
-		handleToggleSelect,
-		isSelected,
 	};
 }

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -181,6 +181,12 @@ export type UseSourceMediaPageResult = {
 	setFileInputRef: (el: HTMLInputElement) => void;
 	restoreInputRef: HTMLInputElement | undefined;
 	setRestoreInputRef: (el: HTMLInputElement) => void;
+	isBulkSelectMode: () => boolean;
+	setIsBulkSelectMode: (mode: boolean) => void;
+	selectedMediaIds: () => string[];
+	setSelectedMediaIds: (ids: string[]) => void;
+	handleToggleSelect: (mediaId: string) => void;
+	isSelected: (mediaId: string) => boolean;
 };
 
 export function useSourceMediaPage(
@@ -360,6 +366,21 @@ export function useSourceMediaPage(
 	const [jobProgress, setJobProgress] = createSignal<JobProgressEvent | null>(
 		null,
 	);
+	const [isBulkSelectMode, setIsBulkSelectMode] = createSignal(false);
+	const [selectedMediaIds, setSelectedMediaIds] = createSignal<string[]>([]);
+
+	const handleToggleSelect = (mediaId: string) => {
+		setIsBulkSelectMode(true);
+		setSelectedMediaIds((prev) =>
+			prev.includes(mediaId)
+				? prev.filter((id) => id !== mediaId)
+				: [...prev, mediaId],
+		);
+	};
+
+	const isSelected = (mediaId: string) => {
+		return selectedMediaIds().includes(mediaId);
+	};
 
 	let fileInputRef: HTMLInputElement | undefined;
 	const setFileInputRef = (el: HTMLInputElement) => {
@@ -940,5 +961,11 @@ export function useSourceMediaPage(
 		setFileInputRef,
 		restoreInputRef,
 		setRestoreInputRef,
+		isBulkSelectMode,
+		setIsBulkSelectMode,
+		selectedMediaIds,
+		setSelectedMediaIds,
+		handleToggleSelect,
+		isSelected,
 	};
 }

--- a/packages/ui/src/media-grid-item.tsx
+++ b/packages/ui/src/media-grid-item.tsx
@@ -46,16 +46,19 @@ export function MediaGridItem(props: MediaGridItemProps) {
 		props.canRenderThumbnail?.(props.media) ??
 		props.media.mediaType !== "audio";
 
-	return props.linkComponent({
-		class: cn(
-			"group relative block aspect-[3/4] overflow-hidden rounded-lg bg-gray-100 transition-all hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2",
-			props.isSelected && "ring-4 ring-blue-500 ring-offset-2",
-			props.class,
-		),
-		"data-media-id": props.media.id,
-		href: href(),
-		onContextMenu: (event) => props.onContextMenu?.(event),
-		children: (
+	const LinkComponent = props.linkComponent;
+
+	return (
+		<LinkComponent
+			class={cn(
+				"group relative block aspect-[3/4] overflow-hidden rounded-lg bg-gray-100 transition-all hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2",
+				props.isSelected && "ring-4 ring-blue-500 ring-offset-2",
+				props.class,
+			)}
+			data-media-id={props.media.id}
+			href={href()}
+			onContextMenu={(event) => props.onContextMenu?.(event)}
+		>
 			<>
 				<Show when={props.isBulkSelectMode}>
 					<div class="absolute right-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-full border border-white bg-black/40 text-white">
@@ -104,6 +107,6 @@ export function MediaGridItem(props: MediaGridItemProps) {
 					</p>
 				</div>
 			</>
-		),
-	});
+		</LinkComponent>
+	);
 }

--- a/packages/ui/src/media-grid-item.tsx
+++ b/packages/ui/src/media-grid-item.tsx
@@ -33,6 +33,8 @@ type MediaGridItemProps = {
 	class?: string;
 	thumbnailClass?: string;
 	overlayClass?: string;
+	isBulkSelectMode?: boolean;
+	isSelected?: boolean;
 };
 
 export function MediaGridItem(props: MediaGridItemProps) {
@@ -47,6 +49,7 @@ export function MediaGridItem(props: MediaGridItemProps) {
 	return props.linkComponent({
 		class: cn(
 			"group relative block aspect-[3/4] overflow-hidden rounded-lg bg-gray-100 transition-all hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2",
+			props.isSelected && "ring-4 ring-blue-500 ring-offset-2",
 			props.class,
 		),
 		"data-media-id": props.media.id,
@@ -54,6 +57,17 @@ export function MediaGridItem(props: MediaGridItemProps) {
 		onContextMenu: (event) => props.onContextMenu?.(event),
 		children: (
 			<>
+				<Show when={props.isBulkSelectMode}>
+					<div class="absolute right-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-full border border-white bg-black/40 text-white">
+						<input
+							type="checkbox"
+							checked={props.isSelected}
+							class="h-4 w-4 cursor-pointer rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+							readOnly
+						/>
+					</div>
+				</Show>
+
 				<Show
 					fallback={
 						<div class="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400">

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -32,7 +32,11 @@ export type SourceMediaScreenProps = {
 	/** Render a single media grid item. */
 	renderItem: (
 		media: Media,
-		options: { onContextMenu: () => void },
+		options: {
+			onContextMenu: () => void;
+			isBulkSelectMode?: boolean;
+			isSelected?: boolean;
+		},
 	) => JSX.Element;
 	renderJobProgress?: (props: {
 		jobProgress: () =>
@@ -58,6 +62,9 @@ export type SourceMediaScreenProps = {
 	enableVirtualization?: boolean;
 	/** Show "Open in New Tab" context menu item. Default: false. */
 	showOpenInNewTab?: boolean;
+	onToggleSelect?: (mediaId: string) => void;
+	isBulkSelectMode?: () => boolean;
+	isSelected?: (mediaId: string) => boolean;
 };
 
 export function SourceMediaScreen(props: SourceMediaScreenProps) {
@@ -133,6 +140,9 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 					onDelete={page().handleDelete}
 					onLoadMore={() => page().mediaQuery.fetchNextPage()}
 					onSyncSingleMedia={page().handleSyncSingleMedia}
+					onToggleSelect={props.onToggleSelect}
+					isBulkSelectMode={props.isBulkSelectMode}
+					isSelected={props.isSelected}
 					hasNextPage={page().mediaQuery.hasNextPage}
 					queryError={page().mediaQuery.error ?? null}
 					renderItem={props.renderItem}

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -65,6 +65,9 @@ export type SourceMediaScreenProps = {
 	onToggleSelect?: (mediaId: string) => void;
 	isBulkSelectMode?: () => boolean;
 	isSelected?: (mediaId: string) => boolean;
+	onBulkAction?: () => void;
+	onClearSelection?: () => void;
+	selectedCount?: () => number;
 };
 
 export function SourceMediaScreen(props: SourceMediaScreenProps) {
@@ -143,6 +146,9 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 					onToggleSelect={props.onToggleSelect}
 					isBulkSelectMode={props.isBulkSelectMode}
 					isSelected={props.isSelected}
+					onBulkAction={props.onBulkAction}
+					onClearSelection={props.onClearSelection}
+					selectedCount={props.selectedCount}
 					hasNextPage={page().mediaQuery.hasNextPage}
 					queryError={page().mediaQuery.error ?? null}
 					renderItem={props.renderItem}

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -35,6 +35,9 @@ type SourceMediaGridProps = {
 	onDelete?: (mediaId: string) => void;
 	onCopyMove?: (mediaId: string, mode: "copy" | "move") => void;
 	onSyncSingleMedia?: (mediaId: string) => void;
+	onToggleSelect?: (mediaId: string) => void;
+	isBulkSelectMode?: () => boolean;
+	isSelected?: (mediaId: string) => boolean;
 	setLoadMoreRef: (el: HTMLDivElement) => void;
 	/** Whether there are more pages to load. */
 	hasNextPage?: boolean;
@@ -43,7 +46,11 @@ type SourceMediaGridProps = {
 	/** Render a single media grid item. */
 	renderItem: (
 		media: Media,
-		options: { onContextMenu: () => void },
+		options: {
+			onContextMenu: () => void;
+			isBulkSelectMode?: boolean;
+			isSelected?: boolean;
+		},
 	) => JSX.Element;
 	/** Enable virtualization for large lists. Default: false. */
 	enableVirtualization?: boolean;
@@ -202,6 +209,8 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 							{(media) =>
 								props.renderItem(media, {
 									onContextMenu: onContextMenuHandler(media.id),
+									isBulkSelectMode: props.isBulkSelectMode?.(),
+									isSelected: props.isSelected?.(media.id),
 								})
 							}
 						</For>
@@ -226,6 +235,8 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 									{(media) =>
 										props.renderItem(media, {
 											onContextMenu: onContextMenuHandler(media.id),
+											isBulkSelectMode: props.isBulkSelectMode?.(),
+											isSelected: props.isSelected?.(media.id),
 										})
 									}
 								</For>
@@ -273,6 +284,22 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 							}
 							when={contextMenuMediaId()}
 						>
+							<ContextMenuItem
+								onSelect={() => {
+									const id = contextMenuMediaId();
+									if (id) props.onToggleSelect?.(id);
+								}}
+							>
+								{(() => {
+									const id = contextMenuMediaId();
+									return id && props.isBulkSelectMode?.() && props.isSelected?.(id)
+										? "Deselect"
+										: "Select";
+								})()}
+							</ContextMenuItem>
+
+							<ContextMenuSeparator />
+
 							<Show when={showOpenInNewTab()}>
 								<ContextMenuItem
 									onSelect={() => {

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -38,6 +38,9 @@ type SourceMediaGridProps = {
 	onToggleSelect?: (mediaId: string) => void;
 	isBulkSelectMode?: () => boolean;
 	isSelected?: (mediaId: string) => boolean;
+	onBulkAction?: () => void;
+	onClearSelection?: () => void;
+	selectedCount?: () => number;
 	setLoadMoreRef: (el: HTMLDivElement) => void;
 	/** Whether there are more pages to load. */
 	hasNextPage?: boolean;
@@ -209,8 +212,12 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 							{(media) =>
 								props.renderItem(media, {
 									onContextMenu: onContextMenuHandler(media.id),
-									isBulkSelectMode: props.isBulkSelectMode?.(),
-									isSelected: props.isSelected?.(media.id),
+									get isBulkSelectMode() {
+										return props.isBulkSelectMode?.();
+									},
+									get isSelected() {
+										return props.isSelected?.(media.id);
+									},
 								})
 							}
 						</For>
@@ -235,8 +242,12 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 									{(media) =>
 										props.renderItem(media, {
 											onContextMenu: onContextMenuHandler(media.id),
-											isBulkSelectMode: props.isBulkSelectMode?.(),
-											isSelected: props.isSelected?.(media.id),
+											get isBulkSelectMode() {
+												return props.isBulkSelectMode?.();
+											},
+											get isSelected() {
+												return props.isSelected?.(media.id);
+											},
 										})
 									}
 								</For>
@@ -299,6 +310,24 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 							</ContextMenuItem>
 
 							<ContextMenuSeparator />
+
+							<Show when={props.isBulkSelectMode?.() && (props.selectedCount?.() ?? 0) > 0}>
+								<ContextMenuItem
+									onSelect={() => {
+										props.onBulkAction?.();
+									}}
+								>
+									Run bulk operations ({props.selectedCount?.()} selected)
+								</ContextMenuItem>
+								<ContextMenuItem
+									onSelect={() => {
+										props.onClearSelection?.();
+									}}
+								>
+									Clear selection
+								</ContextMenuItem>
+								<ContextMenuSeparator />
+							</Show>
 
 							<Show when={showOpenInNewTab()}>
 								<ContextMenuItem

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -44,6 +44,9 @@ export type SourceMediaPageProps = {
 	onToggleSelect?: (mediaId: string) => void;
 	isBulkSelectMode?: () => boolean;
 	isSelected?: (mediaId: string) => boolean;
+	onBulkAction?: () => void;
+	onClearSelection?: () => void;
+	selectedCount?: () => number;
 };
 
 export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
@@ -100,6 +103,9 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 			onToggleSelect={props.onToggleSelect}
 			isBulkSelectMode={props.isBulkSelectMode}
 			isSelected={props.isSelected}
+			onBulkAction={props.onBulkAction}
+			onClearSelection={props.onClearSelection}
+			selectedCount={props.selectedCount}
 		/>
 	);
 }

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -41,6 +41,9 @@ export type SourceMediaPageProps = {
 	uploadModalComponent: SourceMediaScreenProps["uploadModalComponent"];
 	renderItem: SourceMediaScreenProps["renderItem"];
 	showOpenInNewTab?: boolean;
+	onToggleSelect?: (mediaId: string) => void;
+	isBulkSelectMode?: () => boolean;
+	isSelected?: (mediaId: string) => boolean;
 };
 
 export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
@@ -94,6 +97,9 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 			moveCopyDialogComponent={props.moveCopyDialogComponent}
 			uploadModalComponent={props.uploadModalComponent}
 			showOpenInNewTab={props.showOpenInNewTab}
+			onToggleSelect={props.onToggleSelect}
+			isBulkSelectMode={props.isBulkSelectMode}
+			isSelected={props.isSelected}
 		/>
 	);
 }


### PR DESCRIPTION
## 概要
メディアリスト画面において、複数のメディアを右クリックから一括選択モードで選択し、別ソースへの一括コピー、一括移動、同一ソース内のフォルダ移動、および一括削除を行えるUIおよびAPIを実装しました。

## 変更内容
### バックエンド API & スキーマ (packages/core, apps/server)
- 一括コピー bulkCopyToSource および一括移動 bulkMoveToSource 用のリクエスト Zod スキーマを定義。
- bulk-operation-service.ts を実装し、非同期で転送処理を行うロジックを追加。
- oRPCルーターおよびAPIクライアントに該当エンドポイントと関数を追加。

### フロントエンド UI (packages/ui, apps/server)
- グリッドアイテムで一括選択モード時にチェックボックスを表示し、カード全体のクリックでトグル可能に修正。
- 右クリックコンテキストメニューに「一括選択」項目を追加。
- 一括コピー/移動先のメディアソース選択や削除確認を行う bulk-action-dialog.tsx を新規作成。
- source-media-page.tsx で一括選択状態の管理、フローティングツールバーの表示、およびモーダルとの連携を実装。

## 検証結果
- 型チェック (bun run typecheck) にてエラーのないことを確認。
- 自動テスト (bun run test) にて全ユニット/インテグレーションテストがパスすることを確認。
- OpenAPI仕様 (openapi.json) の再生成および更新。
