### PR TITLE
perf(ai): 大規模tagging/CCIP batch投入を非同期dispatch化

### DIFF
--- a/apps/server/public/openapi.json
+++ b/apps/server/public/openapi.json
@@ -2148,36 +2148,10 @@
         }
       }
     },
-    "/ai/batchTagging": {
+    "/ai/startBatchTagging": {
       "post": {
-        "operationId": "ai.batchTagging",
-        "summary": "batchTagging",
-        "tags": [
-          "AI"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/startBatchTaggingWithIds": {
-      "post": {
-        "operationId": "ai.startBatchTaggingWithIds",
-        "summary": "startBatchTaggingWithIds",
+        "operationId": "ai.startBatchTagging",
+        "summary": "startBatchTagging",
         "tags": [
           "AI"
         ],

--- a/apps/server/src/application/services/job-dispatch-service.ts
+++ b/apps/server/src/application/services/job-dispatch-service.ts
@@ -35,6 +35,11 @@ export async function processJob(job: DbJob) {
 		await processCcipExtractionJob(job);
 	} else if (job.type === "bulk_tagging_dispatch") {
 		await processBulkTaggingDispatchJob(job);
+	} else if (job.type === "batch_ccip_dispatch") {
+		const { processBatchCcipDispatchJob } = await import(
+			"~/infrastructure/jobs/ccip-jobs"
+		);
+		await processBatchCcipDispatchJob(job);
 	} else if (job.type === "sync_lancedb" || job.type === "sync_lancedb_full") {
 		if (!mediaSourceId) {
 			throw new Error(`Job ${job.id} missing mediaSourceId`);

--- a/apps/server/src/infrastructure/api-clients/ai-api.ts
+++ b/apps/server/src/infrastructure/api-clients/ai-api.ts
@@ -36,12 +36,11 @@ export function scanBatchTaggingTargets(params: {
 	return orpc.ai.scanBatchTaggingTargets(params);
 }
 
-export function startBatchTaggingWithIds(params: {
+export function startBatchTagging(params: {
 	force?: boolean;
 	mediaSourceId?: string;
-	mediaIds: string[];
 }) {
-	return orpc.ai.startBatchTaggingWithIds(params);
+	return orpc.ai.startBatchTagging(params);
 }
 
 export function getCcipVectorStatus(mediaSourceId: string, mediaId: string) {
@@ -66,7 +65,6 @@ export function scanBatchCcipTargets(params: {
 export function startBatchCcipExtraction(params: {
 	force?: boolean;
 	mediaSourceId?: string;
-	mediaIds: string[];
 }) {
 	return orpc.ai.startBatchCcipExtraction(params);
 }

--- a/apps/server/src/infrastructure/api/routers/ai-router.ts
+++ b/apps/server/src/infrastructure/api/routers/ai-router.ts
@@ -6,13 +6,11 @@ import {
 	CCIP_MODEL,
 } from "@solid-imager/application/services/ccip-vector-service";
 import { createClient } from "@solid-imager/client";
-import {
-	type Media,
-	mediaSchema,
-} from "@solid-imager/core/domain/media/schemas";
+
 import {
 	batchCcipExtractionRequestSchema,
 	batchTaggingRequestSchema,
+	batchTargetCountResponseSchema,
 	ccipDifferenceRequestSchema,
 	ccipDistancesRequestSchema,
 	ccipDistancesResponseSchema,
@@ -20,22 +18,13 @@ import {
 	ccipFeatureRequestSchema,
 	ccipVectorStatusSchema,
 	detectAndCropResponseSchema,
-	type NapiBBox,
 	startBatchTaggingResponseSchema,
 	startCcipExtractionResponseSchema,
 	taggingResponseSchema,
 	tagImageRequestSchema,
+	type NapiBBox,
 } from "@solid-imager/core/domain/tagging/schemas";
-import {
-	and,
-	asc,
-	desc,
-	eq,
-	getTableColumns,
-	inArray,
-	isNull,
-	sql,
-} from "drizzle-orm";
+import { and, asc, desc, eq, isNull, sql } from "drizzle-orm";
 import sharp from "sharp";
 import { z } from "zod";
 import { services } from "~/application/registry";
@@ -336,13 +325,13 @@ export const aiRouter = {
 
 	scanBatchTaggingTargets: os
 		.input(batchTaggingRequestSchema)
-		.output(z.array(mediaSchema))
+		.output(batchTargetCountResponseSchema)
 		.handler(async ({ input }) => {
 			const { mediaSourceId, force } = input;
 
-			const results = await db
+			const [{ count }] = await db
 				.select({
-					...getTableColumns(medias),
+					count: sql<number>`count(distinct ${medias.id})`,
 				})
 				.from(medias)
 				.leftJoin(
@@ -372,33 +361,16 @@ export const aiRouter = {
 									isNull(mediaIps.mediaId),
 								),
 					),
-				)
-				.orderBy(asc(medias.id));
+				);
 
-			return results as unknown as Media[];
+			return { count: count ?? 0 };
 		}),
 
-	batchTagging: os
+	startBatchTagging: os
 		.input(batchTaggingRequestSchema)
-		.handler(async ({ input }) => {
-			const jobRepo = services.getJobRepository();
-			await jobRepo.create({
-				type: "bulk_tagging_dispatch",
-				mediaSourceId: input.mediaSourceId, // Optional but good for tracking if provided
-				payload: input,
-			});
-			return { success: true, message: "Batch tagging started" };
-		}),
-
-	startBatchTaggingWithIds: os
-		.input(
-			batchTaggingRequestSchema.extend({
-				mediaIds: z.array(z.string()),
-			}),
-		)
 		.output(startBatchTaggingResponseSchema)
 		.handler(async ({ input }) => {
-			const { mediaIds, mediaSourceId, force } = input;
+			const { mediaSourceId, force } = input;
 			const jobRepo = services.getJobRepository();
 
 			const parentJob = await jobRepo.create({
@@ -406,43 +378,36 @@ export const aiRouter = {
 				status: "in_progress",
 				mediaSourceId,
 				payload: {
-					total: mediaIds.length,
+					total: 0,
 					processed: 0,
-					processedJobIds: [],
+					failed: 0,
+					mediaSourceId,
+					force,
 				},
 			});
 
-			const mediaItems = await db.query.medias.findMany({
-				where: inArray(medias.id, mediaIds),
-				columns: { id: true, mediaSourceId: true },
+			await jobRepo.create({
+				type: "bulk_tagging_dispatch",
+				mediaSourceId,
+				parentId: parentJob.id,
+				payload: {
+					mediaSourceId,
+					force,
+				},
 			});
 
-			const foundIds = new Set(mediaItems.map((m) => m.id));
-			const notFoundIds = mediaIds.filter((id) => !foundIds.has(id));
-			if (notFoundIds.length > 0) {
-				logger.warn(
-					{ notFoundIds },
-					"Some media IDs were not found for batch tagging",
-				);
-			}
-
-			await Promise.all(
-				mediaItems.map((media) =>
-					jobRepo.create({
-						type: "auto_tagging",
-						mediaSourceId: media.mediaSourceId,
-						parentId: parentJob.id,
-						payload: {
-							mediaId: media.id,
-							force,
-						},
-					}),
-				),
+			logger.info(
+				{
+					jobId: parentJob.id,
+					mediaSourceId,
+					force: force ?? false,
+				},
+				"Batch tagging dispatch queued",
 			);
 
 			return {
 				success: true,
-				message: "Batch tagging started with selected media.",
+				message: "Batch tagging dispatch queued",
 				jobId: parentJob.id,
 			};
 		}),
@@ -511,10 +476,13 @@ export const aiRouter = {
 
 	scanBatchCcipTargets: os
 		.input(batchCcipExtractionRequestSchema)
-		.output(z.array(mediaSchema))
+		.output(batchTargetCountResponseSchema)
 		.handler(async ({ input }) => {
 			const rows = await db
-				.select(getTableColumns(medias))
+				.select({
+					id: medias.id,
+					modifiedAt: medias.modifiedAt,
+				})
 				.from(medias)
 				.innerJoin(mediaSources, eq(mediaSources.id, medias.mediaSourceId))
 				.where(
@@ -527,72 +495,62 @@ export const aiRouter = {
 					),
 				)
 				.orderBy(asc(medias.id));
-			if (input.force) return rows.map((row) => mediaSchema.parse(row));
+			if (input.force) return { count: rows.length };
 			const records = new Map(
 				(await ccipVectorService.listRecords(input.mediaSourceId)).map(
 					(record) => [record.mediaId, record],
 				),
 			);
-			return rows
-				.filter((row) => {
-					const record = records.get(row.id);
-					return (
-						!record ||
-						record.model !== CCIP_MODEL ||
-						record.embeddingVersion !== CCIP_EMBEDDING_VERSION ||
-						record.mediaModifiedAt.getTime() !== row.modifiedAt.getTime()
-					);
-				})
-				.map((row) => mediaSchema.parse(row));
+			const count = rows.filter((row) => {
+				const record = records.get(row.id);
+				return (
+					!record ||
+					record.model !== CCIP_MODEL ||
+					record.embeddingVersion !== CCIP_EMBEDDING_VERSION ||
+					record.mediaModifiedAt.getTime() !== row.modifiedAt.getTime()
+				);
+			}).length;
+			return { count };
 		}),
 
 	startBatchCcipExtraction: os
-		.input(
-			batchCcipExtractionRequestSchema.extend({
-				mediaIds: z.array(z.string().uuid()).min(1),
-			}),
-		)
+		.input(batchCcipExtractionRequestSchema)
 		.output(startCcipExtractionResponseSchema)
 		.handler(async ({ input }) => {
-			const mediaItems = await db.query.medias.findMany({
-				where: and(
-					inArray(medias.id, input.mediaIds),
-					eq(medias.mediaType, "image"),
-					input.mediaSourceId
-						? eq(medias.mediaSourceId, input.mediaSourceId)
-						: undefined,
-				),
-				columns: { id: true, mediaSourceId: true },
-			});
-			if (mediaItems.length === 0) {
-				throw new ORPCError("BAD_REQUEST", {
-					message: "No valid images selected",
-				});
-			}
-			const jobRepository = services.getJobRepository();
-			const parent = await jobRepository.create({
+			const { mediaSourceId, force } = input;
+			const jobRepo = services.getJobRepository();
+			const parent = await jobRepo.create({
 				type: "batch_ccip_parent",
 				status: "in_progress",
-				mediaSourceId: input.mediaSourceId,
+				mediaSourceId,
 				payload: {
-					total: mediaItems.length,
+					total: 0,
 					processed: 0,
-					processedJobIds: [],
+					failed: 0,
+					mediaSourceId,
+					force,
 				},
 			});
-			await Promise.all(
-				mediaItems.map((media) =>
-					jobRepository.create({
-						type: "extract_ccip_vector",
-						mediaSourceId: media.mediaSourceId,
-						parentId: parent.id,
-						payload: { mediaId: media.id, force: input.force },
-					}),
-				),
+			await jobRepo.create({
+				type: "batch_ccip_dispatch",
+				mediaSourceId,
+				parentId: parent.id,
+				payload: {
+					mediaSourceId,
+					force,
+				},
+			});
+			logger.info(
+				{
+					jobId: parent.id,
+					mediaSourceId,
+					force: force ?? false,
+				},
+				"Batch CCIP dispatch queued",
 			);
 			return {
 				success: true,
-				message: "Batch CCIP vector extraction started",
+				message: "Batch CCIP dispatch queued",
 				jobId: parent.id,
 			};
 		}),

--- a/apps/server/src/infrastructure/jobs/ccip-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/ccip-jobs.ts
@@ -1,3 +1,4 @@
+import type { CcipVectorRecord } from "@solid-imager/application/ports/ccip-vector-store";
 import {
 	CCIP_EMBEDDING_VERSION,
 	CCIP_MODEL,
@@ -78,9 +79,19 @@ export async function processBatchCcipDispatchJob(job: Job): Promise<void> {
 			and(
 				eq(jobs.parentId, parentId),
 				eq(jobs.type, "extract_ccip_vector"),
-				sql`${jobs.payload}->>'mediaId' = ${medias.id}`,
+				sql`(${jobs.payload}->>'mediaId')::uuid = ${medias.id}`,
 			),
 		);
+
+	let records: Map<string, CcipVectorRecord> | undefined;
+	if (!force) {
+		records = new Map(
+			(await ccipVectorService.listRecords(mediaSourceId)).map((record) => [
+				record.mediaId,
+				record,
+			]),
+		);
+	}
 
 	let lastSeenId: string | null = null;
 	let dispatchedCount = 0;
@@ -115,23 +126,17 @@ export async function processBatchCcipDispatchJob(job: Job): Promise<void> {
 			break;
 		}
 
-		let targetRows = rows;
-		if (!force) {
-			const records = new Map(
-				(await ccipVectorService.listRecords(mediaSourceId)).map(
-					(record) => [record.mediaId, record],
-				),
-			);
-			targetRows = rows.filter((row) => {
-				const record = records.get(row.id);
-				return (
-					!record ||
-					record.model !== CCIP_MODEL ||
-					record.embeddingVersion !== CCIP_EMBEDDING_VERSION ||
-					record.mediaModifiedAt.getTime() !== row.modifiedAt.getTime()
-				);
-			});
-		}
+		const targetRows = records
+			? rows.filter((row) => {
+					const record = records?.get(row.id);
+					return (
+						!record ||
+						record.model !== CCIP_MODEL ||
+						record.embeddingVersion !== CCIP_EMBEDDING_VERSION ||
+						record.mediaModifiedAt.getTime() !== row.modifiedAt.getTime()
+					);
+				})
+			: rows;
 
 		const jobRows: NewJob[] = targetRows.map((row) => ({
 			type: "extract_ccip_vector",
@@ -167,11 +172,19 @@ export async function processBatchCcipDispatchJob(job: Job): Promise<void> {
 		payload: { ...parentPayload, total: dispatchedCount },
 	});
 
-	RealtimeEventBus.publishJob("job-progress", {
-		jobId: parentId,
-		processed: 0,
-		total: dispatchedCount,
-	});
+	if (dispatchedCount === 0) {
+		await jobRepo.update(parentId, { status: "completed" });
+		RealtimeEventBus.publishJob("job-completed", {
+			jobId: parentId,
+			message: "Batch CCIP extraction completed (no targets)",
+		});
+	} else {
+		RealtimeEventBus.publishJob("job-progress", {
+			jobId: parentId,
+			processed: 0,
+			total: dispatchedCount,
+		});
+	}
 
 	logger.info(
 		{ jobId: job.id, parentId, dispatchedCount },
@@ -209,7 +222,7 @@ export async function processCcipExtractionJob(job: Job): Promise<void> {
 		if (job.parentId) {
 			const jobRepo = services.getJobRepository();
 			const progress = await jobRepo.incrementProgress(job.parentId, job.id);
-			if (progress) {
+			if (progress && progress.total > 0) {
 				RealtimeEventBus.publishJob("job-progress", {
 					jobId: job.parentId,
 					processed: progress.processed,
@@ -235,7 +248,7 @@ export async function processCcipExtractionJob(job: Job): Promise<void> {
 				job.parentId,
 				job.id,
 			);
-			if (progress) {
+			if (progress && progress.total > 0) {
 				RealtimeEventBus.publishJob("job-progress", {
 					jobId: job.parentId,
 					processed: progress.processed,

--- a/apps/server/src/infrastructure/jobs/ccip-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/ccip-jobs.ts
@@ -1,8 +1,21 @@
+import {
+	CCIP_EMBEDDING_VERSION,
+	CCIP_MODEL,
+} from "@solid-imager/application/services/ccip-vector-service";
+import { batchParentPayloadSchema } from "@solid-imager/core/domain/tagging/schemas";
 import { getErrorMessage } from "@solid-imager/core/utils";
+import { and, asc, eq, gt, notExists, sql } from "drizzle-orm";
 import { z } from "zod";
 import { services } from "~/application/registry";
 import { ccipVectorService } from "~/application/services/ccip-vector-service";
-import type { Job } from "~/infrastructure/db/schema";
+import { db } from "~/infrastructure/db";
+import {
+	type Job,
+	jobs,
+	mediaSources,
+	medias,
+	type NewJob,
+} from "~/infrastructure/db/schema";
 import { RealtimeEventBus } from "~/infrastructure/events/realtime-event-bus";
 import { logger } from "~/infrastructure/logger";
 
@@ -11,34 +24,159 @@ const payloadSchema = z.object({
 	force: z.boolean().default(false),
 });
 
-const parentPayloadSchema = z.object({
-	total: z.number().int().nonnegative(),
-	processed: z.number().int().nonnegative(),
-	processedJobIds: z.array(z.string().uuid()).optional(),
+const batchCcipDispatchPayloadSchema = z.object({
+	force: z.boolean().default(false),
+	batchSize: z.number().optional(),
+	mediaSourceId: z.string().uuid().optional(),
 });
 
-async function updateParent(job: Job): Promise<void> {
-	if (!job.parentId) return;
-	const jobRepository = services.getJobRepository();
-	const updated = await jobRepository.incrementProgress(job.parentId, job.id);
-	if (!updated) {
+async function finalizeBatchParent(
+	parentId: string,
+	progress: { processed: number; failed: number; total: number },
+): Promise<void> {
+	const jobRepo = services.getJobRepository();
+	if (progress.failed > 0) {
+		await jobRepo.update(parentId, { status: "failed" });
+		RealtimeEventBus.publishJob("job-failed", {
+			jobId: parentId,
+			error: `${progress.failed} child job(s) failed`,
+		});
 		return;
 	}
-	const parent = await jobRepository.findById(job.parentId);
-	if (!parent) return;
-	const payload = parentPayloadSchema.parse(parent.payload);
-	RealtimeEventBus.publishJob("job-progress", {
-		jobId: parent.id,
-		processed: payload.processed,
-		total: payload.total,
+	await jobRepo.update(parentId, { status: "completed" });
+	RealtimeEventBus.publishJob("job-completed", {
+		jobId: parentId,
+		message: "CCIP vector extraction completed",
 	});
-	if (parent.status !== "failed" && payload.processed >= payload.total) {
-		await jobRepository.markAsCompleted(parent.id, { success: true });
-		RealtimeEventBus.publishJob("job-completed", {
-			jobId: parent.id,
-			message: "CCIP vector extraction completed",
-		});
+}
+
+export async function processBatchCcipDispatchJob(job: Job): Promise<void> {
+	const payload = batchCcipDispatchPayloadSchema.parse(job.payload);
+	const force = payload.force ?? false;
+	const batchSize = payload.batchSize ?? 1000;
+	const mediaSourceId = payload.mediaSourceId;
+	const parentId = job.parentId;
+	if (!parentId) {
+		throw new Error("batch_ccip_dispatch requires parentId");
 	}
+
+	logger.info(
+		{ jobId: job.id, parentId, mediaSourceId, force, batchSize },
+		"Starting batch CCIP dispatch job",
+	);
+
+	const baseWhere = and(
+		eq(medias.mediaType, "image"),
+		eq(mediaSources.type, "local"),
+		mediaSourceId ? eq(medias.mediaSourceId, mediaSourceId) : undefined,
+	);
+
+	const existingChild = db
+		.select({ id: jobs.id })
+		.from(jobs)
+		.where(
+			and(
+				eq(jobs.parentId, parentId),
+				eq(jobs.type, "extract_ccip_vector"),
+				sql`${jobs.payload}->>'mediaId' = ${medias.id}`,
+			),
+		);
+
+	let lastSeenId: string | null = null;
+	let dispatchedCount = 0;
+	const CHILD_INSERT_CHUNK = 500;
+
+	while (true) {
+		const rows = await db
+			.select({
+				id: medias.id,
+				mediaSourceId: medias.mediaSourceId,
+				modifiedAt: medias.modifiedAt,
+			})
+			.from(medias)
+			.innerJoin(mediaSources, eq(mediaSources.id, medias.mediaSourceId))
+			.where(
+				and(
+					baseWhere,
+					notExists(existingChild),
+					lastSeenId ? gt(medias.id, lastSeenId) : undefined,
+				),
+			)
+			.orderBy(asc(medias.id))
+			.limit(batchSize);
+
+		if (rows.length === 0) {
+			if (dispatchedCount === 0) {
+				logger.info(
+					{ jobId: job.id, parentId, mediaSourceId, force },
+					"No matching images found for batch CCIP extraction",
+				);
+			}
+			break;
+		}
+
+		let targetRows = rows;
+		if (!force) {
+			const records = new Map(
+				(await ccipVectorService.listRecords(mediaSourceId)).map(
+					(record) => [record.mediaId, record],
+				),
+			);
+			targetRows = rows.filter((row) => {
+				const record = records.get(row.id);
+				return (
+					!record ||
+					record.model !== CCIP_MODEL ||
+					record.embeddingVersion !== CCIP_EMBEDDING_VERSION ||
+					record.mediaModifiedAt.getTime() !== row.modifiedAt.getTime()
+				);
+			});
+		}
+
+		const jobRows: NewJob[] = targetRows.map((row) => ({
+			type: "extract_ccip_vector",
+			mediaSourceId: row.mediaSourceId,
+			parentId,
+			payload: {
+				mediaId: row.id,
+				force,
+			},
+		}));
+		for (let i = 0; i < jobRows.length; i += CHILD_INSERT_CHUNK) {
+			const chunk = jobRows.slice(i, i + CHILD_INSERT_CHUNK);
+			await db.insert(jobs).values(chunk);
+		}
+
+		dispatchedCount += targetRows.length;
+		lastSeenId = rows[rows.length - 1].id;
+
+		logger.info(
+			{
+				jobId: job.id,
+				parentId,
+				dispatchedCount,
+			},
+			"Batch CCIP dispatch progress",
+		);
+	}
+
+	const jobRepo = services.getJobRepository();
+	const parentJob = await jobRepo.findById(parentId);
+	const parentPayload = batchParentPayloadSchema.parse(parentJob?.payload ?? {});
+	await jobRepo.update(parentId, {
+		payload: { ...parentPayload, total: dispatchedCount },
+	});
+
+	RealtimeEventBus.publishJob("job-progress", {
+		jobId: parentId,
+		processed: 0,
+		total: dispatchedCount,
+	});
+
+	logger.info(
+		{ jobId: job.id, parentId, dispatchedCount },
+		"Batch CCIP dispatch completed",
+	);
 }
 
 export async function processCcipExtractionJob(job: Job): Promise<void> {
@@ -67,7 +205,21 @@ export async function processCcipExtractionJob(job: Job): Promise<void> {
 			jobId: job.id,
 			message: "CCIP vector extraction completed",
 		});
-		await updateParent(job);
+
+		if (job.parentId) {
+			const jobRepo = services.getJobRepository();
+			const progress = await jobRepo.incrementProgress(job.parentId, job.id);
+			if (progress) {
+				RealtimeEventBus.publishJob("job-progress", {
+					jobId: job.parentId,
+					processed: progress.processed,
+					total: progress.total,
+				});
+				if (progress.processed + progress.failed >= progress.total) {
+					await finalizeBatchParent(job.parentId, progress);
+				}
+			}
+		}
 	} catch (error) {
 		logger.error(
 			{ err: error, mediaId: payload.mediaId },
@@ -78,13 +230,21 @@ export async function processCcipExtractionJob(job: Job): Promise<void> {
 			error: getErrorMessage(error),
 		});
 		if (job.parentId) {
-			await services
-				.getJobRepository()
-				.markAsFailed(job.parentId, getErrorMessage(error));
-			RealtimeEventBus.publishJob("job-failed", {
-				jobId: job.parentId,
-				error: getErrorMessage(error),
-			});
+			const jobRepo = services.getJobRepository();
+			const progress = await jobRepo.incrementFailedCount(
+				job.parentId,
+				job.id,
+			);
+			if (progress) {
+				RealtimeEventBus.publishJob("job-progress", {
+					jobId: job.parentId,
+					processed: progress.processed,
+					total: progress.total,
+				});
+				if (progress.processed + progress.failed >= progress.total) {
+					await finalizeBatchParent(job.parentId, progress);
+				}
+			}
 		}
 		throw error;
 	}

--- a/apps/server/src/infrastructure/jobs/job-worker.ts
+++ b/apps/server/src/infrastructure/jobs/job-worker.ts
@@ -17,14 +17,14 @@ export class JobWorker {
 	private readonly activeLanceDbSyncKeys = new Set<string>();
 
 	private readonly jobRepo: IJobRepository;
-	private readonly processor: (job: Job) => Promise<void>;
+	private readonly processor: (job: Job) => Promise<unknown>;
 
 	private readonly aiJobTypes = new Set([
 		"auto_tagging",
 		"extract_ccip_vector",
 	]);
 
-	constructor(jobRepo: IJobRepository, processor: (job: Job) => Promise<void>) {
+	constructor(jobRepo: IJobRepository, processor: (job: Job) => Promise<unknown>) {
 		this.jobRepo = jobRepo;
 		this.processor = processor;
 	}
@@ -168,8 +168,8 @@ export class JobWorker {
 			"Job started",
 		);
 		try {
-			await this.processor(job);
-			await this.jobRepo.markAsCompleted(job.id, { success: true });
+			const result = await this.processor(job);
+			await this.jobRepo.markAsCompleted(job.id, result ?? { success: true });
 			logger.info(
 				{
 					jobId: job.id,

--- a/apps/server/src/infrastructure/jobs/tagging-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/tagging-jobs.ts
@@ -86,7 +86,7 @@ export async function processAutoTaggingJob(job: Job): Promise<void> {
 		if (parentId) {
 			const jobRepo = services.getJobRepository();
 			const progress = await jobRepo.incrementProgress(parentId, job.id);
-			if (!progress) {
+			if (!progress || progress.total === 0) {
 				return;
 			}
 
@@ -105,7 +105,7 @@ export async function processAutoTaggingJob(job: Job): Promise<void> {
 		if (parentId) {
 			const jobRepo = services.getJobRepository();
 			const progress = await jobRepo.incrementFailedCount(parentId, job.id);
-			if (progress) {
+			if (progress && progress.total > 0) {
 				RealtimeEventBus.publishJob("job-progress", {
 					jobId: parentId,
 					processed: progress.processed,
@@ -184,7 +184,7 @@ export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
 			and(
 				eq(jobs.parentId, parentId),
 				eq(jobs.type, "auto_tagging"),
-				sql`${jobs.payload}->>'mediaId' = ${medias.id}`,
+				sql`(${jobs.payload}->>'mediaId')::uuid = ${medias.id}`,
 			),
 		);
 	const whereWithDedupe = and(whereClause, notExists(existingChild));
@@ -253,11 +253,19 @@ export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
 		payload: { ...parentPayload, total: dispatchedCount },
 	});
 
-	RealtimeEventBus.publishJob("job-progress", {
-		jobId: parentId,
-		processed: 0,
-		total: dispatchedCount,
-	});
+	if (dispatchedCount === 0) {
+		await jobRepo.update(parentId, { status: "completed" });
+		RealtimeEventBus.publishJob("job-completed", {
+			jobId: parentId,
+			message: "Batch tagging completed (no targets)",
+		});
+	} else {
+		RealtimeEventBus.publishJob("job-progress", {
+			jobId: parentId,
+			processed: 0,
+			total: dispatchedCount,
+		});
+	}
 
 	logger.info(
 		{ jobId: job.id, parentId, dispatchedCount },

--- a/apps/server/src/infrastructure/jobs/tagging-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/tagging-jobs.ts
@@ -1,5 +1,5 @@
-import { getErrorMessage } from "@solid-imager/core/utils";
-import { and, asc, eq, notExists } from "drizzle-orm";
+import { batchParentPayloadSchema } from "@solid-imager/core/domain/tagging/schemas";
+import { and, asc, eq, gt, notExists, sql } from "drizzle-orm";
 import { z } from "zod";
 import { services } from "~/application/registry";
 import { taggingService } from "~/application/services/tagging-service";
@@ -26,6 +26,26 @@ const bulkTaggingDispatchPayloadSchema = z.object({
 	batchSize: z.number().optional(),
 	mediaSourceId: z.string().optional(),
 });
+
+async function finalizeBatchParent(
+	parentId: string,
+	progress: { processed: number; failed: number; total: number },
+): Promise<void> {
+	const jobRepo = services.getJobRepository();
+	if (progress.failed > 0) {
+		await jobRepo.update(parentId, { status: "failed" });
+		RealtimeEventBus.publishJob("job-failed", {
+			jobId: parentId,
+			error: `${progress.failed} child job(s) failed`,
+		});
+		return;
+	}
+	await jobRepo.update(parentId, { status: "completed" });
+	RealtimeEventBus.publishJob("job-completed", {
+		jobId: parentId,
+		message: "Batch tagging completed",
+	});
+}
 
 export async function processAutoTaggingJob(job: Job): Promise<void> {
 	const payload = autoTaggingPayloadSchema.parse(job.payload);
@@ -65,51 +85,36 @@ export async function processAutoTaggingJob(job: Job): Promise<void> {
 
 		if (parentId) {
 			const jobRepo = services.getJobRepository();
-			const updated = await jobRepo.incrementProgress(parentId, job.id);
-			if (!updated) {
+			const progress = await jobRepo.incrementProgress(parentId, job.id);
+			if (!progress) {
 				return;
 			}
-			const parentJob = await jobRepo.findById(parentId);
 
-			if (parentJob) {
-				const parentPayloadSchema = z.object({
-					total: z.number(),
-					processed: z.number(),
-					processedJobIds: z.array(z.string().uuid()).optional(),
-				});
-				try {
-					const parentPayload = parentPayloadSchema.parse(parentJob.payload);
+			RealtimeEventBus.publishJob("job-progress", {
+				jobId: parentId,
+				processed: progress.processed,
+				total: progress.total,
+			});
 
-					// Publish typed job progress.
-					RealtimeEventBus.publishJob("job-progress", {
-						jobId: parentId,
-						processed: parentPayload.processed,
-						total: parentPayload.total,
-					});
-
-					if (parentPayload.processed >= parentPayload.total) {
-						await jobRepo.update(parentId, { status: "completed" });
-						RealtimeEventBus.publishJob("job-completed", {
-							jobId: parentId,
-						});
-					}
-				} catch (e) {
-					logger.error(
-						{ parentId, payload: parentJob.payload, error: e },
-						"Invalid parent job payload",
-					);
-					return;
-				}
+			if (progress.processed + progress.failed >= progress.total) {
+				await finalizeBatchParent(parentId, progress);
 			}
 		}
 	} catch (error) {
 		logger.error({ err: error, mediaId }, "Auto tagging failed");
 		if (parentId) {
-			await services.getJobRepository().update(parentId, { status: "failed" });
-			RealtimeEventBus.publishJob("job-failed", {
-				jobId: parentId,
-				error: getErrorMessage(error),
-			});
+			const jobRepo = services.getJobRepository();
+			const progress = await jobRepo.incrementFailedCount(parentId, job.id);
+			if (progress) {
+				RealtimeEventBus.publishJob("job-progress", {
+					jobId: parentId,
+					processed: progress.processed,
+					total: progress.total,
+				});
+				if (progress.processed + progress.failed >= progress.total) {
+					await finalizeBatchParent(parentId, progress);
+				}
+			}
 		}
 		throw error;
 	}
@@ -121,8 +126,13 @@ export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
 	const batchSize = payload?.batchSize ?? 1000;
 	const mediaSourceId = payload?.mediaSourceId;
 
+	if (!job.parentId) {
+		throw new Error("bulk_tagging_dispatch requires parentId");
+	}
+	const parentId = job.parentId;
+
 	logger.info(
-		{ jobId: job.id, mediaSourceId, force, batchSize },
+		{ jobId: job.id, parentId, mediaSourceId, force, batchSize },
 		"Starting bulk tagging dispatch job",
 	);
 
@@ -167,8 +177,21 @@ export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
 				),
 	);
 
-	let offset = 0;
-	let processedCount = 0;
+	const existingChild = db
+		.select({ id: jobs.id })
+		.from(jobs)
+		.where(
+			and(
+				eq(jobs.parentId, parentId),
+				eq(jobs.type, "auto_tagging"),
+				sql`${jobs.payload}->>'mediaId' = ${medias.id}`,
+			),
+		);
+	const whereWithDedupe = and(whereClause, notExists(existingChild));
+
+	let lastSeenId: string | null = null;
+	let dispatchedCount = 0;
+	const CHILD_INSERT_CHUNK = 500;
 
 	while (true) {
 		const results = await db
@@ -177,50 +200,67 @@ export async function processBulkTaggingDispatchJob(job: Job): Promise<void> {
 				mediaSourceId: medias.mediaSourceId,
 			})
 			.from(medias)
-			.where(whereClause)
+			.where(
+				and(
+					whereWithDedupe,
+					lastSeenId ? gt(medias.id, lastSeenId) : undefined,
+				),
+			)
 			.orderBy(asc(medias.id))
-			.limit(batchSize)
-			.offset(offset);
+			.limit(batchSize);
 
 		if (results.length === 0) {
-			if (processedCount === 0) {
+			if (dispatchedCount === 0) {
 				logger.info(
-					{ jobId: job.id, mediaSourceId, force },
+					{ jobId: job.id, parentId, mediaSourceId, force },
 					"No matching images found for bulk tagging",
 				);
 			}
 			break;
 		}
 
-		// Create jobs (bulk insert with batch chunking)
 		const jobRows: NewJob[] = results.map((row) => ({
 			type: "auto_tagging",
 			mediaSourceId: row.mediaSourceId,
+			parentId,
 			payload: {
 				mediaId: row.id,
-				mediaSourceId: row.mediaSourceId,
 				force,
 			},
 		}));
-		if (jobRows.length === 0) continue;
-		const BATCH_SIZE = 500;
-		for (let i = 0; i < jobRows.length; i += BATCH_SIZE) {
-			const chunk = jobRows.slice(i, i + BATCH_SIZE);
+		for (let i = 0; i < jobRows.length; i += CHILD_INSERT_CHUNK) {
+			const chunk = jobRows.slice(i, i + CHILD_INSERT_CHUNK);
 			await db.insert(jobs).values(chunk);
 		}
 
-		processedCount += results.length;
-		offset += batchSize;
+		dispatchedCount += results.length;
+		lastSeenId = results[results.length - 1].id;
 
-		// Log progress
 		logger.info(
-			{ jobId: job.id, processedCount },
+			{
+				jobId: job.id,
+				parentId,
+				dispatchedCount,
+			},
 			"Bulk tagging dispatch progress",
 		);
 	}
 
+	const jobRepo = services.getJobRepository();
+	const parentJob = await jobRepo.findById(parentId);
+	const parentPayload = batchParentPayloadSchema.parse(parentJob?.payload ?? {});
+	await jobRepo.update(parentId, {
+		payload: { ...parentPayload, total: dispatchedCount },
+	});
+
+	RealtimeEventBus.publishJob("job-progress", {
+		jobId: parentId,
+		processed: 0,
+		total: dispatchedCount,
+	});
+
 	logger.info(
-		{ jobId: job.id, processedCount },
+		{ jobId: job.id, parentId, dispatchedCount },
 		"Bulk tagging dispatch completed",
 	);
 }

--- a/apps/server/src/routes/manager.tsx
+++ b/apps/server/src/routes/manager.tsx
@@ -1,4 +1,3 @@
-import type { MediaSafe } from "@solid-imager/core/domain/media/schemas";
 import {
 	prefetchManagerPageQueries,
 	useManagerPage,
@@ -6,7 +5,6 @@ import {
 import { ManagerScreen } from "@solid-imager/ui/screens/manager-screen";
 import { useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
-import { MediaCardItem } from "~/components/media/media-card-item";
 import { useBatchJobEvents } from "~/hooks/use-batch-job-events";
 import {
 	scanBatchCcipTargets,
@@ -82,21 +80,5 @@ function ManagerPage() {
 		useBatchJobEvents,
 	});
 
-	return (
-		<ManagerScreen
-			manager={manager}
-			renderMediaCard={(
-				media: MediaSafe,
-				selected: boolean,
-				onToggle: (mediaId: string) => void,
-			) => (
-				<MediaCardItem
-					media={media}
-					onToggle={onToggle}
-					selectable
-					selected={selected}
-				/>
-			)}
-		/>
-	);
+	return <ManagerScreen manager={manager} />;
 }

--- a/apps/server/src/routes/manager.tsx
+++ b/apps/server/src/routes/manager.tsx
@@ -12,7 +12,7 @@ import {
 	scanBatchCcipTargets,
 	scanBatchTaggingTargets,
 	startBatchCcipExtraction,
-	startBatchTaggingWithIds,
+	startBatchTagging,
 } from "~/infrastructure/api-clients/ai-api";
 import {
 	createCharacter,
@@ -58,7 +58,7 @@ const managerActions = {
 	updateCharacter,
 	deleteCharacter,
 	scanBatchTaggingTargets,
-	startBatchTaggingWithIds,
+	startBatchTagging,
 	scanBatchCcipTargets,
 	startBatchCcipExtraction,
 	findDuplicateMedia,

--- a/apps/server/src/tests/unit/application/services/media-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/media-service.test.ts
@@ -114,6 +114,7 @@ describe("MediaService Unit Tests", () => {
 			markAsFailed: vi.fn(),
 			update: vi.fn(),
 			incrementProgress: vi.fn(),
+			incrementFailedCount: vi.fn(),
 		};
 		services.getJobRepository = vi.fn().mockReturnValue(mockJobRepository);
 

--- a/apps/server/src/tests/unit/infrastructure/jobs/ccip-jobs.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/ccip-jobs.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { IJobRepository } from "~/domain/repositories/job-repository";
-import { processCcipExtractionJob } from "~/infrastructure/jobs/ccip-jobs";
+import {
+	processBatchCcipDispatchJob,
+	processCcipExtractionJob,
+} from "~/infrastructure/jobs/ccip-jobs";
 
 const publishJob = vi.fn();
 const extract = vi.fn();
 const loggerError = vi.fn();
+const update = vi.fn();
+const incrementProgress = vi.fn();
+const incrementFailedCount = vi.fn();
 
 const jobRepository: IJobRepository = {
 	create: vi.fn(),
@@ -14,8 +20,11 @@ const jobRepository: IJobRepository = {
 	markAsInProgress: vi.fn(),
 	markAsCompleted: vi.fn(),
 	markAsFailed: vi.fn(),
-	update: vi.fn(),
-	incrementProgress: vi.fn(),
+	update: (...args: Parameters<typeof update>) => update(...args),
+	incrementProgress: (...args: Parameters<typeof incrementProgress>) =>
+		incrementProgress(...args),
+	incrementFailedCount: (...args: Parameters<typeof incrementFailedCount>) =>
+		incrementFailedCount(...args),
 	claimPending: vi.fn(),
 	requeueStaleInProgress: vi.fn(),
 };
@@ -45,29 +54,24 @@ vi.mock("~/infrastructure/logger", () => ({
 	},
 }));
 
+vi.mock("~/infrastructure/db", () => ({
+	db: {},
+}));
+
 describe("processCcipExtractionJob", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
 	it("publishes child completion and completes the parent once", async () => {
-		extract.mockResolvedValue({ record: { mediaId: "00000000-0000-4000-8000-000000000030" }, skipped: false });
-		vi.mocked(jobRepository.incrementProgress).mockResolvedValue(true);
-		vi.mocked(jobRepository.findById).mockResolvedValue({
-			id: "00000000-0000-4000-8000-000000000010",
-			type: "batch_ccip_parent",
-			mediaSourceId: "00000000-0000-4000-8000-000000000001",
-			status: "in_progress",
-			payload: {
-				total: 1,
-				processed: 1,
-				processedJobIds: ["00000000-0000-4000-8000-000000000020"],
-			},
-			result: null,
-			error: null,
-			createdAt: new Date(),
-			updatedAt: new Date(),
-			parentId: null,
+		extract.mockResolvedValue({
+			record: { mediaId: "00000000-0000-4000-8000-000000000030" },
+			skipped: false,
+		});
+		incrementProgress.mockResolvedValue({
+			processed: 1,
+			failed: 0,
+			total: 1,
 		});
 
 		await processCcipExtractionJob({
@@ -87,7 +91,7 @@ describe("processCcipExtractionJob", () => {
 		});
 
 		expect(extract).toHaveBeenCalled();
-		expect(jobRepository.incrementProgress).toHaveBeenCalledWith(
+		expect(incrementProgress).toHaveBeenCalledWith(
 			"00000000-0000-4000-8000-000000000010",
 			"00000000-0000-4000-8000-000000000020",
 		);
@@ -100,15 +104,18 @@ describe("processCcipExtractionJob", () => {
 			processed: 1,
 			total: 1,
 		});
-		expect(jobRepository.markAsCompleted).toHaveBeenCalledWith(
+		expect(update).toHaveBeenCalledWith(
 			"00000000-0000-4000-8000-000000000010",
-			{ success: true },
+			{ status: "completed" },
 		);
 	});
 
 	it("skips parent progress when the child was already counted", async () => {
-		extract.mockResolvedValue({ record: { mediaId: "00000000-0000-4000-8000-000000000031" }, skipped: false });
-		vi.mocked(jobRepository.incrementProgress).mockResolvedValue(false);
+		extract.mockResolvedValue({
+			record: { mediaId: "00000000-0000-4000-8000-000000000031" },
+			skipped: false,
+		});
+		incrementProgress.mockResolvedValue(null);
 
 		await processCcipExtractionJob({
 			id: "00000000-0000-4000-8000-000000000021",
@@ -127,6 +134,72 @@ describe("processCcipExtractionJob", () => {
 		});
 
 		expect(jobRepository.findById).not.toHaveBeenCalled();
-		expect(jobRepository.markAsCompleted).not.toHaveBeenCalled();
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("increments failed count and marks parent failed when all children are done", async () => {
+		extract.mockRejectedValue(new Error("ccip error"));
+		incrementFailedCount.mockResolvedValue({
+			processed: 0,
+			failed: 1,
+			total: 1,
+		});
+
+		await expect(
+			processCcipExtractionJob({
+				id: "00000000-0000-4000-8000-000000000020",
+				type: "extract_ccip_vector",
+				mediaSourceId: "00000000-0000-4000-8000-000000000001",
+				status: "in_progress",
+				payload: {
+					mediaId: "00000000-0000-4000-8000-000000000030",
+					force: false,
+				},
+				result: null,
+				error: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				parentId: "00000000-0000-4000-8000-000000000010",
+			}),
+		).rejects.toThrow("ccip error");
+
+		expect(incrementFailedCount).toHaveBeenCalledWith(
+			"00000000-0000-4000-8000-000000000010",
+			"00000000-0000-4000-8000-000000000020",
+		);
+		expect(update).toHaveBeenCalledWith(
+			"00000000-0000-4000-8000-000000000010",
+			{ status: "failed" },
+		);
+		expect(publishJob).toHaveBeenCalledWith("job-failed", {
+			jobId: "00000000-0000-4000-8000-000000000010",
+			error: "1 child job(s) failed",
+		});
+	});
+});
+
+describe("processBatchCcipDispatchJob", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("throws when parentId is missing", async () => {
+		await expect(
+			processBatchCcipDispatchJob({
+				id: "00000000-0000-4000-8000-000000000100",
+				type: "batch_ccip_dispatch",
+				mediaSourceId: "00000000-0000-4000-8000-000000000001",
+				status: "in_progress",
+				payload: {
+					mediaSourceId: "00000000-0000-4000-8000-000000000001",
+					force: false,
+				},
+				result: null,
+				error: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				parentId: null,
+			}),
+		).rejects.toThrow("batch_ccip_dispatch requires parentId");
 	});
 });

--- a/apps/server/src/tests/unit/infrastructure/jobs/job-worker.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/job-worker.test.ts
@@ -48,6 +48,7 @@ describe("JobWorker", () => {
 			markAsFailed: vi.fn().mockResolvedValue(undefined),
 			update: vi.fn(),
 			incrementProgress: vi.fn(),
+			incrementFailedCount: vi.fn(),
 		};
 
 		processor = vi.fn().mockResolvedValue(undefined);
@@ -199,6 +200,42 @@ describe("JobWorker", () => {
 		);
 
 		expect(processor).toHaveBeenCalledTimes(TotalExpectedCalls);
+	});
+
+	it("should use processor return value as the completed job result", async () => {
+		worker.updateConfig({
+			jobs: { concurrency: 1, aiConcurrency: 1, pollIntervalMs: 1000 },
+		} as AppConfig);
+
+		const customJob = {
+			id: "custom-1",
+			type: "custom",
+			status: "pending",
+		} as Job;
+
+		processor = vi.fn().mockResolvedValue({ success: true, parentProcessed: true });
+		worker = new JobWorker(jobRepo, processor);
+		worker.updateConfig({
+			jobs: { concurrency: 1, aiConcurrency: 1, pollIntervalMs: 1000 },
+		} as AppConfig);
+
+		(jobRepo.claimPending as any).mockImplementation(
+			(limit: number, options: any) => {
+				if (options?.excludeTypes) {
+					return Promise.resolve([customJob].slice(0, limit));
+				}
+				return Promise.resolve([]);
+			},
+		);
+
+		worker.start();
+		await vi.advanceTimersByTimeAsync(TimerDelay);
+
+		expect(processor).toHaveBeenCalledWith(customJob);
+		expect(jobRepo.markAsCompleted).toHaveBeenCalledWith("custom-1", {
+			success: true,
+			parentProcessed: true,
+		});
 	});
 
 	it("should requeue overlapping claimed LanceDB sync jobs per media source", async () => {

--- a/apps/server/src/tests/unit/infrastructure/jobs/tagging-jobs.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/tagging-jobs.test.ts
@@ -1,10 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { IJobRepository } from "~/domain/repositories/job-repository";
-import { processAutoTaggingJob } from "~/infrastructure/jobs/tagging-jobs";
+import {
+	processAutoTaggingJob,
+	processBulkTaggingDispatchJob,
+} from "~/infrastructure/jobs/tagging-jobs";
 
 const createIfUnique = vi.fn();
 const incrementProgress = vi.fn();
+const incrementFailedCount = vi.fn();
 const findById = vi.fn();
+const update = vi.fn();
 const publishJob = vi.fn();
 const getTagsForMedia = vi.fn();
 
@@ -17,9 +22,11 @@ const jobRepository: IJobRepository = {
 	markAsInProgress: vi.fn(),
 	markAsCompleted: vi.fn(),
 	markAsFailed: vi.fn(),
-	update: vi.fn(),
+	update: (...args: Parameters<typeof update>) => update(...args),
 	incrementProgress: (...args: Parameters<typeof incrementProgress>) =>
 		incrementProgress(...args),
+	incrementFailedCount: (...args: Parameters<typeof incrementFailedCount>) =>
+		incrementFailedCount(...args),
 	claimPending: vi.fn(),
 	requeueStaleInProgress: vi.fn(),
 };
@@ -58,9 +65,15 @@ vi.mock("~/infrastructure/logger", () => ({
 describe("processAutoTaggingJob", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		getTagsForMedia.mockResolvedValue({ general: {}, character: {}, ips: [], ips_mapping: {} });
+		getTagsForMedia.mockResolvedValue({
+			general: {},
+			character: {},
+			ips: [],
+			ips_mapping: {},
+		});
 		createIfUnique.mockResolvedValue(null);
-		incrementProgress.mockResolvedValue(false);
+		incrementProgress.mockResolvedValue(null);
+		incrementFailedCount.mockResolvedValue(null);
 	});
 
 	it("does not re-publish parent progress when the child was already counted", async () => {
@@ -86,5 +99,113 @@ describe("processAutoTaggingJob", () => {
 		);
 		expect(findById).not.toHaveBeenCalled();
 		expect(publishJob).not.toHaveBeenCalled();
+	});
+
+	it("publishes parent progress and completes the parent once", async () => {
+		incrementProgress.mockResolvedValue({
+			processed: 1,
+			failed: 0,
+			total: 1,
+		});
+
+		await processAutoTaggingJob({
+			id: "00000000-0000-4000-8000-000000000020",
+			type: "auto_tagging",
+			mediaSourceId: "00000000-0000-4000-8000-000000000001",
+			status: "in_progress",
+			payload: {
+				mediaId: "00000000-0000-4000-8000-000000000030",
+				force: false,
+			},
+			result: null,
+			error: null,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			parentId: "00000000-0000-4000-8000-000000000010",
+		});
+
+		expect(incrementProgress).toHaveBeenCalledWith(
+			"00000000-0000-4000-8000-000000000010",
+			"00000000-0000-4000-8000-000000000020",
+		);
+		expect(publishJob).toHaveBeenCalledWith("job-progress", {
+			jobId: "00000000-0000-4000-8000-000000000010",
+			processed: 1,
+			total: 1,
+		});
+		expect(update).toHaveBeenCalledWith(
+			"00000000-0000-4000-8000-000000000010",
+			{ status: "completed" },
+		);
+		expect(publishJob).toHaveBeenCalledWith("job-completed", {
+			jobId: "00000000-0000-4000-8000-000000000010",
+			message: "Batch tagging completed",
+		});
+	});
+
+	it("increments failed count and marks parent failed when all children are done", async () => {
+		getTagsForMedia.mockRejectedValue(new Error("tagging error"));
+		incrementFailedCount.mockResolvedValue({
+			processed: 0,
+			failed: 1,
+			total: 1,
+		});
+
+		await expect(
+			processAutoTaggingJob({
+				id: "00000000-0000-4000-8000-000000000020",
+				type: "auto_tagging",
+				mediaSourceId: "00000000-0000-4000-8000-000000000001",
+				status: "in_progress",
+				payload: {
+					mediaId: "00000000-0000-4000-8000-000000000030",
+					force: false,
+				},
+				result: null,
+				error: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				parentId: "00000000-0000-4000-8000-000000000010",
+			}),
+		).rejects.toThrow("tagging error");
+
+		expect(incrementFailedCount).toHaveBeenCalledWith(
+			"00000000-0000-4000-8000-000000000010",
+			"00000000-0000-4000-8000-000000000020",
+		);
+		expect(update).toHaveBeenCalledWith(
+			"00000000-0000-4000-8000-000000000010",
+			{ status: "failed" },
+		);
+		expect(publishJob).toHaveBeenCalledWith("job-failed", {
+			jobId: "00000000-0000-4000-8000-000000000010",
+			error: "1 child job(s) failed",
+		});
+	});
+});
+
+describe("processBulkTaggingDispatchJob", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("throws when parentId is missing", async () => {
+		await expect(
+			processBulkTaggingDispatchJob({
+				id: "00000000-0000-4000-8000-000000000100",
+				type: "bulk_tagging_dispatch",
+				mediaSourceId: "00000000-0000-4000-8000-000000000001",
+				status: "in_progress",
+				payload: {
+					mediaSourceId: "00000000-0000-4000-8000-000000000001",
+					force: false,
+				},
+				result: null,
+				error: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				parentId: null,
+			}),
+		).rejects.toThrow("bulk_tagging_dispatch requires parentId");
 	});
 });

--- a/apps/tauri/src/infrastructure/api-clients/ai-api.ts
+++ b/apps/tauri/src/infrastructure/api-clients/ai-api.ts
@@ -7,10 +7,23 @@ export function scanBatchTaggingTargets(params: {
 	return client.ai.scanBatchTaggingTargets(params);
 }
 
-export function startBatchTaggingWithIds(params: {
+export function startBatchTagging(params: {
 	force?: boolean;
 	mediaSourceId?: string;
-	mediaIds: string[];
 }) {
-	return client.ai.startBatchTaggingWithIds(params);
+	return client.ai.startBatchTagging(params);
+}
+
+export function scanBatchCcipTargets(params: {
+	force?: boolean;
+	mediaSourceId?: string;
+}) {
+	return client.ai.scanBatchCcipTargets(params);
+}
+
+export function startBatchCcipExtraction(params: {
+	force?: boolean;
+	mediaSourceId?: string;
+}) {
+	return client.ai.startBatchCcipExtraction(params);
 }

--- a/apps/tauri/src/routes/manager.tsx
+++ b/apps/tauri/src/routes/manager.tsx
@@ -10,7 +10,7 @@ import { MediaCardItem } from "~/components/media/media-card-item";
 import { useBatchJobEvents } from "~/hooks/use-batch-job-events";
 import {
 	scanBatchTaggingTargets,
-	startBatchTaggingWithIds,
+	startBatchTagging,
 } from "~/infrastructure/api-clients/ai-api";
 import {
 	createCharacter,
@@ -57,13 +57,12 @@ const managerActions = {
 	updateCharacter,
 	deleteCharacter,
 	scanBatchTaggingTargets,
-	startBatchTaggingWithIds,
+	startBatchTagging,
 	scanBatchCcipTargets: (input: { force: boolean; mediaSourceId?: string }) =>
 		client.ai.scanBatchCcipTargets(input),
 	startBatchCcipExtraction: (input: {
 		force: boolean;
 		mediaSourceId?: string;
-		mediaIds: string[];
 	}) => client.ai.startBatchCcipExtraction(input),
 	findDuplicateMedia,
 	bulkDeleteMedia,

--- a/apps/tauri/src/routes/manager.tsx
+++ b/apps/tauri/src/routes/manager.tsx
@@ -1,4 +1,3 @@
-import type { MediaSafe } from "@solid-imager/core/domain/media/schemas";
 import {
 	prefetchManagerPageQueries,
 	useManagerPage,
@@ -6,10 +5,11 @@ import {
 import { ManagerScreen } from "@solid-imager/ui/screens/manager-screen";
 import { useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
-import { MediaCardItem } from "~/components/media/media-card-item";
 import { useBatchJobEvents } from "~/hooks/use-batch-job-events";
 import {
+	scanBatchCcipTargets,
 	scanBatchTaggingTargets,
+	startBatchCcipExtraction,
 	startBatchTagging,
 } from "~/infrastructure/api-clients/ai-api";
 import {
@@ -31,7 +31,6 @@ import {
 	deleteProject,
 	updateProject,
 } from "~/infrastructure/api-clients/projects-api";
-import { client } from "~/orpc-client";
 import {
 	allCharactersQueryOptions,
 	allIpsQueryOptions,
@@ -58,12 +57,8 @@ const managerActions = {
 	deleteCharacter,
 	scanBatchTaggingTargets,
 	startBatchTagging,
-	scanBatchCcipTargets: (input: { force: boolean; mediaSourceId?: string }) =>
-		client.ai.scanBatchCcipTargets(input),
-	startBatchCcipExtraction: (input: {
-		force: boolean;
-		mediaSourceId?: string;
-	}) => client.ai.startBatchCcipExtraction(input),
+	scanBatchCcipTargets,
+	startBatchCcipExtraction,
 	findDuplicateMedia,
 	bulkDeleteMedia,
 };
@@ -85,21 +80,5 @@ function ManagerPage() {
 		useBatchJobEvents,
 	});
 
-	return (
-		<ManagerScreen
-			manager={manager}
-			renderMediaCard={(
-				media: MediaSafe,
-				selected: boolean,
-				onToggle: (mediaId: string) => void,
-			) => (
-				<MediaCardItem
-					media={media}
-					onToggle={onToggle}
-					selectable
-					selected={selected}
-				/>
-			)}
-		/>
-	);
+	return <ManagerScreen manager={manager} />;
 }

--- a/packages/core/src/domain/contract/ai.contract.ts
+++ b/packages/core/src/domain/contract/ai.contract.ts
@@ -1,9 +1,9 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
-import { mediaSafeSchema } from "../media/schemas";
 import {
 	batchCcipExtractionRequestSchema,
 	batchTaggingRequestSchema,
+	batchTargetCountResponseSchema,
 	ccipDifferenceRequestSchema,
 	ccipDistancesRequestSchema,
 	ccipDistancesResponseSchema,
@@ -11,6 +11,7 @@ import {
 	ccipFeatureRequestSchema,
 	ccipVectorStatusSchema,
 	detectAndCropResponseSchema,
+	startBatchTaggingResponseSchema,
 	startCcipExtractionResponseSchema,
 	taggingResponseSchema,
 	tagImageRequestSchema,
@@ -52,37 +53,19 @@ export const aiContract = {
 
 	scanBatchCcipTargets: oc
 		.input(batchCcipExtractionRequestSchema)
-		.output(z.array(mediaSafeSchema)),
+		.output(batchTargetCountResponseSchema),
 
 	startBatchCcipExtraction: oc
-		.input(
-			batchCcipExtractionRequestSchema.extend({
-				mediaIds: z.array(z.string().uuid()).min(1),
-			}),
-		)
+		.input(batchCcipExtractionRequestSchema)
 		.output(startCcipExtractionResponseSchema),
 
 	scanBatchTaggingTargets: oc
 		.input(batchTaggingRequestSchema)
-		.output(z.array(mediaSafeSchema)),
+		.output(batchTargetCountResponseSchema),
 
-	batchTagging: oc
+	startBatchTagging: oc
 		.input(batchTaggingRequestSchema)
-		.output(z.object({ success: z.boolean(), message: z.string() })),
-
-	startBatchTaggingWithIds: oc
-		.input(
-			batchTaggingRequestSchema.extend({
-				mediaIds: z.array(z.string()),
-			}),
-		)
-		.output(
-			z.object({
-				success: z.boolean(),
-				message: z.string(),
-				jobId: z.string(),
-			}),
-		),
+		.output(startBatchTaggingResponseSchema),
 
 	detectAndCropCharacters: oc
 		.input(

--- a/packages/core/src/domain/repositories/job-repository.ts
+++ b/packages/core/src/domain/repositories/job-repository.ts
@@ -26,6 +26,12 @@ export type NewJob = {
 	parentId?: string | null;
 };
 
+export type BatchProgress = {
+	processed: number;
+	failed: number;
+	total: number;
+};
+
 export type IJobRepository = {
 	create(job: NewJob): Promise<Job>;
 	createIfUnique(job: NewJob): Promise<Job | null>;
@@ -42,7 +48,14 @@ export type IJobRepository = {
 	markAsCompleted(id: string, result?: unknown): Promise<void>;
 	markAsFailed(id: string, error: string): Promise<void>;
 	update(id: string, data: Partial<Job>): Promise<void>;
-	incrementProgress(id: string, progressKey?: string): Promise<boolean>;
+	incrementProgress(
+		id: string,
+		progressKey?: string,
+	): Promise<BatchProgress | null>;
+	incrementFailedCount(
+		id: string,
+		progressKey?: string,
+	): Promise<BatchProgress | null>;
 	claimPending(
 		limit: number,
 		options?: {

--- a/packages/core/src/domain/tagging/schemas.ts
+++ b/packages/core/src/domain/tagging/schemas.ts
@@ -141,3 +141,21 @@ export const startBatchTaggingResponseSchema = z.object({
 export type StartBatchTaggingResponse = z.infer<
 	typeof startBatchTaggingResponseSchema
 >;
+
+export const batchTargetCountResponseSchema = z.object({
+	count: z.number().int().nonnegative(),
+});
+
+export type BatchTargetCountResponse = z.infer<
+	typeof batchTargetCountResponseSchema
+>;
+
+export const batchParentPayloadSchema = z.object({
+	total: z.number().int().nonnegative(),
+	processed: z.number().int().nonnegative(),
+	failed: z.number().int().nonnegative(),
+	mediaSourceId: z.string().optional(),
+	force: z.boolean().optional(),
+});
+
+export type BatchParentPayload = z.infer<typeof batchParentPayloadSchema>;

--- a/packages/db/src/repositories/job-repository.ts
+++ b/packages/db/src/repositories/job-repository.ts
@@ -591,11 +591,12 @@ async function incrementBatchCount(
 	progressKey?: string,
 ): Promise<BatchProgress | null> {
 	const normalizedPayload = normalizedPayloadExpression();
+	const key = progressKey ?? null;
 	const raw: unknown = await getExecutor().execute(sql`
 		WITH updated_child AS (
 			UPDATE ${jobs}
 			SET result = COALESCE(result, '{}'::jsonb) || '{"parentProcessed": true}'::jsonb
-			WHERE id = ${progressKey ?? null}::uuid
+			WHERE id = ${key}::uuid
 				AND parent_id = ${id}
 				AND (result IS NULL OR result->>'parentProcessed' IS DISTINCT FROM 'true')
 			RETURNING id
@@ -608,7 +609,7 @@ async function incrementBatchCount(
 		),
 		updated_at = NOW()
 		WHERE id = ${id}
-			AND (${progressKey} IS NULL OR EXISTS (SELECT 1 FROM updated_child))
+			AND (${key} IS NULL OR EXISTS (SELECT 1 FROM updated_child))
 		RETURNING payload
 	`);
 	const rows = extractRows(raw);

--- a/packages/db/src/repositories/job-repository.ts
+++ b/packages/db/src/repositories/job-repository.ts
@@ -1,4 +1,6 @@
+import { batchParentPayloadSchema } from "@solid-imager/core/domain/tagging/schemas";
 import type {
+	BatchProgress,
 	IJobRepository,
 	Job,
 	NewJob,
@@ -262,42 +264,15 @@ export function createJobRepository(
 		async incrementProgress(
 			id: string,
 			progressKey?: string,
-		): Promise<boolean> {
-			const normalizedPayload = sql`COALESCE(
-				CASE
-					WHEN jsonb_typeof(payload) = 'string' THEN (payload#>>'{}')::jsonb
-					ELSE payload
-				END,
-				'{}'::jsonb
-			)`;
-			const processedJobIds = sql`COALESCE(${normalizedPayload}->'processedJobIds', '[]'::jsonb)`;
-			const result: unknown = await db().execute(
-				progressKey
-					? sql`UPDATE ${jobs}
-						SET payload = jsonb_set(
-							jsonb_set(
-								${normalizedPayload},
-								'{processed}',
-								(COALESCE((${normalizedPayload}->>'processed'), '0')::int + 1)::text::jsonb
-							),
-							'{processedJobIds}',
-							${processedJobIds} || jsonb_build_array(${progressKey}::text)
-						),
-						updated_at = NOW()
-						WHERE id = ${id}
-							AND NOT (${processedJobIds} @> jsonb_build_array(${progressKey}::text))
-						RETURNING id`
-					: sql`UPDATE ${jobs}
-						SET payload = jsonb_set(
-							${normalizedPayload},
-							'{processed}',
-							(COALESCE((${normalizedPayload}->>'processed'), '0')::int + 1)::text::jsonb
-						),
-						updated_at = NOW()
-						WHERE id = ${id}
-						RETURNING id`,
-			);
-			return extractRows(result).length > 0;
+		): Promise<BatchProgress | null> {
+			return incrementBatchCount(db, id, "processed", progressKey);
+		},
+
+		async incrementFailedCount(
+			id: string,
+			progressKey?: string,
+		): Promise<BatchProgress | null> {
+			return incrementBatchCount(db, id, "failed", progressKey);
 		},
 
 		async claimPending(
@@ -597,4 +572,60 @@ function extractStringArrayOrSingle(value: unknown): string[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizedPayloadExpression() {
+	return sql`COALESCE(
+		CASE
+			WHEN jsonb_typeof(payload) = 'string' THEN (payload#>>'{}')::jsonb
+			ELSE payload
+		END,
+		'{}'::jsonb
+	)`;
+}
+
+async function incrementBatchCount(
+	getExecutor: () => DrizzleExecutor,
+	id: string,
+	field: "processed" | "failed",
+	progressKey?: string,
+): Promise<BatchProgress | null> {
+	const normalizedPayload = normalizedPayloadExpression();
+	const raw: unknown = await getExecutor().execute(sql`
+		WITH updated_child AS (
+			UPDATE ${jobs}
+			SET result = COALESCE(result, '{}'::jsonb) || '{"parentProcessed": true}'::jsonb
+			WHERE id = ${progressKey ?? null}::uuid
+				AND parent_id = ${id}
+				AND (result IS NULL OR result->>'parentProcessed' IS DISTINCT FROM 'true')
+			RETURNING id
+		)
+		UPDATE ${jobs}
+		SET payload = jsonb_set(
+			${normalizedPayload},
+			${`{${field}}`},
+			(COALESCE((${normalizedPayload}->>${field}), '0')::int + 1)::text::jsonb
+		),
+		updated_at = NOW()
+		WHERE id = ${id}
+			AND (${progressKey} IS NULL OR EXISTS (SELECT 1 FROM updated_child))
+		RETURNING payload
+	`);
+	const rows = extractRows(raw);
+	if (rows.length === 0) {
+		return null;
+	}
+	const payload = parseJsonColumn(
+		(rows[0] as { payload?: unknown }).payload,
+		"payload",
+	);
+	const parsed = batchParentPayloadSchema.safeParse(payload);
+	if (!parsed.success) {
+		return null;
+	}
+	return {
+		processed: parsed.data.processed,
+		failed: parsed.data.failed,
+		total: parsed.data.total,
+	};
 }

--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -430,6 +430,9 @@ export function useManagerPage(
 				toast.success(result.message);
 				setTaggingStatus("Batch CCIP extraction in progress...");
 				setActiveJobId(result.jobId);
+			} else {
+				toast.error("Failed to start batch CCIP extraction.");
+				setTaggingStatus("Failed to start batch CCIP extraction.");
 			}
 		} catch (error) {
 			toast.error(`Error: ${getErrorMessage(error)}`);

--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -1,9 +1,6 @@
 import type { Character } from "@solid-imager/core/domain/characters/schemas";
 import type { Ip } from "@solid-imager/core/domain/ips/schemas";
-import type {
-	DuplicateGroup,
-	MediaSafe,
-} from "@solid-imager/core/domain/media/schemas";
+import type { DuplicateGroup } from "@solid-imager/core/domain/media/schemas";
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type {
 	JobCompletedEvent,
@@ -68,20 +65,18 @@ export type ManagerPageActions = {
 	scanBatchTaggingTargets: (input: {
 		force: boolean;
 		mediaSourceId?: string;
-	}) => Promise<MediaSafe[]>;
-	startBatchTaggingWithIds: (input: {
+	}) => Promise<{ count: number }>;
+	startBatchTagging: (input: {
 		force: boolean;
 		mediaSourceId?: string;
-		mediaIds: string[];
 	}) => Promise<StartBatchTaggingResult>;
 	scanBatchCcipTargets: (input: {
 		force: boolean;
 		mediaSourceId?: string;
-	}) => Promise<MediaSafe[]>;
+	}) => Promise<{ count: number }>;
 	startBatchCcipExtraction: (input: {
 		force: boolean;
 		mediaSourceId?: string;
-		mediaIds: string[];
 	}) => Promise<StartBatchTaggingResult>;
 	findDuplicateMedia: (
 		mediaSourceId?: string,
@@ -114,7 +109,6 @@ export type UseManagerPageOptions = {
 		handlers: ManagerJobHandlers,
 	) => void;
 	onBatchTaggingStart?: (result: StartBatchTaggingResult) => void;
-	itemsPerPage?: number;
 };
 
 export async function prefetchManagerPageQueries(
@@ -152,15 +146,8 @@ export type UseManagerPageResult = {
 	forceRetag: Accessor<boolean>;
 	setForceRetag: Setter<boolean>;
 	taggingStatus: Accessor<string | null>;
-	scannedMedia: Accessor<MediaSafe[]>;
-	selectedMedia: Accessor<Set<string>>;
 	jobProgress: Accessor<JobProgressEvent | null>;
 	activeJobId: Accessor<string | null>;
-	currentPage: Accessor<number>;
-	setCurrentPage: Setter<number>;
-	itemsPerPage: number;
-	totalPages: Accessor<number>;
-	paginatedMedia: Accessor<MediaSafe[]>;
 	sources: Accessor<SafeMediaSource[]>;
 	ips: Accessor<Ip[]>;
 	getActiveItems: Accessor<ManagerEntity[]>;
@@ -171,8 +158,6 @@ export type UseManagerPageResult = {
 	handleScan: () => Promise<void>;
 	handleStartBatchTagging: () => Promise<void>;
 	handleStartBatchCcipExtraction: () => Promise<void>;
-	toggleMediaSelection: (mediaId: string) => void;
-	toggleSelectAll: () => void;
 	jobHandlers: ManagerJobHandlers;
 	// Duplicates tab
 	duplicateSourceId: Accessor<string | undefined>;
@@ -225,7 +210,6 @@ export function useManagerPage(
 		queryOptions,
 		useBatchJobEvents,
 		onBatchTaggingStart,
-		itemsPerPage = 50,
 	} = options;
 	const projects = createQuery<Project[]>(() => queryOptions.projects());
 	const ipsQuery = createQuery<Ip[]>(() => queryOptions.ips());
@@ -261,15 +245,10 @@ export function useManagerPage(
 	>(undefined);
 	const [forceRetag, setForceRetag] = createSignal(false);
 	const [taggingStatus, setTaggingStatus] = createSignal<string | null>(null);
-	const [scannedMedia, setScannedMedia] = createSignal<MediaSafe[]>([]);
-	const [selectedMedia, setSelectedMedia] = createSignal<Set<string>>(
-		new Set(),
-	);
 	const [jobProgress, setJobProgress] = createSignal<JobProgressEvent | null>(
 		null,
 	);
 	const [activeJobId, setActiveJobId] = createSignal<string | null>(null);
-	const [currentPage, setCurrentPage] = createSignal(1);
 
 	createEffect(() => {
 		const tab = activeTab();
@@ -277,10 +256,7 @@ export function useManagerPage(
 			return;
 		}
 
-		setScannedMedia([]);
-		setSelectedMedia(new Set<string>());
 		setTaggingStatus(null);
-		setCurrentPage(1);
 	});
 
 	// Duplicates state
@@ -316,18 +292,7 @@ export function useManagerPage(
 		}
 	};
 
-	const totalPages = () => Math.ceil(scannedMedia().length / itemsPerPage);
 
-	const paginatedMedia = () => {
-		const start = (currentPage() - 1) * itemsPerPage;
-		return scannedMedia().slice(start, start + itemsPerPage);
-	};
-
-	createEffect(() => {
-		if (scannedMedia().length > 0) {
-			setCurrentPage(1);
-		}
-	});
 
 	const invalidateActive = () => {
 		const tab = activeCrudTab(activeTab());
@@ -430,7 +395,6 @@ export function useManagerPage(
 
 		try {
 			setTaggingStatus("Scanning...");
-			setScannedMedia([]);
 			const result =
 				scanTab === "vectors"
 					? await actions.scanBatchCcipTargets({
@@ -444,9 +408,7 @@ export function useManagerPage(
 			if (activeTab() !== scanTab) {
 				return;
 			}
-			setScannedMedia(result);
-			setSelectedMedia(new Set(result.map((item) => item.id)));
-			setTaggingStatus(`${result.length} items found.`);
+			setTaggingStatus(`${result.count} items found.`);
 		} catch (error) {
 			if (activeTab() !== scanTab) {
 				return;
@@ -457,24 +419,17 @@ export function useManagerPage(
 	};
 
 	const handleStartBatchCcipExtraction = async () => {
-		if (selectedMedia().size === 0) {
-			toast.error("No media selected");
-			return;
-		}
 		try {
 			setTaggingStatus("Starting...");
 			setJobProgress(null);
 			const result = await actions.startBatchCcipExtraction({
 				force: forceRetag(),
 				mediaSourceId: selectedSourceId(),
-				mediaIds: Array.from(selectedMedia()),
 			});
 			if (result.success && result.jobId) {
 				toast.success(result.message);
 				setTaggingStatus("Batch CCIP extraction in progress...");
 				setActiveJobId(result.jobId);
-				setScannedMedia([]);
-				setSelectedMedia(new Set<string>());
 			}
 		} catch (error) {
 			toast.error(`Error: ${getErrorMessage(error)}`);
@@ -483,26 +438,18 @@ export function useManagerPage(
 	};
 
 	const handleStartBatchTagging = async () => {
-		if (selectedMedia().size === 0) {
-			toast.error("No media selected");
-			return;
-		}
-
 		try {
 			setTaggingStatus("Starting...");
 			setJobProgress(null);
-			const result = await actions.startBatchTaggingWithIds({
+			const result = await actions.startBatchTagging({
 				force: forceRetag(),
 				mediaSourceId: selectedSourceId(),
-				mediaIds: Array.from(selectedMedia()),
 			});
 			if (result.success && result.jobId) {
 				onBatchTaggingStart?.(result);
 				toast.success(result.message);
 				setTaggingStatus("Batch tagging in progress...");
 				setActiveJobId(result.jobId);
-				setScannedMedia([]);
-				setSelectedMedia(new Set<string>());
 			} else {
 				toast.error("Failed to start batch tagging.");
 				setTaggingStatus("Failed to start batch tagging.");
@@ -510,26 +457,6 @@ export function useManagerPage(
 		} catch (error) {
 			toast.error(`Error: ${getErrorMessage(error)}`);
 			setTaggingStatus(`Error: ${getErrorMessage(error)}`);
-		}
-	};
-
-	const toggleMediaSelection = (mediaId: string) => {
-		setSelectedMedia((previous) => {
-			const next = new Set(previous);
-			if (next.has(mediaId)) {
-				next.delete(mediaId);
-			} else {
-				next.add(mediaId);
-			}
-			return next;
-		});
-	};
-
-	const toggleSelectAll = () => {
-		if (selectedMedia().size === scannedMedia().length) {
-			setSelectedMedia(new Set<string>());
-		} else {
-			setSelectedMedia(new Set(scannedMedia().map((item) => item.id)));
 		}
 	};
 
@@ -755,15 +682,8 @@ export function useManagerPage(
 		forceRetag,
 		setForceRetag,
 		taggingStatus,
-		scannedMedia,
-		selectedMedia,
 		jobProgress,
 		activeJobId,
-		currentPage,
-		setCurrentPage,
-		itemsPerPage,
-		totalPages,
-		paginatedMedia,
 		sources,
 		ips,
 		getActiveItems,
@@ -774,8 +694,6 @@ export function useManagerPage(
 		handleScan,
 		handleStartBatchTagging,
 		handleStartBatchCcipExtraction,
-		toggleMediaSelection,
-		toggleSelectAll,
 		jobHandlers,
 		// Duplicates
 		duplicateSourceId,

--- a/packages/ui/src/media-sidebar.tsx
+++ b/packages/ui/src/media-sidebar.tsx
@@ -18,7 +18,6 @@ import {
 	createSignal,
 	For,
 	type JSX,
-	onMount,
 	Show,
 } from "solid-js";
 import { AssociationManager } from "./association-manager";

--- a/packages/ui/src/screens/manager-screen.tsx
+++ b/packages/ui/src/screens/manager-screen.tsx
@@ -49,7 +49,6 @@ import type {
 } from "../hooks/use-manager-page";
 import { Input } from "../input";
 import { Label } from "../label";
-import { PaginationControls } from "../pagination-controls";
 import { Progress } from "../progress";
 import {
 	Select,
@@ -223,7 +222,6 @@ export function ManagerScreen(props: ManagerScreenProps) {
 							<div class="flex items-center gap-x-2 pt-2">
 								<Button onClick={manager().handleScan}>Scan for Targets</Button>
 								<Button
-									disabled={manager().scannedMedia().length === 0}
 									onClick={
 										manager().activeTab() === "vectors"
 											? manager().handleStartBatchCcipExtraction
@@ -232,8 +230,7 @@ export function ManagerScreen(props: ManagerScreenProps) {
 								>
 									{manager().activeTab() === "vectors"
 										? "Start Vector Extraction"
-										: "Start Batch Tagging"}{" "}
-									({manager().selectedMedia().size})
+										: "Start Batch Tagging"}
 								</Button>
 							</div>
 
@@ -253,53 +250,6 @@ export function ManagerScreen(props: ManagerScreenProps) {
 							</Show>
 						</CardContent>
 					</Card>
-
-					<Show when={manager().scannedMedia().length > 0}>
-						<div class="mt-4">
-							<div class="mb-2 flex items-center justify-between">
-								<h3 class="font-bold text-lg">
-									Scanned Media ({manager().scannedMedia().length})
-								</h3>
-								<div class="flex items-center gap-2">
-									<PaginationControls
-										currentPage={manager().currentPage()}
-										onPageChange={manager().setCurrentPage}
-										totalPages={manager().totalPages()}
-									/>
-									<Button
-										onClick={manager().toggleSelectAll}
-										size="sm"
-										variant="outline"
-									>
-										{manager().selectedMedia().size ===
-										manager().scannedMedia().length
-											? "Deselect All"
-											: "Select All"}
-									</Button>
-								</div>
-							</div>
-
-							<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-								<For each={manager().paginatedMedia()}>
-									{(media) =>
-										props.renderMediaCard(
-											media,
-											manager().selectedMedia().has(media.id),
-											manager().toggleMediaSelection,
-										)
-									}
-								</For>
-							</div>
-
-							<div class="mt-4 flex justify-center">
-								<PaginationControls
-									currentPage={manager().currentPage()}
-									onPageChange={manager().setCurrentPage}
-									totalPages={manager().totalPages()}
-								/>
-							</div>
-						</div>
-					</Show>
 				</div>
 			</Show>
 

--- a/packages/ui/src/screens/manager-screen.tsx
+++ b/packages/ui/src/screens/manager-screen.tsx
@@ -1,9 +1,5 @@
 import type { Ip } from "@solid-imager/core/domain/ips/schemas";
-import type {
-	DuplicateGroup,
-	MediaSafe,
-} from "@solid-imager/core/domain/media/schemas";
-import type { JSX } from "solid-js";
+import type { DuplicateGroup } from "@solid-imager/core/domain/media/schemas";
 import { For, Show } from "solid-js";
 import {
 	AlertDialog,
@@ -60,11 +56,6 @@ import {
 
 export type ManagerScreenProps = {
 	manager: UseManagerPageResult;
-	renderMediaCard: (
-		media: MediaSafe,
-		selected: boolean,
-		onToggle: (mediaId: string) => void,
-	) => JSX.Element;
 };
 
 const managerTabs: ManagerEntityType[] = [


### PR DESCRIPTION
## 概要
Issue #569 に対応し、大規模tagging/CCIP batch開始時の30秒timeoutやPostgreSQL parameter上限問題を解消します。

## 変更内容
- scan APIを対象件数(count)のみ返すように変更
- start APIをfilter/source/forceのみ受け取り、親job + dispatcher jobを即時作成
- dispatcherがkeyset paginationで500件ずつ子jobをbulk INSERT
- 親job payloadからprocessedJobIdsを廃止し、processed/failed countのみ管理
- 子job resultにparentProcessedフラグを書き、再実行時の二重カウントを防止
- CCIP用 batch_ccip_dispatch job typeを追加
- 進捗・失敗を構造化ログとrealtime eventへ出力
- UIからscan結果の選択グリッドを廃止
 
## 技術詳細
- DBスキーマ変更は行っていません
- 単体テストを追加・更新済み
- OpenAPI仕様書を再生成済み

Closes #569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * タグ付け・CCIP抽出のAIバッチ開始を「媒体ソース単位」で開始できるようになりました。
* **改善**
  * 対象スキャンは一覧ではなく件数で確認でき、進捗・完了/失敗の反映がより正確になりました。
  * バッチ処理の開始方式を整理し、重複抑止と集計を安定化しました。
  * AI連携APIのバッチ開始エンドポイント/入力仕様を更新しました。
* **UI変更**
  * 管理画面からスキャン結果の表示やページング、選択操作の一部を見直しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->