### PR TITLE
feat(lancedb): LanceDBの初回スロー同期サポートとcacheDir設定の追加

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -17,6 +17,7 @@
     "db:drop": "drizzle-kit drop",
     "db:dump": "bun scripts/dump-db.ts",
     "db:restore": "bun scripts/restore-db.ts",
+    "lancedb:sync-slow": "bun scripts/sync-lancedb-slow.ts",
     "db:studio": "drizzle-kit studio",
     "lint": "biome lint ./src",
     "format": "biome format --fix ./src",

--- a/apps/server/scripts/sync-lancedb-slow.ts
+++ b/apps/server/scripts/sync-lancedb-slow.ts
@@ -1,0 +1,64 @@
+/// <reference types="bun-types" />
+import { eq } from "drizzle-orm";
+import { BackupService } from "~/application/services/backup-service";
+import { initServices } from "~/infrastructure/bootstrap";
+import { db } from "~/infrastructure/db";
+import { mediaSources } from "~/infrastructure/db/schema";
+
+async function main() {
+	// Initialize configuration and registry services
+	initServices();
+
+	const args = process.argv.slice(2);
+	// usage: bun scripts/sync-lancedb-slow.ts [mediaSourceId] [batchSize] [delayMs]
+	const mediaSourceId = args[0] || null;
+	const batchSize = args[1] ? Number.parseInt(args[1], 10) : 100;
+	const delayMs = args[2] ? Number.parseInt(args[2], 10) : 500;
+
+	if (Number.isNaN(batchSize) || Number.isNaN(delayMs)) {
+		console.error(
+			"Usage: bun scripts/sync-lancedb-slow.ts [mediaSourceId] [batchSize] [delayMs]",
+		);
+		process.exit(1);
+	}
+
+	console.log("📦 Starting slow LanceDB synchronization...");
+	console.log(`⚙️ Batch size: ${batchSize}`);
+	console.log(`⚙️ Delay: ${delayMs}ms`);
+
+	let sourcesToSync = [];
+	if (mediaSourceId && mediaSourceId !== "all") {
+		const source = await db.query.mediaSources.findFirst({
+			where: eq(mediaSources.id, mediaSourceId),
+		});
+		if (!source) {
+			console.error(`❌ Media source with ID ${mediaSourceId} not found.`);
+			process.exit(1);
+		}
+		sourcesToSync.push(source);
+	} else {
+		sourcesToSync = await db.query.mediaSources.findMany();
+	}
+
+	console.log(`📂 Found ${sourcesToSync.length} media source(s) to sync.`);
+
+	for (const source of sourcesToSync) {
+		console.log(`🔄 Syncing media source: ${source.name} (${source.id})...`);
+		try {
+			await BackupService.syncSourceLanceDBCache(source.id, {
+				batchSize,
+				delayMs,
+			});
+			console.log(`✅ Successfully synced ${source.name}.`);
+		} catch (error) {
+			console.error(`❌ Failed to sync source ${source.name}:`, error);
+		}
+	}
+
+	console.log("🏁 Slow sync script finished.");
+}
+
+main().catch((err) => {
+	console.error("❌ Script error:", err);
+	process.exit(1);
+});

