### PR TITLE
fix(tauri): resolve import.meta.env.DEV and css import type check errors

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -44,6 +44,7 @@
 		"tailwindcss-animate": "^1.0.7",
 		"typescript": "rc",
 		"vite-plugin-solid": "^2.11.12",
-		"vite-plus": "^0.1.24"
+		"vite-plus": "^0.1.24",
+		"vite": "^8.0.16"
 	}
 }

--- a/apps/tauri/src/env.d.ts
+++ b/apps/tauri/src/env.d.ts
@@ -3,7 +3,3 @@
 interface ImportMetaEnv {
 	readonly VITE_API_URL: string;
 }
-
-interface ImportMeta {
-	readonly env: ImportMetaEnv;
-}

--- a/apps/tauri/tsconfig.json
+++ b/apps/tauri/tsconfig.json
@@ -4,6 +4,7 @@
 		"jsx": "preserve",
 		"jsxImportSource": "solid-js",
 		"isolatedModules": true,
+		"types": ["vite/client"],
 		"paths": {
 			"~/*": ["./src/*"],
 			"@solid-imager/core": ["../../packages/core/src"],

--- a/bun.lock
+++ b/bun.lock
@@ -140,6 +140,7 @@
         "tailwindcss": "^4.3.0",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "rc",
+        "vite": "^8.0.16",
         "vite-plugin-solid": "^2.11.12",
         "vite-plus": "^0.1.24",
       },


### PR DESCRIPTION
## 概要
@solid-imager/tauri パッケージにおいて、Viteの環境変数（import.meta.env.DEV）やCSSインポート（index.css）の型定義が正しく解決されず、bun typecheck が失敗していた問題を修正しました。

## 変更内容
- apps/tauri/package.json に devDependencies として vite を明示的に追加しました。
- apps/tauri/tsconfig.json に types: ['vite/client'] を追加し、Vite標準の型定義を解決できるようにしました。
- apps/tauri/src/env.d.ts 内で不要な ImportMeta 再定義を削除し、Viteの型定義との競合を解消しました。