### PR TITLE
fix(lancedb): dump manifest version判定を共通化

### DIFF
--- a/apps/server/src/application/services/backup-service.ts
+++ b/apps/server/src/application/services/backup-service.ts
@@ -10,6 +10,7 @@ import { getErrorMessage } from "@solid-imager/core/utils/get-error-message";
 import type { Table } from "drizzle-orm";
 import { and, asc, eq, gt, inArray, lt, or, sql } from "drizzle-orm";
 import type { PgColumn } from "drizzle-orm/pg-core";
+import { LANCEDB_DUMP_VERSION } from "~/application/services/lancedb-dump-service";
 import { db } from "~/infrastructure/db";
 import {
 	authorAccounts,
@@ -1194,7 +1195,7 @@ export const BackupService = {
 		try {
 			const content = await fs.readFile(manifestPath, "utf-8");
 			const manifest = JSON.parse(content) as { version?: unknown };
-			if (manifest.version !== 3) {
+			if (manifest.version !== LANCEDB_DUMP_VERSION) {
 				if (!config.lancedb?.autoFullSync) {
 					logger.warn(
 						{ mediaSourceId },

--- a/apps/server/src/application/services/lancedb-dump-service.ts
+++ b/apps/server/src/application/services/lancedb-dump-service.ts
@@ -1,6 +1,10 @@
-import { createLanceDbDumpService } from "@solid-imager/application/services/lancedb-dump-service";
+import {
+	createLanceDbDumpService,
+	LANCEDB_DUMP_VERSION,
+} from "@solid-imager/application/services/lancedb-dump-service";
 
 export type { MediaDumpItemWithImageData } from "@solid-imager/application/ports/lancedb-dump-service";
+export { LANCEDB_DUMP_VERSION };
 
 import { logger } from "~/infrastructure/logger";
 

--- a/apps/server/src/application/services/maintenance-service.ts
+++ b/apps/server/src/application/services/maintenance-service.ts
@@ -202,7 +202,10 @@ export class MaintenanceService {
 		try {
 			const content = await fs.readFile(manifestPath, "utf-8");
 			const manifest = JSON.parse(content) as { version?: unknown };
-			return manifest.version === 3;
+			const { LANCEDB_DUMP_VERSION } = await import(
+				"~/application/services/lancedb-dump-service"
+			);
+			return manifest.version === LANCEDB_DUMP_VERSION;
 		} catch {
 			return false;
 		}

--- a/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
@@ -40,10 +40,13 @@ vi.mock("~/application/registry", () => ({
 
 // Mock lancedb-dump-service
 const mockReadMediaIds = vi.fn();
-vi.mock("~/application/services/lancedb-dump-service", () => ({
-	LANCEDB_DUMP_VERSION: 4,
-	readMediaIds: mockReadMediaIds,
-}));
+vi.mock("~/application/services/lancedb-dump-service", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("~/application/services/lancedb-dump-service")>();
+	return {
+		...actual,
+		readMediaIds: mockReadMediaIds,
+	};
+});
 
 // Mock backup-service
 const mockQueueSourceLanceDBDelta = vi.fn();

--- a/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
@@ -41,6 +41,7 @@ vi.mock("~/application/registry", () => ({
 // Mock lancedb-dump-service
 const mockReadMediaIds = vi.fn();
 vi.mock("~/application/services/lancedb-dump-service", () => ({
+	LANCEDB_DUMP_VERSION: 4,
 	readMediaIds: mockReadMediaIds,
 }));
 
@@ -387,9 +388,9 @@ describe("MaintenanceService", () => {
 			]);
 			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
 
-			// Simulate manifest.json exists (version: 3)
+			// Simulate a current manifest.json.
 			(fs.readFile as unknown as Mock).mockResolvedValue(
-				JSON.stringify({ version: 3 }),
+				JSON.stringify({ version: 4 }),
 			);
 
 			// Both LanceDB and Postgres have media-1
@@ -417,9 +418,9 @@ describe("MaintenanceService", () => {
 			]);
 			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
 
-			// Simulate manifest.json exists (version: 3)
+			// Simulate a current manifest.json.
 			(fs.readFile as unknown as Mock).mockResolvedValue(
-				JSON.stringify({ version: 3 }),
+				JSON.stringify({ version: 4 }),
 			);
 
 			// Postgres: media-1, media-2
@@ -465,9 +466,9 @@ describe("MaintenanceService", () => {
 			]);
 			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
 
-			// Simulate manifest.json exists (version: 3)
+			// Simulate a current manifest.json.
 			(fs.readFile as unknown as Mock).mockResolvedValue(
-				JSON.stringify({ version: 3 }),
+				JSON.stringify({ version: 4 }),
 			);
 
 			// readMediaIds throws error

--- a/packages/application/src/services/lancedb-dump-service.ts
+++ b/packages/application/src/services/lancedb-dump-service.ts
@@ -14,7 +14,7 @@ import type {
 
 const ROW_CHUNK_SIZE = 5000;
 const READ_CHUNK_SIZE = 5000;
-const LANCEDB_DUMP_VERSION = 4;
+export const LANCEDB_DUMP_VERSION = 4;
 
 async function updateLanceDbManifestVersion(lanceDbDir: string): Promise<void> {
 	const manifestPath = path.join(lanceDbDir, "manifest.json");


### PR DESCRIPTION
## 概要
LanceDB dumpがversion 4で作成される一方、delta同期と起動時確認がversion 3を期待していた不整合を修正します。この不整合により、メディア追加時のdelta同期が全件full syncへフォールバックしていました。

## 変更内容
- dump manifest versionを共通定数として公開
- delta同期と起動時キャッシュ判定で共通定数を使用
- maintenance serviceのテストfixtureを現行versionへ更新

## 検証
- bun run lint
- bun run typecheck
- git diff --check

## 補足
対象unit testはViteの既存エイリアス解決エラーによりserver設定ではsuite読込前に停止しました。root設定ではlancedb dump serviceの5テストが成功しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LanceDBダンプのバージョン判定が固定値から、期待値に連動するよう改善されました。
  * その結果、キャッシュの有効判定や差分更新/フル同期の判断がより適切になります。
* **New Features**
  * ダンプのバージョン情報を外部から参照できるようになりました。
* **Tests**
  * manifestのバージョン更新にあわせて関連テストケースを調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->