### PR TITLE
fix(server): sync PostgreSQL and LanceDB discrepancies on startup

### DIFF
--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -19,4 +19,5 @@ export const syncLanceDB = service.syncLanceDB;
 export const syncLanceDBPages = service.syncLanceDBPages;
 export const syncLanceDBDelta = service.syncLanceDBDelta;
 export const readFromLanceDB = service.readFromLanceDB;
+export const readMediaIds = service.readMediaIds;
 export const cleanupLanceDBDir = service.cleanupLanceDBDir;

--- a/apps/server/src/application/services/maintenance-service.ts
+++ b/apps/server/src/application/services/maintenance-service.ts
@@ -100,9 +100,74 @@ export class MaintenanceService {
 			let queuedCount = 0;
 
 			for (const source of sources) {
-				const jobType = (await this.hasLanceDbCache(source.id))
-					? "sync_lancedb_delta"
-					: "sync_lancedb_full";
+				const hasCache = await this.hasLanceDbCache(source.id);
+				let jobType: "sync_lancedb_full" | "sync_lancedb_delta" =
+					"sync_lancedb_full";
+
+				if (hasCache) {
+					try {
+						const cacheDir = await this.getLanceDbCacheDir(source.id);
+						const { readMediaIds } = await import(
+							"~/application/services/lancedb-dump-service"
+						);
+						const lanceDbIds = await readMediaIds(cacheDir);
+						const postgresMedias = await this.mediaRepo.findAllPathsBySourceId(
+							source.id,
+						);
+
+						const postgresIdsSet = new Set(postgresMedias.map((m) => m.id));
+						const lanceDbIdsSet = new Set(lanceDbIds);
+
+						// PostgreSQL にあって LanceDB にない -> 追加 (upsert)
+						const toUpsert = postgresMedias
+							.filter((m) => !lanceDbIdsSet.has(m.id))
+							.map((m) => m.id);
+
+						// LanceDB にあって PostgreSQL にない -> 削除 (delete)
+						const toDelete = lanceDbIds.filter((id) => !postgresIdsSet.has(id));
+
+						if (toUpsert.length > 0 || toDelete.length > 0) {
+							logger.info(
+								{
+									sourceId: source.id,
+									toUpsertCount: toUpsert.length,
+									toDeleteCount: toDelete.length,
+								},
+								"Found discrepancies between PostgreSQL and LanceDB on startup. Queueing delta sync.",
+							);
+
+							const { BackupService } = await import(
+								"~/application/services/backup-service"
+							);
+
+							if (toUpsert.length > 0) {
+								await BackupService.queueSourceLanceDBDelta(
+									source.id,
+									toUpsert,
+									"upsert",
+									{ enqueueJob: false },
+								);
+							}
+							if (toDelete.length > 0) {
+								await BackupService.queueSourceLanceDBDelta(
+									source.id,
+									toDelete,
+									"delete",
+									{ enqueueJob: false },
+								);
+							}
+						}
+
+						jobType = "sync_lancedb_delta";
+					} catch (compareError) {
+						logger.error(
+							{ err: compareError, sourceId: source.id },
+							"Failed to compare PostgreSQL and LanceDB on startup. Falling back to full sync.",
+						);
+						jobType = "sync_lancedb_full";
+					}
+				}
+
 				const created = await this.jobRepo.createIfUnique({
 					type: jobType,
 					mediaSourceId: source.id,
@@ -124,14 +189,16 @@ export class MaintenanceService {
 		}
 	}
 
+	private async getLanceDbCacheDir(sourceId: string): Promise<string> {
+		const { services } = await import("~/application/registry");
+		const config = services.getConfigService().getConfig();
+		const baseCacheDir = config.lancedb?.cacheDir ?? ".cache/lancedb-cache";
+		return path.resolve(process.cwd(), baseCacheDir, `source-${sourceId}`);
+	}
+
 	private async hasLanceDbCache(sourceId: string): Promise<boolean> {
-		const manifestPath = path.join(
-			process.cwd(),
-			".cache",
-			"lancedb-cache",
-			`source-${sourceId}`,
-			"manifest.json",
-		);
+		const cacheDir = await this.getLanceDbCacheDir(sourceId);
+		const manifestPath = path.join(cacheDir, "manifest.json");
 		try {
 			const content = await fs.readFile(manifestPath, "utf-8");
 			const manifest = JSON.parse(content) as { version?: unknown };

--- a/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
@@ -12,10 +12,11 @@ import { MaintenanceService } from "~/application/services/maintenance-service";
 
 // ---- Module mocks ----
 
-// Mock node:fs/promises to control thumbnail directory reads
+// Mock node:fs/promises to control thumbnail directory reads and lanceDb manifest reads
 vi.mock("node:fs/promises", () => ({
 	default: {
 		readdir: vi.fn(),
+		readFile: vi.fn(),
 	},
 }));
 
@@ -24,10 +25,38 @@ vi.mock("~/infrastructure/jobs/thumbnails", () => ({
 	getSourceCacheDir: vi.fn((sourceId: string) => `/cache/${sourceId}`),
 }));
 
+// Mock registry for configuration loading
+vi.mock("~/application/registry", () => ({
+	services: {
+		getConfigService: () => ({
+			getConfig: () => ({
+				lancedb: {
+					cacheDir: ".cache/lancedb-cache",
+				},
+			}),
+		}),
+	},
+}));
+
+// Mock lancedb-dump-service
+const mockReadMediaIds = vi.fn();
+vi.mock("~/application/services/lancedb-dump-service", () => ({
+	readMediaIds: mockReadMediaIds,
+}));
+
+// Mock backup-service
+const mockQueueSourceLanceDBDelta = vi.fn();
+vi.mock("~/application/services/backup-service", () => ({
+	BackupService: {
+		queueSourceLanceDBDelta: mockQueueSourceLanceDBDelta,
+	},
+}));
+
 // Silence logger output during tests
 vi.mock("~/infrastructure/logger", () => ({
 	logger: {
 		info: vi.fn(),
+		debug: vi.fn(),
 		warn: vi.fn(),
 		error: vi.fn(),
 	},
@@ -38,6 +67,7 @@ vi.mock("~/infrastructure/logger", () => ({
 const mockMediaRepo = {
 	findIdsWithMissingGenerationInfo: vi.fn(),
 	findAllMediaIndices: vi.fn(),
+	findAllPathsBySourceId: vi.fn(),
 };
 
 const mockJobRepo = {
@@ -77,10 +107,13 @@ describe("MaintenanceService", () => {
 			mockSourceRepo as any,
 		);
 		mockSourceRepo.findAll.mockResolvedValue([]);
+		mockMediaRepo.findAllPathsBySourceId.mockResolvedValue([]);
 	});
 
 	afterEach(() => {
 		vi.clearAllMocks();
+		mockReadMediaIds.mockReset();
+		mockQueueSourceLanceDBDelta.mockReset();
 	});
 
 	// --------------------------------------------------------------------------
@@ -325,6 +358,10 @@ describe("MaintenanceService", () => {
 			]);
 			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
 
+			// Simulate manifest.json doesn't exist (ENOENT)
+			const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+			(fs.readFile as unknown as Mock).mockRejectedValue(err);
+
 			await service.performStartupChecks();
 
 			expect(mockSourceRepo.findAll).toHaveBeenCalledOnce();
@@ -338,6 +375,111 @@ describe("MaintenanceService", () => {
 				expect.objectContaining({
 					type: "sync_lancedb_full",
 					mediaSourceId: "source-2",
+				}),
+			);
+		});
+
+		it("should queue delta sync job without queueing delta details if PostgreSQL and LanceDB are in sync", async () => {
+			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
+			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
+			mockSourceRepo.findAll.mockResolvedValue([
+				makeLocalSource("source-1", "/path-1"),
+			]);
+			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
+
+			// Simulate manifest.json exists (version: 3)
+			(fs.readFile as unknown as Mock).mockResolvedValue(
+				JSON.stringify({ version: 3 }),
+			);
+
+			// Both LanceDB and Postgres have media-1
+			mockReadMediaIds.mockResolvedValue(["media-1"]);
+			mockMediaRepo.findAllPathsBySourceId.mockResolvedValue([
+				{ id: "media-1", filePath: "/media/media-1.png" },
+			]);
+
+			await service.performStartupChecks();
+
+			expect(mockQueueSourceLanceDBDelta).not.toHaveBeenCalled();
+			expect(mockJobRepo.createIfUnique).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "sync_lancedb_delta",
+					mediaSourceId: "source-1",
+				}),
+			);
+		});
+
+		it("should queue discrepancies to delta table and trigger delta sync job if discrepancies are found", async () => {
+			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
+			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
+			mockSourceRepo.findAll.mockResolvedValue([
+				makeLocalSource("source-1", "/path-1"),
+			]);
+			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
+
+			// Simulate manifest.json exists (version: 3)
+			(fs.readFile as unknown as Mock).mockResolvedValue(
+				JSON.stringify({ version: 3 }),
+			);
+
+			// Postgres: media-1, media-2
+			// LanceDB: media-2, media-3
+			// Discrepancies: upsert [media-1], delete [media-3]
+			mockReadMediaIds.mockResolvedValue(["media-2", "media-3"]);
+			mockMediaRepo.findAllPathsBySourceId.mockResolvedValue([
+				{ id: "media-1", filePath: "/media/media-1.png" },
+				{ id: "media-2", filePath: "/media/media-2.png" },
+			]);
+
+			await service.performStartupChecks();
+
+			expect(mockQueueSourceLanceDBDelta).toHaveBeenCalledTimes(2);
+			expect(mockQueueSourceLanceDBDelta).toHaveBeenNthCalledWith(
+				1,
+				"source-1",
+				["media-1"],
+				"upsert",
+				{ enqueueJob: false },
+			);
+			expect(mockQueueSourceLanceDBDelta).toHaveBeenNthCalledWith(
+				2,
+				"source-1",
+				["media-3"],
+				"delete",
+				{ enqueueJob: false },
+			);
+
+			expect(mockJobRepo.createIfUnique).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "sync_lancedb_delta",
+					mediaSourceId: "source-1",
+				}),
+			);
+		});
+
+		it("should fall back to full sync if comparison throws an error", async () => {
+			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
+			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
+			mockSourceRepo.findAll.mockResolvedValue([
+				makeLocalSource("source-1", "/path-1"),
+			]);
+			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
+
+			// Simulate manifest.json exists (version: 3)
+			(fs.readFile as unknown as Mock).mockResolvedValue(
+				JSON.stringify({ version: 3 }),
+			);
+
+			// readMediaIds throws error
+			mockReadMediaIds.mockRejectedValue(new Error("LanceDB read error"));
+
+			await service.performStartupChecks();
+
+			expect(mockQueueSourceLanceDBDelta).not.toHaveBeenCalled();
+			expect(mockJobRepo.createIfUnique).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "sync_lancedb_full",
+					mediaSourceId: "source-1",
 				}),
 			);
 		});

--- a/packages/application/src/ports/lancedb-dump-service.ts
+++ b/packages/application/src/ports/lancedb-dump-service.ts
@@ -58,5 +58,6 @@ export interface ILanceDbDumpService {
 		lanceDbDir: string,
 		options?: ReadOptions,
 	): Promise<MediaDumpItemWithImageData[]>;
+	readMediaIds(lanceDbDir: string): Promise<string[]>;
 	cleanupLanceDBDir(dir: string): Promise<void>;
 }

