### PR TITLE
perf(ui): 重複メディアの削除処理をバルク化

### DIFF
--- a/apps/server/src/routes/manager.tsx
+++ b/apps/server/src/routes/manager.tsx
@@ -23,6 +23,7 @@ import {
 	updateIp,
 } from "~/infrastructure/api-clients/ips-api";
 import {
+	bulkDeleteMedia,
 	deleteMedia,
 	findDuplicateMedia,
 } from "~/infrastructure/api-clients/media-api";
@@ -59,6 +60,7 @@ const managerActions = {
 	startBatchTaggingWithIds,
 	findDuplicateMedia,
 	deleteMedia,
+	bulkDeleteMedia,
 };
 
 export const Route = createFileRoute("/manager")({

--- a/apps/server/src/routes/manager.tsx
+++ b/apps/server/src/routes/manager.tsx
@@ -24,7 +24,6 @@ import {
 } from "~/infrastructure/api-clients/ips-api";
 import {
 	bulkDeleteMedia,
-	deleteMedia,
 	findDuplicateMedia,
 } from "~/infrastructure/api-clients/media-api";
 import {
@@ -59,7 +58,6 @@ const managerActions = {
 	scanBatchTaggingTargets,
 	startBatchTaggingWithIds,
 	findDuplicateMedia,
-	deleteMedia,
 	bulkDeleteMedia,
 };
 

--- a/apps/tauri/src/api/media-api.ts
+++ b/apps/tauri/src/api/media-api.ts
@@ -37,3 +37,8 @@ export function findDuplicateMedia(mediaSourceId?: string) {
 		mediaSourceId ? { mediaSourceId } : undefined,
 	);
 }
+
+export function bulkDeleteMedia(sourceId: string, mediaIds: string[]) {
+	return client.media.bulkDelete({ mediaSourceId: sourceId, mediaIds });
+}
+

--- a/apps/tauri/src/infrastructure/api-clients/media-api.ts
+++ b/apps/tauri/src/infrastructure/api-clients/media-api.ts
@@ -6,6 +6,7 @@ export {
 	moveMedia,
 	searchMedia,
 	syncMediaItems,
+	bulkDeleteMedia,
 } from "~/api/media-api";
 
 import type { DownloadItem, UpdateMediaRequest } from "@solid-imager/core/domain/media/schemas";

--- a/apps/tauri/src/routes/manager.tsx
+++ b/apps/tauri/src/routes/manager.tsx
@@ -23,6 +23,7 @@ import {
 	updateIp,
 } from "~/infrastructure/api-clients/ips-api";
 import {
+	bulkDeleteMedia,
 	deleteMedia,
 	findDuplicateMedia,
 } from "~/infrastructure/api-clients/media-api";
@@ -59,6 +60,7 @@ const managerActions = {
 	startBatchTaggingWithIds,
 	findDuplicateMedia,
 	deleteMedia,
+	bulkDeleteMedia,
 };
 
 export const Route = createFileRoute("/manager")({

--- a/apps/tauri/src/routes/manager.tsx
+++ b/apps/tauri/src/routes/manager.tsx
@@ -24,7 +24,6 @@ import {
 } from "~/infrastructure/api-clients/ips-api";
 import {
 	bulkDeleteMedia,
-	deleteMedia,
 	findDuplicateMedia,
 } from "~/infrastructure/api-clients/media-api";
 import {
@@ -59,7 +58,6 @@ const managerActions = {
 	scanBatchTaggingTargets,
 	startBatchTaggingWithIds,
 	findDuplicateMedia,
-	deleteMedia,
 	bulkDeleteMedia,
 };
 

--- a/packages/core/src/domain/contract/media.contract.ts
+++ b/packages/core/src/domain/contract/media.contract.ts
@@ -1,6 +1,7 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
 import {
+	bulkDeleteMediaRequestSchema,
 	findDuplicatesRequestSchema,
 	findDuplicatesResponseSchema,
 	mediaDetailsSchema,
@@ -131,4 +132,8 @@ export const mediaContract = {
 	findDuplicates: oc
 		.input(findDuplicatesRequestSchema.optional())
 		.output(findDuplicatesResponseSchema),
+
+	bulkDelete: oc
+		.input(bulkDeleteMediaRequestSchema)
+		.output(z.object({ success: z.boolean() })),
 };

--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -76,7 +76,6 @@ export type ManagerPageActions = {
 	findDuplicateMedia: (
 		mediaSourceId?: string,
 	) => Promise<{ groups: DuplicateGroup[] }>;
-	deleteMedia: (sourceId: string, mediaId: string) => Promise<unknown>;
 	bulkDeleteMedia: (sourceId: string, mediaIds: string[]) => Promise<unknown>;
 	invalidate: (entityType: Exclude<ManagerEntityType, "tagging">) => void;
 };
@@ -561,6 +560,9 @@ export function useManagerPage(
 
 	const handleConfirmDeleteDuplicates = async () => {
 		const toDelete = duplicatesToDelete();
+		if (toDelete.length === 0) {
+			return;
+		}
 		let deleted = 0;
 		let failed = 0;
 		const deletedIds = new Set<string>();

--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -77,6 +77,7 @@ export type ManagerPageActions = {
 		mediaSourceId?: string,
 	) => Promise<{ groups: DuplicateGroup[] }>;
 	deleteMedia: (sourceId: string, mediaId: string) => Promise<unknown>;
+	bulkDeleteMedia: (sourceId: string, mediaIds: string[]) => Promise<unknown>;
 	invalidate: (entityType: Exclude<ManagerEntityType, "tagging">) => void;
 };
 
@@ -564,14 +565,25 @@ export function useManagerPage(
 		let failed = 0;
 		const deletedIds = new Set<string>();
 
+		// Group by sourceId to perform bulk deletion
+		const groupsBySource = new Map<string, string[]>();
+		for (const item of toDelete) {
+			if (!groupsBySource.has(item.sourceId)) {
+				groupsBySource.set(item.sourceId, []);
+			}
+			groupsBySource.get(item.sourceId)!.push(item.mediaId);
+		}
+
 		try {
-			for (const item of toDelete) {
+			for (const [sourceId, mediaIds] of groupsBySource.entries()) {
 				try {
-					await actions.deleteMedia(item.sourceId, item.mediaId);
-					deleted++;
-					deletedIds.add(item.mediaId);
+					await actions.bulkDeleteMedia(sourceId, mediaIds);
+					deleted += mediaIds.length;
+					for (const id of mediaIds) {
+						deletedIds.add(id);
+					}
 				} catch {
-					failed++;
+					failed += mediaIds.length;
 				}
 			}
 		} finally {


### PR DESCRIPTION
## 概要
重複検知（Manager画面の重複管理タブ）で選択されたメディアの削除処理を、従来の逐次（ループによる1件ずつの削除）から、sourceId ごとにグループ化したバルク（一括）削除に切り替えます。

## 変更内容
- useManagerPage.ts 内で削除対象リストを sourceId ごとにグループ化し、一括削除を呼び出すよう修正
- 共通の oRPC 契約 (mediaContract) に bulkDelete エンドポイントの定義を追加
- Tauri アプリ向けの API クライアントに bulkDeleteMedia を定義・エクスポート
- UI 管理画面のアクション引数 managerActions に bulkDeleteMedia を追加