### PR TITLE
perf(backup): LanceDB dump で既存キャッシュを直接使用

### DIFF
--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -1537,54 +1537,63 @@ export const BackupService = {
 			const archiverMod = await importArchiverModule();
 			const { PassThrough } = await import("node:stream");
 
-			let cacheExists = false;
+			let cacheValid = false;
 			try {
-				await fs.access(cacheDir);
-				cacheExists = true;
+				await fs.access(path.join(cacheDir, "manifest.json"));
+				cacheValid = true;
 			} catch {
-				// cache does not exist
+				// cache or manifest does not exist
 			}
 
-			if (cacheExists) {
-				const { readMediaFilePaths } = await import(
-					"~/application/services/lancedb-dump-service"
-				);
-				const driver = getDriver(mediaSource);
-				const mediaFilePaths = await readMediaFilePaths(cacheDir);
+			if (cacheValid) {
+				try {
+					const driver = getDriver(mediaSource);
+					const passThrough = new PassThrough();
+					const archive = new archiverMod.TarArchive();
+					archive.pipe(passThrough);
 
-				const passThrough = new PassThrough();
-				const archive = new archiverMod.TarArchive();
-				archive.pipe(passThrough);
+					(async () => {
+						try {
+							archive.directory(cacheDir, false);
 
-				(async () => {
-					try {
-						archive.directory(cacheDir, false);
+							if (includeImages) {
+								const { readMediaFilePaths } = await import(
+									"~/application/services/lancedb-dump-service"
+								);
+								const mediaFilePaths = await readMediaFilePaths(cacheDir);
 
-						if (includeImages) {
-							for (const item of mediaFilePaths) {
-								if (!item.filePath) continue;
-								try {
-									const buffer = await driver.get(item.filePath);
-									archive.append(buffer, {
-										name: `images/${item.filePath}`,
-									});
-								} catch {
-									// ignore missing files
-								}
+								await Promise.all(
+									mediaFilePaths.map(async (item) => {
+										if (!item.filePath) return;
+										try {
+											const buffer = await driver.get(item.filePath);
+											archive.append(buffer, {
+												name: `images/${item.filePath}`,
+											});
+										} catch {
+											// ignore missing files
+										}
+									}),
+								);
 							}
+
+							await archive.finalize();
+						} catch (err) {
+							logger.error(
+								{ err },
+								"Error generating LanceDB TAR dump from cache",
+							);
+							archive.abort();
 						}
+					})();
 
-						await archive.finalize();
-					} catch (err) {
-						logger.error(
-							{ err },
-							"Error generating LanceDB TAR dump from cache",
-						);
-						archive.abort();
-					}
-				})();
-
-				return nodeStreamToWebReadable(passThrough);
+					return nodeStreamToWebReadable(passThrough);
+				} catch (err) {
+					logger.warn(
+						{ err },
+						"Failed to read LanceDB cache, falling back to DB rebuild",
+					);
+				}
 			}
 
 			// Fallback: rebuild from DB when cache is unavailable

--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -1524,6 +1524,70 @@ export const BackupService = {
 		}
 
 		if (targetMode === "lancedb") {
+			const { services } = await import("~/application/registry");
+			const config = services.getConfigService().getConfig();
+			const baseCacheDir = config.lancedb?.cacheDir ?? ".cache/lancedb-cache";
+			const cacheDir = path.resolve(
+				process.cwd(),
+				baseCacheDir,
+				`source-${mediaSourceId}`,
+			);
+
+			const includeImages = options?.includeImages ?? true;
+			const archiverMod = await importArchiverModule();
+			const { PassThrough } = await import("node:stream");
+
+			let cacheExists = false;
+			try {
+				await fs.access(cacheDir);
+				cacheExists = true;
+			} catch {
+				// cache does not exist
+			}
+
+			if (cacheExists) {
+				const { readMediaFilePaths } = await import(
+					"~/application/services/lancedb-dump-service"
+				);
+				const driver = getDriver(mediaSource);
+				const mediaFilePaths = await readMediaFilePaths(cacheDir);
+
+				const passThrough = new PassThrough();
+				const archive = new archiverMod.TarArchive();
+				archive.pipe(passThrough);
+
+				(async () => {
+					try {
+						archive.directory(cacheDir, false);
+
+						if (includeImages) {
+							for (const item of mediaFilePaths) {
+								if (!item.filePath) continue;
+								try {
+									const buffer = await driver.get(item.filePath);
+									archive.append(buffer, {
+										name: `images/${item.filePath}`,
+									});
+								} catch {
+									// ignore missing files
+								}
+							}
+						}
+
+						await archive.finalize();
+					} catch (err) {
+						logger.error(
+							{ err },
+							"Error generating LanceDB TAR dump from cache",
+						);
+						archive.abort();
+					}
+				})();
+
+				return nodeStreamToWebReadable(passThrough);
+			}
+
+			// Fallback: rebuild from DB when cache is unavailable
 			const { writeToLanceDB, cleanupLanceDBDir } = await import(
 				"~/application/services/lancedb-dump-service"
 			);
@@ -1533,7 +1597,6 @@ export const BackupService = {
 				"lancedb-dump",
 				`source-${mediaSourceId}`,
 			);
-			const includeImages = options?.includeImages ?? true;
 			const dumpedItems: MediaDumpItem[] = [];
 			const limit = 1000;
 			let lastId: string | null = null;
@@ -1574,8 +1637,6 @@ export const BackupService = {
 				tempDir: tempBaseDir,
 			});
 			const driver = getDriver(mediaSource);
-			const archiverMod = await importArchiverModule();
-			const { PassThrough } = await import("node:stream");
 
 			const passThrough = new PassThrough();
 			const archive = new archiverMod.TarArchive();

--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -20,4 +20,5 @@ export const syncLanceDBPages = service.syncLanceDBPages;
 export const syncLanceDBDelta = service.syncLanceDBDelta;
 export const readFromLanceDB = service.readFromLanceDB;
 export const readMediaIds = service.readMediaIds;
+export const readMediaFilePaths = service.readMediaFilePaths;
 export const cleanupLanceDBDir = service.cleanupLanceDBDir;

--- a/packages/application/src/ports/lancedb-dump-service.ts
+++ b/packages/application/src/ports/lancedb-dump-service.ts
@@ -59,5 +59,8 @@ export interface ILanceDbDumpService {
 		options?: ReadOptions,
 	): Promise<MediaDumpItemWithImageData[]>;
 	readMediaIds(lanceDbDir: string): Promise<string[]>;
+	readMediaFilePaths(
+		lanceDbDir: string,
+	): Promise<{ id: string; filePath: string | undefined }[]>;
 	cleanupLanceDBDir(dir: string): Promise<void>;
 }

--- a/packages/application/src/services/lancedb-dump-service.ts
+++ b/packages/application/src/services/lancedb-dump-service.ts
@@ -856,6 +856,19 @@ export function createLanceDbDumpService(deps?: {
 		});
 	}
 
+	async function readMediaFilePaths(
+		lanceDbDir: string,
+	): Promise<{ id: string; filePath: string | undefined }[]> {
+		const connect = await getConnect();
+		const db = await connect(lanceDbDir);
+		const mediaTable = await db.openTable("media");
+		const rows = await mediaTable.query().select(["id", "filePath"]).toArray();
+		return rows.flatMap((row) => {
+			const id = safeString(row.id);
+			return id ? [{ id, filePath: safeString(row.filePath) }] : [];
+		});
+	}
+
 	async function cleanupLanceDBDir(dir: string): Promise<void> {
 		await fs.rm(dir, { recursive: true, force: true });
 	}
@@ -867,6 +880,7 @@ export function createLanceDbDumpService(deps?: {
 		syncLanceDBDelta,
 		readFromLanceDB,
 		readMediaIds,
+		readMediaFilePaths,
 		cleanupLanceDBDir,
 	};
 }


### PR DESCRIPTION
## 概要
createDump の lancedb モードで、既存の LanceDB キャッシュディレクトリを直接 tar にパッケージするように最適化します。

## 変更内容
- readMediaFilePaths を ILanceDbDumpService に追加（cache から id + filePath を取得）
- createDump lancedb ブロックにキャッシュ存在チェックと分岐ロジックを追加
- キャッシュあり: DB クエリ・writeToLanceDB をスキップし cache を直接 tar
- キャッシュなし: 従来通り rebuild (fallback)
- includeImages=true 時も cache から filePath を取得して画像を追加

## 技術詳細
syncSourceLanceDBCache / syncSourceLanceDBDeltaCache が常時最新のキャッシュを維持しているため、dump 時の再構築は不要。metadata only dump でも DB に全件クエリが飛っていた問題を解消します。