### PR TITLE
fix(xtracter): ターゲットホスト切り替え時のキャッシュ不整合を修正

### DIFF
--- a/apps/xtracter/src/background/index.ts
+++ b/apps/xtracter/src/background/index.ts
@@ -83,17 +83,31 @@ async function getTargetSourceId(): Promise<string | null> {
 	const result: { selectedSourceId?: string } = await chrome.storage.local.get([
 		"selectedSourceId",
 	]);
+
+	const sources = await getMediaSources();
+
 	if (result.selectedSourceId) {
-		return result.selectedSourceId;
+		if (sources.length > 0) {
+			const exists = sources.some((s) => s.id === result.selectedSourceId);
+			if (exists) {
+				return result.selectedSourceId;
+			}
+			// Remove invalid source ID from storage and proceed to fallback
+			await chrome.storage.local.remove("selectedSourceId");
+		} else {
+			// Fallback to the stored ID if source retrieval failed (e.g. network issue)
+			return result.selectedSourceId;
+		}
 	}
 
 	// 2. Fallback
-	const sources = await getMediaSources();
 	const twitterSource = sources.find((s) => s.name === "twitter");
 	if (twitterSource?.id) {
+		await chrome.storage.local.set({ selectedSourceId: twitterSource.id });
 		return twitterSource.id;
 	}
 	if (sources.length > 0 && sources[0].id) {
+		await chrome.storage.local.set({ selectedSourceId: sources[0].id });
 		return sources[0].id;
 	}
 

--- a/apps/xtracter/src/background/index.ts
+++ b/apps/xtracter/src/background/index.ts
@@ -83,24 +83,12 @@ async function getTargetSourceId(): Promise<string | null> {
 	const result: { selectedSourceId?: string } = await chrome.storage.local.get([
 		"selectedSourceId",
 	]);
-
-	const sources = await getMediaSources();
-
 	if (result.selectedSourceId) {
-		if (sources.length > 0) {
-			const exists = sources.some((s) => s.id === result.selectedSourceId);
-			if (exists) {
-				return result.selectedSourceId;
-			}
-			// Remove invalid source ID from storage and proceed to fallback
-			await chrome.storage.local.remove("selectedSourceId");
-		} else {
-			// Fallback to the stored ID if source retrieval failed (e.g. network issue)
-			return result.selectedSourceId;
-		}
+		return result.selectedSourceId;
 	}
 
 	// 2. Fallback
+	const sources = await getMediaSources();
 	const twitterSource = sources.find((s) => s.name === "twitter");
 	if (twitterSource?.id) {
 		await chrome.storage.local.set({ selectedSourceId: twitterSource.id });

--- a/apps/xtracter/src/popup/index.tsx
+++ b/apps/xtracter/src/popup/index.tsx
@@ -47,9 +47,6 @@ function Popup() {
 				const firstId = resp[0].id;
 				setSelectedSourceId(firstId);
 				await chrome.storage.local.set({ selectedSourceId: firstId });
-			} else if (!resp || resp.length === 0) {
-				setSelectedSourceId("");
-				await chrome.storage.local.remove("selectedSourceId");
 			}
 			setStatus("");
 		} catch (_err) {

--- a/apps/xtracter/src/popup/index.tsx
+++ b/apps/xtracter/src/popup/index.tsx
@@ -37,10 +37,19 @@ function Popup() {
 				type: "GET_SOURCES",
 			});
 			setSources(resp || []);
-			if (resp && resp.length > 0 && !selectedSourceId()) {
+
+			const hasSelectedSource = resp?.some((s) => s.id === selectedSourceId());
+			if (
+				resp &&
+				resp.length > 0 &&
+				(!selectedSourceId() || !hasSelectedSource)
+			) {
 				const firstId = resp[0].id;
 				setSelectedSourceId(firstId);
 				await chrome.storage.local.set({ selectedSourceId: firstId });
+			} else if (!resp || resp.length === 0) {
+				setSelectedSourceId("");
+				await chrome.storage.local.remove("selectedSourceId");
 			}
 			setStatus("");
 		} catch (_err) {


### PR DESCRIPTION
## 概要
Xtracterブラウザ拡張機能において、ターゲットホスト(apiUrl)切り替え時に古いホストのメディアソースIDキャッシュが残ることで、個別メディアポストが失敗する不具合を修正します。

## 変更内容
- background/index.ts 内で、ストレージの selectedSourceId が現在のホストのソースリストに実在するか検証する処理を追加
- popup/index.tsx 内で、読み込んだソースリストに selectedSourceId が含まれているか検証し、存在しない場合は自動リセット・再選択する処理を追加