### PR TITLE
fix(ui): 検索画面の無限スクロール修正とTauriでの仮想スクロール有効化

### DIFF
--- a/apps/tauri/src/routes/search.tsx
+++ b/apps/tauri/src/routes/search.tsx
@@ -77,6 +77,7 @@ function SearchRoute() {
 
 	return (
 		<SearchScreen
+			enableVirtualization
 			filterData={page.filterData}
 			onSelectSource={(id) => setSearchState("selectedSource", id)}
 			page={page}

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -240,7 +240,7 @@ export function useSearchPage(
 			return;
 		}
 		const hasNextPage = searchResultQuery.hasNextPage;
-		const isFetching = searchResultQuery.isFetchingNextPage;
+		const isFetching = searchResultQuery.isFetching;
 
 		if (!hasNextPage || isFetching) {
 			return;

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -239,13 +239,16 @@ export function useSearchPage(
 		if (!el) {
 			return;
 		}
+		const hasNextPage = searchResultQuery.hasNextPage;
+		const isFetching = searchResultQuery.isFetchingNextPage;
+
+		if (!hasNextPage || isFetching) {
+			return;
+		}
+
 		const observer = new IntersectionObserver(
 			(entries) => {
-				if (
-					entries[0].isIntersecting &&
-					searchResultQuery.hasNextPage &&
-					!searchResultQuery.isFetchingNextPage
-				) {
+				if (entries[0].isIntersecting) {
 					searchResultQuery.fetchNextPage();
 				}
 			},


### PR DESCRIPTION
## 概要
検索画面（Search）において、最初のページ（20件）を表示した段階で無限スクロールが停止してしまい、スクロールによる追加読み込みが機能しなかったバグを修正します。また、Tauriアプリの検索画面でも仮想スクロール（TanStack Virtual）を有効化します。

## 変更内容
- packages/ui の use-search-page.ts: 無限スクロールの IntersectionObserver を監視する createEffect に hasNextPage と isFetchingNextPage を依存関係として追加し、クエリの状態変更をリアクティブに反映して observer を再構築するように修正しました。これにより、初期データロード完了後に正しくスクロール検知が開始されます。
- apps/tauri の search.tsx: SearchScreen に対して enableVirtualization プロップスを渡すようにし、Tauri側でも仮想スクロールが動作するようにしました。