### PR TITLE
fix(server): サムネイル生成中の404ログを抑制

### DIFF
--- a/apps/server/src/routes/api/sources.$mediaSourceId.thumbnail.$mediaId.ts
+++ b/apps/server/src/routes/api/sources.$mediaSourceId.thumbnail.$mediaId.ts
@@ -14,7 +14,14 @@ export const Route = createFileRoute(
 				const file = Bun.file(thumbnailPath);
 
 				if (!(await file.exists())) {
-					return new Response("Thumbnail not found", { status: 404 });
+					// A missing thumbnail is an expected transient state while the
+					// background job is running. The image component treats an empty
+					// response as a load error and retries, without flooding the
+					// browser console with expected 404 responses.
+					return new Response(null, {
+						status: 204,
+						headers: { "Cache-Control": "no-store" },
+					});
 				}
 
 				return new Response(file, {


### PR DESCRIPTION
## 概要
サムネイル生成待ちを通常のリソース欠損として404にせず、ブラウザコンソールへ大量に出ていたエラーを抑制します。

## 変更内容
- 未生成サムネイルのレスポンスを404から204 No Contentへ変更
- 生成待ちレスポンスへ Cache-Control: no-store を設定
- 既存のプレースホルダー表示とリトライ動作は維持

## 検証
- bun x biome check 対象ファイル
- bun --filter @solid-imager/server typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * サムネイルが見つからない場合の応答が更新され、`404` ではなく `204 No Content` を返すようになりました。
  * この場合のレスポンスに `Cache-Control: no-store` が追加され、古い結果が保存されにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->