### PR TITLE
fix(manager): duplicate detection respects source boundaries

### DIFF
--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -1195,44 +1195,55 @@ export function createMediaRepository(
         mediaMap.set(row.id, row);
       }
 
-      const groups: DuplicateGroup[] = [];
-
-      // Group by source URL complete match (all URLs must match)
-      const byUrlSet = new Map<string, string[]>();
+      // Group media by source ID
+      const mediaBySource = new Map<string, (typeof mediaRows)[number][]>();
       for (const row of mediaRows) {
-        const urls = (urlsByMediaId.get(row.id) || []).slice().sort();
-        if (urls.length < 2) continue;
-        const key = urls.join("\0");
-        const arr = byUrlSet.get(key) || [];
-        arr.push(row.id);
-        byUrlSet.set(key, arr);
+        const arr = mediaBySource.get(row.mediaSourceId) || [];
+        arr.push(row);
+        mediaBySource.set(row.mediaSourceId, arr);
       }
 
+      const groups: DuplicateGroup[] = [];
       let urlGroupIndex = 0;
-      for (const [, ids] of byUrlSet) {
-        if (ids.length < 2) continue;
-        const group = ids.map((id) => {
-          // biome-ignore lint/style/noNonNullAssertion: ID mapped from mediaRows
-          const row = mediaMap.get(id)!;
-          return {
-            id: row.id,
-            mediaSourceId: row.mediaSourceId,
-            fileName: row.fileName,
-            filePath: row.filePath,
-            fileSize: row.fileSize,
-            width: row.width,
-            height: row.height,
-            mediaType: row.mediaType,
-            createdAt: row.createdAt,
-            modifiedAt: row.modifiedAt,
-            sourceUrls: urlsByMediaId.get(id) || [],
-          };
-        });
-        groups.push({
-          id: `url-${urlGroupIndex++}`,
-          reason: "sourceUrl",
-          media: group,
-        });
+
+      // Process each source independently
+      for (const [, sourceMediaRows] of mediaBySource) {
+        // Group by source URL complete match (all URLs must match)
+        const byUrlSet = new Map<string, string[]>();
+        for (const row of sourceMediaRows) {
+          const urls = (urlsByMediaId.get(row.id) || []).slice().sort();
+          if (urls.length < 2) continue;
+          const key = urls.join("\0");
+          const arr = byUrlSet.get(key) || [];
+          arr.push(row.id);
+          byUrlSet.set(key, arr);
+        }
+
+        for (const [, ids] of byUrlSet) {
+          if (ids.length < 2) continue;
+          const group = ids.map((id) => {
+            // biome-ignore lint/style/noNonNullAssertion: ID mapped from mediaRows
+            const row = mediaMap.get(id)!;
+            return {
+              id: row.id,
+              mediaSourceId: row.mediaSourceId,
+              fileName: row.fileName,
+              filePath: row.filePath,
+              fileSize: row.fileSize,
+              width: row.width,
+              height: row.height,
+              mediaType: row.mediaType,
+              createdAt: row.createdAt,
+              modifiedAt: row.modifiedAt,
+              sourceUrls: urlsByMediaId.get(id) || [],
+            };
+          });
+          groups.push({
+            id: `url-${urlGroupIndex++}`,
+            reason: "sourceUrl",
+            media: group,
+          });
+        }
       }
 
       return { groups };

--- a/packages/ui/src/screens/manager-screen.tsx
+++ b/packages/ui/src/screens/manager-screen.tsx
@@ -93,6 +93,8 @@ function isCharacter(item: ManagerEntity) {
 	return "ips" in item;
 }
 
+const ALL_SOURCES_OPTION = { id: "__all__", name: "All Sources" };
+
 export function ManagerScreen(props: ManagerScreenProps) {
 	const manager = () => props.manager;
 
@@ -298,7 +300,7 @@ export function ManagerScreen(props: ManagerScreenProps) {
 										)
 									}
 									options={[
-										{ id: "__all__", name: "All Sources" },
+										ALL_SOURCES_OPTION,
 										...manager().sources(),
 									]}
 									optionTextValue="name"
@@ -312,7 +314,7 @@ export function ManagerScreen(props: ManagerScreenProps) {
 														(source) =>
 															source.id === manager().duplicateSourceId(),
 													)
-											: { id: "__all__", name: "All Sources" }
+											: ALL_SOURCES_OPTION
 									}
 								>
 									<SelectTrigger>

--- a/packages/ui/src/screens/manager-screen.tsx
+++ b/packages/ui/src/screens/manager-screen.tsx
@@ -293,9 +293,14 @@ export function ManagerScreen(props: ManagerScreenProps) {
 										</SelectItem>
 									)}
 									onChange={(value) =>
-										manager().setDuplicateSourceId(value?.id)
+										manager().setDuplicateSourceId(
+											value?.id === "__all__" ? undefined : value?.id,
+										)
 									}
-									options={manager().sources()}
+									options={[
+										{ id: "__all__", name: "All Sources" },
+										...manager().sources(),
+									]}
 									optionTextValue="name"
 									optionValue="id"
 									placeholder="All Sources"
@@ -307,7 +312,7 @@ export function ManagerScreen(props: ManagerScreenProps) {
 														(source) =>
 															source.id === manager().duplicateSourceId(),
 													)
-											: null
+											: { id: "__all__", name: "All Sources" }
 									}
 								>
 									<SelectTrigger>


### PR DESCRIPTION
## 概要
managerのdetect duplicate機能で、source選択をリセットできるようにし、source単位で重複検出を行うように修正。

## 変更内容

- Selectコンポーネントに「All Sources」オプションを追加
- source選択をリセットして「All」に戻せるように修正
- findDuplicatesをsourceIdでグループ化し、source間の重複検出を防止

## 技術詳細
- UI:  のSelectにオプションを追加
- DB:  のfindDuplicatesをmediaSourceIdでグループ化