### PR TITLE
fix(db): 起動時のLanceDB同期負荷を抑制

### DIFF
--- a/apps/server/drizzle/0015_green_gargoyle.sql
+++ b/apps/server/drizzle/0015_green_gargoyle.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "lancedb_sync_dirty" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"source_id" uuid NOT NULL,
+	"media_id" uuid NOT NULL,
+	"operation" text DEFAULT 'upsert' NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"last_error" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "lancedb_sync_dirty_source_media_unique" UNIQUE("source_id","media_id")
+);
+--> statement-breakpoint
+ALTER TABLE "lancedb_sync_dirty" ADD CONSTRAINT "lancedb_sync_dirty_source_id_media_sources_id_fk" FOREIGN KEY ("source_id") REFERENCES "public"."media_sources"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_lancedb_sync_dirty_source_updated" ON "lancedb_sync_dirty" USING btree ("source_id","updated_at");

--- a/apps/server/drizzle/meta/0015_snapshot.json
+++ b/apps/server/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2795 @@
+{
+  "id": "f30485ab-bc98-4522-be67-40c91a56287b",
+  "prevId": "82945f77-ade8-495e-b94c-04bb2fb39ce1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_authors_account_id": {
+          "name": "idx_authors_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authors_name": {
+          "name": "idx_authors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#808080'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_ips": {
+      "name": "character_ips",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_id": {
+          "name": "ip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_character_ips_ip_id_character_id": {
+          "name": "idx_character_ips_ip_id_character_id",
+          "columns": [
+            {
+              "expression": "ip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_ips_character_id_characters_id_fk": {
+          "name": "character_ips_character_id_characters_id_fk",
+          "tableFrom": "character_ips",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_ips_ip_id_ips_id_fk": {
+          "name": "character_ips_ip_id_ips_id_fk",
+          "tableFrom": "character_ips",
+          "tableTo": "ips",
+          "columnsFrom": [
+            "ip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "character_ips_character_id_ip_id_pk": {
+          "name": "character_ips_character_id_ip_id_pk",
+          "columns": [
+            "character_id",
+            "ip_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "characters_name_unique": {
+          "name": "characters_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ips": {
+      "name": "ips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ips_name_unique": {
+          "name": "ips_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "jobs_source_id_media_sources_id_fk": {
+          "name": "jobs_source_id_media_sources_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "jobs_parent_id_jobs_id_fk": {
+          "name": "jobs_parent_id_jobs_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lancedb_sync_dirty": {
+      "name": "lancedb_sync_dirty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upsert'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_lancedb_sync_dirty_source_updated": {
+          "name": "idx_lancedb_sync_dirty_source_updated",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lancedb_sync_dirty_source_id_media_sources_id_fk": {
+          "name": "lancedb_sync_dirty_source_id_media_sources_id_fk",
+          "tableFrom": "lancedb_sync_dirty",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lancedb_sync_dirty_source_media_unique": {
+          "name": "lancedb_sync_dirty_source_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "media_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_authors": {
+      "name": "media_authors",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_authors_author_id_media_id": {
+          "name": "idx_media_authors_author_id_media_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_authors_media_id_media_id_fk": {
+          "name": "media_authors_media_id_media_id_fk",
+          "tableFrom": "media_authors",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_authors_author_id_authors_id_fk": {
+          "name": "media_authors_author_id_authors_id_fk",
+          "tableFrom": "media_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_authors_media_id_author_id_pk": {
+          "name": "media_authors_media_id_author_id_pk",
+          "columns": [
+            "media_id",
+            "author_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_categories": {
+      "name": "media_categories",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_categories_category_id_media_id": {
+          "name": "idx_media_categories_category_id_media_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_categories_media_id_media_id_fk": {
+          "name": "media_categories_media_id_media_id_fk",
+          "tableFrom": "media_categories",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_categories_category_id_categories_id_fk": {
+          "name": "media_categories_category_id_categories_id_fk",
+          "tableFrom": "media_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_categories_media_id_category_id_pk": {
+          "name": "media_categories_media_id_category_id_pk",
+          "columns": [
+            "media_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_characters": {
+      "name": "media_characters",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_characters_character_id_media_id": {
+          "name": "idx_media_characters_character_id_media_id",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_characters_media_id_media_id_fk": {
+          "name": "media_characters_media_id_media_id_fk",
+          "tableFrom": "media_characters",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_characters_character_id_characters_id_fk": {
+          "name": "media_characters_character_id_characters_id_fk",
+          "tableFrom": "media_characters",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_characters_media_id_character_id_pk": {
+          "name": "media_characters_media_id_character_id_pk",
+          "columns": [
+            "media_id",
+            "character_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_collections": {
+      "name": "media_collections",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_collections_media_id": {
+          "name": "idx_media_collections_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_collections_collection_id_collections_id_fk": {
+          "name": "media_collections_collection_id_collections_id_fk",
+          "tableFrom": "media_collections",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_collections_media_id_media_id_fk": {
+          "name": "media_collections_media_id_media_id_fk",
+          "tableFrom": "media_collections",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_collections_collection_id_media_id_pk": {
+          "name": "media_collections_collection_id_media_id_pk",
+          "columns": [
+            "collection_id",
+            "media_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_details": {
+      "name": "media_details",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1970-01-01 00:00:00'"
+        }
+      },
+      "indexes": {
+        "idx_media_details_rating": {
+          "name": "idx_media_details_rating",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_details_favorite": {
+          "name": "idx_media_details_favorite",
+          "columns": [
+            {
+              "expression": "favorite",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_details_view_count": {
+          "name": "idx_media_details_view_count",
+          "columns": [
+            {
+              "expression": "view_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_details_media_id_media_id_fk": {
+          "name": "media_details_media_id_media_id_fk",
+          "tableFrom": "media_details",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_generation_info": {
+      "name": "media_generation_info",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negative_prompt": {
+          "name": "negative_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loras": {
+          "name": "loras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vae": {
+          "name": "vae",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hypernetworks": {
+          "name": "hypernetworks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddings": {
+          "name": "embeddings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "seed": {
+          "name": "seed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": -1
+        },
+        "cfg_scale": {
+          "name": "cfg_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_media_generation_info_metadata": {
+          "name": "idx_media_generation_info_metadata",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_generation_info_ai_generated": {
+          "name": "idx_media_generation_info_ai_generated",
+          "columns": [
+            {
+              "expression": "ai_generated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_generation_info_model_name": {
+          "name": "idx_media_generation_info_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_generation_info_media_id_media_id_fk": {
+          "name": "media_generation_info_media_id_media_id_fk",
+          "tableFrom": "media_generation_info",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_ips": {
+      "name": "media_ips",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_id": {
+          "name": "ip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_ips_ip_id_media_id": {
+          "name": "idx_media_ips_ip_id_media_id",
+          "columns": [
+            {
+              "expression": "ip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_ips_media_id_media_id_fk": {
+          "name": "media_ips_media_id_media_id_fk",
+          "tableFrom": "media_ips",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_ips_ip_id_ips_id_fk": {
+          "name": "media_ips_ip_id_ips_id_fk",
+          "tableFrom": "media_ips",
+          "tableTo": "ips",
+          "columnsFrom": [
+            "ip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_ips_media_id_ip_id_pk": {
+          "name": "media_ips_media_id_ip_id_pk",
+          "columns": [
+            "media_id",
+            "ip_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_projects": {
+      "name": "media_projects",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_projects_project_id_media_id": {
+          "name": "idx_media_projects_project_id_media_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_projects_media_id_media_id_fk": {
+          "name": "media_projects_media_id_media_id_fk",
+          "tableFrom": "media_projects",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_projects_project_id_projects_id_fk": {
+          "name": "media_projects_project_id_projects_id_fk",
+          "tableFrom": "media_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_projects_media_id_project_id_pk": {
+          "name": "media_projects_media_id_project_id_pk",
+          "columns": [
+            "media_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_relations": {
+      "name": "media_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_media_id": {
+          "name": "parent_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_media_id": {
+          "name": "child_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "media_relation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_relations_child": {
+          "name": "idx_media_relations_child",
+          "columns": [
+            {
+              "expression": "child_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_relations_type": {
+          "name": "idx_media_relations_type",
+          "columns": [
+            {
+              "expression": "relation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_relations_parent_media_id_media_id_fk": {
+          "name": "media_relations_parent_media_id_media_id_fk",
+          "tableFrom": "media_relations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "parent_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_relations_child_media_id_media_id_fk": {
+          "name": "media_relations_child_media_id_media_id_fk",
+          "tableFrom": "media_relations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "child_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_child_type_unique": {
+          "name": "parent_child_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "parent_media_id",
+            "child_media_id",
+            "relation_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_sources": {
+      "name": "media_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "media_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_info": {
+          "name": "connection_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_sync": {
+      "name": "media_sync",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "media_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'synced'"
+        },
+        "backup_urls": {
+          "name": "backup_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_attempts": {
+          "name": "sync_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_sync_media_id_media_id_fk": {
+          "name": "media_sync_media_id_media_id_fk",
+          "tableFrom": "media_sync",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_tags": {
+      "name": "media_tags",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_type": {
+          "name": "tag_type",
+          "type": "tag_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'positive'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_tags_tag_id_tag_type_media_id": {
+          "name": "idx_media_tags_tag_id_tag_type_media_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_tags_media_id_media_id_fk": {
+          "name": "media_tags_media_id_media_id_fk",
+          "tableFrom": "media_tags",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_tags_tag_id_tags_id_fk": {
+          "name": "media_tags_tag_id_tags_id_fk",
+          "tableFrom": "media_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_tags_media_id_tag_id_tag_type_pk": {
+          "name": "media_tags_media_id_tag_id_tag_type_pk",
+          "columns": [
+            "media_id",
+            "tag_id",
+            "tag_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_technical_info": {
+      "name": "media_technical_info",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color_profile": {
+          "name": "color_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "exif_data": {
+          "name": "exif_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "hash_md5": {
+          "name": "hash_md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hash_perceptual": {
+          "name": "hash_perceptual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frame_rate": {
+          "name": "frame_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitrate_kbps": {
+          "name": "bitrate_kbps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_codec": {
+          "name": "video_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_technical_info_hash_md5": {
+          "name": "idx_media_technical_info_hash_md5",
+          "columns": [
+            {
+              "expression": "hash_md5",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_technical_info_media_id_media_id_fk": {
+          "name": "media_technical_info_media_id_media_id_fk",
+          "tableFrom": "media_technical_info",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_urls": {
+      "name": "media_urls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_urls_media_id": {
+          "name": "idx_media_urls_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_urls_url": {
+          "name": "idx_media_urls_url",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_urls_media_id_url_unique": {
+          "name": "idx_media_urls_media_id_url_unique",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_urls_media_id_media_id_fk": {
+          "name": "media_urls_media_id_media_id_fk",
+          "tableFrom": "media_urls",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "media_organization_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "idx_media_source_id": {
+          "name": "idx_media_source_id",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_file_size": {
+          "name": "idx_media_file_size",
+          "columns": [
+            {
+              "expression": "file_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_file_name": {
+          "name": "idx_media_file_name",
+          "columns": [
+            {
+              "expression": "file_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_created_at": {
+          "name": "idx_media_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_description": {
+          "name": "idx_media_description",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_source_id_media_sources_id_fk": {
+          "name": "media_source_id_media_sources_id_fk",
+          "tableFrom": "media",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_id_file_path_unique": {
+          "name": "source_id_file_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "file_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presets": {
+      "name": "presets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort": {
+          "name": "sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "presets_name_unique": {
+          "name": "presets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.similar_media": {
+      "name": "similar_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media1_id": {
+          "name": "media1_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media2_id": {
+          "name": "media2_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "similarity_score": {
+          "name": "similarity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'perceptual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_similar_media_score": {
+          "name": "idx_similar_media_score",
+          "columns": [
+            {
+              "expression": "similarity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "similar_media_media1_id_media_id_fk": {
+          "name": "similar_media_media1_id_media_id_fk",
+          "tableFrom": "similar_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "similar_media_media2_id_media_id_fk": {
+          "name": "similar_media_media2_id_media_id_fk",
+          "tableFrom": "similar_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media1Id_media2Id_algorithm_unique": {
+          "name": "media1Id_media2Id_algorithm_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "media1_id",
+            "media2_id",
+            "algorithm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tags_author_id": {
+          "name": "idx_tags_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_author_id_authors_id_fk": {
+          "name": "tags_author_id_authors_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.view_history": {
+      "name": "view_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "view_history_media_id_media_id_fk": {
+          "name": "view_history_media_id_media_id_fk",
+          "tableFrom": "view_history",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.media_organization_status": {
+      "name": "media_organization_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived",
+        "deleted"
+      ]
+    },
+    "public.media_relation_type": {
+      "name": "media_relation_type",
+      "schema": "public",
+      "values": [
+        "variant",
+        "version",
+        "page",
+        "derivative",
+        "edit",
+        "source"
+      ]
+    },
+    "public.media_source_type": {
+      "name": "media_source_type",
+      "schema": "public",
+      "values": [
+        "local",
+        "sftp",
+        "s3"
+      ]
+    },
+    "public.media_sync_status": {
+      "name": "media_sync_status",
+      "schema": "public",
+      "values": [
+        "synced",
+        "pending",
+        "failed"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "video",
+        "audio"
+      ]
+    },
+    "public.tag_type": {
+      "name": "tag_type",
+      "schema": "public",
+      "values": [
+        "positive",
+        "negative"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1779018261409,
       "tag": "0014_plain_ken_ellis",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1781879767081,
+      "tag": "0015_green_gargoyle",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -7,7 +7,7 @@ import {
 import { localConnectionSchema } from "@solid-imager/core/domain/sources/schemas";
 import { getErrorMessage } from "@solid-imager/core/utils/get-error-message";
 import type { Table } from "drizzle-orm";
-import { and, asc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, lt, sql } from "drizzle-orm";
 import type { PgColumn } from "drizzle-orm/pg-core";
 import { db } from "~/infrastructure/db";
 import {
@@ -53,6 +53,8 @@ type JsonValue =
 	| null
 	| JsonValue[]
 	| { [key: string]: JsonValue };
+
+const LanceDbDirtyMaxAttempts = 5;
 
 interface MediaListQueryItem {
 	id: string;
@@ -1162,7 +1164,12 @@ export const BackupService = {
 		const dirtyRows = await db
 			.select()
 			.from(lanceDbSyncDirty)
-			.where(eq(lanceDbSyncDirty.mediaSourceId, mediaSourceId))
+			.where(
+				and(
+					eq(lanceDbSyncDirty.mediaSourceId, mediaSourceId),
+					lt(lanceDbSyncDirty.attempts, LanceDbDirtyMaxAttempts),
+				),
+			)
 			.orderBy(asc(lanceDbSyncDirty.updatedAt))
 			.limit(batchSize);
 

--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -7,7 +7,7 @@ import {
 import { localConnectionSchema } from "@solid-imager/core/domain/sources/schemas";
 import { getErrorMessage } from "@solid-imager/core/utils/get-error-message";
 import type { Table } from "drizzle-orm";
-import { and, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, sql } from "drizzle-orm";
 import type { PgColumn } from "drizzle-orm/pg-core";
 import { db } from "~/infrastructure/db";
 import {
@@ -15,6 +15,7 @@ import {
 	characterIps,
 	characters,
 	ips,
+	lanceDbSyncDirty,
 	mediaAuthors,
 	mediaCharacters,
 	mediaGenerationInfo,
@@ -1087,6 +1088,167 @@ export const BackupService = {
 		}
 	},
 
+	async queueSourceLanceDBDelta(
+		mediaSourceId: string,
+		mediaIds: string[],
+		operation: "upsert" | "delete" = "upsert",
+		options: { enqueueJob?: boolean } = {},
+	) {
+		const uniqueMediaIds = [...new Set(mediaIds)].filter(Boolean);
+		if (uniqueMediaIds.length === 0) {
+			return { queued: 0 };
+		}
+
+		const now = new Date();
+		const rows = uniqueMediaIds.map((mediaId) => ({
+			mediaSourceId,
+			mediaId,
+			operation,
+			updatedAt: now,
+		}));
+
+		await db
+			.insert(lanceDbSyncDirty)
+			.values(rows)
+			.onConflictDoUpdate({
+				target: [lanceDbSyncDirty.mediaSourceId, lanceDbSyncDirty.mediaId],
+				set: {
+					operation,
+					lastError: null,
+					updatedAt: now,
+				},
+			});
+
+		if (options.enqueueJob !== false) {
+			const { services } = await import("~/application/registry");
+			await services.getJobRepository().createIfUnique({
+				type: "sync_lancedb_delta",
+				mediaSourceId,
+				payload: { reason: "dirty", batchSize: 500 },
+			});
+		}
+
+		return { queued: uniqueMediaIds.length };
+	},
+
+	async syncSourceLanceDBDeltaCache(mediaSourceId: string, batchSize = 500) {
+		const mediaSource = await db.query.mediaSources.findFirst({
+			where: eq(mediaSources.id, mediaSourceId),
+		});
+
+		if (!mediaSource) {
+			throw new Error("Media source not found");
+		}
+
+		const cacheDir = path.join(
+			process.cwd(),
+			".cache",
+			"lancedb-cache",
+			`source-${mediaSourceId}`,
+		);
+		const manifestPath = path.join(cacheDir, "manifest.json");
+		try {
+			const content = await fs.readFile(manifestPath, "utf-8");
+			const manifest = JSON.parse(content) as { version?: unknown };
+			if (manifest.version !== 3) {
+				await this.syncSourceLanceDBCache(mediaSourceId);
+				return { mode: "full", processed: 0 };
+			}
+		} catch {
+			await this.syncSourceLanceDBCache(mediaSourceId);
+			return { mode: "full", processed: 0 };
+		}
+
+		const dirtyRows = await db
+			.select()
+			.from(lanceDbSyncDirty)
+			.where(eq(lanceDbSyncDirty.mediaSourceId, mediaSourceId))
+			.orderBy(asc(lanceDbSyncDirty.updatedAt))
+			.limit(batchSize);
+
+		if (dirtyRows.length === 0) {
+			return { mode: "delta", processed: 0 };
+		}
+
+		const deleteIds = dirtyRows
+			.filter((row) => row.operation === "delete")
+			.map((row) => row.mediaId);
+		const upsertIds = dirtyRows
+			.filter((row) => row.operation !== "delete")
+			.map((row) => row.mediaId);
+
+		try {
+			let upsertItems: MediaDumpItem[] = [];
+			if (upsertIds.length > 0) {
+				const mediaList: MediaListQueryItem[] = await db.query.medias.findMany({
+					where: and(
+						eq(medias.mediaSourceId, mediaSourceId),
+						inArray(medias.id, upsertIds),
+					),
+					with: {
+						generationInfo: true,
+						urls: true,
+						tags: { with: { tag: true } },
+						authors: { with: { author: true } },
+						characters: {
+							with: {
+								character: {
+									with: { ips: { with: { ip: true } } },
+								},
+							},
+						},
+						ips: { with: { ip: true } },
+						projects: { with: { project: true } },
+					},
+				});
+				upsertItems = this._transformMediaList(mediaList);
+			}
+
+			const { syncLanceDBDelta } = await import(
+				"~/application/services/lancedb-dump-service"
+			);
+			await syncLanceDBDelta(cacheDir, {
+				mediaIdsToDelete: [...deleteIds, ...upsertIds],
+				itemsToUpsert: upsertItems,
+			});
+
+			await db.delete(lanceDbSyncDirty).where(
+				inArray(
+					lanceDbSyncDirty.id,
+					dirtyRows.map((row) => row.id),
+				),
+			);
+
+			logger.info(
+				{
+					mediaSourceId,
+					processed: dirtyRows.length,
+					upserted: upsertItems.length,
+					deleted: deleteIds.length,
+				},
+				"syncSourceLanceDBDeltaCache completed successfully",
+			);
+
+			return { mode: "delta", processed: dirtyRows.length };
+		} catch (error) {
+			const message = getErrorMessage(error);
+			await db
+				.update(lanceDbSyncDirty)
+				.set({
+					attempts: sql`${lanceDbSyncDirty.attempts} + 1`,
+					lastError: message,
+					updatedAt: new Date(),
+				})
+				.where(
+					inArray(
+						lanceDbSyncDirty.id,
+						dirtyRows.map((row) => row.id),
+					),
+				);
+			throw error;
+		}
+	},
+
 	/**
 	 * Generates a dump of the media source.
 	 * Returns a JSON object or a ReadableStream for ZIP download.
@@ -1108,50 +1270,59 @@ export const BackupService = {
 		);
 		await fs.mkdir(cacheDir, { recursive: true });
 
-		const { syncLanceDB } = await import(
+		const { syncLanceDBPages } = await import(
 			"~/application/services/lancedb-dump-service"
 		);
 
 		const limit = 1000;
-		let lastId: string | null = null;
-		const items: MediaDumpItem[] = [];
+		const self = this;
 
-		while (true) {
-			const mediaList: MediaListQueryItem[] = await db.query.medias.findMany({
-				where: lastId
-					? and(eq(medias.mediaSourceId, mediaSourceId), gt(medias.id, lastId))
-					: eq(medias.mediaSourceId, mediaSourceId),
-				limit,
-				with: {
-					generationInfo: true,
-					urls: true,
-					tags: { with: { tag: true } },
-					authors: { with: { author: true } },
-					characters: {
-						with: { character: { with: { ips: { with: { ip: true } } } } },
+		async function* loadPages(): AsyncIterable<MediaDumpItem[]> {
+			let lastId: string | null = null;
+
+			while (true) {
+				const mediaList: MediaListQueryItem[] = await db.query.medias.findMany({
+					where: lastId
+						? and(
+								eq(medias.mediaSourceId, mediaSourceId),
+								gt(medias.id, lastId),
+							)
+						: eq(medias.mediaSourceId, mediaSourceId),
+					limit,
+					with: {
+						generationInfo: true,
+						urls: true,
+						tags: { with: { tag: true } },
+						authors: { with: { author: true } },
+						characters: {
+							with: { character: { with: { ips: { with: { ip: true } } } } },
+						},
+						ips: { with: { ip: true } },
+						projects: { with: { project: true } },
 					},
-					ips: { with: { ip: true } },
-					projects: { with: { project: true } },
-				},
-				orderBy: medias.id,
-			});
+					orderBy: medias.id,
+				});
 
-			if (mediaList.length === 0) {
-				break;
+				if (mediaList.length === 0) {
+					break;
+				}
+
+				yield self._transformMediaList(mediaList);
+
+				if (mediaList.length < limit) {
+					break;
+				}
+				lastId = mediaList.at(-1)?.id ?? lastId;
 			}
-
-			items.push(...this._transformMediaList(mediaList));
-
-			if (mediaList.length < limit) {
-				break;
-			}
-			lastId = mediaList.at(-1)?.id ?? lastId;
 		}
 
-		await syncLanceDB(cacheDir, items);
+		const syncedCount = await syncLanceDBPages(cacheDir, loadPages());
+		await db
+			.delete(lanceDbSyncDirty)
+			.where(eq(lanceDbSyncDirty.mediaSourceId, mediaSourceId));
 
 		logger.info(
-			{ mediaSourceId, upserted: items.length },
+			{ mediaSourceId, upserted: syncedCount },
 			"syncSourceLanceDBCache completed successfully",
 		);
 	},

--- a/apps/server/src/application/services/job-dispatch-service.ts
+++ b/apps/server/src/application/services/job-dispatch-service.ts
@@ -12,7 +12,11 @@ export type DeferredJob = {
 	// Fields for constructing a job
 	mediaId?: string;
 	sourcePath?: string;
-	type: "processMedia" | "downloadImage" | "sync_lancedb";
+	type:
+		| "processMedia"
+		| "downloadImage"
+		| "sync_lancedb"
+		| "sync_lancedb_delta";
 	payload?: unknown;
 };
 
@@ -65,7 +69,7 @@ export async function processJob(job: DbJob) {
 		await processAutoTaggingJob(job);
 	} else if (job.type === "bulk_tagging_dispatch") {
 		await processBulkTaggingDispatchJob(job);
-	} else if (job.type === "sync_lancedb") {
+	} else if (job.type === "sync_lancedb" || job.type === "sync_lancedb_full") {
 		if (!mediaSourceId) {
 			throw new Error(`Job ${job.id} missing mediaSourceId`);
 		}
@@ -73,9 +77,62 @@ export async function processJob(job: DbJob) {
 			"~/application/services/backup-service"
 		);
 		await BackupService.syncSourceLanceDBCache(mediaSourceId);
+	} else if (job.type === "sync_lancedb_delta") {
+		if (!mediaSourceId) {
+			throw new Error(`Job ${job.id} missing mediaSourceId`);
+		}
+		const { BackupService } = await import(
+			"~/application/services/backup-service"
+		);
+		const batchSize = getDeltaBatchSize(job.payload);
+		const payloadDirty = getDeltaDirtyPayload(job.payload);
+		if (payloadDirty.mediaIds.length > 0) {
+			await BackupService.queueSourceLanceDBDelta(
+				mediaSourceId,
+				payloadDirty.mediaIds,
+				payloadDirty.operation,
+				{ enqueueJob: false },
+			);
+		}
+		await BackupService.syncSourceLanceDBDeltaCache(mediaSourceId, batchSize);
 	} else {
 		logger.warn({ jobId: job.id, type: job.type }, "Unknown job type");
 	}
+}
+
+function getDeltaBatchSize(payload: unknown): number {
+	if (
+		payload &&
+		typeof payload === "object" &&
+		"batchSize" in payload &&
+		typeof (payload as { batchSize: unknown }).batchSize === "number"
+	) {
+		return (payload as { batchSize: number }).batchSize;
+	}
+	return 500;
+}
+
+function getDeltaDirtyPayload(payload: unknown): {
+	mediaIds: string[];
+	operation: "upsert" | "delete";
+} {
+	if (!payload || typeof payload !== "object") {
+		return { mediaIds: [], operation: "upsert" };
+	}
+	const data = payload as {
+		mediaIds?: unknown;
+		mediaId?: unknown;
+		operation?: unknown;
+	};
+	const mediaIds = Array.isArray(data.mediaIds)
+		? data.mediaIds.filter(
+				(value): value is string => typeof value === "string",
+			)
+		: typeof data.mediaId === "string"
+			? [data.mediaId]
+			: [];
+	const operation = data.operation === "delete" ? "delete" : "upsert";
+	return { mediaIds, operation };
 }
 
 export async function executeDeferredActions(actions: DeferredActions) {
@@ -90,7 +147,7 @@ export async function executeDeferredActions(actions: DeferredActions) {
 					mediaId: job.mediaId,
 					sourcePath: job.sourcePath,
 				};
-				if (job.type === "sync_lancedb") {
+				if (job.type === "sync_lancedb" || job.type === "sync_lancedb_delta") {
 					await repo.createIfUnique({
 						type: job.type,
 						mediaSourceId: item.mediaSourceId,

--- a/apps/server/src/application/services/job-dispatch-service.ts
+++ b/apps/server/src/application/services/job-dispatch-service.ts
@@ -56,20 +56,6 @@ export async function processJob(job: DbJob) {
 			"~/application/services/media-processing-service"
 		);
 		await MediaProcessingService.executeProcessMediaJob(job);
-		// Queue LanceDB sync job
-		try {
-			const repo = services.getJobRepository();
-			await repo.createIfUnique({
-				type: "sync_lancedb",
-				mediaSourceId,
-				payload: {},
-			});
-		} catch (e) {
-			logger.error(
-				{ err: e, mediaSourceId },
-				"Failed to queue sync_lancedb after processMedia",
-			);
-		}
 	} else if (job.type === "downloadImage") {
 		const { processDownloadJob } = await import(
 			"~/infrastructure/jobs/download-jobs"
@@ -77,20 +63,6 @@ export async function processJob(job: DbJob) {
 		await processDownloadJob(job);
 	} else if (job.type === "auto_tagging") {
 		await processAutoTaggingJob(job);
-		// Queue LanceDB sync job
-		try {
-			const repo = services.getJobRepository();
-			await repo.createIfUnique({
-				type: "sync_lancedb",
-				mediaSourceId,
-				payload: {},
-			});
-		} catch (e) {
-			logger.error(
-				{ err: e, mediaSourceId },
-				"Failed to queue sync_lancedb after auto_tagging",
-			);
-		}
 	} else if (job.type === "bulk_tagging_dispatch") {
 		await processBulkTaggingDispatchJob(job);
 	} else if (job.type === "sync_lancedb") {

--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -16,5 +16,7 @@ const service = createLanceDbDumpService({
 
 export const writeToLanceDB = service.writeToLanceDB;
 export const syncLanceDB = service.syncLanceDB;
+export const syncLanceDBPages = service.syncLanceDBPages;
+export const syncLanceDBDelta = service.syncLanceDBDelta;
 export const readFromLanceDB = service.readFromLanceDB;
 export const cleanupLanceDBDir = service.cleanupLanceDBDir;

--- a/apps/server/src/application/services/maintenance-service.ts
+++ b/apps/server/src/application/services/maintenance-service.ts
@@ -29,6 +29,7 @@ export class MaintenanceService {
 		try {
 			await this.queueMissingMetadata();
 			await this.queueMissingThumbnails();
+			await this.queueLanceDbCacheSync();
 			logger.info("Startup checks completed.");
 		} catch (err) {
 			logger.error({ err }, "Startup checks failed");
@@ -90,6 +91,53 @@ export class MaintenanceService {
 			}
 		} catch (error) {
 			logger.error({ err: error }, "Failed to queue missing thumbnail jobs");
+		}
+	}
+
+	private async queueLanceDbCacheSync() {
+		try {
+			const sources = await this.sourceRepo.findAll();
+			let queuedCount = 0;
+
+			for (const source of sources) {
+				const jobType = (await this.hasLanceDbCache(source.id))
+					? "sync_lancedb_delta"
+					: "sync_lancedb_full";
+				const created = await this.jobRepo.createIfUnique({
+					type: jobType,
+					mediaSourceId: source.id,
+					payload: { reason: "startup" },
+				});
+				if (created) {
+					queuedCount++;
+				}
+			}
+
+			if (queuedCount > 0) {
+				logger.info(
+					{ count: queuedCount },
+					"Queued LanceDB cache sync jobs for startup",
+				);
+			}
+		} catch (error) {
+			logger.error({ err: error }, "Failed to queue LanceDB cache sync jobs");
+		}
+	}
+
+	private async hasLanceDbCache(sourceId: string): Promise<boolean> {
+		const manifestPath = path.join(
+			process.cwd(),
+			".cache",
+			"lancedb-cache",
+			`source-${sourceId}`,
+			"manifest.json",
+		);
+		try {
+			const content = await fs.readFile(manifestPath, "utf-8");
+			const manifest = JSON.parse(content) as { version?: unknown };
+			return manifest.version === 3;
+		} catch {
+			return false;
 		}
 	}
 

--- a/apps/server/src/application/services/maintenance-service.ts
+++ b/apps/server/src/application/services/maintenance-service.ts
@@ -29,35 +29,9 @@ export class MaintenanceService {
 		try {
 			await this.queueMissingMetadata();
 			await this.queueMissingThumbnails();
-			await this.queueLanceDBSync();
 			logger.info("Startup checks completed.");
 		} catch (err) {
 			logger.error({ err }, "Startup checks failed");
-		}
-	}
-
-	private async queueLanceDBSync() {
-		try {
-			const sources = await this.sourceRepo.findAll();
-			let queuedCount = 0;
-			for (const source of sources) {
-				const created = await this.jobRepo.createIfUnique({
-					type: "sync_lancedb",
-					mediaSourceId: source.id,
-					payload: {},
-				});
-				if (created) {
-					queuedCount++;
-				}
-			}
-			if (queuedCount > 0) {
-				logger.info(
-					{ count: queuedCount },
-					"Queued LanceDB sync jobs for sources",
-				);
-			}
-		} catch (error) {
-			logger.error({ err: error }, "Failed to queue LanceDB sync jobs");
 		}
 	}
 
@@ -83,13 +57,13 @@ export class MaintenanceService {
 	private async queueMissingThumbnails() {
 		try {
 			const BATCH_SIZE = 1000;
-			let offset = 0;
+			let lastId: string | undefined;
 			let hasMore = true;
 
 			while (hasMore) {
 				const batch = await this.mediaRepo.findAllMediaIndices(undefined, {
 					limit: BATCH_SIZE,
-					offset,
+					afterId: lastId,
 				});
 
 				if (batch.length === 0) {
@@ -101,7 +75,7 @@ export class MaintenanceService {
 
 				if (missingInBatch.length > 0) {
 					logger.info(
-						{ count: missingInBatch.length, offset },
+						{ count: missingInBatch.length, afterId: lastId },
 						"Found media with missing thumbnails in batch. Queueing jobs...",
 					);
 					await this.dispatchJobs(missingInBatch, {
@@ -109,7 +83,7 @@ export class MaintenanceService {
 					});
 				}
 
-				offset += BATCH_SIZE;
+				lastId = batch.at(-1)?.id ?? lastId;
 				if (batch.length < BATCH_SIZE) {
 					hasMore = false;
 				}

--- a/apps/server/src/application/services/maintenance-service.ts
+++ b/apps/server/src/application/services/maintenance-service.ts
@@ -61,7 +61,7 @@ export class MaintenanceService {
 			let hasMore = true;
 
 			while (hasMore) {
-				const batch = await this.mediaRepo.findAllMediaIndices(undefined, {
+				const batch = await this.mediaRepo.findAllMediaIndices({
 					limit: BATCH_SIZE,
 					afterId: lastId,
 				});

--- a/apps/server/src/infrastructure/jobs/job-worker.ts
+++ b/apps/server/src/infrastructure/jobs/job-worker.ts
@@ -11,6 +11,7 @@ export class JobWorker {
 	private aiConcurrency = 1;
 	private activeJobs = 0;
 	private activeAiJobs = 0;
+	private readonly activeLanceDbSyncKeys = new Set<string>();
 
 	private readonly jobRepo: IJobRepository;
 	private readonly processor: (job: Job) => Promise<void>;
@@ -80,7 +81,7 @@ export class JobWorker {
 						includeTypes: Array.from(this.aiJobTypes),
 					});
 					for (const job of jobs) {
-						this.processJob(job);
+						this.tryProcessJob(job);
 					}
 				}
 			}
@@ -95,7 +96,7 @@ export class JobWorker {
 						excludeTypes: Array.from(this.aiJobTypes),
 					});
 					for (const job of jobs) {
-						this.processJob(job);
+						this.tryProcessJob(job);
 					}
 				}
 			}
@@ -108,7 +109,19 @@ export class JobWorker {
 		}
 	}
 
-	private async processJob(job: Job) {
+	private tryProcessJob(job: Job) {
+		const lanceDbSyncKey = getLanceDbSyncKey(job);
+		if (lanceDbSyncKey) {
+			if (this.activeLanceDbSyncKeys.has(lanceDbSyncKey)) {
+				return;
+			}
+			this.activeLanceDbSyncKeys.add(lanceDbSyncKey);
+		}
+
+		this.processJob(job, lanceDbSyncKey);
+	}
+
+	private async processJob(job: Job, lanceDbSyncKey?: string) {
 		this.activeJobs++;
 		const isAiJob = this.aiJobTypes.has(job.type);
 		if (isAiJob) {
@@ -129,6 +142,21 @@ export class JobWorker {
 			if (isAiJob) {
 				this.activeAiJobs--;
 			}
+			if (lanceDbSyncKey) {
+				this.activeLanceDbSyncKeys.delete(lanceDbSyncKey);
+			}
 		}
 	}
+}
+
+function getLanceDbSyncKey(job: Job): string | undefined {
+	if (
+		job.mediaSourceId &&
+		["sync_lancedb", "sync_lancedb_full", "sync_lancedb_delta"].includes(
+			job.type,
+		)
+	) {
+		return job.mediaSourceId;
+	}
+	return undefined;
 }

--- a/apps/server/src/infrastructure/jobs/tagging-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/tagging-jobs.ts
@@ -41,6 +41,11 @@ export async function processAutoTaggingJob(job: Job): Promise<void> {
 		await taggingService.getTagsForMedia(mediaSourceId, mediaId, {
 			skipCache: force,
 		});
+		await services.getJobRepository().createIfUnique({
+			type: "sync_lancedb_delta",
+			mediaSourceId,
+			payload: { reason: "auto_tagging", mediaIds: [mediaId] },
+		});
 
 		if (parentId) {
 			const jobRepo = services.getJobRepository();

--- a/apps/server/src/tests/unit/application/services/lancedb-dump-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/lancedb-dump-service.test.ts
@@ -163,4 +163,35 @@ describe("LanceDB Dump Service", () => {
 		});
 		expect(chunks[0][0].generationInfo?.workflow).toEqual({ node: true });
 	});
+
+	it("applies delta sync by deleting target media rows before adding current rows", async () => {
+		const { createLanceDbDumpService } = await import(
+			"@solid-imager/application/services/lancedb-dump-service"
+		);
+		const service = createLanceDbDumpService({ connect: createMockConnect() });
+
+		await service.writeToLanceDB([], { includeImages: false });
+		await service.syncLanceDBDelta("/tmp/lancedb", {
+			mediaIdsToDelete: ["old-media"],
+			itemsToUpsert: [
+				{
+					id: "new-media",
+					filePath: "new.png",
+					fileName: "new.png",
+					mediaType: "image",
+					width: 10,
+					height: 20,
+					tags: [{ name: "tag-a", type: "positive" }],
+				},
+			],
+		});
+
+		const mediaTable = await mockOpenTable.mock.results[0].value;
+		expect(mediaTable.delete).toHaveBeenCalledWith(
+			"id IN ('old-media','new-media')",
+		);
+		expect(mediaTable.add).toHaveBeenCalledWith([
+			expect.objectContaining({ id: "new-media", filePath: "new.png" }),
+		]);
+	});
 });

--- a/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
@@ -303,39 +303,42 @@ describe("MaintenanceService", () => {
 
 			// Two calls: first full page, then the empty termination page
 			expect(mockMediaRepo.findAllMediaIndices).toHaveBeenCalledTimes(2);
-			expect(mockMediaRepo.findAllMediaIndices).toHaveBeenNthCalledWith(
-				1,
-				undefined,
-				{
-					limit: 1000,
-					afterId: undefined,
-				},
-			);
-			expect(mockMediaRepo.findAllMediaIndices).toHaveBeenNthCalledWith(
-				2,
-				undefined,
-				{
-					limit: 1000,
-					afterId: "m-999",
-				},
-			);
+			expect(mockMediaRepo.findAllMediaIndices).toHaveBeenNthCalledWith(1, {
+				limit: 1000,
+				afterId: undefined,
+			});
+			expect(mockMediaRepo.findAllMediaIndices).toHaveBeenNthCalledWith(2, {
+				limit: 1000,
+				afterId: "m-999",
+			});
 			expect(mockJobRepo.createIfUnique).not.toHaveBeenCalled();
 		});
 	});
 
 	describe("LanceDB startup behavior", () => {
-		it("should not queue sync_lancedb jobs during startup checks", async () => {
+		it("should queue one full LanceDB sync job per source without a cache during startup checks", async () => {
 			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
 			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
 			mockSourceRepo.findAll.mockResolvedValue([
 				makeLocalSource("source-1", "/path-1"),
+				makeLocalSource("source-2", "/path-2"),
 			]);
+			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
 
 			await service.performStartupChecks();
 
-			expect(mockSourceRepo.findAll).not.toHaveBeenCalled();
-			expect(mockJobRepo.createIfUnique).not.toHaveBeenCalledWith(
-				expect.objectContaining({ type: "sync_lancedb" }),
+			expect(mockSourceRepo.findAll).toHaveBeenCalledOnce();
+			expect(mockJobRepo.createIfUnique).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "sync_lancedb_full",
+					mediaSourceId: "source-1",
+				}),
+			);
+			expect(mockJobRepo.createIfUnique).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "sync_lancedb_full",
+					mediaSourceId: "source-2",
+				}),
 			);
 		});
 	});

--- a/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
@@ -281,7 +281,7 @@ describe("MaintenanceService", () => {
 			expect(mockJobRepo.createIfUnique).toHaveBeenCalledOnce();
 		});
 
-		it("should stop fetching batches when batch size equals BATCH_SIZE (simulate full page)", async () => {
+		it("should fetch the next batch by last media id when a page is full", async () => {
 			// Simulate exactly BATCH_SIZE (1000) items in the first batch.
 			// The loop does NOT exit early and fetches the next page (which is empty).
 			const BATCH_SIZE = 1000;
@@ -308,7 +308,7 @@ describe("MaintenanceService", () => {
 				undefined,
 				{
 					limit: 1000,
-					offset: 0,
+					afterId: undefined,
 				},
 			);
 			expect(mockMediaRepo.findAllMediaIndices).toHaveBeenNthCalledWith(
@@ -316,44 +316,26 @@ describe("MaintenanceService", () => {
 				undefined,
 				{
 					limit: 1000,
-					offset: 1000,
+					afterId: "m-999",
 				},
 			);
 			expect(mockJobRepo.createIfUnique).not.toHaveBeenCalled();
 		});
 	});
 
-	// --------------------------------------------------------------------------
-	// queueLanceDBSync (exercised via performStartupChecks)
-	// --------------------------------------------------------------------------
-
-	describe("queueLanceDBSync", () => {
-		it("should queue sync_lancedb jobs for all sources", async () => {
+	describe("LanceDB startup behavior", () => {
+		it("should not queue sync_lancedb jobs during startup checks", async () => {
 			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
 			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
-
-			const source1 = makeLocalSource("source-1", "/path-1");
-			const source2 = makeLocalSource("source-2", "/path-2");
-			mockSourceRepo.findAll.mockResolvedValue([source1, source2]);
-			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-sync-1" });
+			mockSourceRepo.findAll.mockResolvedValue([
+				makeLocalSource("source-1", "/path-1"),
+			]);
 
 			await service.performStartupChecks();
 
-			expect(mockSourceRepo.findAll).toHaveBeenCalledOnce();
-			expect(mockJobRepo.createIfUnique).toHaveBeenCalledTimes(2);
-			expect(mockJobRepo.createIfUnique).toHaveBeenNthCalledWith(
-				1,
-				expect.objectContaining({
-					type: "sync_lancedb",
-					mediaSourceId: "source-1",
-				}),
-			);
-			expect(mockJobRepo.createIfUnique).toHaveBeenNthCalledWith(
-				2,
-				expect.objectContaining({
-					type: "sync_lancedb",
-					mediaSourceId: "source-2",
-				}),
+			expect(mockSourceRepo.findAll).not.toHaveBeenCalled();
+			expect(mockJobRepo.createIfUnique).not.toHaveBeenCalledWith(
+				expect.objectContaining({ type: "sync_lancedb" }),
 			);
 		});
 	});

--- a/apps/server/src/tests/unit/infrastructure/jobs/job-worker.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/job-worker.test.ts
@@ -190,4 +190,67 @@ describe("JobWorker", () => {
 
 		expect(processor).toHaveBeenCalledTimes(TotalExpectedCalls);
 	});
+
+	it("should serialize LanceDB sync jobs per media source", async () => {
+		worker.updateConfig({
+			jobs: { concurrency: 3, aiConcurrency: 1, pollIntervalMs: 1000 },
+		} as AppConfig);
+
+		let resolveProcessor: () => void = () => {};
+		processor = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveProcessor = resolve;
+				}),
+		);
+		worker = new JobWorker(jobRepo, processor);
+		worker.updateConfig({
+			jobs: { concurrency: 3, aiConcurrency: 1, pollIntervalMs: 1000 },
+		} as AppConfig);
+
+		const fullSyncJob = {
+			id: "lancedb-full-1",
+			type: "sync_lancedb_full",
+			mediaSourceId: "source-1",
+			status: "pending",
+		} as Job;
+		const deltaSyncSameSourceJob = {
+			id: "lancedb-delta-1",
+			type: "sync_lancedb_delta",
+			mediaSourceId: "source-1",
+			status: "pending",
+		} as Job;
+		const deltaSyncOtherSourceJob = {
+			id: "lancedb-delta-2",
+			type: "sync_lancedb_delta",
+			mediaSourceId: "source-2",
+			status: "pending",
+		} as Job;
+
+		(jobRepo.findPending as any).mockImplementation(
+			(limit: number, options: any) => {
+				if (options?.excludeTypes) {
+					return Promise.resolve(
+						[
+							fullSyncJob,
+							deltaSyncSameSourceJob,
+							deltaSyncOtherSourceJob,
+						].slice(0, limit),
+					);
+				}
+				return Promise.resolve([]);
+			},
+		);
+
+		worker.start();
+		await vi.advanceTimersByTimeAsync(TimerDelay);
+
+		expect(processor).toHaveBeenCalledTimes(2);
+		expect(processor).toHaveBeenCalledWith(fullSyncJob);
+		expect(processor).toHaveBeenCalledWith(deltaSyncOtherSourceJob);
+		expect(processor).not.toHaveBeenCalledWith(deltaSyncSameSourceJob);
+
+		resolveProcessor();
+		await vi.runOnlyPendingTimersAsync();
+	});
 });

--- a/apps/server/src/tests/unit/media/copy-media-job.test.ts
+++ b/apps/server/src/tests/unit/media/copy-media-job.test.ts
@@ -127,6 +127,9 @@ describe("Reproduction: Copy Media Job Type", () => {
 				capturedJobs.push(job);
 				return Promise.resolve({ ...job, id: "job-id" });
 			}),
+			createIfUnique: vi.fn((job) =>
+				Promise.resolve({ ...job, id: "sync-job-id" }),
+			),
 		};
 
 		// Register Repositories

--- a/packages/application/src/ports/lancedb-dump-service.ts
+++ b/packages/application/src/ports/lancedb-dump-service.ts
@@ -27,6 +27,14 @@ export type SyncOptions = {
 	deleteChunkSize?: number;
 };
 
+export type SyncPagesOptions = SyncOptions;
+
+export type SyncDeltaOptions = {
+	mediaIdsToDelete?: string[];
+	itemsToUpsert?: MediaDumpItem[];
+	optimize?: boolean;
+};
+
 export interface ILanceDbDumpService {
 	writeToLanceDB(
 		items: MediaDumpItem[],
@@ -37,6 +45,15 @@ export interface ILanceDbDumpService {
 		itemsToUpsert: MediaDumpItem[],
 		options?: SyncOptions,
 	): Promise<void>;
+	syncLanceDBPages(
+		lanceDbDir: string,
+		itemPages: AsyncIterable<MediaDumpItem[]>,
+		options?: SyncPagesOptions,
+	): Promise<number>;
+	syncLanceDBDelta(
+		lanceDbDir: string,
+		options: SyncDeltaOptions,
+	): Promise<{ deleted: number; upserted: number }>;
 	readFromLanceDB(
 		lanceDbDir: string,
 		options?: ReadOptions,

--- a/packages/application/src/ports/media-service.ts
+++ b/packages/application/src/ports/media-service.ts
@@ -21,7 +21,7 @@ import type {
 export type DeferredJob = {
 	mediaId?: string;
 	sourcePath?: string;
-	type: "processMedia" | "downloadImage";
+	type: "processMedia" | "downloadImage" | "sync_lancedb" | "sync_lancedb_delta";
 	payload?: unknown;
 };
 

--- a/packages/application/src/services/lancedb-dump-service.ts
+++ b/packages/application/src/services/lancedb-dump-service.ts
@@ -7,12 +7,14 @@ import type {
 	ILanceDbDumpService,
 	MediaDumpItemWithImageData,
 	ReadOptions,
+	SyncDeltaOptions,
 	SyncOptions,
 	WriteOptions,
 } from "../ports/lancedb-dump-service";
 
 const ROW_CHUNK_SIZE = 5000;
 const READ_CHUNK_SIZE = 5000;
+const LANCEDB_DUMP_VERSION = 3;
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 type RowValue = JsonValue | Date;
@@ -55,6 +57,8 @@ const tableNames: TableName[] = [
 	"media_generation_info",
 ];
 
+type LanceTables = Record<TableName, Table>;
+
 function resolveSafeChildPath(baseDir: string, relativePath: string): string | null {
 	if (!relativePath || path.isAbsolute(relativePath)) return null;
 	const resolvedBase = path.resolve(baseDir);
@@ -93,26 +97,30 @@ async function createSchemas(): Promise<Record<TableName, Schema>> {
 			["modifiedAt", timestamp()],
 		]),
 		media_tags: await createSchema([
-			["mediaId", utf8()], ["name", utf8()], ["type", utf8()], ["confidence", float64()], ["source", utf8()],
+			["key", utf8(), false], ["mediaId", utf8()], ["name", utf8()], ["type", utf8()], ["confidence", float64()], ["source", utf8()],
 		]),
-		media_authors: await createSchema([["mediaId", utf8()], ["name", utf8()], ["accountId", utf8()]]),
+		media_authors: await createSchema([["key", utf8(), false], ["mediaId", utf8()], ["name", utf8()], ["accountId", utf8()]]),
 		media_characters: await createSchema([
-			["mediaId", utf8()], ["name", utf8()], ["description", utf8()], ["confidence", float64()], ["source", utf8()],
+			["key", utf8(), false], ["mediaId", utf8()], ["name", utf8()], ["description", utf8()], ["confidence", float64()], ["source", utf8()],
 		]),
-		media_character_ips: await createSchema([["mediaId", utf8()], ["characterName", utf8()], ["ipName", utf8()]]),
+		media_character_ips: await createSchema([["key", utf8(), false], ["mediaId", utf8()], ["characterName", utf8()], ["ipName", utf8()]]),
 		media_ips: await createSchema([
-			["mediaId", utf8()], ["name", utf8()], ["description", utf8()], ["confidence", float64()], ["source", utf8()],
+			["key", utf8(), false], ["mediaId", utf8()], ["name", utf8()], ["description", utf8()], ["confidence", float64()], ["source", utf8()],
 		]),
-		media_projects: await createSchema([["mediaId", utf8()], ["name", utf8()], ["description", utf8()]]),
-		media_urls: await createSchema([["mediaId", utf8()], ["url", utf8()]]),
+		media_projects: await createSchema([["key", utf8(), false], ["mediaId", utf8()], ["name", utf8()], ["description", utf8()]]),
+		media_urls: await createSchema([["key", utf8(), false], ["mediaId", utf8()], ["url", utf8()]]),
 		media_generation_info: await createSchema([
-			["mediaId", utf8()], ["prompt", utf8()], ["negativePrompt", utf8()], ["modelName", utf8()], ["seed", float64()], ["steps", float64()], ["cfgScale", float64()], ["aiGenerated", bool()], ["workflowJson", utf8()], ["metadataJson", utf8()],
+			["key", utf8(), false], ["mediaId", utf8()], ["prompt", utf8()], ["negativePrompt", utf8()], ["modelName", utf8()], ["seed", float64()], ["steps", float64()], ["cfgScale", float64()], ["aiGenerated", bool()], ["workflowJson", utf8()], ["metadataJson", utf8()],
 		]),
 	};
 }
 
 function itemId(item: MediaDumpItem, index: number): string {
 	return item.id || item.filePath || `item-${index}`;
+}
+
+function rowKey(...parts: Array<string | number | null | undefined>): string {
+	return parts.map((part) => String(part ?? "")).join(":");
 }
 
 function itemsToRows(items: MediaDumpItem[]): TableRows {
@@ -132,17 +140,18 @@ function itemsToRows(items: MediaDumpItem[]): TableRows {
 			modifiedAt: item.modifiedAt ? new Date(item.modifiedAt) : null,
 		});
 
-		for (const tag of item.tags ?? []) rows.tags.push({ mediaId, name: tag.name, type: tag.type ?? null, confidence: tag.confidence ?? null, source: tag.source ?? null });
-		for (const author of item.authors ?? []) rows.authors.push({ mediaId, name: author.name, accountId: author.accountId ?? null });
+		for (const tag of item.tags ?? []) rows.tags.push({ key: rowKey(mediaId, tag.name, tag.type), mediaId, name: tag.name, type: tag.type ?? null, confidence: tag.confidence ?? null, source: tag.source ?? null });
+		for (const author of item.authors ?? []) rows.authors.push({ key: rowKey(mediaId, author.name, author.accountId), mediaId, name: author.name, accountId: author.accountId ?? null });
 		for (const character of item.characters ?? []) {
-			rows.characters.push({ mediaId, name: character.name, description: character.description ?? null, confidence: character.confidence ?? null, source: character.source ?? null });
-			for (const ipName of character.linkedIps ?? []) rows.characterIps.push({ mediaId, characterName: character.name, ipName });
+			rows.characters.push({ key: rowKey(mediaId, character.name), mediaId, name: character.name, description: character.description ?? null, confidence: character.confidence ?? null, source: character.source ?? null });
+			for (const ipName of character.linkedIps ?? []) rows.characterIps.push({ key: rowKey(mediaId, character.name, ipName), mediaId, characterName: character.name, ipName });
 		}
-		for (const ip of item.ips ?? []) rows.ips.push({ mediaId, name: ip.name, description: ip.description ?? null, confidence: ip.confidence ?? null, source: ip.source ?? null });
-		for (const project of item.projects ?? []) rows.projects.push({ mediaId, name: project.name, description: project.description ?? null });
-		for (const url of item.sourceUrls ?? []) rows.urls.push({ mediaId, url });
+		for (const ip of item.ips ?? []) rows.ips.push({ key: rowKey(mediaId, ip.name), mediaId, name: ip.name, description: ip.description ?? null, confidence: ip.confidence ?? null, source: ip.source ?? null });
+		for (const project of item.projects ?? []) rows.projects.push({ key: rowKey(mediaId, project.name), mediaId, name: project.name, description: project.description ?? null });
+		for (const url of item.sourceUrls ?? []) rows.urls.push({ key: rowKey(mediaId, url), mediaId, url });
 		if (item.generationInfo) {
 			rows.generationInfo.push({
+				key: rowKey(mediaId),
 				mediaId,
 				prompt: item.generationInfo.prompt ?? null,
 				negativePrompt: item.generationInfo.negativePrompt ?? null,
@@ -172,17 +181,87 @@ async function createTable(db: Connection, schemas: Record<string, Schema>, name
 	return table;
 }
 
-async function readAll(table: Table): Promise<Row[]> {
-	const rows: Row[] = [];
-	let offset = 0;
-	while (true) {
-		const chunk = await readPage(table, offset, READ_CHUNK_SIZE);
-		if (chunk.length === 0) break;
-		rows.push(...chunk);
-		if (chunk.length < READ_CHUNK_SIZE) break;
-		offset += chunk.length;
-	}
-	return rows;
+async function createTables(db: Connection, schemas: Record<string, Schema>, rows: TableRows): Promise<LanceTables> {
+	const [
+		media,
+		mediaTags,
+		mediaAuthors,
+		mediaCharacters,
+		mediaCharacterIps,
+		mediaIps,
+		mediaProjects,
+		mediaUrls,
+		mediaGenerationInfo,
+	] = await Promise.all([
+		createTable(db, schemas, "media", rows.media),
+		createTable(db, schemas, "media_tags", rows.tags),
+		createTable(db, schemas, "media_authors", rows.authors),
+		createTable(db, schemas, "media_characters", rows.characters),
+		createTable(db, schemas, "media_character_ips", rows.characterIps),
+		createTable(db, schemas, "media_ips", rows.ips),
+		createTable(db, schemas, "media_projects", rows.projects),
+		createTable(db, schemas, "media_urls", rows.urls),
+		createTable(db, schemas, "media_generation_info", rows.generationInfo),
+	]);
+	return {
+		media,
+		media_tags: mediaTags,
+		media_authors: mediaAuthors,
+		media_characters: mediaCharacters,
+		media_character_ips: mediaCharacterIps,
+		media_ips: mediaIps,
+		media_projects: mediaProjects,
+		media_urls: mediaUrls,
+		media_generation_info: mediaGenerationInfo,
+	};
+}
+
+async function addRowsToTables(tables: LanceTables, rows: TableRows): Promise<void> {
+	await Promise.all([
+		addChunked(tables.media, rows.media),
+		addChunked(tables.media_tags, rows.tags),
+		addChunked(tables.media_authors, rows.authors),
+		addChunked(tables.media_characters, rows.characters),
+		addChunked(tables.media_character_ips, rows.characterIps),
+		addChunked(tables.media_ips, rows.ips),
+		addChunked(tables.media_projects, rows.projects),
+		addChunked(tables.media_urls, rows.urls),
+		addChunked(tables.media_generation_info, rows.generationInfo),
+	]);
+}
+
+async function openTables(db: Connection): Promise<LanceTables> {
+	return {
+		media: await db.openTable("media"),
+		media_tags: await db.openTable("media_tags"),
+		media_authors: await db.openTable("media_authors"),
+		media_characters: await db.openTable("media_characters"),
+		media_character_ips: await db.openTable("media_character_ips"),
+		media_ips: await db.openTable("media_ips"),
+		media_projects: await db.openTable("media_projects"),
+		media_urls: await db.openTable("media_urls"),
+		media_generation_info: await db.openTable("media_generation_info"),
+	};
+}
+
+function sqlInList(values: string[]): string {
+	return values.map((value) => `'${escapeLanceSqlString(value)}'`).join(",");
+}
+
+async function deleteMediaRows(tables: LanceTables, mediaIds: string[]): Promise<void> {
+	if (mediaIds.length === 0) return;
+	const ids = sqlInList(mediaIds);
+	await Promise.all([
+		tables.media.delete(`id IN (${ids})`),
+		tables.media_tags.delete(`mediaId IN (${ids})`),
+		tables.media_authors.delete(`mediaId IN (${ids})`),
+		tables.media_characters.delete(`mediaId IN (${ids})`),
+		tables.media_character_ips.delete(`mediaId IN (${ids})`),
+		tables.media_ips.delete(`mediaId IN (${ids})`),
+		tables.media_projects.delete(`mediaId IN (${ids})`),
+		tables.media_urls.delete(`mediaId IN (${ids})`),
+		tables.media_generation_info.delete(`mediaId IN (${ids})`),
+	]);
 }
 
 async function readPage(
@@ -351,19 +430,9 @@ export function createLanceDbDumpService(deps?: {
 			const db = await connect(tempDir);
 			const schemas = await createSchemas();
 			const rows = itemsToRows(items);
-			const tables = await Promise.all([
-				createTable(db, schemas, "media", rows.media),
-				createTable(db, schemas, "media_tags", rows.tags),
-				createTable(db, schemas, "media_authors", rows.authors),
-				createTable(db, schemas, "media_characters", rows.characters),
-				createTable(db, schemas, "media_character_ips", rows.characterIps),
-				createTable(db, schemas, "media_ips", rows.ips),
-				createTable(db, schemas, "media_projects", rows.projects),
-				createTable(db, schemas, "media_urls", rows.urls),
-				createTable(db, schemas, "media_generation_info", rows.generationInfo),
-			]);
-			await Promise.all(tables.map((table) => table.optimize({ cleanupOlderThan: new Date(Date.now() - 1000 * 60 * 5) })));
-			await fs.writeFile(path.join(tempDir, "manifest.json"), JSON.stringify({ format: "solid-imager-lancedb", version: 2, includeImages: options.includeImages, createdAt: new Date().toISOString(), tables: tableNames }, null, 2));
+			const tables = await createTables(db, schemas, rows);
+			await Promise.all(Object.values(tables).map((table) => table.optimize({ cleanupOlderThan: new Date(Date.now() - 1000 * 60 * 5) })));
+			await fs.writeFile(path.join(tempDir, "manifest.json"), JSON.stringify({ format: "solid-imager-lancedb", version: LANCEDB_DUMP_VERSION, includeImages: options.includeImages, createdAt: new Date().toISOString(), tables: tableNames }, null, 2));
 			log.info("LanceDB v2 dump created", { path: tempDir, count: items.length });
 			return tempDir;
 		} catch (error) {
@@ -377,6 +446,69 @@ export function createLanceDbDumpService(deps?: {
 		const createdDir = await writeToLanceDB(itemsToUpsert, { includeImages: false, tempDir: path.dirname(lanceDbDir) });
 		await fs.rm(lanceDbDir, { recursive: true, force: true });
 		await fs.rename(createdDir, lanceDbDir);
+	}
+
+	async function writePagesToLanceDB(itemPages: AsyncIterable<MediaDumpItem[]>, options: WriteOptions): Promise<{ dir: string; count: number }> {
+		const baseDir = options.tempDir ?? path.join(process.cwd(), ".cache", "lancedb-dump");
+		const tempDir = path.join(baseDir, `dump-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`);
+		await fs.mkdir(tempDir, { recursive: true });
+		let count = 0;
+		try {
+			const connect = await getConnect();
+			const db = await connect(tempDir);
+			const schemas = await createSchemas();
+			const tables = await createTables(db, schemas, itemsToRows([]));
+
+			for await (const items of itemPages) {
+				if (items.length === 0) continue;
+				count += items.length;
+				await addRowsToTables(tables, itemsToRows(items));
+			}
+
+			await Promise.all(Object.values(tables).map((table) => table.optimize({ cleanupOlderThan: new Date(Date.now() - 1000 * 60 * 5) })));
+			await fs.writeFile(path.join(tempDir, "manifest.json"), JSON.stringify({ format: "solid-imager-lancedb", version: LANCEDB_DUMP_VERSION, includeImages: options.includeImages, createdAt: new Date().toISOString(), tables: tableNames }, null, 2));
+			log.info("LanceDB v2 dump created", { path: tempDir, count });
+			return { dir: tempDir, count };
+		} catch (error) {
+			await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+			throw error;
+		}
+	}
+
+	async function syncLanceDBPages(lanceDbDir: string, itemPages: AsyncIterable<MediaDumpItem[]>, _options: SyncOptions = {}): Promise<number> {
+		await fs.rm(lanceDbDir, { recursive: true, force: true });
+		const created = await writePagesToLanceDB(itemPages, { includeImages: false, tempDir: path.dirname(lanceDbDir) });
+		await fs.rm(lanceDbDir, { recursive: true, force: true });
+		await fs.rename(created.dir, lanceDbDir);
+		return created.count;
+	}
+
+	async function syncLanceDBDelta(
+		lanceDbDir: string,
+		options: SyncDeltaOptions,
+	): Promise<{ deleted: number; upserted: number }> {
+		const mediaIdsToDelete = options.mediaIdsToDelete ?? [];
+		const itemsToUpsert = options.itemsToUpsert ?? [];
+		const upsertIds = itemsToUpsert.flatMap((item, index) => {
+			const id = itemId(item, index);
+			return id ? [id] : [];
+		});
+		const targetIds = [...new Set([...mediaIdsToDelete, ...upsertIds])];
+		if (targetIds.length === 0) {
+			return { deleted: 0, upserted: 0 };
+		}
+
+		const connect = await getConnect();
+		const db = await connect(lanceDbDir);
+		const tables = await openTables(db);
+		await deleteMediaRows(tables, targetIds);
+		await addRowsToTables(tables, itemsToRows(itemsToUpsert));
+
+		if (options.optimize) {
+			await Promise.all(Object.values(tables).map((table) => table.optimize({ cleanupOlderThan: new Date(Date.now() - 1000 * 60 * 5) })));
+		}
+
+		return { deleted: mediaIdsToDelete.length, upserted: itemsToUpsert.length };
 	}
 
 	async function readFromLanceDB(lanceDbDir: string, options: ReadOptions = {}): Promise<MediaDumpItemWithImageData[]> {
@@ -424,5 +556,5 @@ export function createLanceDbDumpService(deps?: {
 		await fs.rm(dir, { recursive: true, force: true });
 	}
 
-	return { writeToLanceDB, syncLanceDB, readFromLanceDB, cleanupLanceDBDir };
+	return { writeToLanceDB, syncLanceDB, syncLanceDBPages, syncLanceDBDelta, readFromLanceDB, cleanupLanceDBDir };
 }

--- a/packages/application/src/services/media-processing-service.ts
+++ b/packages/application/src/services/media-processing-service.ts
@@ -145,6 +145,11 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 				type: "processMedia",
 			},
 		});
+		await this.jobRepo.createIfUnique({
+			type: "sync_lancedb_delta",
+			mediaSourceId,
+			payload: { reason: "media_added", mediaIds: [media.id] },
+		});
 
 		// Notify clients
 		this.sseSendEvent(mediaSourceId, "media-added", {
@@ -248,6 +253,12 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 				console.warn({ err: e, mediaId }, "Failed to queue AI tagging job");
 			}
 		}
+
+		await this.jobRepo.createIfUnique({
+			type: "sync_lancedb_delta",
+			mediaSourceId,
+			payload: { reason: "media_processed", mediaIds: [media.id] },
+		});
 	}
 
 	private async registerContextMetadata(

--- a/packages/application/src/services/media-transfer-service.ts
+++ b/packages/application/src/services/media-transfer-service.ts
@@ -86,7 +86,13 @@ export class MediaTransferService {
 		if (tx) {
 			return await execute(tx);
 		}
-		return await this.transactionManager.transaction(execute);
+		const updatedMedia = await this.transactionManager.transaction(execute);
+		await this.jobRepo.createIfUnique({
+			type: "sync_lancedb_delta",
+			mediaSourceId: validatedSourceId,
+			payload: { reason: "media_updated", mediaIds: [validatedMediaId] },
+		});
+		return updatedMedia;
 	}
 
 	async copyMedia(
@@ -189,12 +195,16 @@ export class MediaTransferService {
 				type: "processMedia",
 			},
 		};
+		const deferredSyncJob = {
+			type: "sync_lancedb_delta" as const,
+			payload: { reason: "media_added", mediaIds: [newMediaEntry.id] },
+		};
 
 		const deferredActions: DeferredActions = {
 			jobs: [
 				{
 					mediaSourceId: validatedTargetSourceId,
-					jobs: [deferredJob],
+					jobs: [deferredJob, deferredSyncJob],
 				},
 			],
 			sse: [],
@@ -227,6 +237,11 @@ export class MediaTransferService {
 				sourcePath,
 				type: "processMedia",
 			},
+		});
+		await this.jobRepo.createIfUnique({
+			type: "sync_lancedb_delta",
+			mediaSourceId: validatedTargetSourceId,
+			payload: { reason: "media_added", mediaIds: [newMediaEntry.id] },
 		});
 
 		this.sseNotifier.notifyMediaCopied(
@@ -410,12 +425,36 @@ export class MediaTransferService {
 
 		if (tx) {
 			return {
-				jobs: [],
+				jobs: [
+					{
+						mediaSourceId: validatedSourceId,
+						jobs: [
+							{
+								type: "sync_lancedb_delta",
+								payload: {
+									reason: "media_deleted",
+									operation: "delete",
+									mediaIds: [validatedMediaId],
+								},
+							},
+						],
+					},
+				],
 				sse: [sseEvent],
 				filesToDelete,
 				thumbnailsToDelete,
 			};
 		}
+
+		await this.jobRepo.createIfUnique({
+			type: "sync_lancedb_delta",
+			mediaSourceId: validatedSourceId,
+			payload: {
+				reason: "media_deleted",
+				operation: "delete",
+				mediaIds: [validatedMediaId],
+			},
+		});
 
 		if (thumbnailsToDelete) {
 			for (const thumb of thumbnailsToDelete) {

--- a/packages/application/src/services/media-upload-service.ts
+++ b/packages/application/src/services/media-upload-service.ts
@@ -142,6 +142,11 @@ export class MediaUploadService {
 				type: "processMedia",
 			},
 		});
+		await this.jobRepo.createIfUnique({
+			type: "sync_lancedb_delta",
+			mediaSourceId: validatedSourceId,
+			payload: { reason: "media_added", mediaIds: [insertedMedia.id] },
+		});
 
 		return {
 			success: true,
@@ -206,6 +211,14 @@ export class MediaUploadService {
 					},
 				});
 			}
+			await this.jobRepo.createIfUnique({
+				type: "sync_lancedb_delta",
+				mediaSourceId: validatedSourceId,
+				payload: {
+					reason: "media_added",
+					mediaIds: newMediaItems.map((item) => item.id),
+				},
+			});
 		}
 	}
 }

--- a/packages/core/src/domain/repositories/media-repository.ts
+++ b/packages/core/src/domain/repositories/media-repository.ts
@@ -86,8 +86,8 @@ export type IMediaRepository = {
 		tx?: Transaction,
 	): Promise<{ id: string; mediaSourceId: string; filePath: string }[]>;
 	findAllMediaIndices(
+		options: { limit: number; offset?: number; afterId?: string },
 		tx?: Transaction,
-		options?: { limit: number; offset?: number; afterId?: string },
 	): Promise<{ id: string; mediaSourceId: string; filePath: string }[]>;
 	findAllPathsBySourceId(
 		sourceId: string,

--- a/packages/core/src/domain/repositories/media-repository.ts
+++ b/packages/core/src/domain/repositories/media-repository.ts
@@ -87,7 +87,7 @@ export type IMediaRepository = {
 	): Promise<{ id: string; mediaSourceId: string; filePath: string }[]>;
 	findAllMediaIndices(
 		tx?: Transaction,
-		options?: { limit: number; offset: number },
+		options?: { limit: number; offset?: number; afterId?: string },
 	): Promise<{ id: string; mediaSourceId: string; filePath: string }[]>;
 	findAllPathsBySourceId(
 		sourceId: string,

--- a/packages/db/src/repositories/job-repository.ts
+++ b/packages/db/src/repositories/job-repository.ts
@@ -36,6 +36,63 @@ export function createJobRepository(
     },
 
     async createIfUnique(job: NewJob): Promise<Job | null> {
+      if (job.type === "sync_lancedb_delta" && job.mediaSourceId) {
+        const [pending] = await db()
+          .select()
+          .from(jobs)
+          .where(
+            and(
+              eq(jobs.type, job.type),
+              eq(jobs.mediaSourceId, job.mediaSourceId),
+              eq(jobs.status, "pending"),
+            ),
+          )
+          .limit(1);
+
+        if (pending) {
+          await db()
+            .update(jobs)
+            .set({
+              payload: mergeDeltaPayload(pending.payload, job.payload),
+              updatedAt: new Date(),
+            })
+            .where(eq(jobs.id, pending.id));
+          return null;
+        }
+
+        const [created] = await db().insert(jobs).values(job).returning();
+        return mapJob(created);
+      }
+
+      if (
+        ["sync_lancedb", "sync_lancedb_full", "sync_lancedb_delta"].includes(job.type) &&
+        job.mediaSourceId
+      ) {
+        const [existing] = await db()
+          .select({ id: jobs.id })
+          .from(jobs)
+          .where(
+            and(
+              inArray(
+                jobs.type,
+                job.type === "sync_lancedb_delta"
+                  ? ["sync_lancedb_delta"]
+                  : ["sync_lancedb", "sync_lancedb_full"],
+              ),
+              eq(jobs.mediaSourceId, job.mediaSourceId),
+              inArray(jobs.status, ["pending", "in_progress"]),
+            ),
+          )
+          .limit(1);
+
+        if (existing) {
+          return null;
+        }
+
+        const [created] = await db().insert(jobs).values(job).returning();
+        return mapJob(created);
+      }
+
       const payload = job.payload;
       let mediaId: string | undefined;
 
@@ -141,4 +198,28 @@ export function createJobRepository(
       );
     },
   };
+}
+
+function mergeDeltaPayload(existing: unknown, next: unknown): Record<string, unknown> {
+  const existingRecord = isRecord(existing) ? existing : {};
+  const nextRecord = isRecord(next) ? next : {};
+  const mediaIds = [
+    ...extractStringArray(existingRecord.mediaIds),
+    ...extractStringArray(nextRecord.mediaIds),
+  ];
+  return {
+    ...existingRecord,
+    ...nextRecord,
+    mediaIds: [...new Set(mediaIds)],
+  };
+}
+
+function extractStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/db/src/repositories/job-repository.ts
+++ b/packages/db/src/repositories/job-repository.ts
@@ -204,20 +204,28 @@ function mergeDeltaPayload(existing: unknown, next: unknown): Record<string, unk
   const existingRecord = isRecord(existing) ? existing : {};
   const nextRecord = isRecord(next) ? next : {};
   const mediaIds = [
+    ...extractStringArrayOrSingle(existingRecord.mediaId),
     ...extractStringArray(existingRecord.mediaIds),
+    ...extractStringArrayOrSingle(nextRecord.mediaId),
     ...extractStringArray(nextRecord.mediaIds),
   ];
-  return {
+  const merged: Record<string, unknown> = {
     ...existingRecord,
     ...nextRecord,
     mediaIds: [...new Set(mediaIds)],
   };
+  delete merged.mediaId;
+  return merged;
 }
 
 function extractStringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === "string")
     : [];
+}
+
+function extractStringArrayOrSingle(value: unknown): string[] {
+  return typeof value === "string" ? [value] : [];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -1115,9 +1115,13 @@ export function createMediaRepository(
 
     async findAllMediaIndices(
       tx?: Transaction,
-      options?: { limit: number; offset: number },
+      options?: { limit: number; offset?: number; afterId?: string },
     ): Promise<{ id: string; mediaSourceId: string; filePath: string }[]> {
       const client = getExecutor(tx);
+      const conditions = [eq(medias.status, "active")];
+      if (options?.afterId) {
+        conditions.push(gt(medias.id, options.afterId));
+      }
       let query = client
         .select({
           id: medias.id,
@@ -1125,11 +1129,15 @@ export function createMediaRepository(
           filePath: medias.filePath,
         })
         .from(medias)
-        .where(eq(medias.status, "active"))
+        .where(and(...conditions))
+        .orderBy(asc(medias.id))
         .$dynamic();
 
       if (options) {
-        query = query.limit(options.limit).offset(options.offset);
+        query = query.limit(options.limit);
+        if (options.offset != null) {
+          query = query.offset(options.offset);
+        }
       }
 
       return await query;

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -1114,12 +1114,12 @@ export function createMediaRepository(
     },
 
     async findAllMediaIndices(
+      options: { limit: number; offset?: number; afterId?: string },
       tx?: Transaction,
-      options?: { limit: number; offset?: number; afterId?: string },
     ): Promise<{ id: string; mediaSourceId: string; filePath: string }[]> {
       const client = getExecutor(tx);
       const conditions = [eq(medias.status, "active")];
-      if (options?.afterId) {
+      if (options.afterId) {
         conditions.push(gt(medias.id, options.afterId));
       }
       let query = client
@@ -1133,11 +1133,9 @@ export function createMediaRepository(
         .orderBy(asc(medias.id))
         .$dynamic();
 
-      if (options) {
-        query = query.limit(options.limit);
-        if (options.offset != null) {
-          query = query.offset(options.offset);
-        }
+      query = query.limit(options.limit);
+      if (options.offset != null) {
+        query = query.offset(options.offset);
       }
 
       return await query;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -589,6 +589,38 @@ export const mediaSync = pgTable("media_sync", {
 });
 
 /**
+ * Schema for LanceDB synchronization dirty markers.
+ * Tracks media rows that need to be reflected into the per-source LanceDB cache.
+ */
+export const lanceDbSyncDirty = pgTable(
+  "lancedb_sync_dirty",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    mediaSourceId: uuid("source_id")
+      .notNull()
+      .references(() => mediaSources.id, { onDelete: "cascade" }),
+    mediaId: uuid("media_id").notNull(),
+    operation: text("operation").notNull().default("upsert"),
+    attempts: integer("attempts").notNull().default(0),
+    lastError: text("last_error"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    sourceMediaUnique: unique("lancedb_sync_dirty_source_media_unique").on(
+      table.mediaSourceId,
+      table.mediaId,
+    ),
+    sourceUpdatedIndex: index("idx_lancedb_sync_dirty_source_updated").on(
+      table.mediaSourceId,
+      table.updatedAt,
+    ),
+  }),
+);
+
+/**
  * Schema for the view_history table.
  * Records user views of media items for analytics and personalized recommendations.
  */
@@ -1433,6 +1465,16 @@ export type MediaSync = InferSelectModel<typeof mediaSync>;
  * Type definition for inserting new media sync information into the database.
  */
 export type NewMediaSync = InferInsertModel<typeof mediaSync>;
+
+/**
+ * Type definition for selecting LanceDB sync dirty markers from the database.
+ */
+export type LanceDbSyncDirty = InferSelectModel<typeof lanceDbSyncDirty>;
+
+/**
+ * Type definition for inserting LanceDB sync dirty markers into the database.
+ */
+export type NewLanceDbSyncDirty = InferInsertModel<typeof lanceDbSyncDirty>;
 
 /**
  * Type definition for selecting a view history entry from the database.


### PR DESCRIPTION
## 概要
起動時とジョブ完了後に自動投入される LanceDB 同期で重い DB クエリが走らないようにし、missing thumbnail のスキャンを offset から keyset pagination に変更します。

## 変更内容
- startup checks から sync_lancedb 自動投入を削除
- processMedia/auto_tagging 完了後の sync_lancedb 自動投入を削除
- findAllMediaIndices に afterId を追加し keyset pagination に対応
- maintenance の missing thumbnail scan を afterId ベースに変更
- 関連 unit test を更新

## 検証
- bun --filter @solid-imager/server check
- bun --filter @solid-imager/server test:unit -- src/tests/unit/application/services/maintenance-service.test.ts
- bun run typecheck