### PR TITLE
feat(xtracter): pixivFANBOX対応を追加

### DIFF
--- a/apps/server/drizzle/0017_ambitious_gideon.sql
+++ b/apps/server/drizzle/0017_ambitious_gideon.sql
@@ -1,0 +1,22 @@
+CREATE TYPE "public"."author_platform" AS ENUM('twitter', 'pixiv-fanbox', 'danbooru');--> statement-breakpoint
+CREATE TABLE "author_accounts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"author_id" uuid NOT NULL,
+	"platform" "author_platform" NOT NULL,
+	"account_id" text NOT NULL,
+	"profile_url" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "author_accounts" ADD CONSTRAINT "author_accounts_author_id_authors_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."authors"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_author_accounts_author_id" ON "author_accounts" USING btree ("author_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_author_accounts_platform_account_unique" ON "author_accounts" USING btree ("platform","account_id");--> statement-breakpoint
+INSERT INTO "author_accounts" ("author_id", "platform", "account_id")
+SELECT DISTINCT ON ("account_id")
+	"id",
+	'twitter'::"author_platform",
+	"account_id"
+FROM "authors"
+WHERE "account_id" IS NOT NULL AND "account_id" <> ''
+ORDER BY "account_id", "created_at", "id";

--- a/apps/server/drizzle/meta/0017_snapshot.json
+++ b/apps/server/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,3009 @@
+{
+  "id": "1928bf68-5088-4c28-9755-00116d14c19c",
+  "prevId": "ec9e26e5-be2a-4d22-a83c-b8a89b260acf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.author_accounts": {
+      "name": "author_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "author_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_author_accounts_author_id": {
+          "name": "idx_author_accounts_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_author_accounts_platform_account_unique": {
+          "name": "idx_author_accounts_platform_account_unique",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "author_accounts_author_id_authors_id_fk": {
+          "name": "author_accounts_author_id_authors_id_fk",
+          "tableFrom": "author_accounts",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_authors_account_id": {
+          "name": "idx_authors_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authors_name": {
+          "name": "idx_authors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#808080'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_ips": {
+      "name": "character_ips",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_id": {
+          "name": "ip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_character_ips_ip_id_character_id": {
+          "name": "idx_character_ips_ip_id_character_id",
+          "columns": [
+            {
+              "expression": "ip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_ips_character_id_characters_id_fk": {
+          "name": "character_ips_character_id_characters_id_fk",
+          "tableFrom": "character_ips",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_ips_ip_id_ips_id_fk": {
+          "name": "character_ips_ip_id_ips_id_fk",
+          "tableFrom": "character_ips",
+          "tableTo": "ips",
+          "columnsFrom": [
+            "ip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "character_ips_character_id_ip_id_pk": {
+          "name": "character_ips_character_id_ip_id_pk",
+          "columns": [
+            "character_id",
+            "ip_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "characters_name_unique": {
+          "name": "characters_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ips": {
+      "name": "ips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ips_name_unique": {
+          "name": "ips_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_pending_created": {
+          "name": "idx_jobs_pending_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending' AND \"jobs\".\"type\" <> 'import_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_pending_type_created": {
+          "name": "idx_jobs_pending_type_created",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending' AND \"jobs\".\"type\" <> 'import_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_pending_lancedb_source": {
+          "name": "idx_jobs_pending_lancedb_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending'\n\t\t\t\t\tAND \"jobs\".\"type\" IN ('sync_lancedb', 'sync_lancedb_full', 'sync_lancedb_delta')\n\t\t\t\t\tAND \"jobs\".\"source_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_active_lancedb_source": {
+          "name": "idx_jobs_active_lancedb_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'in_progress'\n\t\t\t\t\tAND \"jobs\".\"type\" IN ('sync_lancedb', 'sync_lancedb_full', 'sync_lancedb_delta')\n\t\t\t\t\tAND \"jobs\".\"source_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_source_id_media_sources_id_fk": {
+          "name": "jobs_source_id_media_sources_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "jobs_parent_id_jobs_id_fk": {
+          "name": "jobs_parent_id_jobs_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lancedb_sync_dirty": {
+      "name": "lancedb_sync_dirty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upsert'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_lancedb_sync_dirty_source_updated": {
+          "name": "idx_lancedb_sync_dirty_source_updated",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lancedb_sync_dirty_source_id_media_sources_id_fk": {
+          "name": "lancedb_sync_dirty_source_id_media_sources_id_fk",
+          "tableFrom": "lancedb_sync_dirty",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lancedb_sync_dirty_source_media_unique": {
+          "name": "lancedb_sync_dirty_source_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "media_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_authors": {
+      "name": "media_authors",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_authors_author_id_media_id": {
+          "name": "idx_media_authors_author_id_media_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_authors_media_id_media_id_fk": {
+          "name": "media_authors_media_id_media_id_fk",
+          "tableFrom": "media_authors",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_authors_author_id_authors_id_fk": {
+          "name": "media_authors_author_id_authors_id_fk",
+          "tableFrom": "media_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_authors_media_id_author_id_pk": {
+          "name": "media_authors_media_id_author_id_pk",
+          "columns": [
+            "media_id",
+            "author_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_categories": {
+      "name": "media_categories",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_categories_category_id_media_id": {
+          "name": "idx_media_categories_category_id_media_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_categories_media_id_media_id_fk": {
+          "name": "media_categories_media_id_media_id_fk",
+          "tableFrom": "media_categories",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_categories_category_id_categories_id_fk": {
+          "name": "media_categories_category_id_categories_id_fk",
+          "tableFrom": "media_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_categories_media_id_category_id_pk": {
+          "name": "media_categories_media_id_category_id_pk",
+          "columns": [
+            "media_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_characters": {
+      "name": "media_characters",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_characters_character_id_media_id": {
+          "name": "idx_media_characters_character_id_media_id",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_characters_media_id_media_id_fk": {
+          "name": "media_characters_media_id_media_id_fk",
+          "tableFrom": "media_characters",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_characters_character_id_characters_id_fk": {
+          "name": "media_characters_character_id_characters_id_fk",
+          "tableFrom": "media_characters",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_characters_media_id_character_id_pk": {
+          "name": "media_characters_media_id_character_id_pk",
+          "columns": [
+            "media_id",
+            "character_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_collections": {
+      "name": "media_collections",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_collections_media_id": {
+          "name": "idx_media_collections_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_collections_collection_id_collections_id_fk": {
+          "name": "media_collections_collection_id_collections_id_fk",
+          "tableFrom": "media_collections",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_collections_media_id_media_id_fk": {
+          "name": "media_collections_media_id_media_id_fk",
+          "tableFrom": "media_collections",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_collections_collection_id_media_id_pk": {
+          "name": "media_collections_collection_id_media_id_pk",
+          "columns": [
+            "collection_id",
+            "media_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_details": {
+      "name": "media_details",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1970-01-01 00:00:00'"
+        }
+      },
+      "indexes": {
+        "idx_media_details_rating": {
+          "name": "idx_media_details_rating",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_details_favorite": {
+          "name": "idx_media_details_favorite",
+          "columns": [
+            {
+              "expression": "favorite",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_details_view_count": {
+          "name": "idx_media_details_view_count",
+          "columns": [
+            {
+              "expression": "view_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_details_media_id_media_id_fk": {
+          "name": "media_details_media_id_media_id_fk",
+          "tableFrom": "media_details",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_generation_info": {
+      "name": "media_generation_info",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negative_prompt": {
+          "name": "negative_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loras": {
+          "name": "loras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vae": {
+          "name": "vae",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hypernetworks": {
+          "name": "hypernetworks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddings": {
+          "name": "embeddings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "seed": {
+          "name": "seed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": -1
+        },
+        "cfg_scale": {
+          "name": "cfg_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_media_generation_info_metadata": {
+          "name": "idx_media_generation_info_metadata",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_generation_info_ai_generated": {
+          "name": "idx_media_generation_info_ai_generated",
+          "columns": [
+            {
+              "expression": "ai_generated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_generation_info_model_name": {
+          "name": "idx_media_generation_info_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_generation_info_media_id_media_id_fk": {
+          "name": "media_generation_info_media_id_media_id_fk",
+          "tableFrom": "media_generation_info",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_ips": {
+      "name": "media_ips",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_id": {
+          "name": "ip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_ips_ip_id_media_id": {
+          "name": "idx_media_ips_ip_id_media_id",
+          "columns": [
+            {
+              "expression": "ip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_ips_media_id_media_id_fk": {
+          "name": "media_ips_media_id_media_id_fk",
+          "tableFrom": "media_ips",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_ips_ip_id_ips_id_fk": {
+          "name": "media_ips_ip_id_ips_id_fk",
+          "tableFrom": "media_ips",
+          "tableTo": "ips",
+          "columnsFrom": [
+            "ip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_ips_media_id_ip_id_pk": {
+          "name": "media_ips_media_id_ip_id_pk",
+          "columns": [
+            "media_id",
+            "ip_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_projects": {
+      "name": "media_projects",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_projects_project_id_media_id": {
+          "name": "idx_media_projects_project_id_media_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_projects_media_id_media_id_fk": {
+          "name": "media_projects_media_id_media_id_fk",
+          "tableFrom": "media_projects",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_projects_project_id_projects_id_fk": {
+          "name": "media_projects_project_id_projects_id_fk",
+          "tableFrom": "media_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_projects_media_id_project_id_pk": {
+          "name": "media_projects_media_id_project_id_pk",
+          "columns": [
+            "media_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_relations": {
+      "name": "media_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_media_id": {
+          "name": "parent_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_media_id": {
+          "name": "child_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "media_relation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_relations_child": {
+          "name": "idx_media_relations_child",
+          "columns": [
+            {
+              "expression": "child_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_relations_type": {
+          "name": "idx_media_relations_type",
+          "columns": [
+            {
+              "expression": "relation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_relations_parent_media_id_media_id_fk": {
+          "name": "media_relations_parent_media_id_media_id_fk",
+          "tableFrom": "media_relations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "parent_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_relations_child_media_id_media_id_fk": {
+          "name": "media_relations_child_media_id_media_id_fk",
+          "tableFrom": "media_relations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "child_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_child_type_unique": {
+          "name": "parent_child_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "parent_media_id",
+            "child_media_id",
+            "relation_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_sources": {
+      "name": "media_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "media_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_info": {
+          "name": "connection_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_sync": {
+      "name": "media_sync",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "media_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'synced'"
+        },
+        "backup_urls": {
+          "name": "backup_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_attempts": {
+          "name": "sync_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_sync_media_id_media_id_fk": {
+          "name": "media_sync_media_id_media_id_fk",
+          "tableFrom": "media_sync",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_tags": {
+      "name": "media_tags",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_type": {
+          "name": "tag_type",
+          "type": "tag_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'positive'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_tags_tag_id_tag_type_media_id": {
+          "name": "idx_media_tags_tag_id_tag_type_media_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_tags_media_id_media_id_fk": {
+          "name": "media_tags_media_id_media_id_fk",
+          "tableFrom": "media_tags",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_tags_tag_id_tags_id_fk": {
+          "name": "media_tags_tag_id_tags_id_fk",
+          "tableFrom": "media_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_tags_media_id_tag_id_tag_type_pk": {
+          "name": "media_tags_media_id_tag_id_tag_type_pk",
+          "columns": [
+            "media_id",
+            "tag_id",
+            "tag_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_technical_info": {
+      "name": "media_technical_info",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color_profile": {
+          "name": "color_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "exif_data": {
+          "name": "exif_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "hash_md5": {
+          "name": "hash_md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hash_perceptual": {
+          "name": "hash_perceptual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frame_rate": {
+          "name": "frame_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitrate_kbps": {
+          "name": "bitrate_kbps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_codec": {
+          "name": "video_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_technical_info_hash_md5": {
+          "name": "idx_media_technical_info_hash_md5",
+          "columns": [
+            {
+              "expression": "hash_md5",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_technical_info_media_id_media_id_fk": {
+          "name": "media_technical_info_media_id_media_id_fk",
+          "tableFrom": "media_technical_info",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_urls": {
+      "name": "media_urls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_urls_media_id": {
+          "name": "idx_media_urls_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_urls_url": {
+          "name": "idx_media_urls_url",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_urls_media_id_url_unique": {
+          "name": "idx_media_urls_media_id_url_unique",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_urls_media_id_media_id_fk": {
+          "name": "media_urls_media_id_media_id_fk",
+          "tableFrom": "media_urls",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "media_organization_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "idx_media_source_id": {
+          "name": "idx_media_source_id",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_file_size": {
+          "name": "idx_media_file_size",
+          "columns": [
+            {
+              "expression": "file_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_file_name": {
+          "name": "idx_media_file_name",
+          "columns": [
+            {
+              "expression": "file_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_created_at": {
+          "name": "idx_media_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_description": {
+          "name": "idx_media_description",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_source_id_media_sources_id_fk": {
+          "name": "media_source_id_media_sources_id_fk",
+          "tableFrom": "media",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_id_file_path_unique": {
+          "name": "source_id_file_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "file_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presets": {
+      "name": "presets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort": {
+          "name": "sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "presets_name_unique": {
+          "name": "presets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.similar_media": {
+      "name": "similar_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media1_id": {
+          "name": "media1_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media2_id": {
+          "name": "media2_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "similarity_score": {
+          "name": "similarity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'perceptual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_similar_media_score": {
+          "name": "idx_similar_media_score",
+          "columns": [
+            {
+              "expression": "similarity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "similar_media_media1_id_media_id_fk": {
+          "name": "similar_media_media1_id_media_id_fk",
+          "tableFrom": "similar_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "similar_media_media2_id_media_id_fk": {
+          "name": "similar_media_media2_id_media_id_fk",
+          "tableFrom": "similar_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media1Id_media2Id_algorithm_unique": {
+          "name": "media1Id_media2Id_algorithm_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "media1_id",
+            "media2_id",
+            "algorithm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tags_author_id": {
+          "name": "idx_tags_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_author_id_authors_id_fk": {
+          "name": "tags_author_id_authors_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.view_history": {
+      "name": "view_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "view_history_media_id_media_id_fk": {
+          "name": "view_history_media_id_media_id_fk",
+          "tableFrom": "view_history",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.author_platform": {
+      "name": "author_platform",
+      "schema": "public",
+      "values": [
+        "twitter",
+        "pixiv-fanbox",
+        "danbooru"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.media_organization_status": {
+      "name": "media_organization_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived",
+        "deleted"
+      ]
+    },
+    "public.media_relation_type": {
+      "name": "media_relation_type",
+      "schema": "public",
+      "values": [
+        "variant",
+        "version",
+        "page",
+        "derivative",
+        "edit",
+        "source"
+      ]
+    },
+    "public.media_source_type": {
+      "name": "media_source_type",
+      "schema": "public",
+      "values": [
+        "local",
+        "sftp",
+        "s3"
+      ]
+    },
+    "public.media_sync_status": {
+      "name": "media_sync_status",
+      "schema": "public",
+      "values": [
+        "synced",
+        "pending",
+        "failed"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "video",
+        "audio"
+      ]
+    },
+    "public.tag_type": {
+      "name": "tag_type",
+      "schema": "public",
+      "values": [
+        "positive",
+        "negative"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1782395330635,
       "tag": "0016_nebulous_blade",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1782830770400,
+      "tag": "0017_ambitious_gideon",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
+	type AuthorPlatform,
 	type MediaDumpItem,
 	mediaDumpItemSchema,
 } from "@solid-imager/core/domain/media/schemas";
@@ -11,6 +12,7 @@ import { and, asc, eq, gt, inArray, lt, sql } from "drizzle-orm";
 import type { PgColumn } from "drizzle-orm/pg-core";
 import { db } from "~/infrastructure/db";
 import {
+	authorAccounts,
 	authors,
 	characterIps,
 	characters,
@@ -86,7 +88,14 @@ interface MediaListQueryItem {
 		source: string;
 	}[];
 	authors: {
-		author: { name: string; accountId: string | null };
+		author: {
+			name: string;
+			accountId: string | null;
+			accounts?: {
+				platform: AuthorPlatform;
+				accountId: string;
+			}[];
+		};
 	}[];
 	characters: {
 		character: {
@@ -394,6 +403,33 @@ export const BackupService = {
 			authorData,
 			_tx,
 		);
+		const restoredAuthorAccounts = new Map<
+			string,
+			{
+				authorId: string;
+				platform: AuthorPlatform;
+				accountId: string;
+			}
+		>();
+		for (const item of validItems) {
+			for (const author of item.authors ?? []) {
+				if (!(author.platform && author.accountId)) continue;
+				const authorId = authorMap.get(author.name);
+				if (!authorId) continue;
+				const key = `${author.platform}:${author.accountId}`;
+				restoredAuthorAccounts.set(key, {
+					authorId,
+					platform: author.platform,
+					accountId: author.accountId,
+				});
+			}
+		}
+		if (restoredAuthorAccounts.size > 0) {
+			await (_tx ?? db)
+				.insert(authorAccounts)
+				.values([...restoredAuthorAccounts.values()])
+				.onConflictDoNothing();
+		}
 		const projectMap = await this._ensureMasterData(
 			projects,
 			projects.id,
@@ -1213,7 +1249,7 @@ export const BackupService = {
 						generationInfo: true,
 						urls: true,
 						tags: { with: { tag: true } },
-						authors: { with: { author: true } },
+						authors: { with: { author: { with: { accounts: true } } } },
 						characters: {
 							with: {
 								character: {
@@ -1323,7 +1359,7 @@ export const BackupService = {
 						generationInfo: true,
 						urls: true,
 						tags: { with: { tag: true } },
-						authors: { with: { author: true } },
+						authors: { with: { author: { with: { accounts: true } } } },
 						characters: {
 							with: { character: { with: { ips: { with: { ip: true } } } } },
 						},
@@ -1407,7 +1443,9 @@ export const BackupService = {
 									generationInfo: true,
 									urls: true,
 									tags: { with: { tag: true } },
-									authors: { with: { author: true } },
+									authors: {
+										with: { author: { with: { accounts: true } } },
+									},
 									characters: {
 										with: {
 											character: { with: { ips: { with: { ip: true } } } },
@@ -1474,7 +1512,9 @@ export const BackupService = {
 									generationInfo: true,
 									urls: true,
 									tags: { with: { tag: true } },
-									authors: { with: { author: true } },
+									authors: {
+										with: { author: { with: { accounts: true } } },
+									},
 									characters: {
 										with: {
 											character: { with: { ips: { with: { ip: true } } } },
@@ -1623,7 +1663,7 @@ export const BackupService = {
 						generationInfo: true,
 						urls: true,
 						tags: { with: { tag: true } },
-						authors: { with: { author: true } },
+						authors: { with: { author: { with: { accounts: true } } } },
 						characters: {
 							with: {
 								character: { with: { ips: { with: { ip: true } } } },
@@ -1706,6 +1746,9 @@ export const BackupService = {
 			const simpleAuthors = (media.authors || []).map((ma) => ({
 				name: ma.author?.name || "",
 				accountId: ma.author?.accountId ?? null,
+				platform: ma.author?.accounts?.find(
+					(account) => account.accountId === ma.author?.accountId,
+				)?.platform,
 			}));
 
 			// Extract characters

--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -8,7 +8,7 @@ import {
 import { localConnectionSchema } from "@solid-imager/core/domain/sources/schemas";
 import { getErrorMessage } from "@solid-imager/core/utils/get-error-message";
 import type { Table } from "drizzle-orm";
-import { and, asc, eq, gt, inArray, lt, sql } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, lt, or, sql } from "drizzle-orm";
 import type { PgColumn } from "drizzle-orm/pg-core";
 import { db } from "~/infrastructure/db";
 import {
@@ -57,6 +57,16 @@ type JsonValue =
 	| { [key: string]: JsonValue };
 
 const LanceDbDirtyMaxAttempts = 5;
+
+function authorRestoreKey(author: {
+	name: string;
+	platform?: AuthorPlatform;
+	accountId?: string | null;
+}): string {
+	return author.platform && author.accountId
+		? `${author.platform}:${author.accountId}`
+		: `name:${author.name}`;
+}
 
 interface MediaListQueryItem {
 	id: string;
@@ -334,7 +344,14 @@ export const BackupService = {
 
 	async _restoreMasterData(validItems: MediaDumpItem[], _tx?: BackupDbClient) {
 		const tagNames = new Set<string>();
-		const authorData = new Map<string, { accountId?: string | null }>();
+		const authorData = new Map<
+			string,
+			{
+				name: string;
+				accountId?: string | null;
+				platform?: AuthorPlatform;
+			}
+		>();
 		const projectNames = new Set<string>();
 		const charNames = new Set<string>();
 		const ipNames = new Set<string>();
@@ -349,9 +366,8 @@ export const BackupService = {
 			}
 			if (item.authors) {
 				for (const a of item.authors) {
-					// Preserve accountId if available
-					if (a.name && (!authorData.has(a.name) || a.accountId)) {
-						authorData.set(a.name, { accountId: a.accountId });
+					if (a.name) {
+						authorData.set(authorRestoreKey(a), a);
 					}
 				}
 			}
@@ -395,14 +411,99 @@ export const BackupService = {
 			},
 			_tx,
 		);
-		const authorMap = await this._ensureMasterDataWithExtras(
-			authors,
-			authors.id,
-			authors.name,
-			authors.accountId,
-			authorData,
-			_tx,
-		);
+		const authorInputs = [...authorData.values()];
+		const d = _tx ?? db;
+		const authorMap = new Map<string, string>();
+		for (const input of authorInputs) {
+			let authorId: string | undefined;
+			if (input.platform && input.accountId) {
+				const existingAccount = await d
+					.select({ authorId: authorAccounts.authorId })
+					.from(authorAccounts)
+					.where(
+						and(
+							eq(authorAccounts.platform, input.platform),
+							eq(authorAccounts.accountId, input.accountId),
+						),
+					)
+					.limit(1);
+				authorId = existingAccount[0]?.authorId;
+
+				if (!authorId) {
+					const legacyCandidates = await d
+						.select()
+						.from(authors)
+						.where(
+							or(
+								eq(authors.accountId, input.accountId),
+								eq(authors.name, input.name),
+							),
+						);
+					const candidateIds = legacyCandidates.map((author) => author.id);
+					const linkedIds =
+						candidateIds.length > 0
+							? new Set(
+									(
+										await d
+											.select({ authorId: authorAccounts.authorId })
+											.from(authorAccounts)
+											.where(inArray(authorAccounts.authorId, candidateIds))
+									).map((account) => account.authorId),
+								)
+							: new Set<string>();
+					const reusable = legacyCandidates.find(
+						(author) =>
+							!linkedIds.has(author.id) &&
+							(author.accountId === input.accountId ||
+								(author.name === input.name && !author.accountId)),
+					);
+					if (reusable) {
+						authorId = reusable.id;
+					} else {
+						const inserted = await d
+							.insert(authors)
+							.values({
+								name: input.name,
+								accountId: input.accountId,
+							})
+							.returning();
+						authorId = inserted[0]?.id;
+					}
+					if (authorId) {
+						await d
+							.insert(authorAccounts)
+							.values({
+								authorId,
+								platform: input.platform,
+								accountId: input.accountId,
+							})
+							.onConflictDoNothing();
+					}
+				}
+			} else {
+				const existing = await d
+					.select({ id: authors.id })
+					.from(authors)
+					.where(eq(authors.name, input.name))
+					.limit(1);
+				authorId = existing[0]?.id;
+				if (!authorId) {
+					const inserted = await d
+						.insert(authors)
+						.values({
+							name: input.name,
+							accountId: input.accountId ?? null,
+						})
+						.returning();
+					authorId = inserted[0]?.id;
+				}
+			}
+			if (!authorId) continue;
+			authorMap.set(authorRestoreKey(input), authorId);
+			if (!authorMap.has(`name:${input.name}`)) {
+				authorMap.set(`name:${input.name}`, authorId);
+			}
+		}
 		const restoredAuthorAccounts = new Map<
 			string,
 			{
@@ -414,7 +515,7 @@ export const BackupService = {
 		for (const item of validItems) {
 			for (const author of item.authors ?? []) {
 				if (!(author.platform && author.accountId)) continue;
-				const authorId = authorMap.get(author.name);
+				const authorId = authorMap.get(authorRestoreKey(author));
 				if (!authorId) continue;
 				const key = `${author.platform}:${author.accountId}`;
 				restoredAuthorAccounts.set(key, {
@@ -605,7 +706,9 @@ export const BackupService = {
 
 			if (item.authors) {
 				for (const a of item.authors) {
-					const authorId = a.name ? authorMap.get(a.name) : undefined;
+					const authorId = a.name
+						? authorMap.get(authorRestoreKey(a))
+						: undefined;
 					if (authorId) {
 						mediaAuthorsData.push({ mediaId, authorId });
 					}
@@ -792,106 +895,6 @@ export const BackupService = {
 			.where(inArray(nameColumn, nameList))) as { id: string; name: string }[];
 
 		return new Map(records.map((r) => [r.name, r.id]));
-	},
-
-	/**
-	 * Ensures master data with extra fields (specifically for authors with accountId).
-	 * Authors table has no unique constraint on name (display names can overlap),
-	 * so we use manual dedup by name and update accountId when available.
-	 */
-	async _ensureMasterDataWithExtras(
-		table: Table,
-		idColumn: PgColumn,
-		nameColumn: PgColumn,
-		accountIdColumn: PgColumn,
-		dataMap: Map<string, { accountId?: string | null }>,
-		_tx?: BackupDbClient,
-	): Promise<Map<string, string>> {
-		const d = _tx ?? db;
-		if (dataMap.size === 0) {
-			return new Map();
-		}
-
-		const entries = Array.from(dataMap.entries());
-		const nameList = entries.map(([name]) => name);
-
-		// First, find existing authors by name
-		const existingRecords = (await d
-			.select({
-				id: idColumn,
-				name: nameColumn,
-				accountId: accountIdColumn,
-			})
-			.from(table)
-			.where(inArray(nameColumn, nameList))) as {
-			id: string;
-			name: string;
-			accountId: string | null;
-		}[];
-
-		const existingByName = new Map<
-			string,
-			{ id: string; accountId: string | null }
-		>();
-		for (const r of existingRecords) {
-			const existing = existingByName.get(r.name);
-			// Prioritize entry with an accountId, or just take the first one if none have it yet.
-			if (!existing || (!existing.accountId && r.accountId)) {
-				existingByName.set(r.name, { id: r.id, accountId: r.accountId });
-			}
-		}
-
-		// Update existing authors with new accountId if provided
-		// Note: Update ALL authors with matching name (handles duplicates)
-		for (const [name, data] of entries) {
-			const existing = existingByName.get(name);
-			if (existing && data.accountId && existing.accountId !== data.accountId) {
-				await d
-					.update(table)
-					.set({ accountId: data.accountId })
-					.where(eq(nameColumn, name));
-			}
-		}
-
-		// Insert new authors that don't exist
-		const newEntries = entries.filter(([name]) => !existingByName.has(name));
-		if (newEntries.length > 0) {
-			await d.insert(table).values(
-				newEntries.map(([name, data]) => ({
-					name,
-					accountId: data.accountId || null,
-				})),
-			);
-
-			// Fetch the newly inserted records
-			const newRecords = (await d
-				.select({
-					id: idColumn,
-					name: nameColumn,
-					accountId: accountIdColumn,
-				})
-				.from(table)
-				.where(
-					inArray(
-						nameColumn,
-						newEntries.map(([name]) => name),
-					),
-				)) as { id: string; name: string; accountId: string | null }[];
-
-			for (const r of newRecords) {
-				if (!existingByName.has(r.name)) {
-					existingByName.set(r.name, { id: r.id, accountId: r.accountId });
-				}
-			}
-		}
-
-		// Return map of name -> id
-		return new Map(
-			Array.from(existingByName.entries()).map(([name, data]) => [
-				name,
-				data.id,
-			]),
-		);
 	},
 
 	/**
@@ -1743,13 +1746,21 @@ export const BackupService = {
 			}));
 
 			// Extract authors
-			const simpleAuthors = (media.authors || []).map((ma) => ({
-				name: ma.author?.name || "",
-				accountId: ma.author?.accountId ?? null,
-				platform: ma.author?.accounts?.find(
+			const simpleAuthors = (media.authors || []).map((ma) => {
+				const legacyAccount = ma.author?.accounts?.find(
 					(account) => account.accountId === ma.author?.accountId,
-				)?.platform,
-			}));
+				);
+				const account =
+					legacyAccount ??
+					(ma.author?.accounts?.length === 1
+						? ma.author.accounts[0]
+						: undefined);
+				return {
+					name: ma.author?.name || "",
+					accountId: account?.accountId ?? ma.author?.accountId ?? null,
+					platform: account?.platform,
+				};
+			});
 
 			// Extract characters
 			const simpleCharacters = (media.characters || []).map((mc) => ({

--- a/apps/server/src/components/media/pro-search-builder.tsx
+++ b/apps/server/src/components/media/pro-search-builder.tsx
@@ -25,7 +25,10 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@solid-imager/ui/select";
-import { parseSelectValue } from "@solid-imager/ui/utils";
+import {
+	createDebouncedSignal,
+	parseSelectValue,
+} from "@solid-imager/ui/utils";
 import { cn } from "@solid-imager/ui/utils/cn";
 import { createMemo, Index, Match, Show, Switch } from "solid-js";
 
@@ -345,6 +348,23 @@ function CriterionBuilder(props: {
 				return;
 		}
 	});
+	const [filterText, setFilterText] = createDebouncedSignal("", 150);
+	const filteredItems = createMemo(() => {
+		const items = autocompleteItems();
+		if (!items) return [];
+		const query = filterText().toLowerCase();
+		if (!query) return items.slice(0, 100);
+		return items
+			.filter((item) => {
+				if (!item) return false;
+				const label =
+					props.criterion.target === "author"
+						? getAuthorLabel(item as Author)
+						: (item as { name: string }).name;
+				return label.toLowerCase().includes(query);
+			})
+			.slice(0, 100);
+	});
 
 	const getValidOperators = (target: string) => {
 		// Fast path checks using sets or direct includes
@@ -460,7 +480,7 @@ function CriterionBuilder(props: {
 								props.onChange({ ...props.criterion, value: val.name });
 							}
 						}}
-						defaultFilter="contains"
+						onInputChange={(text) => setFilterText(text)}
 						optionLabel={(item) =>
 							item
 								? props.criterion.target === "author"
@@ -468,7 +488,7 @@ function CriterionBuilder(props: {
 									: (item as { name: string }).name
 								: ""
 						}
-						options={autocompleteItems() ?? []}
+						options={filteredItems()}
 						optionTextValue={(item) =>
 							item
 								? props.criterion.target === "author"

--- a/apps/server/src/components/media/pro-search-builder.tsx
+++ b/apps/server/src/components/media/pro-search-builder.tsx
@@ -25,10 +25,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@solid-imager/ui/select";
-import {
-	createDebouncedSignal,
-	parseSelectValue,
-} from "@solid-imager/ui/utils";
+import { parseSelectValue } from "@solid-imager/ui/utils";
 import { cn } from "@solid-imager/ui/utils/cn";
 import { createMemo, Index, Match, Show, Switch } from "solid-js";
 
@@ -333,25 +330,6 @@ function CriterionBuilder(props: {
 			? `${author.name}: (twitter)${author.accountId}`
 			: author.name;
 
-	const [filterText, setFilterText] = createDebouncedSignal("", 150);
-
-	const filteredItems = createMemo(() => {
-		const items = autocompleteItems();
-		if (!items) return [];
-		const query = filterText().toLowerCase();
-		if (!query) return items.slice(0, 100);
-		return items
-			.filter((item) => {
-				if (!item) return false;
-				const label =
-					props.criterion.target === "author"
-						? getAuthorLabel(item as Author)
-						: (item as { name: string }).name;
-				return label.toLowerCase().includes(query);
-			})
-			.slice(0, 100);
-	});
-
 	// Helper to determine available items for autocomplete
 	const autocompleteItems = createMemo(() => {
 		switch (props.criterion.target) {
@@ -484,7 +462,7 @@ function CriterionBuilder(props: {
 								props.onChange({ ...props.criterion, value: val.name });
 							}
 						}}
-						onInputChange={(text) => setFilterText(text)}
+						defaultFilter="contains"
 						optionLabel={(item) =>
 							item
 								? props.criterion.target === "author"
@@ -492,7 +470,7 @@ function CriterionBuilder(props: {
 									: (item as { name: string }).name
 								: ""
 						}
-						options={filteredItems()}
+						options={autocompleteItems() ?? []}
 						optionTextValue={(item) =>
 							item
 								? props.criterion.target === "author"
@@ -500,7 +478,7 @@ function CriterionBuilder(props: {
 									: (item as { name: string }).name
 								: ""
 						}
-						optionValue={(item: { name: string }) => item.name}
+						optionValue={(item) => item.id}
 						placeholder="検索..."
 						triggerMode="focus"
 						value={(autocompleteItems() || []).find(

--- a/apps/server/src/components/media/pro-search-builder.tsx
+++ b/apps/server/src/components/media/pro-search-builder.tsx
@@ -326,9 +326,7 @@ function CriterionBuilder(props: {
 	tags?: TagResponse[];
 }) {
 	const getAuthorLabel = (author: Author) =>
-		author.accountId
-			? `${author.name}: (twitter)${author.accountId}`
-			: author.name;
+		author.accountId ? `${author.name}: ${author.accountId}` : author.name;
 
 	// Helper to determine available items for autocomplete
 	const autocompleteItems = createMemo(() => {

--- a/apps/server/src/components/media/search-filters.tsx
+++ b/apps/server/src/components/media/search-filters.tsx
@@ -16,8 +16,7 @@ import {
 import { Input } from "@solid-imager/ui/input";
 import { Label } from "@solid-imager/ui/label";
 import { cn } from "@solid-imager/ui/utils/cn";
-import { createDebouncedSignal } from "@solid-imager/ui/utils/debounce";
-import { createMemo, createSignal, For } from "solid-js";
+import { createSignal, For } from "solid-js";
 
 export type SearchFilterState = {
 	searchQuery: string;
@@ -56,23 +55,13 @@ function FilterSection<T>(props: {
 	onSelect: (item: T) => void;
 	onRemove: (id: string) => void;
 	getItemKey: (item: T) => string;
+	getSelectedItemValue?: (item: T) => string;
 	getItemLabel: (item: T) => string;
 	getItemDescription?: (item: T) => string | undefined | null;
 	placeholder?: string;
 	badgeVariant?: "default" | "destructive" | "secondary" | "outline";
 }) {
 	const [value, setValue] = createSignal<T | null>(null);
-	const [filterText, setFilterText] = createDebouncedSignal("", 150);
-
-	const filteredItems = createMemo(() => {
-		const items = props.items;
-		if (!items) return [];
-		const query = filterText().toLowerCase();
-		if (!query) return items.slice(0, 100);
-		return items
-			.filter((item) => props.getItemLabel(item).toLowerCase().includes(query))
-			.slice(0, 100);
-	});
 
 	return (
 		<div class="space-y-2">
@@ -80,7 +69,10 @@ function FilterSection<T>(props: {
 			<div class="mb-2 flex flex-wrap gap-2">
 				<For each={props.selectedItems}>
 					{(id) => {
-						const item = props.items?.find((i) => props.getItemKey(i) === id);
+						const item = props.items?.find(
+							(i) =>
+								(props.getSelectedItemValue?.(i) ?? props.getItemKey(i)) === id,
+						);
 						return (
 							<Badge
 								class="cursor-pointer"
@@ -111,13 +103,12 @@ function FilterSection<T>(props: {
 						setValue(() => val);
 						requestAnimationFrame(() => {
 							setValue(null);
-							setFilterText("");
 						});
 					}
 				}}
-				onInputChange={(text) => setFilterText(text)}
+				defaultFilter="contains"
 				optionLabel={props.getItemLabel}
-				options={filteredItems()}
+				options={props.items ?? []}
 				optionTextValue={props.getItemLabel}
 				optionValue={(item) => props.getItemKey(item)}
 				placeholder={props.placeholder}
@@ -259,8 +250,9 @@ export function SearchFilters(props: SearchFiltersProps) {
 			{/* Author Filter */}
 			<FilterSection
 				badgeVariant="secondary"
-				getItemKey={(author) => author.name}
+				getItemKey={(author) => author.id}
 				getItemLabel={getAuthorLabel}
+				getSelectedItemValue={(author) => author.name}
 				items={props.authors}
 				label="作者"
 				onRemove={(name) =>

--- a/apps/server/src/components/media/search-filters.tsx
+++ b/apps/server/src/components/media/search-filters.tsx
@@ -125,9 +125,7 @@ function FilterSection<T>(props: {
 }
 
 const getAuthorLabel = (author: Author) =>
-	author.accountId
-		? `${author.name}：(twitter)${author.accountId}`
-		: author.name;
+	author.accountId ? `${author.name}：${author.accountId}` : author.name;
 
 export function SearchFilters(props: SearchFiltersProps) {
 	const addTag = (tagName: string) => {

--- a/apps/server/src/components/media/search-filters.tsx
+++ b/apps/server/src/components/media/search-filters.tsx
@@ -16,7 +16,8 @@ import {
 import { Input } from "@solid-imager/ui/input";
 import { Label } from "@solid-imager/ui/label";
 import { cn } from "@solid-imager/ui/utils/cn";
-import { createSignal, For } from "solid-js";
+import { createDebouncedSignal } from "@solid-imager/ui/utils/debounce";
+import { createMemo, createSignal, For } from "solid-js";
 
 export type SearchFilterState = {
 	searchQuery: string;
@@ -62,6 +63,16 @@ function FilterSection<T>(props: {
 	badgeVariant?: "default" | "destructive" | "secondary" | "outline";
 }) {
 	const [value, setValue] = createSignal<T | null>(null);
+	const [filterText, setFilterText] = createDebouncedSignal("", 150);
+	const filteredItems = createMemo(() => {
+		const items = props.items;
+		if (!items) return [];
+		const query = filterText().toLowerCase();
+		if (!query) return items.slice(0, 100);
+		return items
+			.filter((item) => props.getItemLabel(item).toLowerCase().includes(query))
+			.slice(0, 100);
+	});
 
 	return (
 		<div class="space-y-2">
@@ -103,12 +114,13 @@ function FilterSection<T>(props: {
 						setValue(() => val);
 						requestAnimationFrame(() => {
 							setValue(null);
+							setFilterText("");
 						});
 					}
 				}}
-				defaultFilter="contains"
+				onInputChange={(text) => setFilterText(text)}
 				optionLabel={props.getItemLabel}
-				options={props.items ?? []}
+				options={filteredItems()}
 				optionTextValue={props.getItemLabel}
 				optionValue={(item) => props.getItemKey(item)}
 				placeholder={props.placeholder}

--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -754,6 +754,7 @@ async function updateExistingMediaWithMetadata(
 		authors: item.authors?.map((a) => ({
 			name: a.name,
 			accountId: a.accountId ?? null,
+			...(a.platform ? { platform: a.platform } : {}),
 		})),
 		// We can also update other metadata if needed, consistent with registerMedia
 		tags: item.tags,
@@ -794,6 +795,7 @@ async function registerMedia(
 				authors: item.authors?.map((a) => ({
 					name: a.name,
 					accountId: a.accountId ?? null,
+					...(a.platform ? { platform: a.platform } : {}),
 				})),
 				tags: item.tags,
 				characters: item.characters,

--- a/apps/server/src/tests/integration/backup/backup-service.test.ts
+++ b/apps/server/src/tests/integration/backup/backup-service.test.ts
@@ -10,6 +10,7 @@ import {
 import { BackupService } from "~/application/services/backup-service";
 import { db } from "~/infrastructure/db";
 import {
+	authorAccounts,
 	authors,
 	characterIps,
 	characters,
@@ -108,8 +109,13 @@ describe("BackupService Integration", () => {
 			.values({ characterId: character.id, ipId: ip.id, source: "manual" });
 		const [author] = await db
 			.insert(authors)
-			.values({ name: "Dump Author" })
+			.values({ name: "Dump Author", accountId: "dump-author" })
 			.returning();
+		await db.insert(authorAccounts).values({
+			authorId: author.id,
+			platform: "pixiv-fanbox",
+			accountId: "dump-author",
+		});
 
 		await db
 			.insert(mediaProjects)
@@ -166,6 +172,7 @@ describe("BackupService Integration", () => {
 
 		expect(item.authors).toHaveLength(1);
 		expect(item.authors[0].name).toBe("Dump Author");
+		expect(item.authors[0].platform).toBe("pixiv-fanbox");
 
 		expect(item.sourceUrls).toHaveLength(1);
 		expect(item.sourceUrls[0]).toBe("https://example.com/source");
@@ -194,7 +201,13 @@ describe("BackupService Integration", () => {
 				{ name: "Restore Character", confidence: confidenceRestoreChar },
 			],
 			ips: [{ name: "Restore IP" }],
-			authors: [{ name: "Restore Author", accountId: "test_account_123" }],
+			authors: [
+				{
+					name: "Restore Author",
+					accountId: "test_account_123",
+					platform: "pixiv-fanbox",
+				},
+			],
 			sourceUrls: ["https://example.com/restore"],
 		};
 
@@ -214,7 +227,7 @@ describe("BackupService Integration", () => {
 				projects: { with: { project: true } },
 				characters: true,
 				ips: { with: { ip: true } },
-				authors: { with: { author: true } },
+				authors: { with: { author: { with: { accounts: true } } } },
 				urls: true,
 			},
 		});
@@ -235,6 +248,12 @@ describe("BackupService Integration", () => {
 		expect(restoredMedia?.authors).toHaveLength(1);
 		expect(restoredMedia?.authors[0].author.name).toBe("Restore Author");
 		expect(restoredMedia?.authors[0].author.accountId).toBe("test_account_123");
+		expect(restoredMedia?.authors[0].author.accounts).toEqual([
+			expect.objectContaining({
+				platform: "pixiv-fanbox",
+				accountId: "test_account_123",
+			}),
+		]);
 
 		expect(restoredMedia?.urls).toHaveLength(1);
 		expect(restoredMedia?.urls[0].url).toBe("https://example.com/restore");

--- a/apps/server/src/tests/integration/backup/backup-service.test.ts
+++ b/apps/server/src/tests/integration/backup/backup-service.test.ts
@@ -178,6 +178,35 @@ describe("BackupService Integration", () => {
 		expect(item.sourceUrls[0]).toBe("https://example.com/source");
 	});
 
+	it("exports a sole platform account when the legacy account ID is absent", () => {
+		const [item] = BackupService._transformMediaList([
+			{
+				authors: [
+					{
+						author: {
+							name: "Account-only Author",
+							accountId: null,
+							accounts: [
+								{
+									platform: "pixiv-fanbox",
+									accountId: "account-only",
+								},
+							],
+						},
+					},
+				],
+			},
+		]);
+
+		expect(item?.authors).toEqual([
+			{
+				name: "Account-only Author",
+				accountId: "account-only",
+				platform: "pixiv-fanbox",
+			},
+		]);
+	});
+
 	it("should restore projects, characters, ips, authors, and sourceUrls from dump item", async () => {
 		// Update source type to s3 to bypass fs.access check
 		await db
@@ -257,6 +286,59 @@ describe("BackupService Integration", () => {
 
 		expect(restoredMedia?.urls).toHaveLength(1);
 		expect(restoredMedia?.urls[0].url).toBe("https://example.com/restore");
+	});
+
+	it("restores same-name authors separately by platform account identity", async () => {
+		await db
+			.update(mediaSources)
+			.set({ type: "s3" })
+			.where(eq(mediaSources.id, testSourceId));
+
+		const baseItem = {
+			mediaType: "image",
+			width: 100,
+			height: 100,
+			fileSize: 1024,
+			createdAt: new Date().toISOString(),
+			modifiedAt: new Date().toISOString(),
+		};
+		const result = await BackupService.restoreSource(testSourceId, [
+			{
+				...baseItem,
+				filePath: "fanbox.png",
+				fileName: "fanbox.png",
+				authors: [
+					{
+						name: "Shared Name",
+						accountId: "fanbox-creator",
+						platform: "pixiv-fanbox",
+					},
+				],
+			},
+			{
+				...baseItem,
+				filePath: "twitter.png",
+				fileName: "twitter.png",
+				authors: [
+					{
+						name: "Shared Name",
+						accountId: "twitter-creator",
+						platform: "twitter",
+					},
+				],
+			},
+		]);
+
+		expect(result.processed).toBe(2);
+		const restored = await db.query.medias.findMany({
+			where: eq(medias.mediaSourceId, testSourceId),
+			with: { authors: { with: { author: { with: { accounts: true } } } } },
+		});
+		const authorIds = restored.map((media) => media.authors[0]?.author.id);
+		expect(new Set(authorIds).size).toBe(2);
+		expect(
+			restored.map((media) => media.authors[0]?.author.accounts[0]?.platform),
+		).toEqual(expect.arrayContaining(["pixiv-fanbox", "twitter"]));
 	});
 
 	it("should infer character-IP relationships from media when linkedIps is not provided", async () => {

--- a/apps/server/src/tests/integration/repository/author-dedupe.test.ts
+++ b/apps/server/src/tests/integration/repository/author-dedupe.test.ts
@@ -22,6 +22,12 @@ describe("AuthorRepository Deduplication", () => {
 		await db.delete(authors);
 	});
 
+	it("rejects an empty author name", async () => {
+		await expect(
+			AuthorRepository.create({ name: "", accountId: null }),
+		).rejects.toThrow("Author name cannot be empty");
+	});
+
 	it("should NOT create duplicate authors when accountId is missing but name matches", async () => {
 		// 1. Create first author without accountId
 		const author1 = await AuthorRepository.create({

--- a/apps/server/src/tests/integration/repository/author-dedupe.test.ts
+++ b/apps/server/src/tests/integration/repository/author-dedupe.test.ts
@@ -1,8 +1,8 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { migrate } from "drizzle-orm/pglite/migrator";
 import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
 import { db } from "~/infrastructure/db";
-import { authors } from "~/infrastructure/db/schema";
+import { authorAccounts, authors } from "~/infrastructure/db/schema";
 import { AuthorRepository } from "~/infrastructure/repositories/author-repository";
 
 describe("AuthorRepository Deduplication", () => {
@@ -44,5 +44,46 @@ describe("AuthorRepository Deduplication", () => {
 			.from(authors)
 			.where(eq(authors.name, "Duplicate Tester"));
 		expect(count).toHaveLength(1);
+	});
+
+	it("deduplicates an author by platform and account ID", async () => {
+		const author1 = await AuthorRepository.create({
+			name: "Original Name",
+			accountId: "@creator",
+			platform: "twitter",
+		});
+		const author2 = await AuthorRepository.create({
+			name: "Updated Display Name",
+			accountId: "@creator",
+			platform: "twitter",
+		});
+
+		expect(author2.id).toBe(author1.id);
+		const accounts = await db
+			.select()
+			.from(authorAccounts)
+			.where(
+				and(
+					eq(authorAccounts.platform, "twitter"),
+					eq(authorAccounts.accountId, "@creator"),
+				),
+			);
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]?.authorId).toBe(author1.id);
+	});
+
+	it("keeps identical account IDs on different platforms separate", async () => {
+		const twitterAuthor = await AuthorRepository.create({
+			name: "Twitter Creator",
+			accountId: "creator",
+			platform: "twitter",
+		});
+		const fanboxAuthor = await AuthorRepository.create({
+			name: "FANBOX Creator",
+			accountId: "creator",
+			platform: "pixiv-fanbox",
+		});
+
+		expect(fanboxAuthor.id).not.toBe(twitterAuthor.id);
 	});
 });

--- a/apps/server/src/tests/integration/repository/author-dedupe.test.ts
+++ b/apps/server/src/tests/integration/repository/author-dedupe.test.ts
@@ -86,4 +86,34 @@ describe("AuthorRepository Deduplication", () => {
 
 		expect(fanboxAuthor.id).not.toBe(twitterAuthor.id);
 	});
+
+	it("links a platform account to a legacy author without creating a duplicate", async () => {
+		const [legacyAuthor] = await db
+			.insert(authors)
+			.values({ name: "Legacy Creator", accountId: "legacy-creator" })
+			.returning();
+
+		const resolved = await AuthorRepository.create({
+			name: "Legacy Creator",
+			accountId: "legacy-creator",
+			platform: "twitter",
+		});
+
+		expect(resolved.id).toBe(legacyAuthor.id);
+		const matchingAuthors = await db
+			.select()
+			.from(authors)
+			.where(eq(authors.accountId, "legacy-creator"));
+		expect(matchingAuthors).toHaveLength(1);
+		const accounts = await db
+			.select()
+			.from(authorAccounts)
+			.where(eq(authorAccounts.authorId, legacyAuthor.id));
+		expect(accounts).toEqual([
+			expect.objectContaining({
+				platform: "twitter",
+				accountId: "legacy-creator",
+			}),
+		]);
+	});
 });

--- a/apps/server/src/tests/unit/application/services/lancedb-dump-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/lancedb-dump-service.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { MediaDumpItem } from "@solid-imager/core/domain/media/schemas";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
@@ -246,5 +249,45 @@ describe("LanceDB Dump Service", () => {
 
 		const authorTable = await mockOpenTable.mock.results[2].value;
 		expect(authorTable.addColumns).toHaveBeenCalledTimes(1);
+	});
+
+	it("updates the manifest version after delta schema migration", async () => {
+		const { createLanceDbDumpService } = await import(
+			"@solid-imager/application/services/lancedb-dump-service"
+		);
+		const service = createLanceDbDumpService({ connect: createMockConnect() });
+		const dumpDir = await fs.mkdtemp(path.join(os.tmpdir(), "lancedb-v3-"));
+		await fs.writeFile(
+			path.join(dumpDir, "manifest.json"),
+			JSON.stringify({
+				format: "solid-imager-lancedb",
+				version: 3,
+				includeImages: false,
+			}),
+		);
+
+		try {
+			await service.syncLanceDBDelta(dumpDir, {
+				itemsToUpsert: [
+					{
+						id: "new-media",
+						filePath: "new.png",
+						fileName: "new.png",
+						mediaType: "image",
+					},
+				],
+			});
+
+			const manifest = JSON.parse(
+				await fs.readFile(path.join(dumpDir, "manifest.json"), "utf8"),
+			);
+			expect(manifest).toMatchObject({
+				format: "solid-imager-lancedb",
+				version: 4,
+				includeImages: false,
+			});
+		} finally {
+			await fs.rm(dumpDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/apps/server/src/tests/unit/application/services/lancedb-dump-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/lancedb-dump-service.test.ts
@@ -7,13 +7,18 @@ const { mockCreateTable, mockOpenTable, mockOptimize } = vi.hoisted(() => ({
 	mockOptimize: vi.fn(),
 }));
 
-function createTable(rows: Record<string, unknown>[] = []) {
+function createTable(
+	rows: Record<string, unknown>[] = [],
+	schemaFields: { name: string }[] = [],
+) {
 	return {
 		add: vi.fn(async (newRows: Record<string, unknown>[]) =>
 			rows.push(...newRows),
 		),
+		addColumns: vi.fn(),
 		delete: vi.fn(),
 		optimize: mockOptimize,
+		schema: vi.fn(async () => ({ fields: schemaFields })),
 		query: vi.fn(() => ({
 			limit: (limit: number) => ({
 				offset: (offset: number) => ({
@@ -32,8 +37,12 @@ function createMockConnect(
 ) {
 	const tables = new Map<string, ReturnType<typeof createTable>>();
 	mockCreateTable.mockImplementation(
-		async (name: string, rows: Record<string, unknown>[]) => {
-			const table = createTable([...rows]);
+		async (
+			name: string,
+			rows: Record<string, unknown>[],
+			options: { schema?: { fields?: { name: string }[] } },
+		) => {
+			const table = createTable([...rows], options.schema?.fields ?? []);
 			tables.set(name, table);
 			return table;
 		},
@@ -70,7 +79,9 @@ describe("LanceDB Dump Service", () => {
 				height: 100,
 				fileSize: 1024,
 				tags: [{ name: "tag-a", type: "positive", confidence: 0.9 }],
-				authors: [{ name: "author-a", accountId: "acct" }],
+				authors: [
+					{ name: "author-a", accountId: "acct", platform: "pixiv-fanbox" },
+				],
 				characters: [{ name: "char-a", linkedIps: ["ip-a"] }],
 				ips: [{ name: "ip-a" }],
 				projects: [{ name: "project-a" }],
@@ -103,6 +114,11 @@ describe("LanceDB Dump Service", () => {
 			fileName: "image1.png",
 		});
 		expect(mediaRows[0]).not.toHaveProperty("imageData");
+		expect(mockCreateTable.mock.calls[2][1][0]).toMatchObject({
+			name: "author-a",
+			accountId: "acct",
+			platform: "pixiv-fanbox",
+		});
 	});
 
 	it("reads v2 tables back into MediaDumpItem chunks", async () => {
@@ -123,7 +139,12 @@ describe("LanceDB Dump Service", () => {
 				],
 				media_tags: [{ mediaId: "item-1", name: "tag-a", type: "positive" }],
 				media_authors: [
-					{ mediaId: "item-1", name: "author-a", accountId: "acct" },
+					{
+						mediaId: "item-1",
+						name: "author-a",
+						accountId: "acct",
+						platform: "pixiv-fanbox",
+					},
 				],
 				media_characters: [{ mediaId: "item-1", name: "char-a" }],
 				media_character_ips: [
@@ -155,7 +176,9 @@ describe("LanceDB Dump Service", () => {
 			id: "item-1",
 			filePath: "test/image1.png",
 			tags: [{ name: "tag-a", type: "positive" }],
-			authors: [{ name: "author-a", accountId: "acct" }],
+			authors: [
+				{ name: "author-a", accountId: "acct", platform: "pixiv-fanbox" },
+			],
 			characters: [{ name: "char-a", linkedIps: ["ip-a"] }],
 			ips: [{ name: "ip-a" }],
 			projects: [{ name: "project-a" }],
@@ -193,5 +216,35 @@ describe("LanceDB Dump Service", () => {
 		expect(mediaTable.add).toHaveBeenCalledWith([
 			expect.objectContaining({ id: "new-media", filePath: "new.png" }),
 		]);
+	});
+
+	it("adds the author platform column before syncing an older LanceDB cache", async () => {
+		const { createLanceDbDumpService } = await import(
+			"@solid-imager/application/services/lancedb-dump-service"
+		);
+		const service = createLanceDbDumpService({ connect: createMockConnect() });
+
+		await service.syncLanceDBDelta("/tmp/lancedb-v3", {
+			itemsToUpsert: [
+				{
+					id: "new-media",
+					filePath: "new.png",
+					fileName: "new.png",
+					mediaType: "image",
+					width: 10,
+					height: 20,
+					authors: [
+						{
+							name: "creator",
+							accountId: "creator",
+							platform: "pixiv-fanbox",
+						},
+					],
+				},
+			],
+		});
+
+		const authorTable = await mockOpenTable.mock.results[2].value;
+		expect(authorTable.addColumns).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/server/src/tests/unit/application/services/media-processing-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/media-processing-service.test.ts
@@ -141,7 +141,7 @@ describe("MediaProcessingService", () => {
 			});
 
 			expect(mockAuthorRepo.findOrCreateBulk).toHaveBeenCalledWith(
-				["Author Name"],
+				[{ name: "Author Name", accountId: "acc-123" }],
 				undefined,
 			);
 			expect(mockAuthorRepo.addMediaBulk).toHaveBeenCalledWith(

--- a/apps/server/src/tests/unit/domain/media/schemas.test.ts
+++ b/apps/server/src/tests/unit/domain/media/schemas.test.ts
@@ -10,7 +10,9 @@ describe("downloadItemSchema", () => {
 				"https://example.com/image.jpg",
 			],
 			description: "Test description",
-			authors: [{ name: "Test Author", accountId: "@test" }],
+			authors: [
+				{ name: "Test Author", accountId: "@test", platform: "twitter" },
+			],
 			tags: [{ name: "tag1", type: "positive" }],
 			cookies: [{ name: "session", value: "123" }],
 			userAgent: "Mozilla/5.0",
@@ -18,6 +20,21 @@ describe("downloadItemSchema", () => {
 
 		const result = downloadItemSchema.safeParse(validItem);
 		expect(result.success).toBe(true);
+	});
+
+	it("rejects an unsupported author platform", () => {
+		const result = downloadItemSchema.safeParse({
+			targetUrl: "https://example.com/image.jpg",
+			authors: [
+				{
+					name: "Test Author",
+					accountId: "test",
+					platform: "unsupported",
+				},
+			],
+		});
+
+		expect(result.success).toBe(false);
 	});
 
 	it("should allow missing targetUrl (for restore scenarios)", () => {

--- a/apps/server/src/tests/unit/infrastructure/jobs/download-jobs.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/download-jobs.test.ts
@@ -87,8 +87,8 @@ vi.mock("node:child_process", () => ({
 const fetchMock = vi.fn();
 global.fetch = fetchMock as any;
 
-// Regex for download filename pattern (unified format: {author}_{date}_{id}.{ext})
-const DOWNLOAD_FILENAME_PATTERN = /^user_.*123\.jpg$/;
+// Unified format: {author}_{platform}_{postId}_{assetId}.{ext}
+const DOWNLOAD_FILENAME_PATTERN = /^user_twitter_123_image\.jpg$/;
 
 describe("processDownloadJob", () => {
 	beforeEach(async () => {

--- a/apps/xtracter/README.md
+++ b/apps/xtracter/README.md
@@ -1,14 +1,14 @@
 # xtracter
 
-xtracter is a chrome extension that extracts images from a X(twitter) and save them to a local directory.
+xtracter is a chrome extension that extracts images from X (Twitter), pixivFANBOX, and Danbooru and saves them to a local directory.
 
 ## Features
 
 - Xのタイムライン上にある画像の右上にダウンロードボタンを追加、ローカルに保存可能にする。
+- pixivFANBOXの記事画像の右上にダウンロードボタンを追加し、画像CDN URLと元記事URLを保存する。
 - タイムライン上にある画像の情報をJSONファイルに出力する。
     - json ファイルには画像のソースURL、元ポストのURL、元ポストの文面、元ポストの投稿日時、元ポストの投稿者の名前、元ポストの投稿者のIDが含まれる
 
 ## Development
 
 開発言語はTS、ビルドシステムにはviteを使用する
-

--- a/apps/xtracter/public/manifest.json
+++ b/apps/xtracter/public/manifest.json
@@ -15,6 +15,8 @@
     "https://twimg.com/*",
     "https://pbs.twimg.com/*",
     "https://video.twimg.com/*",
+    "https://*.fanbox.cc/*",
+    "https://downloads.fanbox.cc/*",
     "https://danbooru.donmai.us/*",
     "http://localhost:*/*",
     "http://127.0.0.1:*/*",
@@ -33,6 +35,7 @@
       "matches": [
         "https://twitter.com/*",
         "https://x.com/*",
+        "https://*.fanbox.cc/*",
         "https://danbooru.donmai.us/*"
       ],
       "js": ["content.js"],

--- a/apps/xtracter/src/content/danbooru.ts
+++ b/apps/xtracter/src/content/danbooru.ts
@@ -191,7 +191,11 @@ function parseDanbooruApiMetadata(
 
 	// Parse artists
 	for (const name of parseTagsFromApiString(data.tag_string_artist)) {
-		authors.push({ name, accountId: twitterAccountId });
+		authors.push({
+			name,
+			accountId: twitterAccountId ?? name,
+			platform: twitterAccountId ? "twitter" : "danbooru",
+		});
 	}
 
 	// Parse copyrights (IPs)
@@ -267,6 +271,12 @@ function extractDanbooruMetadata(container: HTMLElement): TweetMetadata | null {
 			if (!author.accountId) {
 				author.accountId = twitterAccountId;
 			}
+			author.platform = "twitter";
+		}
+	} else {
+		for (const author of authors) {
+			author.accountId = author.accountId ?? author.name;
+			author.platform = "danbooru";
 		}
 	}
 

--- a/apps/xtracter/src/content/fanbox.ts
+++ b/apps/xtracter/src/content/fanbox.ts
@@ -1,0 +1,111 @@
+import type { Author, TweetMetadata } from "@ext/schema";
+import { querySelectorAllTyped } from "../utils/dom-utils";
+
+const PROCESSED_IMAGE_CLASS = "xtracter-fanbox-image-processed";
+const FANBOX_IMAGE_HOSTNAME = "downloads.fanbox.cc";
+const FANBOX_POST_PATH = /^\/posts\/(\d+)/;
+
+export function processFanboxMedia(
+	processedMetadata: Map<string, TweetMetadata>,
+	createButtonContainer: (
+		metadata: TweetMetadata,
+		type: "IMAGE" | "VIDEO",
+	) => HTMLDivElement,
+) {
+	const postUrl = getPostUrl();
+	if (!postUrl) {
+		return;
+	}
+
+	const postId = new URL(postUrl).pathname.match(FANBOX_POST_PATH)?.[1];
+	if (!postId) {
+		return;
+	}
+
+	const images = querySelectorAllTyped<HTMLImageElement>(document, "img");
+	for (const imageElement of images) {
+		const targetUrl = getFanboxImageUrl(imageElement, postId);
+		if (!targetUrl || imageElement.dataset.xtracterProcessed === "true") {
+			continue;
+		}
+
+		const container = imageElement.parentElement;
+		if (!container) {
+			continue;
+		}
+
+		const metadata = extractMetadata(targetUrl, postUrl);
+		processedMetadata.set(targetUrl, metadata);
+
+		if (window.getComputedStyle(container).position === "static") {
+			container.style.position = "relative";
+		}
+		container.classList.add(PROCESSED_IMAGE_CLASS);
+		imageElement.dataset.xtracterProcessed = "true";
+		container.appendChild(createButtonContainer(metadata, "IMAGE"));
+	}
+}
+
+function getPostUrl(): string | null {
+	const match = window.location.pathname.match(FANBOX_POST_PATH);
+	if (!match) {
+		return null;
+	}
+
+	return `${window.location.origin}/posts/${match[1]}`;
+}
+
+function getFanboxImageUrl(
+	imageElement: HTMLImageElement,
+	postId: string,
+): string | null {
+	const linkedUrl = imageElement.closest("a")?.href;
+	const candidates = [linkedUrl, imageElement.currentSrc, imageElement.src];
+
+	for (const candidate of candidates) {
+		if (!candidate) {
+			continue;
+		}
+
+		try {
+			const url = new URL(candidate);
+			if (
+				url.hostname === FANBOX_IMAGE_HOSTNAME &&
+				url.pathname.startsWith(`/images/post/${postId}/`)
+			) {
+				return url.toString();
+			}
+		} catch {
+			// Ignore malformed candidates and try the next image source.
+		}
+	}
+
+	return null;
+}
+
+function extractMetadata(targetUrl: string, postUrl: string): TweetMetadata {
+	const creatorId = window.location.hostname.endsWith(".fanbox.cc")
+		? window.location.hostname.slice(0, -".fanbox.cc".length)
+		: "";
+	const authorName =
+		document.querySelector<HTMLElement>('a[href="/"] h1')?.innerText.trim() ||
+		creatorId;
+	const authors: Author[] = [];
+
+	if (authorName || creatorId) {
+		authors.push({
+			name: authorName || creatorId,
+			accountId: creatorId || undefined,
+			platform: "pixiv-fanbox",
+		});
+	}
+
+	return {
+		targetUrl,
+		sourceUrls: [targetUrl, postUrl],
+		description:
+			document.querySelector("article h1")?.textContent?.trim() ?? "",
+		authors,
+		userAgent: navigator.userAgent,
+	};
+}

--- a/apps/xtracter/src/content/fanbox.ts
+++ b/apps/xtracter/src/content/fanbox.ts
@@ -48,7 +48,12 @@ function getFanboxImageUrl(
 	postId: string,
 ): string | null {
 	const linkedUrl = imageElement.closest("a")?.href;
-	const candidates = [linkedUrl, imageElement.currentSrc, imageElement.src];
+	const candidates = [
+		linkedUrl,
+		imageElement.dataset.src,
+		imageElement.currentSrc,
+		imageElement.src,
+	];
 
 	for (const candidate of candidates) {
 		if (!candidate) {
@@ -78,8 +83,9 @@ function extractMetadata(targetUrl: string, postUrl: string): TweetMetadata {
 			? hostname.slice(0, -".fanbox.cc".length)
 			: "";
 	const authorName =
-		document.querySelector<HTMLElement>('a[href="/"] h1')?.innerText.trim() ||
-		creatorId;
+		document
+			.querySelector<HTMLElement>('a[href="/"] h1')
+			?.textContent?.trim() || creatorId;
 	const authors: Author[] = [];
 
 	if (authorName || creatorId) {

--- a/apps/xtracter/src/content/fanbox.ts
+++ b/apps/xtracter/src/content/fanbox.ts
@@ -12,15 +12,12 @@ export function processFanboxMedia(
 		type: "IMAGE" | "VIDEO",
 	) => HTMLDivElement,
 ) {
-	const postUrl = getPostUrl();
-	if (!postUrl) {
+	const match = window.location.pathname.match(FANBOX_POST_PATH);
+	if (!match) {
 		return;
 	}
-
-	const postId = new URL(postUrl).pathname.match(FANBOX_POST_PATH)?.[1];
-	if (!postId) {
-		return;
-	}
+	const postId = match[1];
+	const postUrl = `${window.location.origin}/posts/${postId}`;
 
 	const images = querySelectorAllTyped<HTMLImageElement>(document, "img");
 	for (const imageElement of images) {
@@ -44,15 +41,6 @@ export function processFanboxMedia(
 		imageElement.dataset.xtracterProcessed = "true";
 		container.appendChild(createButtonContainer(metadata, "IMAGE"));
 	}
-}
-
-function getPostUrl(): string | null {
-	const match = window.location.pathname.match(FANBOX_POST_PATH);
-	if (!match) {
-		return null;
-	}
-
-	return `${window.location.origin}/posts/${match[1]}`;
 }
 
 function getFanboxImageUrl(
@@ -84,9 +72,11 @@ function getFanboxImageUrl(
 }
 
 function extractMetadata(targetUrl: string, postUrl: string): TweetMetadata {
-	const creatorId = window.location.hostname.endsWith(".fanbox.cc")
-		? window.location.hostname.slice(0, -".fanbox.cc".length)
-		: "";
+	const hostname = window.location.hostname;
+	const creatorId =
+		hostname.endsWith(".fanbox.cc") && !hostname.startsWith("www.")
+			? hostname.slice(0, -".fanbox.cc".length)
+			: "";
 	const authorName =
 		document.querySelector<HTMLElement>('a[href="/"] h1')?.innerText.trim() ||
 		creatorId;

--- a/apps/xtracter/src/content/index.ts
+++ b/apps/xtracter/src/content/index.ts
@@ -1,5 +1,6 @@
 import type { TweetMetadata } from "@ext/schema";
 import { processDanbooruMedia } from "./danbooru";
+import { processFanboxMedia } from "./fanbox";
 import { processTwitterMedia } from "./twitter";
 
 const OBSERVER_CONFIG = { childList: true, subtree: true };
@@ -180,6 +181,8 @@ function processMedia() {
 	const hostname = window.location.hostname;
 	if (hostname.includes("twitter.com") || hostname.includes("x.com")) {
 		processTwitterMedia(processedMetadata, createButtonContainer);
+	} else if (hostname === "fanbox.cc" || hostname.endsWith(".fanbox.cc")) {
+		processFanboxMedia(processedMetadata, createButtonContainer);
 	} else if (hostname.includes("danbooru.donmai.us")) {
 		processDanbooruMedia(createButtonContainer, createAsyncButtonContainer);
 	}

--- a/apps/xtracter/src/content/twitter.ts
+++ b/apps/xtracter/src/content/twitter.ts
@@ -176,6 +176,7 @@ function extractMetadata(
 		authors.push({
 			name: authorName || authorId,
 			accountId: authorId,
+			platform: "twitter",
 		});
 	}
 

--- a/apps/xtracter/src/schema.ts
+++ b/apps/xtracter/src/schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const authorSchema = z.object({
 	name: z.string(),
 	accountId: z.string().nullable().optional(),
+	platform: z.enum(["twitter", "pixiv-fanbox", "danbooru"]).optional(),
 });
 
 export type Author = z.infer<typeof authorSchema>;

--- a/packages/application/src/services/lancedb-dump-service.ts
+++ b/packages/application/src/services/lancedb-dump-service.ts
@@ -16,6 +16,27 @@ const ROW_CHUNK_SIZE = 5000;
 const READ_CHUNK_SIZE = 5000;
 const LANCEDB_DUMP_VERSION = 4;
 
+async function updateLanceDbManifestVersion(lanceDbDir: string): Promise<void> {
+	const manifestPath = path.join(lanceDbDir, "manifest.json");
+	let manifest: unknown;
+	try {
+		manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+	} catch {
+		return;
+	}
+	if (
+		typeof manifest !== "object" ||
+		manifest === null ||
+		Array.isArray(manifest)
+	) {
+		return;
+	}
+	await fs.writeFile(
+		manifestPath,
+		JSON.stringify({ ...manifest, version: LANCEDB_DUMP_VERSION }, null, 2),
+	);
+}
+
 type JsonValue =
 	| string
 	| number
@@ -793,6 +814,7 @@ export function createLanceDbDumpService(deps?: {
 		await migrateLanceDbSchema(tables);
 		await deleteMediaRows(tables, targetIds);
 		await addRowsToTables(tables, itemsToRows(itemsToUpsert));
+		await updateLanceDbManifestVersion(lanceDbDir);
 
 		if (options.optimize) {
 			await Promise.all(

--- a/packages/application/src/services/lancedb-dump-service.ts
+++ b/packages/application/src/services/lancedb-dump-service.ts
@@ -14,7 +14,7 @@ import type {
 
 const ROW_CHUNK_SIZE = 5000;
 const READ_CHUNK_SIZE = 5000;
-const LANCEDB_DUMP_VERSION = 3;
+const LANCEDB_DUMP_VERSION = 4;
 
 type JsonValue =
 	| string
@@ -126,6 +126,7 @@ async function createSchemas(): Promise<Record<TableName, Schema>> {
 			["mediaId", utf8()],
 			["name", utf8()],
 			["accountId", utf8()],
+			["platform", utf8()],
 		]),
 		media_characters: await createSchema([
 			["key", utf8(), false],
@@ -222,10 +223,11 @@ function itemsToRows(items: MediaDumpItem[]): TableRows {
 			});
 		for (const author of item.authors ?? [])
 			rows.authors.push({
-				key: rowKey(mediaId, author.name, author.accountId),
+				key: rowKey(mediaId, author.name, author.platform, author.accountId),
 				mediaId,
 				name: author.name,
 				accountId: author.accountId ?? null,
+				platform: author.platform ?? null,
 			});
 		for (const character of item.characters ?? []) {
 			rows.characters.push({
@@ -377,6 +379,16 @@ async function openTables(db: Connection): Promise<LanceTables> {
 		media_urls: await db.openTable("media_urls"),
 		media_generation_info: await db.openTable("media_generation_info"),
 	};
+}
+
+async function migrateLanceDbSchema(tables: LanceTables): Promise<void> {
+	const authorSchema = await tables.media_authors.schema();
+	if (!authorSchema.fields.some((field) => field.name === "platform")) {
+		const arrow = await import("apache-arrow");
+		await tables.media_authors.addColumns(
+			new arrow.Field("platform", new arrow.Utf8(), true),
+		);
+	}
 }
 
 function sqlInList(values: string[]): string {
@@ -548,6 +560,12 @@ function rowsToItems(
 			authors: (authors.get(id) ?? []).map((row) => ({
 				name: safeString(row.name) ?? "",
 				accountId: safeString(row.accountId),
+				platform:
+					row.platform === "twitter" ||
+					row.platform === "pixiv-fanbox" ||
+					row.platform === "danbooru"
+						? row.platform
+						: undefined,
 			})),
 			characters: (characters.get(id) ?? []).map((row) => {
 				const name = safeString(row.name) ?? "";
@@ -772,6 +790,7 @@ export function createLanceDbDumpService(deps?: {
 		const connect = await getConnect();
 		const db = await connect(lanceDbDir);
 		const tables = await openTables(db);
+		await migrateLanceDbSchema(tables);
 		await deleteMediaRows(tables, targetIds);
 		await addRowsToTables(tables, itemsToRows(itemsToUpsert));
 

--- a/packages/application/src/services/media-processing-service.ts
+++ b/packages/application/src/services/media-processing-service.ts
@@ -345,9 +345,8 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 		if (authors.length === 0) {
 			return;
 		}
-		const names = authors.map((a) => a.name);
 		try {
-			const allAuthors = await this.authorRepo.findOrCreateBulk(names, tx);
+			const allAuthors = await this.authorRepo.findOrCreateBulk(authors, tx);
 			const authorIds = allAuthors.map((a) => a.id);
 			await this.authorRepo.addMediaBulk(mediaId, authorIds, tx);
 		} catch (e) {

--- a/packages/core/src/domain/authors/schemas.ts
+++ b/packages/core/src/domain/authors/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { authorPlatformSchema } from "../media/schemas";
 
 export const authorSchema = z.object({
 	id: z.string().uuid(),
@@ -9,3 +10,15 @@ export const authorSchema = z.object({
 });
 
 export type Author = z.infer<typeof authorSchema>;
+
+export const authorAccountSchema = z.object({
+	id: z.string().uuid(),
+	authorId: z.string().uuid(),
+	platform: authorPlatformSchema,
+	accountId: z.string().min(1),
+	profileUrl: z.string().url().nullable(),
+	createdAt: z.coerce.date(),
+	updatedAt: z.coerce.date(),
+});
+
+export type AuthorAccount = z.infer<typeof authorAccountSchema>;

--- a/packages/core/src/domain/media/schemas.ts
+++ b/packages/core/src/domain/media/schemas.ts
@@ -12,6 +12,13 @@ import { z } from "zod";
 export const mediaTypeSchema = z.enum(["image", "video", "audio"]);
 export type MediaType = z.infer<typeof mediaTypeSchema>;
 
+export const authorPlatformSchema = z.enum([
+	"twitter",
+	"pixiv-fanbox",
+	"danbooru",
+]);
+export type AuthorPlatform = z.infer<typeof authorPlatformSchema>;
+
 /**
  * Zod schema for validating the request body when adding new media.
  * Ensures all required fields for new media are present and correctly formatted.
@@ -71,6 +78,7 @@ export const updateMediaRequestSchema = z.object({
 			z.object({
 				name: z.string(),
 				accountId: z.string().optional().nullable(),
+				platform: authorPlatformSchema.optional(),
 			}),
 		)
 		.optional(),
@@ -183,6 +191,7 @@ export type Author = z.infer<typeof authorSchema>;
 export const newAuthorSchema = z.object({
 	name: z.string(),
 	accountId: z.string().nullable().optional(),
+	platform: authorPlatformSchema.optional(),
 });
 
 export type NewAuthor = z.infer<typeof newAuthorSchema>;
@@ -412,6 +421,7 @@ export const mediaMetadataContextSchema = z.object({
 			z.object({
 				name: z.string(),
 				accountId: z.string().nullable().optional(),
+				platform: authorPlatformSchema.optional(),
 			}),
 		)
 		.optional(),

--- a/packages/core/src/domain/media/utils/filename-utils.ts
+++ b/packages/core/src/domain/media/utils/filename-utils.ts
@@ -1,4 +1,4 @@
-import type { DownloadItem } from "../schemas";
+import type { AuthorPlatform, DownloadItem } from "../schemas";
 
 const TWITTER_ID_PREFIX_LENGTH = 1;
 const FILENAME_SANITIZE_REGEX = /[/\\?%*:|"<>.]/g;
@@ -22,9 +22,10 @@ export function sanitizeFilenamePart(part: string): string {
 
 const TWITTER_STATUS_REGEX = /\/status\/(\d+)/;
 const DANBOORU_POST_REGEX = /\/posts\/(\d+)/;
+const FANBOX_POST_REGEX = /\/posts\/(\d+)/;
 
 /**
- * Extract a unique ID from common media source URLs (Twitter, Danbooru).
+ * Extract a unique post ID from supported media source URLs.
  */
 export function extractIdFromUrl(url: string): string | null {
 	try {
@@ -42,6 +43,14 @@ export function extractIdFromUrl(url: string): string | null {
 			const match = urlObj.pathname.match(DANBOORU_POST_REGEX);
 			return match ? match[1] : null;
 		}
+		// pixivFANBOX: https://creator.fanbox.cc/posts/123456
+		if (
+			urlObj.hostname === "fanbox.cc" ||
+			urlObj.hostname.endsWith(".fanbox.cc")
+		) {
+			const match = urlObj.pathname.match(FANBOX_POST_REGEX);
+			return match ? match[1] : null;
+		}
 	} catch (_e) {
 		return null;
 	}
@@ -50,35 +59,24 @@ export function extractIdFromUrl(url: string): string | null {
 
 /**
  * Generate a unified filename based on media metadata.
- * Format: {authorId}_{date}_{contentId}.{extension}
+ * Format: {accountId}_{platform}_{postId}_{assetId}.{extension}
  */
 export function generateMediaFilename(
 	item: DownloadItem,
 	extension: string,
 ): string {
 	const authorId = getAuthorPart(item);
-	const dateStr = getDatePart(item);
+	const platform = getPlatformPart(item);
 	const contentId = getContentIdPart(item);
+	const assetId = getAssetIdPart(item);
 
-	let base = "";
-	if (authorId || dateStr || contentId) {
-		const parts: string[] = [];
-		if (authorId) {
-			parts.push(authorId);
-		}
-		if (dateStr) {
-			parts.push(dateStr);
-		}
-		if (contentId) {
-			parts.push(contentId);
-		}
-		base = parts.join("_");
-	} else {
-		base = getFallbackBase(item);
-	}
+	const parts = [authorId, platform, contentId, assetId].filter(
+		(part) => part.length > 0,
+	);
+	let base = parts.join("_");
 
 	if (!base) {
-		base = "media";
+		base = getFallbackBase(item) || "media";
 	}
 
 	return `${base}${sanitizeExtension(extension)}`;
@@ -95,19 +93,43 @@ function getAuthorPart(item: DownloadItem): string {
 	return "";
 }
 
-function getDatePart(item: DownloadItem): string {
-	if (item.createdAt) {
-		const date = new Date(item.createdAt);
-		if (!Number.isNaN(date.getTime())) {
-			const DATE_ISO_SUBSTRING_START = 0;
-			const DATE_ISO_SUBSTRING_END = 10;
-			return date
-				.toISOString()
-				.slice(DATE_ISO_SUBSTRING_START, DATE_ISO_SUBSTRING_END)
-				.replace(/-/g, "");
-		}
+function getPlatformPart(item: DownloadItem): string {
+	const declaredPlatform = item.authors?.[0]?.platform;
+	if (declaredPlatform) {
+		return declaredPlatform;
 	}
+
+	for (const candidate of [...(item.sourceUrls ?? []), item.targetUrl]) {
+		if (!candidate) continue;
+		const inferred = inferPlatformFromUrl(candidate);
+		if (inferred) return inferred;
+	}
+
 	return "";
+}
+
+function inferPlatformFromUrl(url: string): AuthorPlatform | null {
+	try {
+		const hostname = new URL(url).hostname;
+		if (
+			hostname === "twitter.com" ||
+			hostname.endsWith(".twitter.com") ||
+			hostname === "x.com" ||
+			hostname.endsWith(".x.com") ||
+			hostname.endsWith(".twimg.com")
+		) {
+			return "twitter";
+		}
+		if (hostname === "fanbox.cc" || hostname.endsWith(".fanbox.cc")) {
+			return "pixiv-fanbox";
+		}
+		if (hostname === "danbooru.donmai.us" || hostname.endsWith(".donmai.us")) {
+			return "danbooru";
+		}
+	} catch {
+		return null;
+	}
+	return null;
 }
 
 function getContentIdPart(item: DownloadItem): string {
@@ -125,6 +147,21 @@ function getContentIdPart(item: DownloadItem): string {
 	}
 
 	return "";
+}
+
+function getAssetIdPart(item: DownloadItem): string {
+	if (!item.targetUrl) return "";
+
+	try {
+		const pathname = new URL(item.targetUrl).pathname;
+		const filename = pathname.split("/").filter(Boolean).pop() ?? "";
+		const extensionIndex = filename.lastIndexOf(".");
+		const assetId =
+			extensionIndex > 0 ? filename.slice(0, extensionIndex) : filename;
+		return sanitizeFilenamePart(assetId);
+	} catch {
+		return "";
+	}
 }
 
 function getFallbackBase(item: DownloadItem): string {

--- a/packages/core/src/domain/repositories/author-repository.ts
+++ b/packages/core/src/domain/repositories/author-repository.ts
@@ -37,6 +37,6 @@ export type IAuthorRepository = {
 		tx?: Transaction,
 	): Promise<void>;
 
-	/** Bulk find-or-create authors by name (uses ON CONFLICT DO NOTHING with unique constraint on name). */
-	findOrCreateBulk(names: string[], tx?: Transaction): Promise<Author[]>;
+	/** Bulk find-or-create authors, preferring platform-scoped account identity. */
+	findOrCreateBulk(authors: NewAuthor[], tx?: Transaction): Promise<Author[]>;
 };

--- a/packages/core/tests/filename-utils.test.ts
+++ b/packages/core/tests/filename-utils.test.ts
@@ -1,86 +1,117 @@
-import { describe, it, expect } from "vite-plus/test";
-import { generateMediaFilename, sanitizeFilenamePart, extractIdFromUrl } from "../src/domain/media/utils/filename-utils";
+import { describe, expect, it } from "vite-plus/test";
+import {
+	extractIdFromUrl,
+	generateMediaFilename,
+	sanitizeFilenamePart,
+} from "../src/domain/media/utils/filename-utils";
 import type { DownloadItem } from "../src/domain/media/schemas";
 
 describe("filename-utils", () => {
-  describe("sanitizeFilenamePart", () => {
-    it("should remove @ from the beginning", () => {
-      expect(sanitizeFilenamePart("@user_name")).toBe("user_name");
-    });
+	describe("sanitizeFilenamePart", () => {
+		it("should remove @ from the beginning", () => {
+			expect(sanitizeFilenamePart("@user_name")).toBe("user_name");
+		});
 
-    it("should remove invalid characters including dots", () => {
-      expect(sanitizeFilenamePart("user/name.ext?%")).toBe("usernameext");
-    });
+		it("should remove invalid characters including dots", () => {
+			expect(sanitizeFilenamePart("user/name.ext?%")).toBe("usernameext");
+		});
 
-    it("should replace spaces with underscores", () => {
-      expect(sanitizeFilenamePart("user name")).toBe("user_name");
-    });
+		it("should replace spaces with underscores", () => {
+			expect(sanitizeFilenamePart("user name")).toBe("user_name");
+		});
 
-    it("should trim leading and trailing spaces", () => {
-      expect(sanitizeFilenamePart("  artist_name  ")).toBe("artist_name");
-    });
-  });
+		it("should trim leading and trailing spaces", () => {
+			expect(sanitizeFilenamePart("  artist_name  ")).toBe("artist_name");
+		});
+	});
 
-  describe("extractIdFromUrl", () => {
-    it("should extract Twitter status ID", () => {
-      expect(extractIdFromUrl("https://twitter.com/user/status/123456789?s=20")).toBe("123456789");
-      expect(extractIdFromUrl("https://x.com/user/status/987654321")).toBe("987654321");
-    });
+	describe("extractIdFromUrl", () => {
+		it("should extract Twitter status ID", () => {
+			expect(
+				extractIdFromUrl(
+					"https://twitter.com/user/status/123456789?s=20",
+				),
+			).toBe("123456789");
+			expect(
+				extractIdFromUrl("https://x.com/user/status/987654321"),
+			).toBe("987654321");
+		});
 
-    it("should extract Danbooru post ID", () => {
-      expect(extractIdFromUrl("https://danbooru.donmai.us/posts/123456")).toBe("123456");
-    });
+		it("should extract Danbooru post ID", () => {
+			expect(
+				extractIdFromUrl("https://danbooru.donmai.us/posts/123456"),
+			).toBe("123456");
+		});
 
-    it("should return null for other URLs", () => {
-      expect(extractIdFromUrl("https://google.com")).toBeNull();
-    });
-  });
+		it("should extract pixivFANBOX post ID", () => {
+			expect(
+				extractIdFromUrl("https://example-creator.fanbox.cc/posts/12345678"),
+			).toBe("12345678");
+		});
 
-  describe("generateMediaFilename", () => {
-    it("should generate unified filename with author, date, and ID", () => {
-      const item: DownloadItem = {
-        targetUrl: "https://pbs.twimg.com/media/abc.jpg",
-        authors: [{ name: "Artist", accountId: "@artist_id" }],
-        createdAt: "2023-10-27T10:00:00Z",
-        sourceUrls: ["https://twitter.com/artist_id/status/1717891234"]
-      };
-      expect(generateMediaFilename(item, ".jpg")).toBe("artist_id_20231027_1717891234.jpg");
-    });
+		it("should return null for other URLs", () => {
+			expect(extractIdFromUrl("https://google.com")).toBeNull();
+		});
+	});
 
-    it("should fallback to name if accountId is missing", () => {
-      const item: DownloadItem = {
-        targetUrl: "https://pbs.twimg.com/media/abc.jpg",
-        authors: [{ name: "Artist Name" }],
-        createdAt: "2023-10-27T10:00:00Z",
-        sourceUrls: ["https://twitter.com/artist_id/status/1717891234"]
-      };
-      expect(generateMediaFilename(item, ".jpg")).toBe("Artist_Name_20231027_1717891234.jpg");
-    });
+	describe("generateMediaFilename", () => {
+		it("should generate a Twitter filename", () => {
+			const item: DownloadItem = {
+				targetUrl: "https://pbs.twimg.com/media/abc.jpg",
+				authors: [
+					{
+						name: "Artist",
+						accountId: "@artist_id",
+						platform: "twitter",
+					},
+				],
+				sourceUrls: [
+					"https://twitter.com/artist_id/status/1717891234",
+				],
+			};
+			expect(generateMediaFilename(item, ".jpg")).toBe(
+				"artist_id_twitter_1717891234_abc.jpg",
+			);
+		});
 
-    it("should handle missing date", () => {
-      const item: DownloadItem = {
-        targetUrl: "https://pbs.twimg.com/media/abc.jpg",
-        authors: [{ name: "Artist" }],
-        sourceUrls: ["https://danbooru.donmai.us/posts/123456"]
-      };
-      expect(generateMediaFilename(item, ".png")).toBe("Artist_123456.png");
-    });
+		it("should generate a pixivFANBOX filename", () => {
+			const item: DownloadItem = {
+				targetUrl:
+					"https://downloads.fanbox.cc/images/post/12345678/exampleAssetId.jpeg",
+				authors: [
+					{
+						name: "Example Creator",
+						accountId: "example-creator",
+						platform: "pixiv-fanbox",
+					},
+				],
+				sourceUrls: [
+					"https://downloads.fanbox.cc/images/post/12345678/exampleAssetId.jpeg",
+					"https://example-creator.fanbox.cc/posts/12345678",
+				],
+			};
+			expect(generateMediaFilename(item, ".jpeg")).toBe(
+				"example-creator_pixiv-fanbox_12345678_exampleAssetId.jpeg",
+			);
+		});
 
-    it("should handle missing author", () => {
-      const item: DownloadItem = {
-        targetUrl: "https://pbs.twimg.com/media/abc.jpg",
-        createdAt: "2023-10-27T10:00:00Z",
-        sourceUrls: ["https://danbooru.donmai.us/posts/123456"]
-      };
-      expect(generateMediaFilename(item, ".png")).toBe("20231027_123456.png");
-    });
+		it("should infer platform for legacy metadata", () => {
+			const item: DownloadItem = {
+				targetUrl: "https://cdn.donmai.us/original/hash.png",
+				authors: [{ name: "Artist" }],
+				sourceUrls: ["https://danbooru.donmai.us/posts/123456"],
+			};
+			expect(generateMediaFilename(item, ".png")).toBe(
+				"Artist_danbooru_123456_hash.png",
+			);
+		});
 
-    it("should not have a trailing dot if extension is empty", () => {
-      const item: DownloadItem = {
-        targetUrl: "https://example.com/image",
-        authors: [{ name: "Artist" }]
-      };
-      expect(generateMediaFilename(item, "")).toBe("Artist");
-    });
-  });
+		it("should not have a trailing dot if extension is empty", () => {
+			const item: DownloadItem = {
+				targetUrl: "https://example.com/image",
+				authors: [{ name: "Artist" }],
+			};
+			expect(generateMediaFilename(item, "")).toBe("Artist_image");
+		});
+	});
 });

--- a/packages/db/src/repositories/author-repository.ts
+++ b/packages/db/src/repositories/author-repository.ts
@@ -1,10 +1,11 @@
+import { randomUUID } from "node:crypto";
 import { ResourceNotFoundError } from "@solid-imager/core/domain/errors";
 import type {
 	Author,
 	NewAuthor,
 } from "@solid-imager/core/domain/media/schemas";
 import type { IAuthorRepository } from "@solid-imager/core/domain/repositories/author-repository";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, or, type SQL } from "drizzle-orm";
 import { authorAccounts, authors, mediaAuthors } from "../schema";
 import type { DrizzleExecutor } from "../types";
 
@@ -20,6 +21,154 @@ function mapAuthor(row: typeof authors.$inferSelect): Author {
 		createdAt: row.createdAt,
 		updatedAt: row.updatedAt,
 	};
+}
+
+function authorInputKey(author: NewAuthor): string {
+	return author.platform && author.accountId
+		? `${author.platform}:${author.accountId}`
+		: `name:${author.name}`;
+}
+
+async function findOrCreateAuthorsBulk(
+	client: DrizzleExecutor,
+	inputs: NewAuthor[],
+): Promise<Author[]> {
+	const uniqueInputs = new Map<string, NewAuthor>();
+	for (const input of inputs) {
+		if (input.name.length > 0) {
+			uniqueInputs.set(authorInputKey(input), input);
+		}
+	}
+	if (uniqueInputs.size === 0) return [];
+
+	const identityConditions: SQL[] = [];
+	for (const input of uniqueInputs.values()) {
+		if (input.platform && input.accountId) {
+			const condition = and(
+				eq(authorAccounts.platform, input.platform),
+				eq(authorAccounts.accountId, input.accountId),
+			);
+			if (condition) identityConditions.push(condition);
+		}
+	}
+
+	const resolved = new Map<string, typeof authors.$inferSelect>();
+	if (identityConditions.length > 0) {
+		const existingIdentities = await client
+			.select({ account: authorAccounts, author: authors })
+			.from(authorAccounts)
+			.innerJoin(authors, eq(authorAccounts.authorId, authors.id))
+			.where(or(...identityConditions));
+		for (const row of existingIdentities) {
+			resolved.set(
+				`${row.account.platform}:${row.account.accountId}`,
+				row.author,
+			);
+		}
+	}
+
+	const unresolved = [...uniqueInputs.entries()].filter(
+		([key]) => !resolved.has(key),
+	);
+	const accountIds = [
+		...new Set(
+			unresolved.flatMap(([, input]) =>
+				input.accountId ? [input.accountId] : [],
+			),
+		),
+	];
+	const names = [...new Set(unresolved.map(([, input]) => input.name))];
+	const legacyConditions: SQL[] = [];
+	if (accountIds.length > 0) {
+		legacyConditions.push(inArray(authors.accountId, accountIds));
+	}
+	if (names.length > 0) {
+		legacyConditions.push(inArray(authors.name, names));
+	}
+
+	const legacyAuthors =
+		legacyConditions.length > 0
+			? await client
+					.select()
+					.from(authors)
+					.where(or(...legacyConditions))
+			: [];
+	const legacyByAccount = new Map(
+		legacyAuthors.flatMap((author) =>
+			author.accountId ? [[author.accountId, author] as const] : [],
+		),
+	);
+	const legacyByName = new Map(
+		legacyAuthors.map((author) => [author.name, author] as const),
+	);
+	const legacyAuthorIds = legacyAuthors.map((author) => author.id);
+	const linkedLegacyAuthorIds =
+		legacyAuthorIds.length > 0
+			? new Set(
+					(
+						await client
+							.select({ authorId: authorAccounts.authorId })
+							.from(authorAccounts)
+							.where(inArray(authorAccounts.authorId, legacyAuthorIds))
+					).map((account) => account.authorId),
+				)
+			: new Set<string>();
+
+	const accountsToInsert: (typeof authorAccounts.$inferInsert)[] = [];
+	const authorsToInsert: (typeof authors.$inferInsert)[] = [];
+	for (const [key, input] of unresolved) {
+		const legacyByMatchingAccount = input.accountId
+			? legacyByAccount.get(input.accountId)
+			: undefined;
+		const legacyByMatchingName = legacyByName.get(input.name);
+		const legacy =
+			legacyByMatchingAccount ??
+			(legacyByMatchingName?.accountId ? undefined : legacyByMatchingName);
+		const canReuseLegacy =
+			legacy && (!input.platform || !linkedLegacyAuthorIds.has(legacy.id));
+
+		const author =
+			canReuseLegacy && legacy
+				? legacy
+				: {
+						id: randomUUID(),
+						name: input.name,
+						accountId: input.accountId ?? null,
+						createdAt: new Date(),
+						updatedAt: new Date(),
+					};
+		if (!canReuseLegacy) {
+			authorsToInsert.push({
+				id: author.id,
+				name: author.name,
+				accountId: author.accountId,
+			});
+		}
+		resolved.set(key, author);
+
+		if (input.platform && input.accountId) {
+			accountsToInsert.push({
+				authorId: author.id,
+				platform: input.platform,
+				accountId: input.accountId,
+			});
+		}
+	}
+
+	if (authorsToInsert.length > 0) {
+		await client.insert(authors).values(authorsToInsert);
+	}
+	if (accountsToInsert.length > 0) {
+		await client
+			.insert(authorAccounts)
+			.values(accountsToInsert)
+			.onConflictDoNothing();
+	}
+
+	return [...uniqueInputs.keys()].flatMap((key) => {
+		const author = resolved.get(key);
+		return author ? [mapAuthor(author)] : [];
+	});
 }
 
 export function createAuthorRepository(
@@ -61,57 +210,8 @@ export function createAuthorRepository(
 		},
 
 		async create(author: NewAuthor, tx?: unknown): Promise<Author> {
-			const client = getExecutor(tx);
-
-			if (author.platform && author.accountId) {
-				const existingByAccount = await client
-					.select({ author: authors })
-					.from(authorAccounts)
-					.innerJoin(authors, eq(authorAccounts.authorId, authors.id))
-					.where(
-						and(
-							eq(authorAccounts.platform, author.platform),
-							eq(authorAccounts.accountId, author.accountId),
-						),
-					)
-					.limit(1);
-
-				if (existingByAccount[0]) {
-					return mapAuthor(existingByAccount[0].author);
-				}
-			} else {
-				const condition = author.accountId
-					? eq(authors.accountId, author.accountId)
-					: eq(authors.name, author.name);
-				const existing = await client
-					.select()
-					.from(authors)
-					.where(condition)
-					.limit(1);
-
-				if (existing[0]) {
-					return mapAuthor(existing[0]);
-				}
-			}
-
-			const result = await client
-				.insert(authors)
-				.values({
-					name: author.name,
-					accountId: author.accountId,
-				})
-				.returning();
-			const created = result[0];
-
-			if (author.platform && author.accountId) {
-				await client.insert(authorAccounts).values({
-					authorId: created.id,
-					platform: author.platform,
-					accountId: author.accountId,
-				});
-			}
-
-			return mapAuthor(created);
+			const result = await findOrCreateAuthorsBulk(getExecutor(tx), [author]);
+			return result[0];
 		},
 
 		async update(
@@ -205,21 +305,7 @@ export function createAuthorRepository(
 			inputs: NewAuthor[],
 			tx?: unknown,
 		): Promise<Author[]> {
-			const uniqueInputs = new Map<string, NewAuthor>();
-			for (const input of inputs) {
-				if (input.name.length === 0) continue;
-				const key =
-					input.platform && input.accountId
-						? `${input.platform}:${input.accountId}`
-						: `name:${input.name}`;
-				uniqueInputs.set(key, input);
-			}
-
-			const result: Author[] = [];
-			for (const input of uniqueInputs.values()) {
-				result.push(await this.create(input, tx));
-			}
-			return result;
+			return findOrCreateAuthorsBulk(getExecutor(tx), inputs);
 		},
 	};
 }

--- a/packages/db/src/repositories/author-repository.ts
+++ b/packages/db/src/repositories/author-repository.ts
@@ -5,7 +5,7 @@ import type {
 } from "@solid-imager/core/domain/media/schemas";
 import type { IAuthorRepository } from "@solid-imager/core/domain/repositories/author-repository";
 import { and, eq, inArray } from "drizzle-orm";
-import { authors, mediaAuthors } from "../schema";
+import { authorAccounts, authors, mediaAuthors } from "../schema";
 import type { DrizzleExecutor } from "../types";
 
 type AuthorRepositoryOptions = {
@@ -62,22 +62,56 @@ export function createAuthorRepository(
 
 		async create(author: NewAuthor, tx?: unknown): Promise<Author> {
 			const client = getExecutor(tx);
-			const condition = author.accountId
-				? eq(authors.accountId, author.accountId)
-				: eq(authors.name, author.name);
 
-			const existing = await client
-				.select()
-				.from(authors)
-				.where(condition)
-				.limit(1);
+			if (author.platform && author.accountId) {
+				const existingByAccount = await client
+					.select({ author: authors })
+					.from(authorAccounts)
+					.innerJoin(authors, eq(authorAccounts.authorId, authors.id))
+					.where(
+						and(
+							eq(authorAccounts.platform, author.platform),
+							eq(authorAccounts.accountId, author.accountId),
+						),
+					)
+					.limit(1);
 
-			if (existing[0]) {
-				return mapAuthor(existing[0]);
+				if (existingByAccount[0]) {
+					return mapAuthor(existingByAccount[0].author);
+				}
+			} else {
+				const condition = author.accountId
+					? eq(authors.accountId, author.accountId)
+					: eq(authors.name, author.name);
+				const existing = await client
+					.select()
+					.from(authors)
+					.where(condition)
+					.limit(1);
+
+				if (existing[0]) {
+					return mapAuthor(existing[0]);
+				}
 			}
 
-			const result = await client.insert(authors).values(author).returning();
-			return mapAuthor(result[0]);
+			const result = await client
+				.insert(authors)
+				.values({
+					name: author.name,
+					accountId: author.accountId,
+				})
+				.returning();
+			const created = result[0];
+
+			if (author.platform && author.accountId) {
+				await client.insert(authorAccounts).values({
+					authorId: created.id,
+					platform: author.platform,
+					accountId: author.accountId,
+				});
+			}
+
+			return mapAuthor(created);
 		},
 
 		async update(
@@ -167,30 +201,25 @@ export function createAuthorRepository(
 				.onConflictDoNothing();
 		},
 
-		async findOrCreateBulk(names: string[], tx?: unknown): Promise<Author[]> {
-			if (names.length === 0) return [];
-			const uniqueNames = [...new Set(names)].filter((n) => n.length > 0);
-			const client = getExecutor(tx);
-
-			const existing = await client
-				.select()
-				.from(authors)
-				.where(inArray(authors.name, uniqueNames));
-			const existingNames = new Set(existing.map((a) => a.name));
-
-			const newNames = uniqueNames.filter((n) => !existingNames.has(n));
-			if (newNames.length > 0) {
-				await client
-					.insert(authors)
-					.values(newNames.map((name) => ({ name })))
-					.onConflictDoNothing();
+		async findOrCreateBulk(
+			inputs: NewAuthor[],
+			tx?: unknown,
+		): Promise<Author[]> {
+			const uniqueInputs = new Map<string, NewAuthor>();
+			for (const input of inputs) {
+				if (input.name.length === 0) continue;
+				const key =
+					input.platform && input.accountId
+						? `${input.platform}:${input.accountId}`
+						: `name:${input.name}`;
+				uniqueInputs.set(key, input);
 			}
 
-			const all = await client
-				.select()
-				.from(authors)
-				.where(inArray(authors.name, uniqueNames));
-			return all.map(mapAuthor);
+			const result: Author[] = [];
+			for (const input of uniqueInputs.values()) {
+				result.push(await this.create(input, tx));
+			}
+			return result;
 		},
 	};
 }

--- a/packages/db/src/repositories/author-repository.ts
+++ b/packages/db/src/repositories/author-repository.ts
@@ -210,8 +210,15 @@ export function createAuthorRepository(
 		},
 
 		async create(author: NewAuthor, tx?: unknown): Promise<Author> {
+			if (author.name.trim().length === 0) {
+				throw new Error("Author name cannot be empty");
+			}
 			const result = await findOrCreateAuthorsBulk(getExecutor(tx), [author]);
-			return result[0];
+			const created = result[0];
+			if (!created) {
+				throw new Error("Failed to create author");
+			}
+			return created;
 		},
 
 		async update(

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -82,6 +82,12 @@ export const mediaRelationTypeEnum = pgEnum("media_relation_type", [
  */
 export const tagTypeEnum = pgEnum("tag_type", ["positive", "negative"]);
 
+export const authorPlatformEnum = pgEnum("author_platform", [
+	"twitter",
+	"pixiv-fanbox",
+	"danbooru",
+]);
+
 // テーブル
 /**
  * Schema for the media_sources table.
@@ -743,6 +749,31 @@ export const authors = pgTable(
 );
 
 /**
+ * External accounts belonging to an author.
+ * An author can be linked to multiple platform identities.
+ */
+export const authorAccounts = pgTable(
+	"author_accounts",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		authorId: uuid("author_id")
+			.notNull()
+			.references(() => authors.id, { onDelete: "cascade" }),
+		platform: authorPlatformEnum("platform").notNull(),
+		accountId: text("account_id").notNull(),
+		profileUrl: text("profile_url"),
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		authorIdIndex: index("idx_author_accounts_author_id").on(table.authorId),
+		platformAccountUnique: uniqueIndex(
+			"idx_author_accounts_platform_account_unique",
+		).on(table.platform, table.accountId),
+	}),
+);
+
+/**
  * Schema for the media_authors join table.
  * Many-to-many relationship between media and authors.
  */
@@ -1298,8 +1329,17 @@ export const mediaCollectionsRelations = relations(
 export const authorsRelations = relations(authors, ({ many }) => ({
 	/** Authorに関連するメディア */
 	media: many(mediaAuthors),
+	/** Authorの外部サービス上のアカウント */
+	accounts: many(authorAccounts),
 	/** Authorに関連するタグ */
 	tags: many(tags),
+}));
+
+export const authorAccountsRelations = relations(authorAccounts, ({ one }) => ({
+	author: one(authors, {
+		fields: [authorAccounts.authorId],
+		references: [authors.id],
+	}),
 }));
 
 /**

--- a/packages/ui/src/pro-search-builder.tsx
+++ b/packages/ui/src/pro-search-builder.tsx
@@ -27,6 +27,7 @@ import {
 	SelectValue,
 } from "./select";
 import { cn } from "./utils/cn";
+import { createDebouncedSignal } from "./utils/debounce";
 import { parseSelectValue } from "./utils/parse-select-value";
 
 const TARGET_LABELS: Record<string, string> = {
@@ -326,6 +327,20 @@ function CriterionBuilder(props: {
 				return undefined;
 		}
 	});
+	const [filterText, setFilterText] = createDebouncedSignal("", 150);
+	const filteredItems = createMemo(() => {
+		const items = autocompleteItems();
+		if (!items) return [];
+		const query = filterText().toLowerCase();
+		if (!query) return items.slice(0, 100);
+		return items
+			.filter((item) => {
+				if (!item) return false;
+				const label = "accountId" in item ? getAuthorLabel(item) : item.name;
+				return label.toLowerCase().includes(query);
+			})
+			.slice(0, 100);
+	});
 
 	const isNumericTarget = createMemo(() =>
 		[
@@ -460,7 +475,7 @@ function CriterionBuilder(props: {
 								props.onChange({ ...props.criterion, value: value.name });
 							}
 						}}
-						defaultFilter="contains"
+						onInputChange={(text) => setFilterText(text)}
 						optionLabel={(item) =>
 							item
 								? "accountId" in item
@@ -468,7 +483,7 @@ function CriterionBuilder(props: {
 									: item.name
 								: ""
 						}
-						options={autocompleteItems() ?? []}
+						options={filteredItems()}
 						optionTextValue={(item) =>
 							item
 								? "accountId" in item

--- a/packages/ui/src/pro-search-builder.tsx
+++ b/packages/ui/src/pro-search-builder.tsx
@@ -308,9 +308,7 @@ function CriterionBuilder(props: {
 	authors?: Author[];
 }) {
 	const getAuthorLabel = (author: Author) =>
-		author.accountId
-			? `${author.name}：(twitter)${author.accountId}`
-			: author.name;
+		author.accountId ? `${author.name}：${author.accountId}` : author.name;
 
 	const autocompleteItems = createMemo<RelationOption[] | undefined>(() => {
 		switch (props.criterion.target) {

--- a/packages/ui/src/pro-search-builder.tsx
+++ b/packages/ui/src/pro-search-builder.tsx
@@ -27,7 +27,6 @@ import {
 	SelectValue,
 } from "./select";
 import { cn } from "./utils/cn";
-import { createDebouncedSignal } from "./utils/debounce";
 import { parseSelectValue } from "./utils/parse-select-value";
 
 const TARGET_LABELS: Record<string, string> = {
@@ -313,22 +312,6 @@ function CriterionBuilder(props: {
 			? `${author.name}：(twitter)${author.accountId}`
 			: author.name;
 
-	const [filterText, setFilterText] = createDebouncedSignal("", 150);
-
-	const filteredItems = createMemo(() => {
-		const items = autocompleteItems();
-		if (!items) return [];
-		const query = filterText().toLowerCase();
-		if (!query) return items.slice(0, 100);
-		return items
-			.filter((item) => {
-				if (!item) return false;
-				const label = "accountId" in item ? getAuthorLabel(item) : item.name;
-				return label.toLowerCase().includes(query);
-			})
-			.slice(0, 100);
-	});
-
 	const autocompleteItems = createMemo<RelationOption[] | undefined>(() => {
 		switch (props.criterion.target) {
 			case "tag":
@@ -479,7 +462,7 @@ function CriterionBuilder(props: {
 								props.onChange({ ...props.criterion, value: value.name });
 							}
 						}}
-						onInputChange={(text) => setFilterText(text)}
+						defaultFilter="contains"
 						optionLabel={(item) =>
 							item
 								? "accountId" in item
@@ -487,7 +470,7 @@ function CriterionBuilder(props: {
 									: item.name
 								: ""
 						}
-						options={filteredItems()}
+						options={autocompleteItems() ?? []}
 						optionTextValue={(item) =>
 							item
 								? "accountId" in item
@@ -495,7 +478,7 @@ function CriterionBuilder(props: {
 									: item.name
 								: ""
 						}
-						optionValue={(item) => item.name}
+						optionValue={(item) => item.id}
 						placeholder="検索..."
 						triggerMode="focus"
 						value={(autocompleteItems() || []).find(

--- a/packages/ui/src/search-filters.tsx
+++ b/packages/ui/src/search-filters.tsx
@@ -4,7 +4,7 @@ import type { Ip } from "@solid-imager/core/domain/ips/schemas";
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type { SearchState } from "@solid-imager/core/domain/search/schema";
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
-import { createSignal, For } from "solid-js";
+import { createMemo, createSignal, For } from "solid-js";
 import type { SetStoreFunction } from "solid-js/store";
 import { Badge } from "./badge";
 import { Button } from "./button";
@@ -19,6 +19,7 @@ import {
 import { Input } from "./input";
 import { Label } from "./label";
 import { cn } from "./utils/cn";
+import { createDebouncedSignal } from "./utils/debounce";
 
 type SearchFiltersProps = {
 	state: SearchState;
@@ -47,6 +48,16 @@ function FilterSection<T>(props: {
 	badgeVariant?: "default" | "destructive" | "secondary" | "outline";
 }) {
 	const [value, setValue] = createSignal<T | null>(null);
+	const [filterText, setFilterText] = createDebouncedSignal("", 150);
+	const filteredItems = createMemo(() => {
+		const items = props.items;
+		if (!items) return [];
+		const query = filterText().toLowerCase();
+		if (!query) return items.slice(0, 100);
+		return items
+			.filter((item) => props.getItemLabel(item).toLowerCase().includes(query))
+			.slice(0, 100);
+	});
 
 	return (
 		<div class="space-y-2">
@@ -88,12 +99,13 @@ function FilterSection<T>(props: {
 						setValue(() => val);
 						requestAnimationFrame(() => {
 							setValue(null);
+							setFilterText("");
 						});
 					}
 				}}
-				defaultFilter="contains"
+				onInputChange={(text) => setFilterText(text)}
 				optionLabel={props.getItemLabel}
-				options={props.items ?? []}
+				options={filteredItems()}
 				optionTextValue={props.getItemLabel}
 				optionValue={(item) => props.getItemKey(item)}
 				placeholder={props.placeholder}

--- a/packages/ui/src/search-filters.tsx
+++ b/packages/ui/src/search-filters.tsx
@@ -110,9 +110,7 @@ function FilterSection<T>(props: {
 }
 
 const getAuthorLabel = (author: Author) =>
-	author.accountId
-		? `${author.name}：(twitter)${author.accountId}`
-		: author.name;
+	author.accountId ? `${author.name}：${author.accountId}` : author.name;
 
 export function SearchFilters(props: SearchFiltersProps) {
 	const addTag = (tagName: string) => {

--- a/packages/ui/src/search-filters.tsx
+++ b/packages/ui/src/search-filters.tsx
@@ -4,7 +4,7 @@ import type { Ip } from "@solid-imager/core/domain/ips/schemas";
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type { SearchState } from "@solid-imager/core/domain/search/schema";
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
-import { createMemo, createSignal, For } from "solid-js";
+import { createSignal, For } from "solid-js";
 import type { SetStoreFunction } from "solid-js/store";
 import { Badge } from "./badge";
 import { Button } from "./button";
@@ -19,7 +19,6 @@ import {
 import { Input } from "./input";
 import { Label } from "./label";
 import { cn } from "./utils/cn";
-import { createDebouncedSignal } from "./utils/debounce";
 
 type SearchFiltersProps = {
 	state: SearchState;
@@ -41,23 +40,13 @@ function FilterSection<T>(props: {
 	onSelect: (item: T) => void;
 	onRemove: (id: string) => void;
 	getItemKey: (item: T) => string;
+	getSelectedItemValue?: (item: T) => string;
 	getItemLabel: (item: T) => string;
 	getItemDescription?: (item: T) => string | undefined | null;
 	placeholder?: string;
 	badgeVariant?: "default" | "destructive" | "secondary" | "outline";
 }) {
 	const [value, setValue] = createSignal<T | null>(null);
-	const [filterText, setFilterText] = createDebouncedSignal("", 150);
-
-	const filteredItems = createMemo(() => {
-		const items = props.items;
-		if (!items) return [];
-		const query = filterText().toLowerCase();
-		if (!query) return items.slice(0, 100);
-		return items
-			.filter((item) => props.getItemLabel(item).toLowerCase().includes(query))
-			.slice(0, 100);
-	});
 
 	return (
 		<div class="space-y-2">
@@ -66,7 +55,8 @@ function FilterSection<T>(props: {
 				<For each={props.selectedItems}>
 					{(id) => {
 						const item = props.items?.find(
-							(i) => props.getItemKey(i) === id,
+							(i) =>
+								(props.getSelectedItemValue?.(i) ?? props.getItemKey(i)) === id,
 						) as T;
 						return (
 							<Badge
@@ -98,13 +88,12 @@ function FilterSection<T>(props: {
 						setValue(() => val);
 						requestAnimationFrame(() => {
 							setValue(null);
-							setFilterText("");
 						});
 					}
 				}}
-				onInputChange={(text) => setFilterText(text)}
+				defaultFilter="contains"
 				optionLabel={props.getItemLabel}
-				options={filteredItems()}
+				options={props.items ?? []}
 				optionTextValue={props.getItemLabel}
 				optionValue={(item) => props.getItemKey(item)}
 				placeholder={props.placeholder}
@@ -240,8 +229,9 @@ export function SearchFilters(props: SearchFiltersProps) {
 
 			<FilterSection
 				badgeVariant="secondary"
-				getItemKey={(author) => author.name}
+				getItemKey={(author) => author.id}
 				getItemLabel={getAuthorLabel}
+				getSelectedItemValue={(author) => author.name}
 				items={props.authors}
 				label="作者"
 				onRemove={(name) =>


### PR DESCRIPTION
## 概要
xtracterからpixivFANBOXの記事画像を保存・POSTできるようにします。

## 変更内容
- FANBOX記事画像へのDL・POSTボタン追加
- CDN画像URLと元記事URLのメタデータ登録
- platform単位のAuthorアカウント管理と既存Twitterデータ移行
- JSON・バックアップ・LanceDB同期へのplatform反映
- accountId_platform_postId_assetId形式の統一ファイル名

## 検証
- 対象ワークスペースのtypecheck・lint
- xtracter build
- core unit tests
- server関連unit・integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 作者に外部アカウント情報を持たせられるようになり、Twitter、pixivFANBOX、Danbooru に対応しました。
  * xtracter が pixivFANBOX 投稿ページでもメディアを検出し、取得ボタンを表示するようになりました。
  * メディアファイル名がプラットフォーム付きの新形式になりました。

* **改善**
  * バックアップ、復元、同期処理で作者アカウント情報を保持できるようになりました。
  * 検索・絞り込みUIの候補表示がより安定し、選択済み項目の扱いが改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->