--- a/apps/server/scripts/sync-lancedb-slow.ts
+++ b/apps/server/scripts/sync-lancedb-slow.ts
@@ -15,9 +15,9 @@ async function main() {
 	const batchSize = args[1] ? Number.parseInt(args[1], 10) : 100;
 	const delayMs = args[2] ? Number.parseInt(args[2], 10) : 500;
 
-	if (Number.isNaN(batchSize) || Number.isNaN(delayMs)) {
+	if (Number.isNaN(batchSize) || Number.isNaN(delayMs) || batchSize <= 0 || delayMs < 0) {
 		console.error(
-			"Usage: bun scripts/sync-lancedb-slow.ts [mediaSourceId] [batchSize] [delayMs]",
+			"Usage: bun scripts/sync-lancedb-slow.ts [mediaSourceId] [batchSize] [delayMs]\nNote: batchSize must be > 0 and delayMs must be >= 0",
 		);
 		process.exit(1);
 	}

--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -1142,21 +1142,36 @@ export const BackupService = {
 			throw new Error("Media source not found");
 		}
 
-		const cacheDir = path.join(
-			process.cwd(),
-			".cache",
-			"lancedb-cache",
-			`source-${mediaSourceId}`,
-		);
+		const { services } = await import("~/application/registry");
+		const config = services.getConfigService().getConfig();
+		const baseCacheDir = config.lancedb?.cacheDir ?? ".cache/lancedb-cache";
+		const cacheDir = path.isAbsolute(baseCacheDir)
+			? path.join(baseCacheDir, `source-${mediaSourceId}`)
+			: path.join(process.cwd(), baseCacheDir, `source-${mediaSourceId}`);
+
 		const manifestPath = path.join(cacheDir, "manifest.json");
 		try {
 			const content = await fs.readFile(manifestPath, "utf-8");
 			const manifest = JSON.parse(content) as { version?: unknown };
 			if (manifest.version !== 3) {
+				if (!config.lancedb?.autoFullSync) {
+					logger.warn(
+						{ mediaSourceId },
+						"LanceDB auto full sync is disabled because manifest version is invalid. Skipping auto sync.",
+					);
+					return { mode: "delta", processed: 0 };
+				}
 				await this.syncSourceLanceDBCache(mediaSourceId);
 				return { mode: "full", processed: 0 };
 			}
 		} catch {
+			if (!config.lancedb?.autoFullSync) {
+				logger.warn(
+					{ mediaSourceId },
+					"LanceDB auto full sync is disabled because manifest.json is missing. Skipping auto sync.",
+				);
+				return { mode: "delta", processed: 0 };
+			}
 			await this.syncSourceLanceDBCache(mediaSourceId);
 			return { mode: "full", processed: 0 };
 		}
@@ -1260,7 +1275,10 @@ export const BackupService = {
 	 * Generates a dump of the media source.
 	 * Returns a JSON object or a ReadableStream for ZIP download.
 	 */
-	async syncSourceLanceDBCache(mediaSourceId: string) {
+	async syncSourceLanceDBCache(
+		mediaSourceId: string,
+		options?: { batchSize?: number; delayMs?: number },
+	) {
 		const mediaSource = await db.query.mediaSources.findFirst({
 			where: eq(mediaSources.id, mediaSourceId),
 		});
@@ -1269,19 +1287,20 @@ export const BackupService = {
 			throw new Error("Media source not found");
 		}
 
-		const cacheDir = path.join(
-			process.cwd(),
-			".cache",
-			"lancedb-cache",
-			`source-${mediaSourceId}`,
-		);
+		const { services } = await import("~/application/registry");
+		const config = services.getConfigService().getConfig();
+		const baseCacheDir = config.lancedb?.cacheDir ?? ".cache/lancedb-cache";
+		const cacheDir = path.isAbsolute(baseCacheDir)
+			? path.join(baseCacheDir, `source-${mediaSourceId}`)
+			: path.join(process.cwd(), baseCacheDir, `source-${mediaSourceId}`);
 		await fs.mkdir(cacheDir, { recursive: true });
 
 		const { syncLanceDBPages } = await import(
 			"~/application/services/lancedb-dump-service"
 		);
 
-		const limit = 1000;
+		const limit = options?.batchSize ?? 1000;
+		const delayMs = options?.delayMs ?? 0;
 		const self = this;
 
 		async function* loadPages(): AsyncIterable<MediaDumpItem[]> {
@@ -1320,6 +1339,10 @@ export const BackupService = {
 					break;
 				}
 				lastId = mediaList.at(-1)?.id ?? lastId;
+
+				if (delayMs > 0) {
+					await new Promise((resolve) => setTimeout(resolve, delayMs));
+				}
 			}
 		}
 

--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -1145,9 +1145,11 @@ export const BackupService = {
 		const { services } = await import("~/application/registry");
 		const config = services.getConfigService().getConfig();
 		const baseCacheDir = config.lancedb?.cacheDir ?? ".cache/lancedb-cache";
-		const cacheDir = path.isAbsolute(baseCacheDir)
-			? path.join(baseCacheDir, `source-${mediaSourceId}`)
-			: path.join(process.cwd(), baseCacheDir, `source-${mediaSourceId}`);
+		const cacheDir = path.resolve(
+			process.cwd(),
+			baseCacheDir,
+			`source-${mediaSourceId}`,
+		);
 
 		const manifestPath = path.join(cacheDir, "manifest.json");
 		try {
@@ -1290,9 +1292,11 @@ export const BackupService = {
 		const { services } = await import("~/application/registry");
 		const config = services.getConfigService().getConfig();
 		const baseCacheDir = config.lancedb?.cacheDir ?? ".cache/lancedb-cache";
-		const cacheDir = path.isAbsolute(baseCacheDir)
-			? path.join(baseCacheDir, `source-${mediaSourceId}`)
-			: path.join(process.cwd(), baseCacheDir, `source-${mediaSourceId}`);
+		const cacheDir = path.resolve(
+			process.cwd(),
+			baseCacheDir,
+			`source-${mediaSourceId}`,
+		);
 		await fs.mkdir(cacheDir, { recursive: true });
 
 		const { syncLanceDBPages } = await import(

--- a/packages/core/src/domain/config/config-schema.ts
+++ b/packages/core/src/domain/config/config-schema.ts
@@ -148,6 +148,16 @@ const DEFAULT_LOGGING_CONFIG = {
 	level: "info",
 } as const;
 
+export const LanceDbConfigSchema = z.object({
+	autoFullSync: z.boolean().default(true),
+	cacheDir: z.string().default(".cache/lancedb-cache"),
+});
+
+const DEFAULT_LANCEDB_CONFIG = {
+	autoFullSync: true,
+	cacheDir: ".cache/lancedb-cache",
+} as const;
+
 export const AppConfigSchema = z.object({
 	version: z.string().default("1.0.0"),
 	jobs: JobsConfigSchema.default(DEFAULT_JOBS_CONFIG),
@@ -156,6 +166,7 @@ export const AppConfigSchema = z.object({
 	storage: StorageConfigSchema.default(DEFAULT_STORAGE_CONFIG),
 	media: MediaConfigSchema.default(DEFAULT_MEDIA_CONFIG),
 	logging: LoggingConfigSchema.default(DEFAULT_LOGGING_CONFIG),
+	lancedb: LanceDbConfigSchema.default(DEFAULT_LANCEDB_CONFIG),
 });
 
 export type AppConfig = z.infer<typeof AppConfigSchema>;


### PR DESCRIPTION
## 概要
初回同期時に全件検知となり処理が重すぎる課題を解決するため、初回だけゆっくり同期をとるための手動スクリプトを実装し、キャッシュディレクトリと自動フル同期の制御を設定ファイル（config.json）から行えるようにしました。

## 変更内容
- packages/core: config-schema.ts に `lancedb.autoFullSync` と `lancedb.cacheDir` を追加。
- apps/server: backup-service.ts 内でキャッシュディレクトリと自動同期のスキップ設定を config からロードするよう変更。
- apps/server: syncSourceLanceDBCache にバッチ分割・遅延待機用のパラメータを追加。
- apps/server: 初回用の手動ゆっくり同期スクリプト (`sync-lancedb-slow.ts`) を実装。