--- a/packages/application/src/services/lancedb-dump-service.ts
+++ b/packages/application/src/services/lancedb-dump-service.ts
@@ -845,6 +845,17 @@ export function createLanceDbDumpService(deps?: {
 		return allItems;
 	}
 
+	async function readMediaIds(lanceDbDir: string): Promise<string[]> {
+		const connect = await getConnect();
+		const db = await connect(lanceDbDir);
+		const mediaTable = await db.openTable("media");
+		const rows = await mediaTable.query().select(["id"]).toArray();
+		return rows.flatMap((row) => {
+			const id = safeString(row.id);
+			return id ? [id] : [];
+		});
+	}
+
 	async function cleanupLanceDBDir(dir: string): Promise<void> {
 		await fs.rm(dir, { recursive: true, force: true });
 	}
@@ -855,6 +866,7 @@ export function createLanceDbDumpService(deps?: {
 		syncLanceDBPages,
 		syncLanceDBDelta,
 		readFromLanceDB,
+		readMediaIds,
 		cleanupLanceDBDir,
 	};
 }


### PR DESCRIPTION
## 概要
サーバー起動時に PostgreSQL と LanceDB のメディアデータの不整合を検出し、差分同期ジョブを実行する機能を追加します。

## 変更内容
- `ILanceDbDumpService` に `readMediaIds` 関数を追加し、LanceDB に格納されているメディアID一覧を取得できるように変更
- `MaintenanceService` のスタートアップ処理にて、LanceDB の manifest ファイルが存在する場合に PostgreSQL 内のメディアIDと LanceDB 内のメディアIDを比較する処理を追加
- 差分（不整合）を検出した場合、`BackupService.queueSourceLanceDBDelta` を呼んで差分データをキューし、差分同期ジョブ（`sync_lancedb_delta`）を生成する処理を実装
- 起動時チェックにおける不整合検出処理のユニットテストを追加