### PR TITLE
fix(db): support jsonb string scalars in incrementProgress

### DIFF
--- a/packages/db/src/repositories/job-repository.ts
+++ b/packages/db/src/repositories/job-repository.ts
@@ -206,21 +206,21 @@ export function createJobRepository(
 		async incrementProgress(id: string): Promise<void> {
 			await db().execute(
 				sql`UPDATE ${jobs} SET payload = jsonb_set(
-					CASE 
-						WHEN payload IS NULL THEN '{}'::jsonb
-						WHEN jsonb_typeof(payload) = 'string' THEN (payload#>>'{}')::jsonb
-						ELSE payload
-					END,
+					t.parsed_payload,
 					'{processed}',
-					(COALESCE(
-						(CASE 
+					(COALESCE(t.parsed_payload->>'processed', '0')::int + 1)::text::jsonb
+				)
+				FROM (
+					SELECT id,
+						CASE 
 							WHEN payload IS NULL THEN '{}'::jsonb
 							WHEN jsonb_typeof(payload) = 'string' THEN (payload#>>'{}')::jsonb
 							ELSE payload
-						END)->>'processed',
-						'0'
-					)::int + 1)::text::jsonb
-				) WHERE id = ${id}`,
+						END AS parsed_payload
+					FROM ${jobs}
+					WHERE id = ${id}
+				) t
+				WHERE ${jobs}.id = t.id`,
 			);
 		},
 	};

--- a/packages/db/src/repositories/job-repository.ts
+++ b/packages/db/src/repositories/job-repository.ts
@@ -205,7 +205,22 @@ export function createJobRepository(
 
 		async incrementProgress(id: string): Promise<void> {
 			await db().execute(
-				sql`UPDATE ${jobs} SET payload = jsonb_set(payload, '{processed}', (COALESCE(payload->>'processed', '0')::int + 1)::text::jsonb) WHERE id = ${id}`,
+				sql`UPDATE ${jobs} SET payload = jsonb_set(
+					CASE 
+						WHEN payload IS NULL THEN '{}'::jsonb
+						WHEN jsonb_typeof(payload) = 'string' THEN (payload#>>'{}')::jsonb
+						ELSE payload
+					END,
+					'{processed}',
+					(COALESCE(
+						(CASE 
+							WHEN payload IS NULL THEN '{}'::jsonb
+							WHEN jsonb_typeof(payload) = 'string' THEN (payload#>>'{}')::jsonb
+							ELSE payload
+						END)->>'processed',
+						'0'
+					)::int + 1)::text::jsonb
+				) WHERE id = ${id}`,
 			);
 		},
 	};


### PR DESCRIPTION
## 概要
Auto tagging などのジョブ進行状況更新時に発生していた `cannot set path in scalar` エラーを修正します。

## 変更内容
- `packages/db/src/repositories/job-repository.ts` の `incrementProgress` において、既存の `payload` が JSON 文字列スカラ型として保存されている場合に、SQL レベルで `jsonb` オブジェクトへキャストしてから `jsonb_set` を実行するように修正しました。
