### PR TITLE
fix(authors): refresh display names by account identity

### DIFF
--- a/apps/server/src/tests/integration/repository/author-dedupe.test.ts
+++ b/apps/server/src/tests/integration/repository/author-dedupe.test.ts
@@ -52,10 +52,10 @@ describe("AuthorRepository Deduplication", () => {
 		expect(count).toHaveLength(1);
 	});
 
-	it("deduplicates an author by platform and account ID", async () => {
+	it("deduplicates by platform account and refreshes the display name", async () => {
 		const author1 = await AuthorRepository.create({
 			name: "Original Name",
-			accountId: "@creator",
+			accountId: "@Creator",
 			platform: "twitter",
 		});
 		const author2 = await AuthorRepository.create({
@@ -65,6 +65,7 @@ describe("AuthorRepository Deduplication", () => {
 		});
 
 		expect(author2.id).toBe(author1.id);
+		expect(author2.name).toBe("Updated Display Name");
 		const accounts = await db
 			.select()
 			.from(authorAccounts)
@@ -76,6 +77,10 @@ describe("AuthorRepository Deduplication", () => {
 			);
 		expect(accounts).toHaveLength(1);
 		expect(accounts[0]?.authorId).toBe(author1.id);
+		const storedAuthor = await db.query.authors.findFirst({
+			where: eq(authors.id, author1.id),
+		});
+		expect(storedAuthor?.name).toBe("Updated Display Name");
 	});
 
 	it("keeps identical account IDs on different platforms separate", async () => {

--- a/apps/xtracter/src/content/twitter.test.ts
+++ b/apps/xtracter/src/content/twitter.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vite-plus/test";
+import { extractTwitterAuthorIdFromStatusUrl } from "./twitter";
+
+describe("extractTwitterAuthorIdFromStatusUrl", () => {
+	it("extracts the handle from an X status permalink", () => {
+		expect(
+			extractTwitterAuthorIdFromStatusUrl(
+				"https://x.com/Creator_123/status/1234567890",
+			),
+		).toBe("@Creator_123");
+	});
+
+	it("extracts the handle from a legacy Twitter status permalink", () => {
+		expect(
+			extractTwitterAuthorIdFromStatusUrl(
+				"https://twitter.com/creator/status/1234567890?s=20",
+			),
+		).toBe("@creator");
+	});
+
+	it("rejects status URLs that do not contain an account handle", () => {
+		expect(
+			extractTwitterAuthorIdFromStatusUrl(
+				"https://x.com/i/web/status/1234567890",
+			),
+		).toBe("");
+	});
+
+	it("does not interpret display-name mentions as account IDs", () => {
+		expect(
+			extractTwitterAuthorIdFromStatusUrl(
+				"https://x.com/not-a-status/display-name-@C107",
+			),
+		).toBe("");
+	});
+});

--- a/apps/xtracter/src/content/twitter.ts
+++ b/apps/xtracter/src/content/twitter.ts
@@ -3,7 +3,32 @@ import { querySelectorAllTyped, querySelectorTyped } from "../utils/dom-utils";
 
 const PROCESSED_IMAGE_CLASS = "xtracter-image-processed";
 const PROCESSED_VIDEO_CLASS = "xtracter-video-processed";
-const AUTHOR_ID_REGEX = /@\w+/;
+const TWITTER_HANDLE_REGEX = /^[A-Za-z0-9_]{1,15}$/;
+
+export function extractTwitterAuthorIdFromStatusUrl(urlValue: string): string {
+	try {
+		const url = new URL(urlValue);
+		const isTwitterHost =
+			url.hostname === "x.com" ||
+			url.hostname === "www.x.com" ||
+			url.hostname === "twitter.com" ||
+			url.hostname === "www.twitter.com";
+		if (!isTwitterHost) {
+			return "";
+		}
+		const pathParts = url.pathname.split("/").filter(Boolean);
+		if (
+			pathParts.length < 3 ||
+			pathParts[1] !== "status" ||
+			!TWITTER_HANDLE_REGEX.test(pathParts[0] ?? "")
+		) {
+			return "";
+		}
+		return `@${pathParts[0]}`;
+	} catch {
+		return "";
+	}
+}
 
 export function processTwitterMedia(
 	processedMetadata: Map<string, TweetMetadata>,
@@ -125,7 +150,6 @@ function extractMetadataFromUrl(): { authorId: string; tweetUrl: string } {
 	const url = new URL(window.location.href);
 	const pathParts = url.pathname.split("/").filter((p) => p);
 
-	let authorId = "";
 	let tweetUrl = window.location.href;
 
 	const MIN_PATH_PARTS_FOR_STATUS = 3;
@@ -136,11 +160,13 @@ function extractMetadataFromUrl(): { authorId: string; tweetUrl: string } {
 		pathParts.length >= MIN_PATH_PARTS_FOR_STATUS &&
 		pathParts[STATUS_PART_INDEX] === "status"
 	) {
-		authorId = `@${pathParts[0]}`;
 		tweetUrl = `${url.origin}/${pathParts[0]}/status/${pathParts[TWEET_ID_PART_INDEX]}`;
 	}
 
-	return { authorId, tweetUrl };
+	return {
+		authorId: extractTwitterAuthorIdFromStatusUrl(tweetUrl),
+		tweetUrl,
+	};
 }
 
 function extractMetadata(
@@ -211,7 +237,7 @@ function determineTargetUrl(
 		const url = new URL(element.src);
 		url.searchParams.set("name", "orig");
 		return url.toString();
-	} catch (_e) {
+	} catch {
 		if (element instanceof HTMLImageElement) {
 			return element.src;
 		}
@@ -238,23 +264,7 @@ function extractFromArticle(article: HTMLElement) {
 	const userNameNode = article.querySelector('div[data-testid="User-Name"]');
 	const authorName = userNameNode?.querySelector("span")?.innerText || "";
 
-	let authorId = "";
-	const userAnchor = userNameNode?.querySelector("a");
-	if (userAnchor) {
-		try {
-			const url = new URL(userAnchor.href);
-			const pathParts = url.pathname.split("/").filter((p) => p);
-			if (pathParts.length > 0) {
-				authorId = `@${pathParts[0]}`;
-			}
-		} catch (_e) {
-			// Ignored
-		}
-	}
-
-	if (!authorId) {
-		authorId = userNameNode?.textContent?.match(AUTHOR_ID_REGEX)?.[0] || "";
-	}
+	const authorId = extractTwitterAuthorIdFromStatusUrl(tweetUrl);
 
 	return { tweetText, timestamp, tweetUrl, authorName, authorId };
 }

--- a/apps/xtracter/src/content/twitter.ts
+++ b/apps/xtracter/src/content/twitter.ts
@@ -147,25 +147,9 @@ function findTweetArticle(element: HTMLElement): HTMLElement | null {
 }
 
 function extractMetadataFromUrl(): { authorId: string; tweetUrl: string } {
-	const url = new URL(window.location.href);
-	const pathParts = url.pathname.split("/").filter((p) => p);
-
-	let tweetUrl = window.location.href;
-
-	const MIN_PATH_PARTS_FOR_STATUS = 3;
-	const STATUS_PART_INDEX = 1;
-	const TWEET_ID_PART_INDEX = 2;
-
-	if (
-		pathParts.length >= MIN_PATH_PARTS_FOR_STATUS &&
-		pathParts[STATUS_PART_INDEX] === "status"
-	) {
-		tweetUrl = `${url.origin}/${pathParts[0]}/status/${pathParts[TWEET_ID_PART_INDEX]}`;
-	}
-
 	return {
-		authorId: extractTwitterAuthorIdFromStatusUrl(tweetUrl),
-		tweetUrl,
+		authorId: extractTwitterAuthorIdFromStatusUrl(window.location.href),
+		tweetUrl: window.location.href,
 	};
 }
 

--- a/packages/db/src/repositories/author-repository.ts
+++ b/packages/db/src/repositories/author-repository.ts
@@ -51,6 +51,10 @@ function authorIdentityKey(
 	return `${platform}:${identity}`;
 }
 
+function normalizeLegacyAccountId(accountId: string): string {
+	return accountId.replace(/^@/, "").toLowerCase();
+}
+
 function authorInputKey(author: NewAuthor): string {
 	return author.platform && author.accountId
 		? authorIdentityKey(author.platform, author.accountId)
@@ -111,7 +115,10 @@ async function findOrCreateAuthorsBulk(
 	const names = [...new Set(unresolved.map(([, input]) => input.name))];
 	const legacyConditions: SQL[] = [];
 	if (accountIds.length > 0) {
-		legacyConditions.push(inArray(authors.accountId, accountIds));
+		const allVariants = [
+			...new Set(accountIds.flatMap((id) => [id, `@${id}`])),
+		];
+		legacyConditions.push(inArray(authors.accountId, allVariants));
 	}
 	if (names.length > 0) {
 		legacyConditions.push(inArray(authors.name, names));
@@ -125,9 +132,17 @@ async function findOrCreateAuthorsBulk(
 					.where(or(...legacyConditions))
 			: [];
 	const legacyByAccount = new Map(
-		legacyAuthors.flatMap((author) =>
-			author.accountId ? [[author.accountId, author] as const] : [],
-		),
+		legacyAuthors.flatMap((author) => {
+			if (!author.accountId) return [];
+			const normalized = normalizeLegacyAccountId(author.accountId);
+			const entries: [string, typeof authors.$inferSelect][] = [
+				[normalized, author],
+			];
+			if (normalized !== author.accountId) {
+				entries.push([author.accountId, author]);
+			}
+			return entries;
+		}),
 	);
 	const legacyByName = new Map(
 		legacyAuthors.map((author) => [author.name, author] as const),
@@ -259,7 +274,7 @@ async function findOrCreateAuthorsBulk(
 	if (desiredNames.size > 0) {
 		const ids = [...desiredNames.keys()];
 		const cases = ids.map(
-			(id) => sql`WHEN ${id}::uuid THEN ${desiredNames.get(id)}`,
+			(id) => sql`WHEN ${authors.id} = ${id}::uuid THEN ${desiredNames.get(id)}`,
 		);
 		await client
 			.update(authors)

--- a/packages/db/src/repositories/author-repository.ts
+++ b/packages/db/src/repositories/author-repository.ts
@@ -28,7 +28,7 @@ function normalizeAccountId(
 	accountId: string,
 ): string {
 	if (platform !== "twitter") return accountId;
-	return accountId.toLowerCase();
+	return accountId.replace(/^@/, "").toLowerCase();
 }
 
 function normalizeAuthorInput(author: NewAuthor): NewAuthor {
@@ -64,7 +64,7 @@ async function findOrCreateAuthorsBulk(
 	const uniqueInputs = new Map<string, NewAuthor>();
 	for (const rawInput of inputs) {
 		const input = normalizeAuthorInput(rawInput);
-		if (input.name.length > 0) {
+		if (input.name.trim().length > 0) {
 			uniqueInputs.set(authorInputKey(input), input);
 		}
 	}
@@ -147,6 +147,7 @@ async function findOrCreateAuthorsBulk(
 
 	const accountsToInsert: (typeof authorAccounts.$inferInsert)[] = [];
 	const authorsToInsert: (typeof authors.$inferInsert)[] = [];
+	const newlyCreatedAuthorByKey = new Map<string, string>();
 	for (const [key, input] of unresolved) {
 		const legacyByMatchingAccount = input.accountId
 			? legacyByAccount.get(input.accountId)
@@ -174,6 +175,7 @@ async function findOrCreateAuthorsBulk(
 				name: author.name,
 				accountId: author.accountId,
 			});
+			newlyCreatedAuthorByKey.set(key, author.id);
 		}
 		resolved.set(key, author);
 
@@ -190,10 +192,54 @@ async function findOrCreateAuthorsBulk(
 		await client.insert(authors).values(authorsToInsert);
 	}
 	if (accountsToInsert.length > 0) {
-		await client
+		const insertedAccounts = await client
 			.insert(authorAccounts)
 			.values(accountsToInsert)
-			.onConflictDoNothing();
+			.onConflictDoNothing()
+			.returning();
+		const insertedKeys = new Set(
+			insertedAccounts.map(
+				(account) => authorIdentityKey(account.platform, account.accountId),
+			),
+		);
+		const attemptedKeys = new Set(
+			accountsToInsert.map(
+				(account) => authorIdentityKey(account.platform, account.accountId),
+			),
+		);
+		const conflicted = [...uniqueInputs.entries()].filter(
+			([key, input]) =>
+				input.platform &&
+				input.accountId &&
+				attemptedKeys.has(key) &&
+				!insertedKeys.has(key),
+		);
+		if (conflicted.length > 0) {
+			const conditions = conflicted.flatMap(([, input]) => {
+				if (!(input.platform && input.accountId)) return [];
+				const condition = and(
+					eq(authorAccounts.platform, input.platform),
+					eq(authorAccounts.accountId, input.accountId),
+				);
+				return condition ? [condition] : [];
+			});
+			const canonicalAccounts = await client
+				.select({ account: authorAccounts, author: authors })
+				.from(authorAccounts)
+				.innerJoin(authors, eq(authorAccounts.authorId, authors.id))
+				.where(or(...conditions));
+			for (const row of canonicalAccounts) {
+				const key = authorIdentityKey(row.account.platform, row.account.accountId);
+				resolved.set(key, row.author);
+			}
+			const orphanIds = conflicted.flatMap(([key]) => {
+				const id = newlyCreatedAuthorByKey.get(key);
+				return id ? [id] : [];
+			});
+			if (orphanIds.length > 0) {
+				await client.delete(authors).where(inArray(authors.id, orphanIds));
+			}
+		}
 	}
 
 	const desiredNames = new Map<string, string>();
@@ -210,13 +256,26 @@ async function findOrCreateAuthorsBulk(
 	}
 
 	const refreshedAuthors = new Map<string, typeof authors.$inferSelect>();
-	for (const [authorId, name] of desiredNames) {
-		const [updated] = await client
+	if (desiredNames.size > 0) {
+		const ids = [...desiredNames.keys()];
+		const cases = ids.map(
+			(id) => sql`WHEN ${id}::uuid THEN ${desiredNames.get(id)}`,
+		);
+		await client
 			.update(authors)
-			.set({ name, updatedAt: new Date() })
-			.where(eq(authors.id, authorId))
-			.returning();
-		if (updated) refreshedAuthors.set(authorId, updated);
+			.set({
+				name: sql`CASE ${sql.join(cases, sql` `)} END`,
+				updatedAt: new Date(),
+			})
+			.where(inArray(authors.id, ids));
+
+		const updatedRows = await client
+			.select()
+			.from(authors)
+			.where(inArray(authors.id, ids));
+		for (const row of updatedRows) {
+			refreshedAuthors.set(row.id, row);
+		}
 	}
 
 	for (const [key, author] of resolved) {

--- a/packages/db/src/repositories/author-repository.ts
+++ b/packages/db/src/repositories/author-repository.ts
@@ -5,7 +5,7 @@ import type {
 	NewAuthor,
 } from "@solid-imager/core/domain/media/schemas";
 import type { IAuthorRepository } from "@solid-imager/core/domain/repositories/author-repository";
-import { and, eq, inArray, or, type SQL } from "drizzle-orm";
+import { and, eq, inArray, or, sql, type SQL } from "drizzle-orm";
 import { authorAccounts, authors, mediaAuthors } from "../schema";
 import type { DrizzleExecutor } from "../types";
 
@@ -23,9 +23,37 @@ function mapAuthor(row: typeof authors.$inferSelect): Author {
 	};
 }
 
+function normalizeAccountId(
+	platform: NonNullable<NewAuthor["platform"]>,
+	accountId: string,
+): string {
+	if (platform !== "twitter") return accountId;
+	return accountId.toLowerCase();
+}
+
+function normalizeAuthorInput(author: NewAuthor): NewAuthor {
+	if (!(author.platform && author.accountId)) return author;
+	return {
+		...author,
+		accountId: normalizeAccountId(author.platform, author.accountId),
+	};
+}
+
+function authorIdentityKey(
+	platform: NonNullable<NewAuthor["platform"]>,
+	accountId: string,
+): string {
+	const normalizedAccountId = normalizeAccountId(platform, accountId);
+	const identity =
+		platform === "twitter"
+			? normalizedAccountId.replace(/^@/, "")
+			: normalizedAccountId;
+	return `${platform}:${identity}`;
+}
+
 function authorInputKey(author: NewAuthor): string {
 	return author.platform && author.accountId
-		? `${author.platform}:${author.accountId}`
+		? authorIdentityKey(author.platform, author.accountId)
 		: `name:${author.name}`;
 }
 
@@ -34,7 +62,8 @@ async function findOrCreateAuthorsBulk(
 	inputs: NewAuthor[],
 ): Promise<Author[]> {
 	const uniqueInputs = new Map<string, NewAuthor>();
-	for (const input of inputs) {
+	for (const rawInput of inputs) {
+		const input = normalizeAuthorInput(rawInput);
 		if (input.name.length > 0) {
 			uniqueInputs.set(authorInputKey(input), input);
 		}
@@ -46,7 +75,9 @@ async function findOrCreateAuthorsBulk(
 		if (input.platform && input.accountId) {
 			const condition = and(
 				eq(authorAccounts.platform, input.platform),
-				eq(authorAccounts.accountId, input.accountId),
+				input.platform === "twitter"
+					? sql`lower(regexp_replace(${authorAccounts.accountId}, '^@', '')) = ${input.accountId.replace(/^@/, "")}`
+					: eq(authorAccounts.accountId, input.accountId),
 			);
 			if (condition) identityConditions.push(condition);
 		}
@@ -61,7 +92,7 @@ async function findOrCreateAuthorsBulk(
 			.where(or(...identityConditions));
 		for (const row of existingIdentities) {
 			resolved.set(
-				`${row.account.platform}:${row.account.accountId}`,
+				authorIdentityKey(row.account.platform, row.account.accountId),
 				row.author,
 			);
 		}
@@ -163,6 +194,34 @@ async function findOrCreateAuthorsBulk(
 			.insert(authorAccounts)
 			.values(accountsToInsert)
 			.onConflictDoNothing();
+	}
+
+	const desiredNames = new Map<string, string>();
+	for (const [key, input] of uniqueInputs) {
+		const author = resolved.get(key);
+		if (
+			author &&
+			input.platform &&
+			input.accountId &&
+			author.name !== input.name
+		) {
+			desiredNames.set(author.id, input.name);
+		}
+	}
+
+	const refreshedAuthors = new Map<string, typeof authors.$inferSelect>();
+	for (const [authorId, name] of desiredNames) {
+		const [updated] = await client
+			.update(authors)
+			.set({ name, updatedAt: new Date() })
+			.where(eq(authors.id, authorId))
+			.returning();
+		if (updated) refreshedAuthors.set(authorId, updated);
+	}
+
+	for (const [key, author] of resolved) {
+		const refreshed = refreshedAuthors.get(author.id);
+		if (refreshed) resolved.set(key, refreshed);
 	}
 
 	return [...uniqueInputs.keys()].flatMap((key) => {


### PR DESCRIPTION
## 概要
Twitter/Xの表示名変更時に同一アカウントを再利用し、Author表示名を最新値へ更新します。表示名内の@文字列をIDとして誤抽出する経路も除去します。

## 変更内容
- Twitter account IDを大文字小文字と@有無を無視して照合
- 同一platform/account IDで表示名が変わった場合に既存Authorを更新
- XtracterのAuthor IDをstatus permalinkからのみ抽出
- repository統合テストとURL抽出テストを追加

## 検証
- AuthorRepository統合テスト: 5件成功
- Xtracter URL抽出テスト: 4件成功
- db/xtracter/server typecheck成功
- 対象lint成功
- Xtracter build成功

## 既存環境の注意
全体vp checkはルートVite設定が存在しないsrc/routesを参照して停止します。全体vp testは別worktreeを重複収集し、server aliasを解決できない既存問題で失敗します。対象テストは専用configで成功しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * X/Twitterの投稿URLから投稿者ID（`@...`）を、URL形式に応じてより正確に抽出できるようになりました。
* **バグ修正**
  * 表記ゆれ（`@`有無・大文字小文字）でも同一投稿者として重複排除されます。
  * 重複排除後、既存レコードの表示名を最新の値に同期します。
  * 対象外のURL形式では抽出結果を空にします。
* **テスト**
  * 投稿者ID抽出と重複排除のテストを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->