### PR TITLE
fix(search): AI処理の可観測性と類似検索の復旧操作を改善

### DIFF
--- a/apps/server/src/infrastructure/api/routers/ai-router.ts
+++ b/apps/server/src/infrastructure/api/routers/ai-router.ts
@@ -187,10 +187,29 @@ export const aiRouter = {
 			]),
 		)
 		.handler(async ({ input }) => {
+			const startedAt = Date.now();
+			const logContext =
+				"file" in input
+					? {
+							inputType: "file",
+							fileName: input.file.name,
+							fileSize: input.file.size,
+						}
+					: {
+							inputType: "media",
+							mediaSourceId: input.mediaSourceId,
+							mediaId: input.mediaId,
+						};
+			logger.info(logContext, "AI tagging started");
 			try {
 				if ("file" in input) {
 					const buffer = await input.file.arrayBuffer();
-					return await taggingService.getTags(buffer);
+					const result = await taggingService.getTags(buffer);
+					logger.info(
+						{ ...logContext, durationMs: Date.now() - startedAt },
+						"AI tagging completed",
+					);
+					return result;
 				}
 
 				const { mediaSourceId, mediaId } = input;
@@ -224,17 +243,45 @@ export const aiRouter = {
 					}
 					const fullPath = path.join(connectionInfo.path, media.filePath);
 					const fileBuffer = await readFileBuffer(fullPath);
-					return (await callRemoteTagging(
+					const result = (await callRemoteTagging(
 						remoteUrl,
 						fileBuffer,
 						path.basename(fullPath),
 						config.ai.timeoutMs,
 					)) as import("@solid-imager/core/domain/tagging/schemas").TaggingResponse;
+					logger.info(
+						{
+							...logContext,
+							execution: "remote",
+							durationMs: Date.now() - startedAt,
+						},
+						"AI tagging completed",
+					);
+					return result;
 				}
 
-				return await taggingService.getTagsForMedia(mediaSourceId, mediaId);
+				const result = await taggingService.getTagsForMedia(
+					mediaSourceId,
+					mediaId,
+				);
+				logger.info(
+					{
+						...logContext,
+						execution: "local",
+						durationMs: Date.now() - startedAt,
+					},
+					"AI tagging completed",
+				);
+				return result;
 			} catch (error) {
-				logger.error({ err: error, input }, "AI tagging failed");
+				logger.error(
+					{
+						err: error,
+						...logContext,
+						durationMs: Date.now() - startedAt,
+					},
+					"AI tagging failed",
+				);
 				const message =
 					error instanceof Error ? error.message : "Unknown error";
 				throw new ORPCError("UNPROCESSABLE_CONTENT", {
@@ -443,6 +490,15 @@ export const aiRouter = {
 				mediaSourceId: input.mediaSourceId,
 				payload: { mediaId: input.mediaId, force: input.force },
 			});
+			logger.info(
+				{
+					jobId: job.id,
+					mediaSourceId: input.mediaSourceId,
+					mediaId: input.mediaId,
+					force: input.force,
+				},
+				"CCIP vector extraction queued",
+			);
 			return {
 				success: true,
 				message: "CCIP vector extraction queued",
@@ -499,7 +555,9 @@ export const aiRouter = {
 				where: and(
 					inArray(medias.id, input.mediaIds),
 					eq(medias.mediaType, "image"),
-					input.mediaSourceId ? eq(medias.mediaSourceId, input.mediaSourceId) : undefined,
+					input.mediaSourceId
+						? eq(medias.mediaSourceId, input.mediaSourceId)
+						: undefined,
 				),
 				columns: { id: true, mediaSourceId: true },
 			});
@@ -550,6 +608,21 @@ export const aiRouter = {
 			]),
 		)
 		.handler(async ({ input }) => {
+			const startedAt = Date.now();
+			const logContext =
+				"file" in input
+					? {
+							inputType: "file",
+							fileName: input.file.name,
+							fileSize: input.file.size,
+							transparent: input.transparent,
+						}
+					: {
+							inputType: "media",
+							mediaId: input.mediaId,
+							transparent: input.transparent,
+						};
+			logger.info(logContext, "Character detection and cropping started");
 			try {
 				const transparent = input.transparent ?? false;
 
@@ -570,6 +643,14 @@ export const aiRouter = {
 							),
 						);
 
+						logger.info(
+							{
+								...logContext,
+								detectionCount: resultDetections.length,
+								durationMs: Date.now() - startedAt,
+							},
+							"Character detection and cropping completed",
+						);
 						return { detections: resultDetections };
 					} finally {
 						await Bun.file(tmpPath)
@@ -608,7 +689,7 @@ export const aiRouter = {
 				const config = services.getConfigService().getConfig();
 				if (remoteUrl && !isRemoteServerLocal(remoteUrl)) {
 					const fileBuffer = await readFileBuffer(fullPath);
-					return (await callRemoteCrop(
+					const result = (await callRemoteCrop(
 						remoteUrl,
 						fileBuffer,
 						path.basename(fullPath),
@@ -624,6 +705,16 @@ export const aiRouter = {
 							height: number;
 						}>;
 					};
+					logger.info(
+						{
+							...logContext,
+							execution: "remote",
+							detectionCount: result.detections.length,
+							durationMs: Date.now() - startedAt,
+						},
+						"Character detection and cropping completed",
+					);
+					return result;
 				}
 
 				const { detectPerson } = await import("dghs-imgutils-rs");
@@ -635,10 +726,23 @@ export const aiRouter = {
 					),
 				);
 
+				logger.info(
+					{
+						...logContext,
+						execution: "local",
+						detectionCount: resultDetections.length,
+						durationMs: Date.now() - startedAt,
+					},
+					"Character detection and cropping completed",
+				);
 				return { detections: resultDetections };
 			} catch (error) {
 				logger.error(
-					{ err: error, input },
+					{
+						err: error,
+						...logContext,
+						durationMs: Date.now() - startedAt,
+					},
 					"Character detection and cropping failed",
 				);
 				const message =

--- a/apps/server/src/infrastructure/api/routers/media-router.ts
+++ b/apps/server/src/infrastructure/api/routers/media-router.ts
@@ -43,11 +43,45 @@ export const mediaRouter = {
 		.input(similarMediaRequestSchema)
 		.output(similarMediaSearchResponseSchema)
 		.handler(async ({ input }) => {
-			return await ccipVectorService.searchSimilar(
-				input.anchorMediaId,
-				input.topK,
-				input.mediaSourceId,
+			const startedAt = Date.now();
+			logger.info(
+				{
+					anchorMediaId: input.anchorMediaId,
+					mediaSourceId: input.mediaSourceId,
+					topK: input.topK,
+				},
+				"Vector similarity search started",
 			);
+			try {
+				const result = await ccipVectorService.searchSimilar(
+					input.anchorMediaId,
+					input.topK,
+					input.mediaSourceId,
+				);
+				logger.info(
+					{
+						anchorMediaId: input.anchorMediaId,
+						mediaSourceId: input.mediaSourceId,
+						topK: input.topK,
+						resultCount: result.media.length,
+						durationMs: Date.now() - startedAt,
+					},
+					"Vector similarity search completed",
+				);
+				return result;
+			} catch (error) {
+				logger.error(
+					{
+						err: error,
+						anchorMediaId: input.anchorMediaId,
+						mediaSourceId: input.mediaSourceId,
+						topK: input.topK,
+						durationMs: Date.now() - startedAt,
+					},
+					"Vector similarity search failed",
+				);
+				throw error;
+			}
 		}),
 
 	/**
@@ -204,7 +238,10 @@ export const mediaRouter = {
 			try {
 				await ccipVectorService.delete(input.mediaId);
 			} catch (err) {
-				logger.warn({ err, mediaId: input.mediaId }, "[MediaRouter] Vector delete failed after media delete");
+				logger.warn(
+					{ err, mediaId: input.mediaId },
+					"[MediaRouter] Vector delete failed after media delete",
+				);
 			}
 			return { success: true };
 		}),
@@ -242,7 +279,10 @@ export const mediaRouter = {
 			try {
 				await ccipVectorService.delete(input.mediaId);
 			} catch (err) {
-				logger.warn({ err, mediaId: input.mediaId }, "[MediaRouter] Vector delete failed after media move");
+				logger.warn(
+					{ err, mediaId: input.mediaId },
+					"[MediaRouter] Vector delete failed after media move",
+				);
 			}
 			return result;
 		}),
@@ -303,7 +343,10 @@ export const mediaRouter = {
 					try {
 						await ccipVectorService.delete(mediaId);
 					} catch (err) {
-						logger.warn({ err, mediaId }, "[MediaRouter] Vector delete failed after bulk media delete");
+						logger.warn(
+							{ err, mediaId },
+							"[MediaRouter] Vector delete failed after bulk media delete",
+						);
 					}
 				}),
 			);

--- a/apps/server/src/infrastructure/jobs/ccip-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/ccip-jobs.ts
@@ -47,10 +47,21 @@ export async function processCcipExtractionJob(job: Job): Promise<void> {
 		throw new Error("CCIP extraction job is missing mediaSourceId");
 	}
 	try {
-		await ccipVectorService.extract(
+		const result = await ccipVectorService.extract(
 			job.mediaSourceId,
 			payload.mediaId,
 			payload.force,
+		);
+		logger.info(
+			{
+				jobId: job.id,
+				parentId: job.parentId,
+				mediaSourceId: job.mediaSourceId,
+				mediaId: payload.mediaId,
+				force: payload.force,
+				skipped: result.skipped,
+			},
+			"CCIP vector extraction completed",
 		);
 		RealtimeEventBus.publishJob("job-completed", {
 			jobId: job.id,

--- a/apps/server/src/infrastructure/jobs/job-worker.ts
+++ b/apps/server/src/infrastructure/jobs/job-worker.ts
@@ -152,17 +152,48 @@ export class JobWorker {
 	private async processJob(job: Job, lanceDbSyncKey?: string) {
 		this.activeJobs++;
 		const isAiJob = this.aiJobTypes.has(job.type);
+		const startedAt = Date.now();
 		if (isAiJob) {
 			this.activeAiJobs++;
 		}
 
+		logger.info(
+			{
+				jobId: job.id,
+				type: job.type,
+				mediaSourceId: job.mediaSourceId,
+				parentId: job.parentId,
+				isAiJob,
+			},
+			"Job started",
+		);
 		try {
 			await this.processor(job);
 			await this.jobRepo.markAsCompleted(job.id, { success: true });
+			logger.info(
+				{
+					jobId: job.id,
+					type: job.type,
+					mediaSourceId: job.mediaSourceId,
+					parentId: job.parentId,
+					durationMs: Date.now() - startedAt,
+				},
+				"Job completed",
+			);
 		} catch (error) {
 			const errorMessage =
 				error instanceof Error ? error.message : String(error);
-			logger.error({ err: error, jobId: job.id }, "Job failed");
+			logger.error(
+				{
+					err: error,
+					jobId: job.id,
+					type: job.type,
+					mediaSourceId: job.mediaSourceId,
+					parentId: job.parentId,
+					durationMs: Date.now() - startedAt,
+				},
+				"Job failed",
+			);
 			await this.jobRepo.markAsFailed(job.id, errorMessage);
 		} finally {
 			this.activeJobs--;

--- a/apps/server/src/infrastructure/jobs/tagging-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/tagging-jobs.ts
@@ -37,9 +37,26 @@ export async function processAutoTaggingJob(job: Job): Promise<void> {
 	}
 
 	try {
-		await taggingService.getTagsForMedia(mediaSourceId, mediaId, {
-			skipCache: force,
-		});
+		const result = await taggingService.getTagsForMedia(
+			mediaSourceId,
+			mediaId,
+			{
+				skipCache: force,
+			},
+		);
+		logger.info(
+			{
+				jobId: job.id,
+				parentId,
+				mediaSourceId,
+				mediaId,
+				force: force ?? false,
+				tagCount: result ? Object.keys(result.general).length : 0,
+				characterCount: result ? Object.keys(result.character).length : 0,
+				ipCount: result?.ips.length ?? 0,
+			},
+			"Auto tagging completed",
+		);
 		await services.getJobRepository().createIfUnique({
 			type: "sync_lancedb_delta",
 			mediaSourceId,

--- a/apps/server/src/routes/api/rpc.$.ts
+++ b/apps/server/src/routes/api/rpc.$.ts
@@ -2,6 +2,7 @@ import { RPCHandler } from "@orpc/server/fetch";
 import { createFileRoute } from "@tanstack/solid-router";
 import { appRouter } from "~/domain/shared/api-contract";
 import { bootstrap } from "~/infrastructure/bootstrap";
+import { logger } from "~/infrastructure/logger";
 
 const handler = new RPCHandler(appRouter);
 
@@ -14,7 +15,14 @@ export const Route = createFileRoute("/api/rpc/$")({
 					prefix: "/api/rpc",
 					context: {},
 				});
-				return response ?? new Response("Not Found", { status: 404 });
+				if (response) {
+					return response;
+				}
+				logger.warn(
+					{ method: request.method, url: request.url },
+					"Unmatched RPC request",
+				);
+				return new Response("Not Found", { status: 404 });
 			},
 		},
 	},

--- a/packages/ui/src/search-control-panel.tsx
+++ b/packages/ui/src/search-control-panel.tsx
@@ -19,6 +19,7 @@ import {
 } from "./select";
 import { SortControls } from "./sort-controls";
 import {
+	clearVectorSearchAnchor,
 	searchState,
 	setSearchMode,
 	setSearchState,
@@ -161,6 +162,16 @@ export function SearchControlPanel(props: SearchControlPanelProps) {
 							{searchState.similarityAnchorMediaId ??
 								"メディア個別画面の「Find Similar」から選択してください。"}
 						</div>
+						<Show when={searchState.similarityAnchorMediaId}>
+							<Button
+								class="w-full"
+								onClick={clearVectorSearchAnchor}
+								size="sm"
+								variant="outline"
+							>
+								類似元を解除
+							</Button>
+						</Show>
 					</div>
 					<div class="space-y-2">
 						<Label>表示件数</Label>

--- a/packages/ui/src/stores/search-store.ts
+++ b/packages/ui/src/stores/search-store.ts
@@ -61,5 +61,13 @@ export const activateVectorSearch = (mediaId: string) => {
 	}
 };
 
+export const clearVectorSearchAnchor = () => {
+	setSearchState({
+		similarityAnchorMediaId: null,
+		offset: 0,
+		scrollY: 0,
+	});
+};
+
 export const getSearchCondition = () =>
 	getSearchConditionFromState(searchState);


### PR DESCRIPTION
## 概要
AI tagging、character crop、CCIP抽出、vector類似検索の状態を構造化ログで追跡可能にし、vector検索の類似元を検索画面から解除できるようにします。

## 変更内容
- AI taggingとcharacter cropの開始・完了・失敗ログを追加
- background jobにjob ID、type、media source、処理時間を含むライフサイクルログを追加
- CCIP抽出とvector類似検索に対象media、結果件数、処理時間のログを追加
- 未マッチRPCリクエストを警告ログへ記録
- 検索画面に類似元を解除する操作を追加

## 検証
- bun run typecheck
- Biome check（対象8ファイル）
- server production build
- searchSimilar RPCルートのハンドラ登録確認

## 補足
関連unit testはVite+のworker起動タイムアウトおよび変更元ファイルを直接filterした際のNo test files foundにより、テスト本体の実行前に停止しました。