### PR TITLE
perf(ai): CCIPベクトルをチャンク単位でbulk upsert

### DIFF
--- a/apps/server/scripts/extract-ccip-batch.ts
+++ b/apps/server/scripts/extract-ccip-batch.ts
@@ -127,10 +127,10 @@ async function main(): Promise<void> {
     }
 
     batchNumber += 1;
-    const results = await Promise.allSettled(
-      batch.map((media) =>
-        ccipVectorService.extract(options.sourceId, media.id, options.forceReextract),
-      ),
+    const results = await ccipVectorService.extractBatch(
+      options.sourceId,
+      batch.map((media) => media.id),
+      options.forceReextract,
     );
 
     for (const [index, result] of results.entries()) {

--- a/apps/server/src/infrastructure/ai/lancedb-ccip-vector-store.ts
+++ b/apps/server/src/infrastructure/ai/lancedb-ccip-vector-store.ts
@@ -127,16 +127,20 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 	}
 
 	async upsert(record: CcipVectorRecord): Promise<void> {
+		await this.upsertMany([record]);
+	}
+
+	async upsertMany(records: CcipVectorRecord[]): Promise<void> {
+		if (records.length === 0) {
+			return;
+		}
 		await this.serializeWrite(async () => {
 			const table = await this.table();
-			await table.delete(`mediaId = '${escapeSqlString(record.mediaId)}'`);
-			await table.add([
-				{
-					...record,
-					mediaModifiedAt: record.mediaModifiedAt,
-					extractedAt: record.extractedAt,
-				},
-			]);
+			await table
+				.mergeInsert("mediaId")
+				.whenMatchedUpdateAll()
+				.whenNotMatchedInsertAll()
+				.execute(records);
 		});
 	}
 

--- a/apps/server/src/tests/unit/application/services/ccip-vector-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/ccip-vector-service.test.ts
@@ -14,7 +14,7 @@ describe("CcipVectorService", () => {
 		const record = {
 			mediaId: media.id,
 			mediaSourceId: source.id,
-			vector: new Array(768).fill(0),
+			vector: Array.from({ length: 768 }, () => 0),
 			model: "ccip-caformer-24-randaug-pruned",
 			embeddingVersion: 1,
 			mediaModifiedAt: media.modifiedAt,
@@ -40,8 +40,53 @@ describe("CcipVectorService", () => {
 		expect(taggingService.getCcipFeatureForMedia).not.toHaveBeenCalled();
 	});
 
+	it("persists successful batch extractions with one bulk upsert", async () => {
+		const secondMedia = {
+			...media,
+			id: "00000000-0000-4000-8000-000000000002",
+		};
+		const vectorStore = {
+			get: vi.fn().mockResolvedValue(null),
+			upsertMany: vi.fn().mockResolvedValue(undefined),
+		};
+		const taggingService = {
+			getCcipFeatureForMedia: vi
+				.fn()
+				.mockResolvedValueOnce({
+					feature: Array.from({ length: 768 }, () => 1),
+				})
+				.mockResolvedValueOnce({
+					feature: Array.from({ length: 768 }, () => 2),
+				}),
+		};
+		const service = new CcipVectorService({
+			mediaRepository: {
+				findById: vi.fn((id: string) =>
+					Promise.resolve(id === media.id ? media : secondMedia),
+				),
+			} as any,
+			sourceRepository: {
+				findById: vi.fn().mockResolvedValue(source),
+			} as any,
+			taggingService: taggingService as any,
+			vectorStore: vectorStore as any,
+		});
+
+		const results = await service.extractBatch(source.id, [
+			media.id,
+			secondMedia.id,
+		]);
+
+		expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+		expect(vectorStore.upsertMany).toHaveBeenCalledOnce();
+		expect(vectorStore.upsertMany.mock.calls[0]?.[0]).toEqual([
+			expect.objectContaining({ mediaId: media.id }),
+			expect.objectContaining({ mediaId: secondMedia.id }),
+		]);
+	});
+
 	it("reranks LanceDB candidates using CCIP distance", async () => {
-		const anchorVector = new Array(768).fill(0);
+		const anchorVector = Array.from({ length: 768 }, () => 0);
 		const candidateA = {
 			...media,
 			id: "00000000-0000-4000-8000-000000000002",
@@ -74,11 +119,17 @@ describe("CcipVectorService", () => {
 				get: vi.fn().mockResolvedValue(record(media, anchorVector)),
 				search: vi.fn().mockResolvedValue([
 					{
-						...record(candidateA, new Array(768).fill(1)),
+						...record(
+							candidateA,
+							Array.from({ length: 768 }, () => 1),
+						),
 						cosineDistance: 0.1,
 					},
 					{
-						...record(candidateB, new Array(768).fill(2)),
+						...record(
+							candidateB,
+							Array.from({ length: 768 }, () => 2),
+						),
 						cosineDistance: 0.2,
 					},
 				]),

--- a/packages/application/src/ports/ccip-vector-store.ts
+++ b/packages/application/src/ports/ccip-vector-store.ts
@@ -15,6 +15,7 @@ export type CcipVectorCandidate = CcipVectorRecord & {
 export interface ICcipVectorStore {
 	get(mediaId: string): Promise<CcipVectorRecord | null>;
 	upsert(record: CcipVectorRecord): Promise<void>;
+	upsertMany(records: CcipVectorRecord[]): Promise<void>;
 	delete(mediaId: string): Promise<void>;
 	deleteBySource(mediaSourceId: string): Promise<void>;
 	listMediaIds(mediaSourceId?: string): Promise<string[]>;

--- a/packages/application/src/services/ccip-vector-service.ts
+++ b/packages/application/src/services/ccip-vector-service.ts
@@ -31,6 +31,44 @@ export class CcipVectorService {
 		mediaId: string,
 		force = false,
 	): Promise<{ record: CcipVectorRecord; skipped: boolean }> {
+		const result = await this.prepareExtraction(mediaSourceId, mediaId, force);
+		if (!result.skipped) {
+			await this.deps.vectorStore.upsert(result.record);
+		}
+		return result;
+	}
+
+	async extractBatch(
+		mediaSourceId: string,
+		mediaIds: string[],
+		force = false,
+	): Promise<
+		PromiseSettledResult<{
+			mediaId: string;
+			record: CcipVectorRecord;
+			skipped: boolean;
+		}>[]
+	> {
+		const results = await Promise.allSettled(
+			mediaIds.map(async (mediaId) => ({
+				mediaId,
+				...(await this.prepareExtraction(mediaSourceId, mediaId, force)),
+			})),
+		);
+		const records = results.flatMap((result) =>
+			result.status === "fulfilled" && !result.value.skipped
+				? [result.value.record]
+				: [],
+		);
+		await this.deps.vectorStore.upsertMany(records);
+		return results;
+	}
+
+	private async prepareExtraction(
+		mediaSourceId: string,
+		mediaId: string,
+		force: boolean,
+	): Promise<{ record: CcipVectorRecord; skipped: boolean }> {
 		const media = await this.requireImage(mediaSourceId, mediaId);
 		const existing = await this.deps.vectorStore.get(mediaId);
 		if (!force && existing && this.isCurrent(existing, media, mediaSourceId)) {
@@ -50,7 +88,6 @@ export class CcipVectorService {
 			mediaModifiedAt: media.modifiedAt,
 			extractedAt: new Date(),
 		};
-		await this.deps.vectorStore.upsert(record);
 		return { record, skipped: false };
 	}
 
@@ -96,7 +133,10 @@ export class CcipVectorService {
 		const anchorMedia = await this.deps.mediaRepository.findById(anchorMediaId);
 		if (!anchorMedia) throw new Error(`Media not found: ${anchorMediaId}`);
 		const anchor = await this.deps.vectorStore.get(anchorMediaId);
-		if (!anchor || !this.isCurrent(anchor, anchorMedia, anchorMedia.mediaSourceId)) {
+		if (
+			!anchor ||
+			!this.isCurrent(anchor, anchorMedia, anchorMedia.mediaSourceId)
+		) {
 			throw new Error("CCIP vector is missing or stale for the anchor media");
 		}
 
@@ -156,7 +196,11 @@ export class CcipVectorService {
 		};
 	}
 
-	private isCurrent(record: CcipVectorRecord, media: Media, mediaSourceId: string): boolean {
+	private isCurrent(
+		record: CcipVectorRecord,
+		media: Media,
+		mediaSourceId: string,
+	): boolean {
 		return (
 			record.model === CCIP_MODEL &&
 			record.embeddingVersion === CCIP_EMBEDDING_VERSION &&


### PR DESCRIPTION
## 概要

CCIPバッチスクリプトのLanceDB保存を、1件ごとのdelete/addからチャンク単位のmerge insertへ変更します。

## 変更内容

- ICcipVectorStoreへupsertManyを追加
- LanceDBのmediaId merge insertで複数vectorを一括更新
- CcipVectorServiceへextractBatchを追加し、成功した推論結果をまとめて保存
- バッチスクリプトをextractBatch利用へ変更
- service unit testとLanceDB実体でinsert/updateを検証

## 検証

- Biome check
- server/application typecheck
- CcipVectorService unit test: 3件成功
- LanceDB実体で2件insert後の同一mediaId更新を確認

## 関連Issue

- #569 UIの大規模tagging/CCIP batch投入改善は別途対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 複数メディアの抽出処理をまとめて実行できるようになり、処理効率が向上しました。
* **バグ修正**
  * 既存データの更新方法を改善し、重複や不要な削除を避けて安定した保存ができるようになりました。
  * 取得済みデータの状態確認や検索時の判定を整理し、より一貫した動作になりました。
* **テスト**
  * 一括処理と保存の動作を検証するテストを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->