### PR TITLE
fix(server): LanceDB同期中のジョブワーカー飢餓問題を修正

### DIFF
--- a/apps/server/src/infrastructure/jobs/job-worker.ts
+++ b/apps/server/src/infrastructure/jobs/job-worker.ts
@@ -94,6 +94,7 @@ export class JobWorker {
 				if (slots > 0) {
 					const jobs = await this.jobRepo.findPending(slots, {
 						excludeTypes: Array.from(this.aiJobTypes),
+						excludeLanceDbSourceIds: Array.from(this.activeLanceDbSyncKeys),
 					});
 					for (const job of jobs) {
 						this.tryProcessJob(job);

--- a/apps/server/src/tests/unit/infrastructure/jobs/job-worker.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/job-worker.test.ts
@@ -253,4 +253,62 @@ describe("JobWorker", () => {
 		resolveProcessor();
 		await vi.runOnlyPendingTimersAsync();
 	});
+
+	it("should pass active LanceDB sync source IDs to findPending for exclusion", async () => {
+		worker.updateConfig({
+			jobs: { concurrency: 3, aiConcurrency: 1, pollIntervalMs: 1000 },
+		} as AppConfig);
+
+		const syncJob = {
+			id: "lancedb-sync-1",
+			type: "sync_lancedb",
+			mediaSourceId: "source-active",
+			status: "pending",
+		} as Job;
+
+		let resolveProcessor: () => void = () => {};
+		processor = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveProcessor = resolve;
+				}),
+		);
+		worker = new JobWorker(jobRepo, processor);
+		worker.updateConfig({
+			jobs: { concurrency: 3, aiConcurrency: 1, pollIntervalMs: 1000 },
+		} as AppConfig);
+
+		// First call: returns the sync job, making it active
+		(jobRepo.findPending as any).mockImplementationOnce(() => {
+			return Promise.resolve([syncJob]);
+		});
+
+		// Second call: should include "source-active" in excludeLanceDbSourceIds
+		(jobRepo.findPending as any).mockImplementationOnce(
+			(_limit: number, options: any) => {
+				expect(options?.excludeLanceDbSourceIds).toContain("source-active");
+				return Promise.resolve([]);
+			},
+		);
+
+		worker.start();
+		// Advance to trigger first poll and start processing syncJob
+		await vi.advanceTimersByTimeAsync(TimerDelay);
+
+		expect(processor).toHaveBeenCalledTimes(1);
+		expect(processor).toHaveBeenCalledWith(syncJob);
+
+		// Advance to trigger second poll while syncJob is still active
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(jobRepo.findPending).toHaveBeenLastCalledWith(
+			2, // 3 slots total - 1 active job = 2 slots remaining
+			expect.objectContaining({
+				excludeLanceDbSourceIds: ["source-active"],
+			}),
+		);
+
+		resolveProcessor();
+		await vi.runOnlyPendingTimersAsync();
+	});
 });

--- a/packages/core/src/domain/repositories/job-repository.ts
+++ b/packages/core/src/domain/repositories/job-repository.ts
@@ -32,7 +32,11 @@ export type IJobRepository = {
 	findById(id: string): Promise<Job | null>;
 	findPending(
 		limit: number,
-		options?: { excludeTypes?: string[]; includeTypes?: string[] },
+		options?: {
+			excludeTypes?: string[];
+			includeTypes?: string[];
+			excludeLanceDbSourceIds?: string[];
+		},
 	): Promise<Job[]>;
 	markAsInProgress(id: string): Promise<void>;
 	markAsCompleted(id: string, result?: unknown): Promise<void>;

--- a/packages/db/src/repositories/job-repository.ts
+++ b/packages/db/src/repositories/job-repository.ts
@@ -4,7 +4,17 @@ import type {
 	NewJob,
 } from "@solid-imager/core/domain/repositories/job-repository";
 import { isJobStatus } from "@solid-imager/core/utils/type-guards";
-import { and, asc, eq, inArray, ne, not, notInArray, sql } from "drizzle-orm";
+import {
+	and,
+	asc,
+	eq,
+	inArray,
+	isNotNull,
+	ne,
+	not,
+	notInArray,
+	sql,
+} from "drizzle-orm";
 import { jobs } from "../schema";
 import type { DrizzleExecutor } from "../types";
 
@@ -161,6 +171,7 @@ export function createJobRepository(
 						"sync_lancedb_full",
 						"sync_lancedb_delta",
 					]),
+					isNotNull(jobs.mediaSourceId),
 					inArray(jobs.mediaSourceId, options.excludeLanceDbSourceIds),
 				);
 				if (innerCond) {

--- a/packages/db/src/repositories/job-repository.ts
+++ b/packages/db/src/repositories/job-repository.ts
@@ -4,7 +4,7 @@ import type {
 	NewJob,
 } from "@solid-imager/core/domain/repositories/job-repository";
 import { isJobStatus } from "@solid-imager/core/utils/type-guards";
-import { and, asc, eq, inArray, ne, notInArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, ne, not, notInArray, sql } from "drizzle-orm";
 import { jobs } from "../schema";
 import type { DrizzleExecutor } from "../types";
 
@@ -126,7 +126,11 @@ export function createJobRepository(
 
 		async findPending(
 			limit: number,
-			options?: { excludeTypes?: string[]; includeTypes?: string[] },
+			options?: {
+				excludeTypes?: string[];
+				includeTypes?: string[];
+				excludeLanceDbSourceIds?: string[];
+			},
 		): Promise<Job[]> {
 			if (options?.excludeTypes?.length && options?.includeTypes?.length) {
 				throw new Error(
@@ -145,6 +149,26 @@ export function createJobRepository(
 
 			if (options?.includeTypes?.length) {
 				conditions.push(inArray(jobs.type, options.includeTypes));
+			}
+
+			if (
+				options?.excludeLanceDbSourceIds &&
+				options.excludeLanceDbSourceIds.length > 0
+			) {
+				const innerCond = and(
+					inArray(jobs.type, [
+						"sync_lancedb",
+						"sync_lancedb_full",
+						"sync_lancedb_delta",
+					]),
+					inArray(jobs.mediaSourceId, options.excludeLanceDbSourceIds),
+				);
+				if (innerCond) {
+					const excludeCond = not(innerCond);
+					if (excludeCond) {
+						conditions.push(excludeCond);
+					}
+				}
 			}
 
 			const rows = await db()


### PR DESCRIPTION
## 概要
LanceDB同期ジョブが並列実行制限（直列化）でスキップされる際、キューの先頭に居座ってダウンロードなど他のジョブの取得スロット（findPendingのLimit）を塞いでしまう「ジョブの飢餓」問題を修正します。

## 変更内容
- IJobRepository.findPending() に excludeLanceDbSourceIds オプションを追加
- JobWorker でポーリングする際、現在アクティブな同期ソースIDを渡してクエリレベルで除外
- 除外が正しくクエリパラメータに渡されることを検証するユニットテストの追加