### PR TITLE
fix(server): Bun.Imageのフォーマット判定をマジックバイトベースに変更

### DIFF
--- a/apps/server/src/infrastructure/processing/image-processor.ts
+++ b/apps/server/src/infrastructure/processing/image-processor.ts
@@ -112,7 +112,10 @@ export class LocalImageProcessor implements IImageProcessor {
 
 		// Default image processing
 		try {
-			await new Bun.Image(mediaPath)
+			// Use buffer to allow Bun.Image to auto-detect format from magic bytes,
+			// avoiding issues with mismatched extensions (e.g. JPEG data saved as .png)
+			const buffer = Buffer.from(await Bun.file(mediaPath).arrayBuffer());
+			await new Bun.Image(buffer)
 				.resize(size, size, { fit: "inside", withoutEnlargement: true })
 				.webp({ quality: _quality })
 				.write(outputPath);
@@ -169,8 +172,15 @@ export class LocalImageProcessor implements IImageProcessor {
 
 			const comments: ImageMetadataComment[] = [];
 
-			// 1. Extract PNG chunks (tEXt) if it's a PNG file
-			if (ext === ".png") {
+			// 1. Extract PNG chunks (tEXt) — detect by magic bytes, not extension
+			// PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A
+			const isPng =
+				fileBuffer.length >= 8 &&
+				fileBuffer[0] === 0x89 &&
+				fileBuffer[1] === 0x50 &&
+				fileBuffer[2] === 0x4e &&
+				fileBuffer[3] === 0x47;
+			if (isPng) {
 				try {
 					const chunks = extract(fileBuffer);
 					for (const chunk of chunks) {
@@ -308,7 +318,8 @@ export class LocalImageProcessor implements IImageProcessor {
 			});
 		}
 
-		const metadata = await new Bun.Image(mediaPath).metadata();
+		const buffer = Buffer.from(await Bun.file(mediaPath).arrayBuffer());
+		const metadata = await new Bun.Image(buffer).metadata();
 		if (metadata.width === undefined || metadata.height === undefined) {
 			throw new Error(`Failed to get dimensions for image: ${mediaPath}`);
 		}

--- a/apps/server/src/infrastructure/storage/server-media-storage.ts
+++ b/apps/server/src/infrastructure/storage/server-media-storage.ts
@@ -221,7 +221,8 @@ export const ServerMediaStorage: IMediaStorage = {
 
 		// Image formats (try Bun.Image first, fall back to ffprobe for misidentified videos)
 		try {
-			const metadata = await new Bun.Image(fullPath).metadata();
+			const buffer = Buffer.from(await Bun.file(fullPath).arrayBuffer());
+			const metadata = await new Bun.Image(buffer).metadata();
 
 			if (metadata.width && metadata.height) {
 				return {


### PR DESCRIPTION
## 概要
xtracter経由でダウンロードしたTwitter画像が拡張子`.png`で保存されるが実データはJPEGのため、Bun.Imageでのサムネイル生成に失敗する問題を修正。

## 変更内容
- `generateThumbnail` / `getDimensions`: ファイルパスではなくバッファをBun.Imageに渡し、マジックバイトから自動フォーマット判定させる
- `extractMetadata`: PNG chunk抽出の判定を`ext === ".png"`からPNGマジックバイトチェックに変更
- `server-media-storage`: `getFileMetadata`も同様にバッファ経由に変更

## 技術詳細
sharpはマジックバイトベースでフォーマット判定していたが、Bun.Imageはファイルパス渡しだと拡張子に依存する場合がある。バッファ経由で渡すことでマジックバイトベースの自動判定を実現。