### PR TITLE
perf(lancedb): page sync pruning

### DIFF
--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -7,7 +7,7 @@ import {
 import { localConnectionSchema } from "@solid-imager/core/domain/sources/schemas";
 import { getErrorMessage } from "@solid-imager/core/utils/get-error-message";
 import type { Table } from "drizzle-orm";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, sql } from "drizzle-orm";
 import type { PgColumn } from "drizzle-orm/pg-core";
 import { db, type TransactionClient } from "~/infrastructure/db";
 import {
@@ -1107,17 +1107,22 @@ export const BackupService = {
 			lastSynced = 0;
 		}
 
-		const { gte } = await import("drizzle-orm");
-
-		const activeRows = await db
-			.select({ id: medias.id })
-			.from(medias)
-			.where(eq(medias.mediaSourceId, mediaSourceId));
-		const activeIds = activeRows.map((r) => r.id);
-
 		const { syncLanceDB } = await import(
 			"~/application/services/lancedb-dump-service"
 		);
+		const resolveActiveIds = async (candidateIds: string[]) => {
+			if (candidateIds.length === 0) return [];
+			const activeRows = await db
+				.select({ id: medias.id })
+				.from(medias)
+				.where(
+					and(
+						eq(medias.mediaSourceId, mediaSourceId),
+						inArray(medias.id, candidateIds),
+					),
+				);
+			return activeRows.map((row) => row.id);
+		};
 
 		const limit = 500;
 		let offset = 0;
@@ -1150,7 +1155,10 @@ export const BackupService = {
 			}
 
 			const transformedItems = this._transformMediaList(mediaList);
-			await syncLanceDB(cacheDir, transformedItems, activeIds);
+			await syncLanceDB(cacheDir, transformedItems, {
+				optimize: false,
+				pruneMissing: false,
+			});
 			totalUpserted += transformedItems.length;
 
 			if (mediaList.length < limit) {
@@ -1159,9 +1167,7 @@ export const BackupService = {
 			offset += limit;
 		}
 
-		if (totalUpserted === 0) {
-			await syncLanceDB(cacheDir, [], activeIds);
-		}
+		await syncLanceDB(cacheDir, [], { resolveActiveIds });
 
 		await fs.writeFile(lastSyncedFile, Date.now().toString(), "utf-8");
 		logger.info(

--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -5,7 +5,7 @@ export type { MediaDumpItemWithImageData } from "@solid-imager/application/ports
 import { logger } from "~/infrastructure/logger";
 
 // LanceDB メモリプールサイズはアプリケーションエントリポイントで設定
-process.env.LANCE_MEM_POOL_SIZE ??= "2147483648";
+process.env.LANCE_MEM_POOL_SIZE ??= "536870912";
 
 const service = createLanceDbDumpService({
 	logger: {

--- a/apps/server/src/tests/unit/application/services/lancedb-dump-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/lancedb-dump-service.test.ts
@@ -420,10 +420,18 @@ describe("LanceDB Dump Service", () => {
 
 			mockOpenTable.mockResolvedValue(mockTable);
 
+			const mockSelectToArray = vi
+				.fn()
+				.mockResolvedValueOnce([{ id: "item-1" }, { id: "item-2" }])
+				.mockResolvedValueOnce([]);
+			const mockSelectOffset = vi.fn().mockReturnValue({
+				toArray: mockSelectToArray,
+			});
+			const mockSelectLimit = vi.fn().mockReturnValue({
+				offset: mockSelectOffset,
+			});
 			const mockSelect = vi.fn().mockReturnValue({
-				toArray: vi
-					.fn()
-					.mockResolvedValue([{ id: "item-1" }, { id: "item-2" }]),
+				limit: mockSelectLimit,
 			});
 			mockQuery.mockReturnValue({
 				select: mockSelect,
@@ -440,18 +448,22 @@ describe("LanceDB Dump Service", () => {
 					mediaType: "image",
 				},
 			];
-			const activeIds = ["item-1", "item-3"];
+			const resolveActiveIds = vi.fn().mockResolvedValue(["item-1"]);
 
 			const path = await import("node:path");
 			const fs = await import("node:fs/promises");
 			const testPath = path.join(process.cwd(), ".cache", "test-sync-lancedb");
 
 			try {
-				await service.syncLanceDB(testPath, itemsToUpsert, activeIds);
+				await service.syncLanceDB(testPath, itemsToUpsert, {
+					existingIdPageSize: 2,
+					resolveActiveIds,
+				});
 
 				expect(mockMergeInsert).toHaveBeenCalledWith("id");
 				expect(mockExecute).toHaveBeenCalledTimes(1);
 				expect(mockExecute.mock.calls[0][0][0].id).toBe("item-3");
+				expect(resolveActiveIds).toHaveBeenCalledWith(["item-1", "item-2"]);
 
 				expect(mockDelete).toHaveBeenCalledTimes(1);
 				expect(mockDelete).toHaveBeenCalledWith("id IN ('item-2')");

--- a/packages/application/src/ports/index.ts
+++ b/packages/application/src/ports/index.ts
@@ -1,27 +1,32 @@
-export type { ICategoryService } from "./category-service";
-export type { ITagService } from "./tag-service";
-export type { IPresetService } from "./preset-service";
-export type { IUserService } from "./user-service";
-export type { ICollectionService } from "./collection-service";
-export type { IProjectService } from "./project-service";
-export type { IIpService } from "./ip-service";
 export type { IAuthorService } from "./author-service";
+export type { ICategoryService } from "./category-service";
 export type { ICharacterService } from "./character-service";
-export type { IMediaProcessingService } from "./media-processing-service";
-export type { IThumbnailService } from "./thumbnail-service";
-export type { ITaggingService } from "./tagging-service";
-export type { ISearchService, SearchOptions } from "./search-service";
-export type { IMediaService } from "./media-service";
+export type { ICollectionService } from "./collection-service";
+export type { IIpService } from "./ip-service";
 export type {
-  DeferredActions,
-  DeferredJob,
-  DeferredJobs,
-  DeferredSse,
-  IDeferredActionExecutor,
-  ILogger,
-  IMediaContextProcessor,
-  ISseNotifier,
-  IThumbnailManager,
+	ILanceDbDumpService,
+	MediaDumpItemWithImageData,
+	ReadOptions,
+	SyncOptions,
+	WriteOptions,
+} from "./lancedb-dump-service";
+export type { IMediaProcessingService } from "./media-processing-service";
+export type {
+	DeferredActions,
+	DeferredJob,
+	DeferredJobs,
+	DeferredSse,
+	IDeferredActionExecutor,
+	ILogger,
+	IMediaContextProcessor,
+	IMediaService,
+	ISseNotifier,
+	IThumbnailManager,
 } from "./media-service";
-export type { ILanceDbDumpService, MediaDumpItemWithImageData, WriteOptions, ReadOptions } from "./lancedb-dump-service";
-
+export type { IPresetService } from "./preset-service";
+export type { IProjectService } from "./project-service";
+export type { ISearchService, SearchOptions } from "./search-service";
+export type { ITagService } from "./tag-service";
+export type { ITaggingService } from "./tagging-service";
+export type { IThumbnailService } from "./thumbnail-service";
+export type { IUserService } from "./user-service";

--- a/packages/application/src/ports/lancedb-dump-service.ts
+++ b/packages/application/src/ports/lancedb-dump-service.ts
@@ -16,6 +16,17 @@ export type ReadOptions = {
 	onChunk?: (chunk: MediaDumpItemWithImageData[]) => Promise<void>;
 };
 
+export type SyncOptions = {
+	pruneMissing?: boolean;
+	optimize?: boolean;
+	activeIds?: string[];
+	resolveActiveIds?: (
+		candidateIds: string[],
+	) => Promise<ReadonlySet<string> | string[]>;
+	existingIdPageSize?: number;
+	deleteChunkSize?: number;
+};
+
 export interface ILanceDbDumpService {
 	writeToLanceDB(
 		items: MediaDumpItem[],
@@ -24,7 +35,7 @@ export interface ILanceDbDumpService {
 	syncLanceDB(
 		lanceDbDir: string,
 		itemsToUpsert: MediaDumpItem[],
-		activeIds: string[],
+		options?: SyncOptions,
 	): Promise<void>;
 	readFromLanceDB(
 		lanceDbDir: string,

--- a/packages/application/src/services/lancedb-dump-service.ts
+++ b/packages/application/src/services/lancedb-dump-service.ts
@@ -5,11 +5,14 @@ import type {
 	ILanceDbDumpService,
 	MediaDumpItemWithImageData,
 	ReadOptions,
+	SyncOptions,
 	WriteOptions,
 } from "../ports/lancedb-dump-service";
 
 const METADATA_CHUNK_SIZE = 1000;
 const IMAGE_CHUNK_SIZE = 100;
+const EXISTING_ID_PAGE_SIZE = 1000;
+const DELETE_CHUNK_SIZE = 500;
 
 function resolveSafeChildPath(
 	baseDir: string,
@@ -402,6 +405,10 @@ type LanceConnectFn = (
 	opts?: Record<string, unknown>,
 ) => Promise<LanceDbLike>;
 
+function escapeLanceSqlString(value: string): string {
+	return value.replaceAll("'", "''");
+}
+
 export function createLanceDbDumpService(deps?: {
 	logger?: {
 		info(msg: string, data?: unknown): void;
@@ -424,7 +431,7 @@ export function createLanceDbDumpService(deps?: {
 	async function syncLanceDB(
 		lanceDbDir: string,
 		itemsToUpsert: MediaDumpItem[],
-		activeIds: string[],
+		options: SyncOptions = {},
 	): Promise<void> {
 		await fs.mkdir(lanceDbDir, { recursive: true });
 
@@ -452,28 +459,79 @@ export function createLanceDbDumpService(deps?: {
 			}
 		}
 
-		const allRows = await table.query().select(["id"]).toArray();
-		const lanceDbIds = allRows.map((r) => r.id as string).filter(Boolean);
+		const pruneMissing = options.pruneMissing ?? true;
+		let deleteCount = 0;
 
-		const activeIdSet = new Set(activeIds);
-		const idsToDelete = lanceDbIds.filter((id) => !activeIdSet.has(id));
+		if (pruneMissing) {
+			const activeIdSet = options.activeIds
+				? new Set(options.activeIds)
+				: undefined;
+			const pageSize = options.existingIdPageSize ?? EXISTING_ID_PAGE_SIZE;
+			const deleteChunkSize = options.deleteChunkSize ?? DELETE_CHUNK_SIZE;
+			const idsToDelete: string[] = [];
+			let offset = 0;
 
-		if (idsToDelete.length > 0) {
-			const chunkSize = 500;
-			for (let i = 0; i < idsToDelete.length; i += chunkSize) {
-				const chunk = idsToDelete.slice(i, i + chunkSize);
-				const whereClause = `id IN (${chunk.map((id) => `'${id}'`).join(",")})`;
-				await table.delete(whereClause);
+			while (true) {
+				const rows = await table
+					.query()
+					.select(["id"])
+					.limit(pageSize)
+					.offset(offset)
+					.toArray();
+				const candidateIds = rows
+					.map((row) => row.id)
+					.filter(
+						(id): id is string => typeof id === "string" && id.length > 0,
+					);
+
+				if (candidateIds.length === 0) {
+					if (rows.length < pageSize) break;
+					offset += rows.length;
+					continue;
+				}
+
+				let pageActiveIds: ReadonlySet<string>;
+				if (activeIdSet) {
+					pageActiveIds = activeIdSet;
+				} else if (options.resolveActiveIds) {
+					const resolved = await options.resolveActiveIds(candidateIds);
+					pageActiveIds =
+						resolved instanceof Set ? resolved : new Set(resolved);
+				} else {
+					pageActiveIds = new Set(candidateIds);
+				}
+
+				for (const id of candidateIds) {
+					if (!pageActiveIds.has(id)) {
+						idsToDelete.push(id);
+					}
+				}
+
+				if (rows.length < pageSize) break;
+				offset += rows.length;
+			}
+
+			if (idsToDelete.length > 0) {
+				for (let i = 0; i < idsToDelete.length; i += deleteChunkSize) {
+					const chunk = idsToDelete.slice(i, i + deleteChunkSize);
+					const whereClause = `id IN (${chunk
+						.map((id) => `'${escapeLanceSqlString(id)}'`)
+						.join(",")})`;
+					await table.delete(whereClause);
+				}
+				deleteCount = idsToDelete.length;
 			}
 		}
 
-		await table.optimize({
-			cleanupOlderThan: new Date(Date.now() - 1000 * 60 * 5),
-		});
+		if (options.optimize ?? true) {
+			await table.optimize({
+				cleanupOlderThan: new Date(Date.now() - 1000 * 60 * 5),
+			});
+		}
 		log.info("LanceDB cache synced", {
 			path: lanceDbDir,
 			upsertCount: itemsToUpsert.length,
-			deleteCount: idsToDelete.length,
+			deleteCount,
 		});
 	}
 


### PR DESCRIPTION
## 概要
LanceDB同期時に既存IDとactive IDを全件メモリに保持していた処理をページング化し、同期ジョブのピークメモリを抑えます。

## 変更内容
- LanceDB既存IDの削除判定をページングし、候補IDごとにDBへactive確認するよう変更
- upsert中の削除判定とoptimizeを抑制し、最後に1回だけpruneとoptimizeを実行
- LanceDBメモリプールのデフォルトを512MBへ調整
- syncLanceDBのテストをページング削除の挙動に更新

## 検証
- rtk bun --filter @solid-imager/server typecheck
- rtk bun --filter @solid-imager/application typecheck
- rtk bun run lint

## 補足
対象ユニットテストは実行を試しましたが、Vitest worker起動タイムアウトでテスト本体前に失敗しました。