### PR TITLE
perf(ui): 作者検索のパフォーマンス向上と仮想化バグの修正

### DIFF
--- a/apps/server/src/components/media/pro-search-builder.tsx
+++ b/apps/server/src/components/media/pro-search-builder.tsx
@@ -342,6 +342,7 @@ function CriterionBuilder(props: {
 		if (!query) return items.slice(0, 100);
 		return items
 			.filter((item) => {
+				if (!item) return false;
 				const label =
 					props.criterion.target === "author"
 						? getAuthorLabel(item as Author)
@@ -485,15 +486,19 @@ function CriterionBuilder(props: {
 						}}
 						onInputChange={(text) => setFilterText(text)}
 						optionLabel={(item) =>
-							props.criterion.target === "author"
-								? getAuthorLabel(item as Author)
-								: (item as { name: string }).name
+							item
+								? props.criterion.target === "author"
+									? getAuthorLabel(item as Author)
+									: (item as { name: string }).name
+								: ""
 						}
 						options={filteredItems()}
 						optionTextValue={(item) =>
-							props.criterion.target === "author"
-								? getAuthorLabel(item as Author)
-								: (item as { name: string }).name
+							item
+								? props.criterion.target === "author"
+									? getAuthorLabel(item as Author)
+									: (item as { name: string }).name
+								: ""
 						}
 						optionValue={(item: { name: string }) => item.name}
 						placeholder="検索..."

--- a/apps/server/src/components/media/pro-search-builder.tsx
+++ b/apps/server/src/components/media/pro-search-builder.tsx
@@ -25,7 +25,10 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@solid-imager/ui/select";
-import { parseSelectValue } from "@solid-imager/ui/utils";
+import {
+	createDebouncedSignal,
+	parseSelectValue,
+} from "@solid-imager/ui/utils";
 import { cn } from "@solid-imager/ui/utils/cn";
 import { createMemo, Index, Match, Show, Switch } from "solid-js";
 
@@ -330,6 +333,24 @@ function CriterionBuilder(props: {
 			? `${author.name}: (twitter)${author.accountId}`
 			: author.name;
 
+	const [filterText, setFilterText] = createDebouncedSignal("", 150);
+
+	const filteredItems = createMemo(() => {
+		const items = autocompleteItems();
+		if (!items) return [];
+		const query = filterText().toLowerCase();
+		if (!query) return items.slice(0, 100);
+		return items
+			.filter((item) => {
+				const label =
+					props.criterion.target === "author"
+						? getAuthorLabel(item as Author)
+						: (item as { name: string }).name;
+				return label.toLowerCase().includes(query);
+			})
+			.slice(0, 100);
+	});
+
 	// Helper to determine available items for autocomplete
 	const autocompleteItems = createMemo(() => {
 		switch (props.criterion.target) {
@@ -462,12 +483,13 @@ function CriterionBuilder(props: {
 								props.onChange({ ...props.criterion, value: val.name });
 							}
 						}}
+						onInputChange={(text) => setFilterText(text)}
 						optionLabel={(item) =>
 							props.criterion.target === "author"
 								? getAuthorLabel(item as Author)
 								: (item as { name: string }).name
 						}
-						options={autocompleteItems() || []}
+						options={filteredItems()}
 						optionTextValue={(item) =>
 							props.criterion.target === "author"
 								? getAuthorLabel(item as Author)

--- a/apps/server/src/components/media/search-filters.tsx
+++ b/apps/server/src/components/media/search-filters.tsx
@@ -68,10 +68,10 @@ function FilterSection<T>(props: {
 		const items = props.items;
 		if (!items) return [];
 		const query = filterText().toLowerCase();
-		if (!query) return items;
-		return items.filter((item) =>
-			props.getItemLabel(item).toLowerCase().includes(query),
-		);
+		if (!query) return items.slice(0, 100);
+		return items
+			.filter((item) => props.getItemLabel(item).toLowerCase().includes(query))
+			.slice(0, 100);
 	});
 
 	return (

--- a/packages/ui/src/combobox.tsx
+++ b/packages/ui/src/combobox.tsx
@@ -2,7 +2,14 @@ import * as ComboboxPrimitive from "@kobalte/core/combobox";
 import type { PolymorphicProps } from "@kobalte/core/polymorphic";
 import { createVirtualizer } from "@tanstack/solid-virtual";
 import type { JSX, ValidComponent } from "solid-js";
-import { createEffect, createMemo, For, Show, splitProps } from "solid-js";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	For,
+	Show,
+	splitProps,
+} from "solid-js";
 
 import { cn } from "./utils/cn";
 
@@ -200,11 +207,11 @@ const VirtualComboboxContent = <T extends ValidComponent = "div">(
 	props: PolymorphicProps<T, ComboboxContentProps<T>>,
 ) => {
 	const [local, others] = splitProps(props as ComboboxContentProps, ["class"]);
-	let scrollEl: HTMLUListElement | undefined;
+	const [scrollEl, setScrollEl] = createSignal<HTMLUListElement | null>(null);
 
 	const virtualizer = createVirtualizer({
 		count: 0,
-		getScrollElement: () => scrollEl ?? null,
+		getScrollElement: () => scrollEl(),
 		estimateSize: () => ITEM_HEIGHT_PX,
 		overscan: VIRTUAL_OVERSCAN,
 	});
@@ -221,7 +228,7 @@ const VirtualComboboxContent = <T extends ValidComponent = "div">(
 				<ComboboxPrimitive.Listbox
 					class="m-0 p-1"
 					ref={(el: Element) => {
-						scrollEl = el as HTMLUListElement;
+						setScrollEl(el as HTMLUListElement);
 					}}
 					scrollToItem={(key) => {
 						const items = virtualizer.getVirtualItems();

--- a/packages/ui/src/pro-search-builder.tsx
+++ b/packages/ui/src/pro-search-builder.tsx
@@ -27,6 +27,7 @@ import {
 	SelectValue,
 } from "./select";
 import { cn } from "./utils/cn";
+import { createDebouncedSignal } from "./utils/debounce";
 import { parseSelectValue } from "./utils/parse-select-value";
 
 const TARGET_LABELS: Record<string, string> = {
@@ -312,6 +313,21 @@ function CriterionBuilder(props: {
 			? `${author.name}：(twitter)${author.accountId}`
 			: author.name;
 
+	const [filterText, setFilterText] = createDebouncedSignal("", 150);
+
+	const filteredItems = createMemo(() => {
+		const items = autocompleteItems();
+		if (!items) return [];
+		const query = filterText().toLowerCase();
+		if (!query) return items.slice(0, 100);
+		return items
+			.filter((item) => {
+				const label = "accountId" in item ? getAuthorLabel(item) : item.name;
+				return label.toLowerCase().includes(query);
+			})
+			.slice(0, 100);
+	});
+
 	const autocompleteItems = createMemo<RelationOption[] | undefined>(() => {
 		switch (props.criterion.target) {
 			case "tag":
@@ -462,10 +478,11 @@ function CriterionBuilder(props: {
 								props.onChange({ ...props.criterion, value: value.name });
 							}
 						}}
+						onInputChange={(text) => setFilterText(text)}
 						optionLabel={(item) =>
 							"accountId" in item ? getAuthorLabel(item) : item.name
 						}
-						options={autocompleteItems() || []}
+						options={filteredItems()}
 						optionTextValue={(item) =>
 							"accountId" in item ? getAuthorLabel(item) : item.name
 						}

--- a/packages/ui/src/pro-search-builder.tsx
+++ b/packages/ui/src/pro-search-builder.tsx
@@ -322,6 +322,7 @@ function CriterionBuilder(props: {
 		if (!query) return items.slice(0, 100);
 		return items
 			.filter((item) => {
+				if (!item) return false;
 				const label = "accountId" in item ? getAuthorLabel(item) : item.name;
 				return label.toLowerCase().includes(query);
 			})
@@ -480,11 +481,19 @@ function CriterionBuilder(props: {
 						}}
 						onInputChange={(text) => setFilterText(text)}
 						optionLabel={(item) =>
-							"accountId" in item ? getAuthorLabel(item) : item.name
+							item
+								? "accountId" in item
+									? getAuthorLabel(item)
+									: item.name
+								: ""
 						}
 						options={filteredItems()}
 						optionTextValue={(item) =>
-							"accountId" in item ? getAuthorLabel(item) : item.name
+							item
+								? "accountId" in item
+									? getAuthorLabel(item)
+									: item.name
+								: ""
 						}
 						optionValue={(item) => item.name}
 						placeholder="検索..."

--- a/packages/ui/src/screens/media-detail-screen.tsx
+++ b/packages/ui/src/screens/media-detail-screen.tsx
@@ -40,7 +40,10 @@ export function MediaDetailScreen(props: MediaDetailScreenProps) {
 
 	const handleUpdate = async () => {
 		await queryClient.invalidateQueries({
-			queryKey: props.mediaDetailsQueryOptions(props.mediaSourceId, props.mediaId).queryKey,
+			queryKey: props.mediaDetailsQueryOptions(
+				props.mediaSourceId,
+				props.mediaId,
+			).queryKey,
 		});
 		if (props.onAdditionalInvalidate) {
 			await props.onAdditionalInvalidate();

--- a/packages/ui/src/search-filters.tsx
+++ b/packages/ui/src/search-filters.tsx
@@ -53,10 +53,10 @@ function FilterSection<T>(props: {
 		const items = props.items;
 		if (!items) return [];
 		const query = filterText().toLowerCase();
-		if (!query) return items;
-		return items.filter((item) =>
-			props.getItemLabel(item).toLowerCase().includes(query),
-		);
+		if (!query) return items.slice(0, 100);
+		return items
+			.filter((item) => props.getItemLabel(item).toLowerCase().includes(query))
+			.slice(0, 100);
 	});
 
 	return (


### PR DESCRIPTION
## 概要
作者（author）の件数が多い場合に、簡易検索サイドバーおよび詳細検索の Combobox で入力や描画が重くなる問題を解消しました。

## 変更内容
- **仮想スクロールの修正** (combobox.tsx):
  - scrollEl をシグナルにして、マウント時に createVirtualizer が要素を正しくリアクティブに登録できるようにし、仮想化が正常に動作するようにしました。
- **詳細検索の改善** (pro-search-builder.tsx):
  - FilterSection にすでに導入されていた 150ms デバウンスフィルタを詳細検索の Combobox にも適用し、入力時の高負荷を回避しました。
- **最大表示件数の制限** (search-filters.tsx, pro-search-builder.tsx):
  - 入力および初期フォーカス時に返却するオプション数を最大 100 件に制限し、Kobalte コンポーネントが数万件のノードを一度に解析するのを防ぎました。