### PR TITLE
perf(ai): CCIP既存vector判定をチャンク一括化

### DIFF
--- a/apps/server/src/infrastructure/ai/lancedb-ccip-vector-store.ts
+++ b/apps/server/src/infrastructure/ai/lancedb-ccip-vector-store.ts
@@ -117,13 +117,27 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 	}
 
 	async get(mediaId: string): Promise<CcipVectorRecord | null> {
+		return (await this.getMany([mediaId])).get(mediaId) ?? null;
+	}
+
+	async getMany(mediaIds: string[]): Promise<Map<string, CcipVectorRecord>> {
+		if (mediaIds.length === 0) {
+			return new Map();
+		}
+		const predicate = mediaIds
+			.map((mediaId) => `'${escapeSqlString(mediaId)}'`)
+			.join(", ");
 		const table = await this.table();
 		const rows = await table
 			.query()
-			.where(`mediaId = '${escapeSqlString(mediaId)}'`)
-			.limit(1)
+			.where(`mediaId IN (${predicate})`)
 			.toArray();
-		return rows[0] ? toRecord(rows[0]) : null;
+		return new Map(
+			rows.map((row) => {
+				const record = toRecord(row);
+				return [record.mediaId, record];
+			}),
+		);
 	}
 
 	async upsert(record: CcipVectorRecord): Promise<void> {

--- a/apps/server/src/tests/unit/application/services/ccip-vector-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/ccip-vector-service.test.ts
@@ -46,7 +46,7 @@ describe("CcipVectorService", () => {
 			id: "00000000-0000-4000-8000-000000000002",
 		};
 		const vectorStore = {
-			get: vi.fn().mockResolvedValue(null),
+			getMany: vi.fn().mockResolvedValue(new Map()),
 			upsertMany: vi.fn().mockResolvedValue(undefined),
 		};
 		const taggingService = {
@@ -78,6 +78,7 @@ describe("CcipVectorService", () => {
 		]);
 
 		expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+		expect(vectorStore.getMany).toHaveBeenCalledOnce();
 		expect(vectorStore.upsertMany).toHaveBeenCalledOnce();
 		expect(vectorStore.upsertMany.mock.calls[0]?.[0]).toEqual([
 			expect.objectContaining({ mediaId: media.id }),

--- a/packages/application/src/ports/ccip-vector-store.ts
+++ b/packages/application/src/ports/ccip-vector-store.ts
@@ -14,6 +14,7 @@ export type CcipVectorCandidate = CcipVectorRecord & {
 
 export interface ICcipVectorStore {
 	get(mediaId: string): Promise<CcipVectorRecord | null>;
+	getMany(mediaIds: string[]): Promise<Map<string, CcipVectorRecord>>;
 	upsert(record: CcipVectorRecord): Promise<void>;
 	upsertMany(records: CcipVectorRecord[]): Promise<void>;
 	delete(mediaId: string): Promise<void>;

--- a/packages/application/src/services/ccip-vector-service.ts
+++ b/packages/application/src/services/ccip-vector-service.ts
@@ -31,7 +31,12 @@ export class CcipVectorService {
 		mediaId: string,
 		force = false,
 	): Promise<{ record: CcipVectorRecord; skipped: boolean }> {
-		const result = await this.prepareExtraction(mediaSourceId, mediaId, force);
+		const existing = force ? null : await this.deps.vectorStore.get(mediaId);
+		const result = await this.prepareExtraction(
+			mediaSourceId,
+			mediaId,
+			existing,
+		);
 		if (!result.skipped) {
 			await this.deps.vectorStore.upsert(result.record);
 		}
@@ -49,10 +54,17 @@ export class CcipVectorService {
 			skipped: boolean;
 		}>[]
 	> {
+		const existingById = force
+			? new Map<string, CcipVectorRecord>()
+			: await this.deps.vectorStore.getMany(mediaIds);
 		const results = await Promise.allSettled(
 			mediaIds.map(async (mediaId) => ({
 				mediaId,
-				...(await this.prepareExtraction(mediaSourceId, mediaId, force)),
+				...(await this.prepareExtraction(
+					mediaSourceId,
+					mediaId,
+					existingById.get(mediaId) ?? null,
+				)),
 			})),
 		);
 		const records = results.flatMap((result) =>
@@ -67,11 +79,10 @@ export class CcipVectorService {
 	private async prepareExtraction(
 		mediaSourceId: string,
 		mediaId: string,
-		force: boolean,
+		existing: CcipVectorRecord | null,
 	): Promise<{ record: CcipVectorRecord; skipped: boolean }> {
 		const media = await this.requireImage(mediaSourceId, mediaId);
-		const existing = await this.deps.vectorStore.get(mediaId);
-		if (!force && existing && this.isCurrent(existing, media, mediaSourceId)) {
+		if (existing && this.isCurrent(existing, media, mediaSourceId)) {
 			return { record: existing, skipped: true };
 		}
 


### PR DESCRIPTION
## 概要

CCIPバッチのスキップ判定でmediaごとにLanceDBを検索していた処理を、チャンク単位のbulk lookupへ変更します。

## 変更内容

- ICcipVectorStoreへgetManyを追加
- LanceDBをmediaId IN条件でチャンク1回だけ検索
- extractBatchで既存vectorを一括取得
- force=true時は既存vector検索を省略
- 単件getもgetManyへ集約

## 効果

batch size 100の場合、既存vector判定のLanceDB queryを100回から1回へ削減します。

## 検証

- Biome check
- server typecheck
- CcipVectorService unit test: 3件成功
- LanceDB実体でbulk lookupを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 複数の項目のベクトル情報をまとめて取得できるようになりました。
* **Bug Fixes**
  * 単一取得もまとめ取得経由に統一し、取得結果の扱いが一貫しました。
  * 既存データが最新の場合は再生成をスキップし、古い場合のみ更新するようになりました。
* **Tests**
  * バッチ処理でまとめ取得が1回だけ呼ばれることを確認するテストに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->