### PR TITLE
refactor: integrate console logs into pino logger and add logging rules

### DIFF
--- a/.agents/skills/logging-rules/SKILL.md
+++ b/.agents/skills/logging-rules/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: logging-rules
+description: solid-imager プロジェクトにおけるロギング方針、Pino loggerの利用、アプリケーション・コア層でのILoggerインターフェースによる依存注入ルール、および console.log 禁止に関するガイドライン。
+---
+
+# solid-imager ロギング規約 (logging-rules)
+
+このプロジェクトでは、サーバーサイドのロギングを統一し、構造化ログを活用するために **Pino** にロギングを統合しています。また、クリーンアーキテクチャの依存ルールを守るため、層ごとにロギングの方法が規定されています。
+
+---
+
+## 1. 基本ルール
+* **`console.log`, `console.warn`, `console.error` の直接使用は原則禁止** (サーバーサイド・アプリケーション層)。
+* ログは **構造化ログ** として出力する。
+  - 第一引数: 関連データを含むオブジェクト (例: `{ err, mediaId }`)
+  - 第二引数: ログメッセージ文字列
+
+---
+
+## 2. レイヤーごとのロギング実装方針
+
+### 2.1. インフラ層・サーバー側エントリーポイント (`apps/server/src/infrastructure`, `apps/server/src/application`)
+インフラ層は直接 Pino ロガーのインスタンスに依存して構いません。
+
+* **使用方法**:
+  ```typescript
+  import { logger } from "~/infrastructure/logger";
+
+  logger.info({ dbHost }, "[DB] Database connected");
+  logger.error({ err }, "An error occurred");
+  ```
+
+### 2.2. アプリケーション層 (`packages/application/src`)
+アプリケーション層はインフラ層 (`~/infrastructure/logger`) に直接依存してはいけません (依存ルール違反)。
+代わりに `ILogger` ポートインターフェースを介した依存性注入 (Dependency Injection) を行います。
+
+* **`ILogger` インターフェース定義** (`packages/application/src/ports/media-service.ts`):
+  ```typescript
+  export interface ILogger {
+  	info(obj: object, msg: string): void;
+  	error(obj: object, msg: string): void;
+  	warn(obj: object, msg: string): void;
+  }
+  ```
+* **依存関係の定義**:
+  ```typescript
+  import type { ILogger } from "../ports/media-service";
+
+  export type SomeServiceDeps = {
+  	logger?: ILogger;
+  	// ...
+  };
+  ```
+* **ロギングの実装**:
+  ```typescript
+  export class SomeServiceImpl {
+  	private readonly logger?: ILogger;
+
+  	constructor(deps: SomeServiceDeps) {
+  		this.logger = deps.logger;
+  	}
+
+  	someMethod() {
+  		this.logger?.info({ data: 123 }, "Executing business logic");
+  	}
+  }
+  ```
+* **インフラ層での注入** (`apps/server/src/infrastructure/bootstrap.ts`):
+  インフラ層の Pino `logger` は `ILogger` のシグネチャと互換性があるため、そのままプロパティとして渡せます。
+  ```typescript
+  const someService = new SomeServiceImpl({
+  	logger, // pino logger
+  	// ...
+  });
+  ```
+
+### 2.3. コア層・ドメイン層 (`packages/core/src`)
+コア層はロガーに依存せず、ログ出力をしません。
+* エラーは例外を投げるか、戻り値 (`{ ok: false, error: string }` 等) として呼び出し側に返し、ロギングはそれを受け取ったアプリケーション層やインフラ層で行います。
+
+### 2.4. Isomorphic コード (サーバー・クライアント共有コード)
+`router.tsx` など、SSR環境とブラウザ環境の両方でロードされるファイルでは、Node/Pino依存モジュールをトップレベルでインポートするとブラウザビルドでエラーになります。
+* **`isServer` 条件下で動的インポート**を行ってロギングを呼び出します。
+  ```typescript
+  import { isServer } from "solid-js/web";
+
+  if (isServer) {
+  	import("./infrastructure/logger").then(({ logger }) => {
+  		logger.info("[Router] Service initialized");
+  	});
+  }
+  ```
+
+### 2.5. クライアントサイド (UI層・ブラウザ環境)
+ブラウザでのみ動作するUIコンポーネントやカスタムフック内では、デバッグや警告のために通常の `console` メソッドを使用して構いません。
+
+* **使用方法**:
+  ```typescript
+  console.warn("Media file loading timed out");
+  ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@
 | スキル名 | 説明 | ロード条件 |
 |---|---|---|
 | `solid-imager` | プロジェクト概要、セットアップ、コーディング規約 | 常時 |
+| `logging-rules` | ロギング方針、Pino loggerの利用、アプリケーション・コア層でのILogger依存注入ルール | ログ出力の実装・変更、デバッグコードの整理時 |
 | `orpc-api` | oRPC APIエンドポイント開発ワークフロー | API実装・変更時 |
 | `database-schema` | DBスキーマ変更・マイグレーション手順 | DBスキーマ変更時 |
 | `ai-service` | Python AIサービス連携 | AI機能実装時 |

--- a/apps/server/src/application/services/tagging-service.ts
+++ b/apps/server/src/application/services/tagging-service.ts
@@ -2,6 +2,7 @@ import type { TaggingServiceDeps } from "@solid-imager/application/services/tagg
 import { TaggingServiceImpl } from "@solid-imager/application/services/tagging-service";
 import { services } from "~/application/registry";
 import { SseManager } from "~/infrastructure/jobs/sse-manager";
+import { logger } from "~/infrastructure/logger";
 
 export { TaggingServiceImpl } from "@solid-imager/application/services/tagging-service";
 
@@ -20,6 +21,7 @@ const getTaggingService = () => {
 			tagRepo: services.getTagRepository(),
 			characterRepo: services.getCharacterRepository(),
 			ipRepo: services.getIpRepository(),
+			logger,
 			sseSendEvent: (mediaSourceId: string, eventType: string, data: unknown) =>
 				SseManager.sendEvent(mediaSourceId, eventType, data),
 			readFileBuffer,

--- a/apps/server/src/infrastructure/bootstrap.ts
+++ b/apps/server/src/infrastructure/bootstrap.ts
@@ -34,6 +34,7 @@ export function initServices() {
 	if (isBootstrapped) {
 		return;
 	}
+	logger.info("[Bootstrap] Initializing server services...");
 	isBootstrapped = true;
 
 	// Initialize and load configuration
@@ -102,6 +103,7 @@ export function initServices() {
 		jobRepo,
 		imageProcessor: services.getImageProcessor(),
 		mediaStorage: services.getMediaStorage(),
+		logger,
 		enableAutoTagging: config.jobs.enableAutoTagging,
 		supportedExtensions: config.media.supportedExtensions,
 		generateThumbnail: (

--- a/apps/server/src/infrastructure/db/index.ts
+++ b/apps/server/src/infrastructure/db/index.ts
@@ -3,6 +3,7 @@ import { PGlite } from "@electric-sql/pglite";
 import { SQL } from "bun";
 import { drizzle as drizzleBunSql } from "drizzle-orm/bun-sql";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import { logger } from "~/infrastructure/logger";
 import * as schema from "./schema";
 
 export type BunSqlDb = ReturnType<typeof drizzleBunSql<typeof schema>>;
@@ -34,8 +35,9 @@ function initializeDb() {
 	const isTestEnv =
 		process.env.NODE_ENV === "test" || process.env.VITEST === "true";
 
-	console.log(
-		`[DB] Initializing. Host: ${dbHost}, Env: ${process.env.NODE_ENV}`,
+	logger.info(
+		{ dbHost, env: process.env.NODE_ENV },
+		"[DB] Initializing database connection",
 	);
 
 	// テスト環境では必ずPGliteを使用
@@ -43,8 +45,9 @@ function initializeDb() {
 		const pglitePath =
 			process.env.PGLITE_DATA_DIR ||
 			path.join(process.cwd(), ".data", "pglite");
-		console.log(
-			`[DB] Using persistent PGlite at path: ${pglitePath} (Absolute: ${path.resolve(pglitePath)})`,
+		logger.info(
+			{ path: pglitePath, absolutePath: path.resolve(pglitePath) },
+			"[DB] Using persistent PGlite database",
 		);
 		const client = new PGlite(pglitePath);
 		_queryClient = client;

--- a/apps/server/src/infrastructure/utils/ffmpeg.ts
+++ b/apps/server/src/infrastructure/utils/ffmpeg.ts
@@ -4,6 +4,7 @@
  */
 
 import ffmpeg from "fluent-ffmpeg";
+import { logger } from "~/infrastructure/logger";
 
 let ffmpegPath: string | null = null;
 let isInitialized = false;
@@ -35,7 +36,7 @@ export async function resolveFfmpegPath(): Promise<string | null> {
 			ffmpegPath = "ffmpeg";
 			return ffmpegPath;
 		} catch (_e) {
-			console.error("Failed to resolve ffmpeg path:", _e);
+			logger.error({ err: _e }, "Failed to resolve ffmpeg path");
 			ffmpegPath = null;
 			return null;
 		}

--- a/apps/server/src/router.tsx
+++ b/apps/server/src/router.tsx
@@ -3,6 +3,7 @@ import { createRouter as createTanStackRouter } from "@tanstack/solid-router";
 import { isServer } from "solid-js/web";
 import { isTransientApiError } from "./infrastructure/api-clients/error-policy";
 import { routeTree } from "./routeTree.gen";
+import type { logger as LoggerInstance } from "./infrastructure/logger";
 
 const QUERY_RETRY_DELAY_CAP_MS = 5_000;
 const QUERY_RETRY_DELAY_BASE_MS = 1_000;
@@ -29,7 +30,15 @@ function createAppQueryClient(): QueryClient {
 	});
 }
 
+let serverLogger: typeof LoggerInstance | null = null;
+
 if (isServer) {
+	import("./infrastructure/logger")
+		.then(({ logger }) => {
+			serverLogger = logger;
+		})
+		.catch(() => {});
+
 	// Initialize services on server startup.
 	// We don't use top-level await here to avoid module format issues with CJS dependencies.
 	import("./infrastructure/bootstrap")
@@ -37,13 +46,11 @@ if (isServer) {
 			initServices();
 		})
 		.catch((err) => {
-			import("./infrastructure/logger")
-				.then(({ logger }) => {
-					logger.error({ err }, "[Router] Failed to initialize services");
-				})
-				.catch(() => {
-					console.error("[Router] Failed to initialize services:", err);
-				});
+			if (serverLogger) {
+				serverLogger.error({ err }, "[Router] Failed to initialize services");
+			} else {
+				console.error("[Router] Failed to initialize services:", err);
+			}
 		});
 }
 
@@ -73,14 +80,8 @@ export function getRouter() {
 			),
 		});
 	} catch (error) {
-		if (isServer) {
-			import("./infrastructure/logger")
-				.then(({ logger }) => {
-					logger.error({ err: error }, "[Router] Error creating router");
-				})
-				.catch(() => {
-					console.error("[Router] Error creating router:", error);
-				});
+		if (isServer && serverLogger) {
+			serverLogger.error({ err: error }, "[Router] Error creating router");
 		} else {
 			console.error("[Router] Error creating router:", error);
 		}

--- a/apps/server/src/router.tsx
+++ b/apps/server/src/router.tsx
@@ -30,16 +30,20 @@ function createAppQueryClient(): QueryClient {
 }
 
 if (isServer) {
-	console.log("[Router] Server-side initialization starting...");
 	// Initialize services on server startup.
 	// We don't use top-level await here to avoid module format issues with CJS dependencies.
 	import("./infrastructure/bootstrap")
 		.then(({ initServices }) => {
-			console.log("[Router] Calling initServices()...");
 			initServices();
 		})
 		.catch((err) => {
-			console.error("[Router] Failed to initialize services:", err);
+			import("./infrastructure/logger")
+				.then(({ logger }) => {
+					logger.error({ err }, "[Router] Failed to initialize services");
+				})
+				.catch(() => {
+					console.error("[Router] Failed to initialize services:", err);
+				});
 		});
 }
 
@@ -69,7 +73,17 @@ export function getRouter() {
 			),
 		});
 	} catch (error) {
-		console.error("[Router] Error creating router:", error);
+		if (isServer) {
+			import("./infrastructure/logger")
+				.then(({ logger }) => {
+					logger.error({ err: error }, "[Router] Error creating router");
+				})
+				.catch(() => {
+					console.error("[Router] Error creating router:", error);
+				});
+		} else {
+			console.error("[Router] Error creating router:", error);
+		}
 		throw error;
 	}
 }

--- a/packages/application/src/services/media-processing-service.ts
+++ b/packages/application/src/services/media-processing-service.ts
@@ -21,6 +21,7 @@ import { localConnectionSchema } from "@solid-imager/core/domain/sources/schemas
 import type { IMediaStorage } from "@solid-imager/core/interfaces/media-storage";
 import { isRecord } from "@solid-imager/core/utils/type-guards";
 import type { IMediaProcessingService } from "../ports/media-processing-service";
+import type { ILogger } from "../ports/media-service";
 
 export type MediaProcessingServiceDeps = {
 	sourceRepo: SourceRepository;
@@ -33,7 +34,7 @@ export type MediaProcessingServiceDeps = {
 	jobRepo: IJobRepository;
 	imageProcessor: IImageProcessor;
 	mediaStorage: IMediaStorage;
-	logger?: { warn(msg: string, data?: unknown): void };
+	logger?: ILogger;
 	enableAutoTagging: boolean;
 	supportedExtensions: {
 		image: string[];
@@ -67,7 +68,7 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 	private readonly supportedExtensions: MediaProcessingServiceDeps["supportedExtensions"];
 	private readonly generateThumbnail: MediaProcessingServiceDeps["generateThumbnail"];
 	private readonly sseSendEvent: MediaProcessingServiceDeps["sseSendEvent"];
-	private readonly logger?: { warn(msg: string, data?: unknown): void };
+	private readonly logger?: ILogger;
 
 	constructor(deps: MediaProcessingServiceDeps) {
 		this.sourceRepo = deps.sourceRepo;
@@ -235,7 +236,7 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 					);
 				}
 			} catch (e) {
-				console.warn(
+				this.logger?.warn(
 					{ err: e, mediaId },
 					"Metadata extraction failed, continuing...",
 				);
@@ -249,7 +250,7 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 				mediaId: media.id,
 			});
 		} catch (e) {
-			console.error({ err: e, mediaId }, "Thumbnail generation failed");
+			this.logger?.error({ err: e, mediaId }, "Thumbnail generation failed");
 		}
 
 		// Step 3: AI tagging
@@ -267,7 +268,10 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 					},
 				});
 			} catch (e) {
-				console.warn({ err: e, mediaId }, "Failed to queue AI tagging job");
+				this.logger?.warn(
+					{ err: e, mediaId },
+					"Failed to queue AI tagging job",
+				);
 			}
 		}
 
@@ -336,7 +340,7 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 			const authorIds = allAuthors.map((a) => a.id);
 			await this.authorRepo.addMediaBulk(mediaId, authorIds, tx);
 		} catch (e) {
-			console.warn({ err: e }, "Failed to register authors");
+			this.logger?.warn({ err: e }, "Failed to register authors");
 		}
 	}
 
@@ -471,7 +475,7 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 				);
 			}
 		} catch (e) {
-			console.warn({ err: e }, "Failed to register characters");
+			this.logger?.warn({ err: e }, "Failed to register characters");
 		}
 	}
 
@@ -509,7 +513,7 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 
 			await this.ipRepo.addMediaBulk(mediaId, ipsToLink, "manual", tx);
 		} catch (e) {
-			console.warn({ err: e }, "Failed to register IPs");
+			this.logger?.warn({ err: e }, "Failed to register IPs");
 		}
 	}
 
@@ -527,7 +531,7 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 			const projectIds = allProjects.map((p) => p.id);
 			await this.projectRepo.addMediaBulk(mediaId, projectIds, tx);
 		} catch (e) {
-			console.warn({ err: e }, "Failed to register projects");
+			this.logger?.warn({ err: e }, "Failed to register projects");
 		}
 	}
 

--- a/packages/application/src/services/media-processing-service.ts
+++ b/packages/application/src/services/media-processing-service.ts
@@ -179,37 +179,40 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 
 		const payload = job.payload;
 		if (!isRecord(payload)) {
-			this.logger?.warn("Missing payload or invalid payload in job", {
-				jobId: job.id,
-			});
+			this.logger?.warn(
+				{ jobId: job.id },
+				"Missing payload or invalid payload in job",
+			);
 			return;
 		}
 		const mediaId = payload.mediaId;
 		if (typeof mediaId !== "string") {
-			this.logger?.warn("Missing or invalid mediaId in job payload", {
-				jobId: job.id,
-			});
+			this.logger?.warn(
+				{ jobId: job.id },
+				"Missing or invalid mediaId in job payload",
+			);
 			return;
 		}
 
 		const media = await this.mediaRepo.findById(mediaId);
 		if (!media) {
-			this.logger?.warn("Media not found for processMedia job", { mediaId });
+			this.logger?.warn({ mediaId }, "Media not found for processMedia job");
 			return;
 		}
 
 		const sourcePath = payload.sourcePath;
 		if (typeof sourcePath !== "string") {
-			this.logger?.warn("Missing or invalid sourcePath in job payload", {
-				jobId: job.id,
-			});
+			this.logger?.warn(
+				{ jobId: job.id },
+				"Missing or invalid sourcePath in job payload",
+			);
 			return;
 		}
 		const mediaPath = path.join(sourcePath, media.filePath);
 
 		const mediaSourceId = job.mediaSourceId;
 		if (!mediaSourceId) {
-			this.logger?.warn("Missing mediaSourceId in job", { jobId: job.id });
+			this.logger?.warn({ jobId: job.id }, "Missing mediaSourceId in job");
 			return;
 		}
 

--- a/packages/application/src/services/tagging-service.ts
+++ b/packages/application/src/services/tagging-service.ts
@@ -11,6 +11,7 @@ import type {
 	CcipFeatureResponse,
 	TaggingResponse,
 } from "@solid-imager/core/domain/tagging/schemas";
+import type { ILogger } from "../ports/media-service";
 import type { ITaggingService } from "../ports/tagging-service";
 
 export type TaggingServiceDeps = {
@@ -20,6 +21,7 @@ export type TaggingServiceDeps = {
 	tagRepo: TagRepositoryDef;
 	characterRepo: CharacterRepository;
 	ipRepo: IIpRepository;
+	logger?: ILogger;
 	sseSendEvent: (
 		mediaSourceId: string,
 		eventType: string,
@@ -41,6 +43,7 @@ export class TaggingServiceImpl implements ITaggingService {
 		data: unknown,
 	) => void;
 	private readonly readFileBuffer: (filePath: string) => Promise<ArrayBuffer>;
+	private readonly logger?: ILogger;
 
 	constructor(deps: TaggingServiceDeps) {
 		this.aiClient = deps.aiClient;
@@ -51,6 +54,7 @@ export class TaggingServiceImpl implements ITaggingService {
 		this.ipRepo = deps.ipRepo;
 		this.sseSendEvent = deps.sseSendEvent;
 		this.readFileBuffer = deps.readFileBuffer;
+		this.logger = deps.logger;
 	}
 
 	async isServiceAvailable(): Promise<boolean> {
@@ -144,7 +148,10 @@ export class TaggingServiceImpl implements ITaggingService {
 		}
 
 		if (mediaSource.type !== "local") {
-			console.error("Only local media sources are supported.");
+			this.logger?.error(
+				{ mediaSourceId, type: mediaSource.type },
+				"Only local media sources are supported for AI tagging.",
+			);
 			return null;
 		}
 

--- a/packages/core/src/utils/event-parsers.ts
+++ b/packages/core/src/utils/event-parsers.ts
@@ -13,7 +13,6 @@ export function parseJsonEventPayload<T>(
 		return parseEventPayload(parsed, schema);
 	} catch (e) {
 		const message = e instanceof Error ? e.message : String(e);
-		console.error("Failed to parse event JSON:", message);
 		return { ok: false, error: message };
 	}
 }
@@ -28,7 +27,6 @@ export function parseEventPayload<T>(
 			result.error instanceof Error
 				? result.error.message
 				: String(result.error);
-		console.error("Failed to validate event payload:", message);
 		return { ok: false, error: message };
 	}
 	return { ok: true, data: result.data };


### PR DESCRIPTION
## 概要
サーバーサイドやアプリケーションサービス等で散在していた console.log/console.error を pino logger へ統合しました。また、今後の開発でログ出力設計がブレないように logging-rules スキルを追加しました。

## 変更内容
- サーバーインフラ層（DB初期化、FFmpegパス解決、サーバーブートストラップ、isomorphicなルーターのエラーハンドリング）の console ロギングを pino logger へ置き換え。
- packages/application のメディア処理およびAIタグ付けサービスへ ILogger 依存関係を追加し、pino logger インスタンスを注入することで console.warn/error を駆逐。
- packages/core の event-parsers ユーティリティから不要なログ出力副作用（console.error）を削除。
- 新規スキルとして logging-rules (.agents/skills/logging-rules/SKILL.md) を追加し、AGENTS.md へ登録。