### PR TITLE
fix(job): claim jobs atomically

### DIFF
--- a/apps/server/src/domain/repositories/job-repository.ts
+++ b/apps/server/src/domain/repositories/job-repository.ts
@@ -33,10 +33,28 @@ export type IJobRepository = {
 	): Promise<Job[]>;
 
 	/**
+	 * Atomically claims pending jobs for processing.
+	 * Claimed jobs are returned after their status is changed to in_progress.
+	 * @param limit - The maximum number of jobs to claim.
+	 * @returns Claimed jobs.
+	 */
+	claimPending(
+		limit: number,
+		options?: { excludeTypes?: string[]; includeTypes?: string[] },
+	): Promise<Job[]>;
+
+	/**
 	 * Marks a job as in progress.
 	 * @param id - The ID of the job.
 	 */
 	markAsInProgress(id: string): Promise<void>;
+
+	/**
+	 * Requeues in-progress jobs that have not been updated since the given date.
+	 * @param olderThan - Jobs older than this timestamp are moved back to pending.
+	 * @returns Number of requeued jobs.
+	 */
+	requeueStaleInProgress(olderThan: Date): Promise<number>;
 
 	/**
 	 * Marks a job as completed.

--- a/apps/server/src/infrastructure/jobs/job-worker.ts
+++ b/apps/server/src/infrastructure/jobs/job-worker.ts
@@ -3,6 +3,8 @@ import type { IJobRepository } from "~/domain/repositories/job-repository";
 import type { Job } from "~/infrastructure/db/schema";
 import { logger } from "~/infrastructure/logger";
 
+const StaleInProgressJobMs = 60 * 60 * 1000;
+
 export class JobWorker {
 	private isRunning = false;
 	private timeoutId: NodeJS.Timeout | null = null;
@@ -28,6 +30,7 @@ export class JobWorker {
 		}
 		this.isRunning = true;
 		logger.info("Job processing worker started");
+		void this.recoverStaleJobs();
 		this.poll();
 	}
 
@@ -76,7 +79,7 @@ export class JobWorker {
 			if (this.activeAiJobs < this.aiConcurrency) {
 				const slots = this.aiConcurrency - this.activeAiJobs;
 				if (slots > 0) {
-					const jobs = await this.jobRepo.findPending(slots, {
+					const jobs = await this.jobRepo.claimPending(slots, {
 						includeTypes: Array.from(this.aiJobTypes),
 					});
 					for (const job of jobs) {
@@ -91,7 +94,7 @@ export class JobWorker {
 			if (activeOtherJobs < this.concurrency) {
 				const slots = this.concurrency - activeOtherJobs;
 				if (slots > 0) {
-					const jobs = await this.jobRepo.findPending(slots, {
+					const jobs = await this.jobRepo.claimPending(slots, {
 						excludeTypes: Array.from(this.aiJobTypes),
 					});
 					for (const job of jobs) {
@@ -116,7 +119,6 @@ export class JobWorker {
 		}
 
 		try {
-			await this.jobRepo.markAsInProgress(job.id);
 			await this.processor(job);
 			await this.jobRepo.markAsCompleted(job.id, { success: true });
 		} catch (error) {
@@ -129,6 +131,21 @@ export class JobWorker {
 			if (isAiJob) {
 				this.activeAiJobs--;
 			}
+		}
+	}
+
+	private async recoverStaleJobs() {
+		const olderThan = new Date(Date.now() - StaleInProgressJobMs);
+		try {
+			const count = await this.jobRepo.requeueStaleInProgress(olderThan);
+			if (count > 0) {
+				logger.warn(
+					{ count, olderThan },
+					"Requeued stale in-progress jobs on worker startup",
+				);
+			}
+		} catch (error) {
+			logger.error({ err: error }, "Failed to requeue stale in-progress jobs");
 		}
 	}
 }

--- a/apps/server/src/infrastructure/repositories/job-repository.ts
+++ b/apps/server/src/infrastructure/repositories/job-repository.ts
@@ -1,7 +1,22 @@
-import { and, asc, eq, inArray, ne, notInArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, lt, ne, notInArray, sql } from "drizzle-orm";
 import type { IJobRepository } from "~/domain/repositories/job-repository";
 import { db } from "~/infrastructure/db";
 import { type Job, jobs, type NewJob } from "~/infrastructure/db/schema";
+
+type FindPendingOptions = { excludeTypes?: string[]; includeTypes?: string[] };
+
+type RawClaimedJob = {
+	id: unknown;
+	type: unknown;
+	mediaSourceId: unknown;
+	status: unknown;
+	payload: unknown;
+	result: unknown;
+	error: unknown;
+	createdAt: unknown;
+	updatedAt: unknown;
+	parentId: unknown;
+};
 
 export class JobRepository implements IJobRepository {
 	async create(job: NewJob): Promise<Job> {
@@ -43,35 +58,63 @@ export class JobRepository implements IJobRepository {
 		return job || null;
 	}
 
-	findPending(
-		limit: number,
-		options?: { excludeTypes?: string[]; includeTypes?: string[] },
-	): Promise<Job[]> {
-		if (options?.excludeTypes?.length && options?.includeTypes?.length) {
-			throw new Error(
-				"Cannot use excludeTypes and includeTypes simultaneously.",
-			);
-		}
-
-		const conditions = [
-			eq(jobs.status, "pending"),
-			ne(jobs.type, "import_request"),
-		];
-
-		if (options?.excludeTypes?.length) {
-			conditions.push(notInArray(jobs.type, options.excludeTypes));
-		}
-
-		if (options?.includeTypes?.length) {
-			conditions.push(inArray(jobs.type, options.includeTypes));
-		}
-
+	findPending(limit: number, options?: FindPendingOptions): Promise<Job[]> {
+		const conditions = this.buildPendingConditions(options);
 		return db
 			.select()
 			.from(jobs)
 			.where(and(...conditions))
 			.orderBy(asc(jobs.createdAt))
 			.limit(limit);
+	}
+
+	async claimPending(
+		limit: number,
+		options?: FindPendingOptions,
+	): Promise<Job[]> {
+		if (limit <= 0) {
+			return [];
+		}
+
+		this.validatePendingOptions(options);
+
+		const conditions = [sql`status = 'pending'`, sql`type <> 'import_request'`];
+
+		if (options?.excludeTypes?.length) {
+			conditions.push(sql`type NOT IN ${sqlTuple(options.excludeTypes)}`);
+		}
+
+		if (options?.includeTypes?.length) {
+			conditions.push(sql`type IN ${sqlTuple(options.includeTypes)}`);
+		}
+
+		const now = new Date();
+		const result: unknown = await db.execute(sql`
+			WITH next_jobs AS (
+				SELECT id
+				FROM jobs
+				WHERE ${sql.join(conditions, sql` AND `)}
+				ORDER BY created_at ASC
+				LIMIT ${limit}
+				FOR UPDATE SKIP LOCKED
+			)
+			UPDATE jobs
+			SET status = 'in_progress', updated_at = ${now}
+			WHERE id IN (SELECT id FROM next_jobs)
+			RETURNING
+				id,
+				type,
+				source_id AS "mediaSourceId",
+				status,
+				payload,
+				result,
+				error,
+				created_at AS "createdAt",
+				updated_at AS "updatedAt",
+				parent_id AS "parentId"
+		`);
+
+		return extractRows(result).map(mapClaimedJob);
 	}
 
 	async markAsInProgress(id: string): Promise<void> {
@@ -84,12 +127,25 @@ export class JobRepository implements IJobRepository {
 			.where(eq(jobs.id, id));
 	}
 
+	async requeueStaleInProgress(olderThan: Date): Promise<number> {
+		const rows = await db
+			.update(jobs)
+			.set({
+				status: "pending",
+				updatedAt: new Date(),
+			})
+			.where(and(eq(jobs.status, "in_progress"), lt(jobs.updatedAt, olderThan)))
+			.returning({ id: jobs.id });
+
+		return rows.length;
+	}
+
 	async markAsCompleted(id: string, result?: unknown): Promise<void> {
 		await db
 			.update(jobs)
 			.set({
 				status: "completed",
-				result: result as any,
+				result,
 				updatedAt: new Date(),
 			})
 			.where(eq(jobs.id, id));
@@ -115,4 +171,112 @@ export class JobRepository implements IJobRepository {
 			sql`UPDATE ${jobs} SET payload = jsonb_set(payload, '{processed}', (COALESCE(payload->>'processed', '0')::int + 1)::text::jsonb) WHERE id = ${id}`,
 		);
 	}
+
+	private buildPendingConditions(options?: FindPendingOptions) {
+		this.validatePendingOptions(options);
+		const conditions = [
+			eq(jobs.status, "pending"),
+			ne(jobs.type, "import_request"),
+		];
+
+		if (options?.excludeTypes?.length) {
+			conditions.push(notInArray(jobs.type, options.excludeTypes));
+		}
+
+		if (options?.includeTypes?.length) {
+			conditions.push(inArray(jobs.type, options.includeTypes));
+		}
+
+		return conditions;
+	}
+
+	private validatePendingOptions(options?: FindPendingOptions) {
+		if (options?.excludeTypes?.length && options?.includeTypes?.length) {
+			throw new Error(
+				"Cannot use excludeTypes and includeTypes simultaneously.",
+			);
+		}
+	}
+}
+
+function sqlTuple(values: string[]) {
+	return sql`(${sql.join(
+		values.map((value) => sql`${value}`),
+		sql`, `,
+	)})`;
+}
+
+function extractRows(result: unknown): unknown[] {
+	if (Array.isArray(result)) {
+		return result;
+	}
+
+	if (result && typeof result === "object" && "rows" in result) {
+		const rows = (result as { rows: unknown }).rows;
+		return Array.isArray(rows) ? rows : [];
+	}
+
+	return [];
+}
+
+function mapClaimedJob(row: unknown): Job {
+	if (!row || typeof row !== "object") {
+		throw new Error("Invalid claimed job row");
+	}
+
+	const raw = row as RawClaimedJob;
+	return {
+		id: requireString(raw.id, "id"),
+		type: requireString(raw.type, "type"),
+		mediaSourceId: nullableString(raw.mediaSourceId, "mediaSourceId"),
+		status: requireJobStatus(raw.status),
+		payload: raw.payload,
+		result: raw.result,
+		error: nullableString(raw.error, "error"),
+		createdAt: requireDate(raw.createdAt, "createdAt"),
+		updatedAt: requireDate(raw.updatedAt, "updatedAt"),
+		parentId: nullableString(raw.parentId, "parentId"),
+	};
+}
+
+function requireString(value: unknown, fieldName: string): string {
+	if (typeof value !== "string") {
+		throw new Error(`Invalid claimed job row: ${fieldName}`);
+	}
+	return value;
+}
+
+function nullableString(value: unknown, fieldName: string): string | null {
+	if (value === null) {
+		return null;
+	}
+	if (typeof value !== "string") {
+		throw new Error(`Invalid claimed job row: ${fieldName}`);
+	}
+	return value;
+}
+
+function requireJobStatus(value: unknown): Job["status"] {
+	if (
+		value === "pending" ||
+		value === "in_progress" ||
+		value === "completed" ||
+		value === "failed"
+	) {
+		return value;
+	}
+	throw new Error("Invalid claimed job row: status");
+}
+
+function requireDate(value: unknown, fieldName: string): Date {
+	if (value instanceof Date) {
+		return value;
+	}
+	if (typeof value === "string") {
+		const date = new Date(value);
+		if (!Number.isNaN(date.getTime())) {
+			return date;
+		}
+	}
+	throw new Error(`Invalid claimed job row: ${fieldName}`);
 }

--- a/apps/server/src/tests/unit/infrastructure/jobs/job-worker.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/job-worker.test.ts
@@ -41,7 +41,9 @@ describe("JobWorker", () => {
 			createIfUnique: vi.fn(),
 			findById: vi.fn(),
 			findPending: vi.fn().mockResolvedValue([]),
+			claimPending: vi.fn().mockResolvedValue([]),
 			markAsInProgress: vi.fn().mockResolvedValue(undefined),
+			requeueStaleInProgress: vi.fn().mockResolvedValue(0),
 			markAsCompleted: vi.fn().mockResolvedValue(undefined),
 			markAsFailed: vi.fn().mockResolvedValue(undefined),
 			update: vi.fn(),
@@ -75,9 +77,9 @@ describe("JobWorker", () => {
 				}) as Job,
 		);
 
-		// Mock findPending to return jobs
+		// Mock claimPending to return jobs
 		// When excluding AI types, return normal jobs
-		(jobRepo.findPending as any).mockImplementation(
+		(jobRepo.claimPending as any).mockImplementation(
 			(limit: number, options: any) => {
 				if (options?.excludeTypes) {
 					return Promise.resolve(normalJobs.slice(0, limit));
@@ -90,7 +92,7 @@ describe("JobWorker", () => {
 		await vi.advanceTimersByTimeAsync(TimerDelay);
 
 		// Should fetch 2 normal jobs
-		expect(jobRepo.findPending).toHaveBeenCalledWith(
+		expect(jobRepo.claimPending).toHaveBeenCalledWith(
 			2,
 			expect.objectContaining({ excludeTypes: ["auto_tagging"] }),
 		);
@@ -114,8 +116,8 @@ describe("JobWorker", () => {
 				}) as Job,
 		);
 
-		// Mock findPending
-		(jobRepo.findPending as any).mockImplementation(
+		// Mock claimPending
+		(jobRepo.claimPending as any).mockImplementation(
 			(limit: number, options: any) => {
 				if (options?.includeTypes) {
 					return Promise.resolve(aiJobs.slice(0, limit));
@@ -128,7 +130,7 @@ describe("JobWorker", () => {
 		await vi.advanceTimersByTimeAsync(TimerDelay);
 
 		// Should fetch 1 AI job
-		expect(jobRepo.findPending).toHaveBeenCalledWith(
+		expect(jobRepo.claimPending).toHaveBeenCalledWith(
 			1,
 			expect.objectContaining({ includeTypes: ["auto_tagging"] }),
 		);
@@ -160,8 +162,8 @@ describe("JobWorker", () => {
 			status: "pending",
 		} as Job;
 
-		// Mock findPending
-		(jobRepo.findPending as any).mockImplementation(
+		// Mock claimPending
+		(jobRepo.claimPending as any).mockImplementation(
 			(limit: number, options: any) => {
 				if (options?.includeTypes) {
 					// AI request
@@ -179,11 +181,11 @@ describe("JobWorker", () => {
 		await vi.advanceTimersByTimeAsync(TimerDelay);
 
 		// Should fetch 1 AI job and 2 Normal jobs
-		expect(jobRepo.findPending).toHaveBeenCalledWith(
+		expect(jobRepo.claimPending).toHaveBeenCalledWith(
 			1,
 			expect.objectContaining({ includeTypes: ["auto_tagging"] }),
 		);
-		expect(jobRepo.findPending).toHaveBeenCalledWith(
+		expect(jobRepo.claimPending).toHaveBeenCalledWith(
 			2,
 			expect.objectContaining({ excludeTypes: ["auto_tagging"] }),
 		);

--- a/apps/server/src/tests/unit/infrastructure/repositories/job-repository.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/repositories/job-repository.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { db } from "~/infrastructure/db";
+import { JobRepository } from "~/infrastructure/repositories/job-repository";
+
+describe("JobRepository", () => {
+	const repository = new JobRepository();
+
+	beforeEach(() => {
+		(db as { execute?: unknown }).execute = vi.fn().mockResolvedValue({
+			rows: [
+				{
+					id: "11111111-1111-4111-8111-111111111111",
+					type: "processMedia",
+					mediaSourceId: null,
+					status: "in_progress",
+					payload: { mediaId: "media-1" },
+					result: null,
+					error: null,
+					createdAt: "2026-06-23T00:00:00.000Z",
+					updatedAt: "2026-06-23T00:00:01.000Z",
+					parentId: null,
+				},
+			],
+		});
+	});
+
+	it("claims pending jobs and maps returned rows", async () => {
+		const claimed = await repository.claimPending(1, {
+			excludeTypes: ["auto_tagging"],
+		});
+
+		expect(claimed).toEqual([
+			expect.objectContaining({
+				id: "11111111-1111-4111-8111-111111111111",
+				type: "processMedia",
+				status: "in_progress",
+				createdAt: new Date("2026-06-23T00:00:00.000Z"),
+				updatedAt: new Date("2026-06-23T00:00:01.000Z"),
+			}),
+		]);
+		expect(db.execute).toHaveBeenCalledOnce();
+	});
+
+	it("rejects conflicting pending filters", async () => {
+		await expect(
+			repository.claimPending(1, {
+				includeTypes: ["auto_tagging"],
+				excludeTypes: ["processMedia"],
+			}),
+		).rejects.toThrow(
+			"Cannot use excludeTypes and includeTypes simultaneously.",
+		);
+	});
+
+	it("returns the number of stale jobs requeued", async () => {
+		const count = await repository.requeueStaleInProgress(
+			new Date("2026-06-23T00:00:00.000Z"),
+		);
+
+		expect(count).toBe(1);
+	});
+});


### PR DESCRIPTION
## 概要
ジョブ取得を原子的にして、worker 再起動や複数 worker で同じ pending job を取り合う状態を防ぎます。

## 変更内容
- claimPending() で FOR UPDATE SKIP LOCKED を使って job をまとめて claim
- in_progress の古い job を起動時に pending に戻す復旧処理を追加
- worker 側を claim ベースに切り替え、二重で in_progress に更新しないよう修正
- repository と worker の unit test を追加

## 技術詳細
nginx 起因の再接続問題は対象外として、ジョブシステムの競合と stale job 復旧だけを修正しています。
