### PR TITLE
fix(search): 詳細検索の対象選択を更新できるよう修正

### DIFF
--- a/apps/server/src/components/media/pro-search-builder.tsx
+++ b/apps/server/src/components/media/pro-search-builder.tsx
@@ -30,7 +30,7 @@ import {
 	parseSelectValue,
 } from "@solid-imager/ui/utils";
 import { cn } from "@solid-imager/ui/utils/cn";
-import { createMemo, Index, Match, Show, Switch } from "solid-js";
+import { createMemo, For, Match, Show, Switch } from "solid-js";
 
 // Labels for targets
 const TARGET_LABELS: Record<string, string> = {
@@ -263,37 +263,37 @@ function GroupBuilder(props: {
 				</div>
 
 				<div class="space-y-2 border-border border-l pl-2 sm:pl-4">
-					<Index each={props.group.children}>
+					<For each={props.group.children}>
 						{(child, index) => (
 							<Show
 								fallback={
 									<CriterionBuilder
 										authors={props.authors}
 										characters={props.characters}
-										criterion={child() as SearchCriterion}
+										criterion={child as SearchCriterion}
 										ips={props.ips}
-										onChange={(c) => updateChild(index, c)}
-										onRemove={() => removeChild(index)}
+										onChange={(c) => updateChild(index(), c)}
+										onRemove={() => removeChild(index())}
 										projects={props.projects}
 										tags={props.tags}
 									/>
 								}
-								when={isSearchGroup(child())}
+								when={isSearchGroup(child)}
 							>
 								<GroupBuilder
 									authors={props.authors}
 									characters={props.characters}
 									depth={props.depth + 1}
-									group={child() as SearchGroup}
+									group={child as SearchGroup}
 									ips={props.ips}
-									onChange={(g) => updateChild(index, g)}
-									onRemove={() => removeChild(index)}
+									onChange={(g) => updateChild(index(), g)}
+									onRemove={() => removeChild(index())}
 									projects={props.projects}
 									tags={props.tags}
 								/>
 							</Show>
 						)}
-					</Index>
+					</For>
 					{props.group.children.length === 0 && (
 						<div class="p-2 text-muted-foreground text-sm italic">
 							条件がありません。「+ 条件」ボタンで追加してください。

--- a/packages/ui/src/pro-search-builder.tsx
+++ b/packages/ui/src/pro-search-builder.tsx
@@ -7,7 +7,7 @@ import type {
 } from "@solid-imager/core/domain/media/schemas";
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
-import { createMemo, Index, Match, Show, Switch } from "solid-js";
+import { createMemo, For, Match, Show, Switch } from "solid-js";
 import { Button } from "./button";
 import { Card, CardContent } from "./card";
 import {
@@ -258,18 +258,17 @@ function GroupBuilder(props: {
 				</div>
 
 				<div class="space-y-2 border-border border-l pl-2 sm:pl-4">
-					<Index each={props.group.children}>
-						{(child, index) => {
-							const c = child();
-							return c.type === "group" ? (
+					<For each={props.group.children}>
+						{(child, index) =>
+							child.type === "group" ? (
 								<GroupBuilder
 									authors={props.authors}
 									characters={props.characters}
 									depth={props.depth + 1}
-									group={c}
+									group={child}
 									ips={props.ips}
-									onChange={(value) => updateChild(index, value)}
-									onRemove={() => removeChild(index)}
+									onChange={(value) => updateChild(index(), value)}
+									onRemove={() => removeChild(index())}
 									projects={props.projects}
 									tags={props.tags}
 								/>
@@ -277,16 +276,16 @@ function GroupBuilder(props: {
 								<CriterionBuilder
 									authors={props.authors}
 									characters={props.characters}
-									criterion={c}
+									criterion={child}
 									ips={props.ips}
-									onChange={(value) => updateChild(index, value)}
-									onRemove={() => removeChild(index)}
+									onChange={(value) => updateChild(index(), value)}
+									onRemove={() => removeChild(index())}
 									projects={props.projects}
 									tags={props.tags}
 								/>
-							);
-						}}
-					</Index>
+							)
+						}
+					</For>
 					<Show when={props.group.children.length === 0}>
 						<div class="p-2 text-muted-foreground text-sm italic">
 							条件がありません。「+ 条件」ボタンで追加してください。


### PR DESCRIPTION
## 概要
詳細検索で対象をタグや作者などに変更しても、ファイル名表示のままになる問題を修正します。

## 変更内容
- 条件リストの描画を Index から For に変更
- 更新後の条件オブジェクトが CriterionBuilder へ再伝播するよう修正
- server版と共有UI版の実装を統一

## 検証
- UI package typecheck
- Server package typecheck
- UI package test
- 対象ファイルの Biome lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 検索ビルダーの子要素表示を更新し、条件やグループの並び替え・追加削除時の挙動を改善しました。
  * グループ内の再帰表示とインデックス参照の処理を見直し、より安定した編集体験にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->