### PR TITLE
perf(web): Selective SSRとQuery hydrationを再設計

### DIFF
--- a/apps/server/src/router.tsx
+++ b/apps/server/src/router.tsx
@@ -7,8 +7,9 @@ import {
 	RoutePendingScreen,
 } from "@solid-imager/ui/router-status";
 import { NotFoundScreen } from "@solid-imager/ui/screens/not-found-screen";
-import { QueryClient, QueryClientProvider } from "@tanstack/solid-query";
+import { QueryClient } from "@tanstack/solid-query";
 import { createRouter as createTanStackRouter } from "@tanstack/solid-router";
+import { setupRouterSsrQueryIntegration } from "@tanstack/solid-router-ssr-query";
 import { isServer } from "solid-js/web";
 import { routeTree } from "#route-tree";
 import type { logger as LoggerInstance } from "./infrastructure/logger";
@@ -18,33 +19,32 @@ function createAppQueryClient(): QueryClient {
 }
 
 let serverLogger: typeof LoggerInstance | null = null;
+let serverInitializationPromise: Promise<void> | undefined;
 
-if (isServer) {
-	import("./infrastructure/logger")
-		.then(({ logger }) => {
+async function initializeServerDependencies(): Promise<void> {
+	if (!isServer) {
+		return;
+	}
+
+	if (!serverInitializationPromise) {
+		serverInitializationPromise = Promise.all([
+			import("./infrastructure/logger"),
+			import("./infrastructure/bootstrap"),
+		]).then(([{ logger }, { initServices }]) => {
 			serverLogger = logger;
-		})
-		.catch(() => {});
-
-	// Initialize services on server startup.
-	// We don't use top-level await here to avoid module format issues with CJS dependencies.
-	import("./infrastructure/bootstrap")
-		.then(({ initServices }) => {
 			initServices();
-		})
-		.catch((err) => {
-			if (serverLogger) {
-				serverLogger.error({ err }, "[Router] Failed to initialize services");
-			} else {
-				console.error("[Router] Failed to initialize services:", err);
-			}
 		});
+	}
+
+	await serverInitializationPromise;
 }
 
 let clientQueryClient: QueryClient | undefined;
 
-export function getRouter() {
+export async function getRouter() {
 	try {
+		await initializeServerDependencies();
+
 		if (!isServer && !clientQueryClient) {
 			clientQueryClient = createAppQueryClient();
 		}
@@ -54,7 +54,7 @@ export function getRouter() {
 				? createAppQueryClient()
 				: clientQueryClient;
 
-		return createTanStackRouter({
+		const router = createTanStackRouter({
 			routeTree,
 			context: { queryClient },
 			scrollRestoration: true,
@@ -68,16 +68,13 @@ export function getRouter() {
 			defaultNotFoundComponent: NotFoundScreen,
 			defaultPendingMs: ROUTE_PENDING_DELAY_MS,
 			defaultPendingMinMs: ROUTE_PENDING_MIN_DURATION_MS,
-			Wrap: (props) => (
-				<QueryClientProvider client={queryClient}>
-					{props.children}
-				</QueryClientProvider>
-			),
 		});
+		setupRouterSsrQueryIntegration({ router, queryClient });
+		return router;
 	} catch (error) {
 		if (isServer && serverLogger) {
 			serverLogger.error({ err: error }, "[Router] Error creating router");
-		} else {
+		} else if (!isServer) {
 			console.error("[Router] Error creating router:", error);
 		}
 		throw error;
@@ -86,6 +83,6 @@ export function getRouter() {
 
 declare module "@tanstack/solid-router" {
 	interface Register {
-		router: ReturnType<typeof getRouter>;
+		router: Awaited<ReturnType<typeof getRouter>>;
 	}
 }

--- a/apps/server/src/routes/__root.tsx
+++ b/apps/server/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import {
 	Outlet,
 	Scripts,
 } from "@tanstack/solid-router";
+import { createSignal, onMount } from "solid-js";
 import { HydrationScript } from "solid-js/web";
 import styleCss from "~/app.css?url";
 import { ApiActivityIndicator } from "~/components/api-activity-indicator";
@@ -37,8 +38,13 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 });
 
 function RootComponent() {
+	const [isHydrated, setIsHydrated] = createSignal(false);
+	onMount(() => {
+		setIsHydrated(true);
+	});
+
 	return (
-		<html lang="ja">
+		<html data-hydrated={isHydrated() ? "true" : "false"} lang="ja">
 			<head>
 				<HydrationScript />
 				<HeadContent />

--- a/apps/server/src/routes/config.tsx
+++ b/apps/server/src/routes/config.tsx
@@ -1,44 +1,50 @@
 import { configQueryKeys } from "@solid-imager/ui/query-options";
 import { toQueryUiState } from "@solid-imager/ui/query-state";
+import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { ConfigScreen } from "@solid-imager/ui/screens/config-screen";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
-import { ClientOnly, createFileRoute } from "@tanstack/solid-router";
+import { createFileRoute } from "@tanstack/solid-router";
 import { Show } from "solid-js";
-import { isServer } from "solid-js/web";
 import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import { configQueryOptions } from "~/infrastructure/api-clients/queries";
 
 export const Route = createFileRoute("/config")({
-	ssr: false,
-	pendingComponent: () => null,
-	component: ConfigPage,
+	ssr: true,
+	loader: async ({ context }) => {
+		const config = await context.queryClient.fetchQuery(configQueryOptions());
+		return { config };
+	},
+	pendingComponent: () => (
+		<RouteDataPendingScreen
+			description="設定を準備しています..."
+			title="Settings"
+		/>
+	),
+	pendingMinMs: 0,
+	component: ConfigPageContent,
 });
 
-function ConfigPage() {
-	return (
-		<ClientOnly fallback={null}>
-			<ConfigPageContent />
-		</ClientOnly>
-	);
-}
-
 function ConfigPageContent() {
-	const configQuery = createQuery(() => ({
-		...configQueryOptions(),
-		enabled: !isServer,
-	}));
+	const loaderData = Route.useLoaderData();
+	const configQuery = createQuery(configQueryOptions);
 	const queryClient = useQueryClient();
 	const state = () => toQueryUiState(configQuery);
+	const config = () => configQuery.data ?? loaderData().config;
 
 	return (
 		<div class="container mx-auto max-w-4xl p-6">
-			<Show when={state().phase === "pending"}>
+			<Show when={state().phase === "pending" && config() === undefined}>
 				<div class="py-10 text-center" role="status">
 					Loading settings...
 				</div>
 			</Show>
 
-			<Show when={state().phase === "error" || state().phase === "offline"}>
+			<Show
+				when={
+					(state().phase === "error" || state().phase === "offline") &&
+					config() === undefined
+				}
+			>
 				<div class="py-10 text-red-500" role="alert">
 					{state().phase === "offline"
 						? "Offline. Settings will load after reconnecting."
@@ -58,7 +64,7 @@ function ConfigPageContent() {
 				</p>
 			</Show>
 
-			<Show when={state().data}>
+			<Show when={config()}>
 				{(data) => (
 					<ConfigScreen
 						data={data()}

--- a/apps/server/src/routes/manager.tsx
+++ b/apps/server/src/routes/manager.tsx
@@ -1,7 +1,9 @@
 import { useManagerPage } from "@solid-imager/ui/hooks/use-manager-page";
+import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { ManagerScreen } from "@solid-imager/ui/screens/manager-screen";
 import { useQueryClient } from "@tanstack/solid-query";
-import { ClientOnly, createFileRoute } from "@tanstack/solid-router";
+import { createFileRoute } from "@tanstack/solid-router";
+import { createSignal, onMount, Show } from "solid-js";
 import { useBatchJobEvents } from "~/hooks/use-batch-job-events";
 import {
 	scanBatchCcipTargets,
@@ -61,16 +63,40 @@ const managerActions = {
 };
 
 export const Route = createFileRoute("/manager")({
-	ssr: false,
-	pendingComponent: () => null,
+	ssr: true,
+	loader: async ({ context }) => {
+		await Promise.all([
+			context.queryClient.prefetchQuery(allProjectsQueryOptions()),
+			context.queryClient.prefetchQuery(allIpsQueryOptions()),
+			context.queryClient.prefetchQuery(allCharactersQueryOptions()),
+			context.queryClient.prefetchQuery(mediaSourcesQueryOptions()),
+		]);
+	},
+	pendingComponent: ManagerRouteFallback,
+	pendingMinMs: 0,
 	component: ManagerPage,
 });
 
-function ManagerPage() {
+function ManagerRouteFallback() {
 	return (
-		<ClientOnly fallback={null}>
-			<ManagerPageContent />
-		</ClientOnly>
+		<RouteDataPendingScreen
+			description="管理データを準備しています..."
+			title="Entity Manager"
+		/>
+	);
+}
+
+function ManagerPage() {
+	const [isMounted, setIsMounted] = createSignal(false);
+
+	onMount(() => {
+		setIsMounted(true);
+	});
+
+	return (
+		<Show fallback={<ManagerRouteFallback />} when={isMounted()}>
+			{(_mounted) => <ManagerPageContent />}
+		</Show>
 	);
 }
 

--- a/apps/server/src/routes/search.tsx
+++ b/apps/server/src/routes/search.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@solid-imager/ui/button";
+import { useCurrentSearchPersistence } from "@solid-imager/ui/hooks/use-current-search-persistence";
 import { useSearchPage } from "@solid-imager/ui/hooks/use-search-page";
 import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { SearchScreen } from "@solid-imager/ui/screens/search-screen";
@@ -6,7 +7,6 @@ import { useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
 import { createSignal, onMount, Show } from "solid-js";
 import { MediaGridItem } from "~/components/media/media-grid-item";
-import { useCurrentSearchPersistence } from "~/hooks/use-current-search-persistence";
 import { useMediaSourceEvents } from "~/hooks/use-media-source-events";
 import { PresetClient as rawPresetClient } from "~/infrastructure/api/clients/preset-client";
 
@@ -29,18 +29,27 @@ import {
 } from "~/presentation/store/search-store";
 
 export const Route = createFileRoute("/search")({
-	// SearchScreen is client-only, but this route itself must render on the
-	// server so its static fallback hydrates against the same component tree.
 	ssr: true,
+	loader: async ({ context }) => {
+		await Promise.all([
+			context.queryClient.prefetchQuery(tagsQueryOptions()),
+			context.queryClient.prefetchQuery(mediaSourcesQueryOptions()),
+			context.queryClient.prefetchQuery(allProjectsQueryOptions()),
+			context.queryClient.prefetchQuery(allIpsQueryOptions()),
+			context.queryClient.prefetchQuery(allCharactersQueryOptions()),
+			context.queryClient.prefetchQuery(allAuthorsQueryOptions()),
+		]);
+	},
 	pendingComponent: SearchRouteFallback,
-	component: SearchRoute,
+	pendingMinMs: 0,
+	component: SearchRouteBoundary,
 });
 
 const SEARCH_RESULTS_REFRESH_DEBOUNCE_MS = 300;
 
 const PresetClient = createPresetClient(rawPresetClient);
 
-function SearchRoute() {
+function SearchRouteBoundary() {
 	const [isMounted, setIsMounted] = createSignal(false);
 
 	onMount(() => {
@@ -49,7 +58,7 @@ function SearchRoute() {
 
 	return (
 		<Show fallback={<SearchRouteFallback />} when={isMounted()}>
-			{(_mounted) => <SearchRouteContent />}
+			{(_mounted) => <SearchRoute />}
 		</Show>
 	);
 }
@@ -69,10 +78,10 @@ function SearchRouteFallback() {
 	);
 }
 
-function SearchRouteContent() {
+function SearchRoute() {
 	const queryClient = useQueryClient();
 
-	useCurrentSearchPersistence("all", PresetClient);
+	const isSearchStateRestored = useCurrentSearchPersistence("all");
 
 	const page = useSearchPage({
 		searchMedia,
@@ -98,6 +107,7 @@ function SearchRouteContent() {
 		similarityAnchorMediaId: () => searchState.similarityAnchorMediaId,
 		similarityTopK: () => searchState.similarityTopK,
 		refreshDebounceMs: SEARCH_RESULTS_REFRESH_DEBOUNCE_MS,
+		isSearchStateRestored,
 	});
 
 	useMediaSourceEvents(() => searchState.selectedSource || undefined, {

--- a/apps/server/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
@@ -4,13 +4,31 @@ import { createSignal, onMount, Show } from "solid-js";
 import { MediaSidebar } from "~/components/media/media-sidebar";
 import { MediaViewer } from "~/components/media/media-viewer";
 import { createServerTransport } from "~/hooks/use-media-source-events";
-import { mediaDetailsQueryOptions } from "~/infrastructure/api-clients/queries";
+import {
+	allCharactersQueryOptions,
+	allIpsQueryOptions,
+	allProjectsQueryOptions,
+	mediaDetailsQueryOptions,
+	projectsForMediaQueryOptions,
+} from "~/infrastructure/api-clients/queries";
 
 export const Route = createFileRoute("/sources/$mediaSourceId/$mediaId/")({
-	// The detail data remains client-fetched, but render a server-safe static
-	// fallback so direct navigation never starts with an empty page.
 	ssr: true,
+	loader: async ({ context, params }) => {
+		await Promise.all([
+			context.queryClient.prefetchQuery(
+				mediaDetailsQueryOptions(params.mediaSourceId, params.mediaId),
+			),
+			context.queryClient.prefetchQuery(
+				projectsForMediaQueryOptions(params.mediaSourceId, params.mediaId),
+			),
+			context.queryClient.prefetchQuery(allProjectsQueryOptions()),
+			context.queryClient.prefetchQuery(allIpsQueryOptions()),
+			context.queryClient.prefetchQuery(allCharactersQueryOptions()),
+		]);
+	},
 	pendingComponent: MediaRouteFallback,
+	pendingMinMs: 0,
 	component: Media,
 });
 

--- a/apps/server/src/routes/sources/$mediaSourceId/index.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/index.tsx
@@ -1,6 +1,50 @@
+import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { createFileRoute } from "@tanstack/solid-router";
+import { createSignal, onMount, Show } from "solid-js";
+import {
+	allAuthorsQueryOptions,
+	allCharactersQueryOptions,
+	allIpsQueryOptions,
+	allProjectsQueryOptions,
+	tagsQueryOptions,
+} from "~/infrastructure/api-clients/queries";
 import { SourceMediaPage } from "./components/source-media-page";
 
 export const Route = createFileRoute("/sources/$mediaSourceId/")({
-	component: SourceMediaPage,
+	ssr: true,
+	loader: async ({ context }) => {
+		await Promise.all([
+			context.queryClient.prefetchQuery(tagsQueryOptions()),
+			context.queryClient.prefetchQuery(allProjectsQueryOptions()),
+			context.queryClient.prefetchQuery(allIpsQueryOptions()),
+			context.queryClient.prefetchQuery(allCharactersQueryOptions()),
+			context.queryClient.prefetchQuery(allAuthorsQueryOptions()),
+		]);
+	},
+	pendingComponent: SourceMediaRouteFallback,
+	pendingMinMs: 0,
+	component: SourceMediaRoute,
 });
+
+function SourceMediaRouteFallback() {
+	return (
+		<RouteDataPendingScreen
+			description="メディア一覧を準備しています..."
+			title="メディア一覧"
+		/>
+	);
+}
+
+function SourceMediaRoute() {
+	const [isMounted, setIsMounted] = createSignal(false);
+
+	onMount(() => {
+		setIsMounted(true);
+	});
+
+	return (
+		<Show fallback={<SourceMediaRouteFallback />} when={isMounted()}>
+			{(_mounted) => <SourceMediaPage />}
+		</Show>
+	);
+}

--- a/apps/server/src/routes/sources/index.tsx
+++ b/apps/server/src/routes/sources/index.tsx
@@ -3,13 +3,13 @@ import { subscribeToEventStream } from "@solid-imager/ui/event-stream";
 import type { RawEventHandler } from "@solid-imager/ui/hooks/use-sources-events";
 import { useSourcesPage } from "@solid-imager/ui/hooks/use-sources-page";
 import { toQueryUiState } from "@solid-imager/ui/query-state";
+import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { SourcesScreen } from "@solid-imager/ui/screens/sources-screen";
 import { SourceCard } from "@solid-imager/ui/source-card";
 import { SourceDeleteModal } from "@solid-imager/ui/source-delete-modal";
 import { SourceFormModal } from "@solid-imager/ui/source-form-modal";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
-import { ClientOnly, createFileRoute } from "@tanstack/solid-router";
-import { isServer } from "solid-js/web";
+import { createFileRoute } from "@tanstack/solid-router";
 import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import { mediaSourcesQueryOptions } from "~/infrastructure/api-clients/queries";
 import {
@@ -20,9 +20,21 @@ import {
 } from "~/infrastructure/api-clients/sources-api";
 
 export const Route = createFileRoute("/sources/")({
-	ssr: false,
-	pendingComponent: () => null,
-	component: SourcesRoute,
+	ssr: true,
+	loader: async ({ context }) => {
+		const mediaSources = await context.queryClient.fetchQuery(
+			mediaSourcesQueryOptions(),
+		);
+		return { mediaSources };
+	},
+	pendingComponent: () => (
+		<RouteDataPendingScreen
+			description="ソース一覧を準備しています..."
+			title="Media Sources"
+		/>
+	),
+	pendingMinMs: 0,
+	component: SourcesRouteContent,
 });
 
 function registerSourceEvents(handler: RawEventHandler): () => void {
@@ -32,20 +44,11 @@ function registerSourceEvents(handler: RawEventHandler): () => void {
 	);
 }
 
-function SourcesRoute() {
-	return (
-		<ClientOnly fallback={null}>
-			<SourcesRouteContent />
-		</ClientOnly>
-	);
-}
-
 function SourcesRouteContent() {
 	const queryClient = useQueryClient();
-	const mediaSources = createQuery(() => ({
-		...mediaSourcesQueryOptions(),
-		enabled: !isServer,
-	}));
+	const loaderData = Route.useLoaderData();
+	const mediaSources = createQuery(mediaSourcesQueryOptions);
+	const sourceData = () => mediaSources.data ?? loaderData().mediaSources;
 
 	const page = useSourcesPage({
 		actions: {
@@ -60,15 +63,14 @@ function SourcesRouteContent() {
 		invalidateQueryKey: mediaSourcesQueryOptions().queryKey,
 		registerEvents: registerSourceEvents,
 		getSourceIds: () =>
-			mediaSources.data
+			sourceData()
 				?.map((s) => s.id)
 				.filter((id): id is string => Boolean(id)) ?? [],
 	});
-
 	return (
 		<SourcesScreen
 			page={page}
-			mediaSources={() => mediaSources.data}
+			mediaSources={sourceData}
 			state={() =>
 				toQueryUiState(mediaSources, {
 					isEmpty: (data) => data.length === 0,

--- a/apps/server/src/tests/e2e/loading-recovery.spec.ts
+++ b/apps/server/src/tests/e2e/loading-recovery.spec.ts
@@ -1,4 +1,8 @@
-import { E2E_PRIMARY_FILE_NAME, mediaPath } from "./support/fixture";
+import {
+	E2E_PRIMARY_FILE_NAME,
+	mediaPath,
+	sourcePath,
+} from "./support/fixture";
 import { expect, test } from "./support/test";
 
 const searchEndpoint = /\/api\/rpc\/media\/search(?:\?|$)/;
@@ -91,31 +95,46 @@ test.describe("loading and recovery", () => {
 		).toHaveCount(0);
 	});
 
-	test("keeps a media-detail status visible while its initial response is delayed", async ({
+	test("keeps route content visible while SPA media-detail preload is delayed", async ({
 		page,
 	}) => {
 		let releaseRequest: () => void = () => {};
+		let markRequestSeen: () => void = () => {};
 		const requestGate = new Promise<void>((resolve) => {
 			releaseRequest = resolve;
 		});
+		const requestSeen = new Promise<void>((resolve) => {
+			markRequestSeen = resolve;
+		});
 		await page.route(mediaDetailsEndpoint, async (route) => {
+			markRequestSeen();
 			await requestGate;
 			await route.continue();
 		});
 
-		await page.goto(mediaPath(), { waitUntil: "commit" });
+		await page.goto(sourcePath());
+		const mediaLink = page.getByRole("link", {
+			name: new RegExp(E2E_PRIMARY_FILE_NAME),
+		});
+		await expect(mediaLink).toBeVisible();
+
+		const navigation = mediaLink.click();
+		await requestSeen;
 		await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
 		await expect(
-			page.getByText("メディア詳細を準備しています...", { exact: true }),
+			page.getByRole("heading", {
+				name: /Media in Source:/,
+			}),
 		).toBeVisible();
 
 		releaseRequest();
+		await navigation;
 		await expect(
 			page.getByRole("heading", { name: E2E_PRIMARY_FILE_NAME, exact: true }),
 		).toBeVisible();
 	});
 
-	test("shows a recoverable error and reload recovery when media detail is unavailable", async ({
+	test("shows a recoverable SPA error and reload recovery when media detail is unavailable", async ({
 		page,
 		browserHealth,
 	}) => {
@@ -131,7 +150,11 @@ test.describe("loading and recovery", () => {
 			}),
 		);
 
-		await page.goto(mediaPath());
+		await page.goto(sourcePath());
+		await page
+			.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) })
+			.click();
+		await expect(page).toHaveURL(new RegExp(`${mediaPath()}/?$`));
 		await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
 		await expect(page.getByRole("alert")).toContainText("Error:");
 

--- a/apps/server/src/tests/e2e/realtime-preservation.spec.ts
+++ b/apps/server/src/tests/e2e/realtime-preservation.spec.ts
@@ -9,7 +9,7 @@ import {
 	getFixtureMediaPath,
 	sourcePath,
 } from "./support/fixture";
-import { expect, test } from "./support/test";
+import { expect, test, waitForAppHydration } from "./support/test";
 
 const sourceEventsEndpoint = /\/api\/rpc\/sources\/events(?:\?|$)/;
 
@@ -43,6 +43,7 @@ test("preserves an open dialog, input value, and focus after an SSE reconnect re
 
 	await page.goto(sourcePath());
 	await expect(page.getByRole("button", { name: "Add media" })).toBeVisible();
+	await waitForAppHydration(page);
 	await reconnected;
 	expect(streamAttempts).toBeGreaterThanOrEqual(2);
 	await page.unroute(sourceEventsEndpoint);
@@ -72,7 +73,19 @@ test("preserves an open dialog, input value, and focus after an SSE reconnect re
 		.getByTestId("source-card")
 		.filter({ hasText: E2E_SOURCE_NAME });
 	await expect(sourceCard).toBeVisible();
-	await sourceCard.getByTestId("sync-source-btn").click();
+	await waitForAppHydration(syncPage);
+	const addSourceButton = syncPage.getByRole("button", { name: "Add Source" });
+	await addSourceButton.click();
+	await expect(syncPage.getByRole("dialog")).toBeVisible();
+	await syncPage.getByRole("button", { name: "Cancel" }).click();
+	await expect(syncPage.getByRole("dialog")).toHaveCount(0);
+	const syncResponse = syncPage.waitForResponse((response) => {
+		const url = new URL(response.url());
+		return url.pathname === "/api/rpc/sources/sync" && response.ok();
+	});
+	const syncButton = sourceCard.getByTestId("sync-source-btn");
+	await syncButton.click();
+	await syncResponse;
 
 	await expect(
 		page.locator("p").filter({ hasText: /^3 件の結果$/ }),

--- a/apps/server/src/tests/e2e/route-reload.spec.ts
+++ b/apps/server/src/tests/e2e/route-reload.spec.ts
@@ -1,45 +1,92 @@
+import type { Page } from "@playwright/test";
 import {
 	E2E_PRIMARY_FILE_NAME,
 	E2E_SOURCE_ID,
+	E2E_SOURCE_NAME,
 	mediaPath,
 	sourcePath,
 } from "./support/fixture";
-import { expect, expectRouteHealthy, test } from "./support/test";
+import {
+	expect,
+	expectRouteHealthy,
+	test,
+	waitForAppHydration,
+} from "./support/test";
 
 const routeErrorMarkup = [
 	"画面を読み込んでいます...",
 	"画面を表示できませんでした",
 	"[object Object]",
 ];
-const INITIAL_CONTENT_BUDGET_MS = 12_000;
-const SPA_CONTENT_BUDGET_MS = 5_000;
+const isProduction = process.env.E2E_MODE === "production";
+const TTFB_BUDGET_MS = isProduction ? 1_000 : 1_500;
+const SPA_CONTENT_BUDGET_MS = isProduction ? 1_500 : 3_000;
+
+const searchFilterEndpoints = [
+	"/api/rpc/tags/list",
+	"/api/rpc/sources/list",
+	"/api/rpc/projects/list",
+	"/api/rpc/ips/list",
+	"/api/rpc/characters/list",
+	"/api/rpc/authors/list",
+] as const;
+
+const sourceMediaFilterEndpoints = [
+	"/api/rpc/tags/list",
+	"/api/rpc/projects/list",
+	"/api/rpc/ips/list",
+	"/api/rpc/characters/list",
+	"/api/rpc/authors/list",
+] as const;
+
+const mediaDetailHydratedEndpoints = [
+	"/api/rpc/media/getDetails",
+	"/api/rpc/projects/listForMedia",
+	"/api/rpc/projects/list",
+	"/api/rpc/ips/list",
+	"/api/rpc/characters/list",
+] as const;
 
 async function expectSsrHtmlHealthy(
-	page: import("@playwright/test").Page,
-	path: string,
-	staticFallbackText?: string,
+	response: { status(): number; text(): Promise<string> },
+	expectedSsrText: string,
+	expectedSsrMarkup?: string,
 ): Promise<void> {
-	const response = await page.request.get(path);
 	expect(response.status()).toBeLessThan(500);
 	const html = await response.text();
-	// Client-only route bodies may defer their data, but the App Shell itself
-	// must still be server-rendered so a cold navigation is never a blank page.
 	expect(html).toContain("Home");
-	if (staticFallbackText) {
-		expect(html).toContain(staticFallbackText);
+	expect(html).toContain(expectedSsrText);
+	if (expectedSsrMarkup) {
+		expect(html).toContain(expectedSsrMarkup);
 	}
 	for (const markup of routeErrorMarkup) {
 		expect(html).not.toContain(markup);
 	}
 }
 
+async function expectTtfbWithinBudget(page: Page): Promise<void> {
+	const responseStartMs = await page.evaluate(() => {
+		const navigation = performance.getEntriesByType("navigation").at(0) as
+			| PerformanceNavigationTiming
+			| undefined;
+		return navigation?.responseStart ?? Number.POSITIVE_INFINITY;
+	});
+	expect(responseStartMs).toBeLessThan(TTFB_BUDGET_MS);
+}
+
 type RouteCase = {
 	name: string;
 	path: string;
 	heading: string;
-	apiEndpoint?: string;
+	ssrText: string;
+	ssrMarkup?: string;
+	hydratedEndpoints: readonly string[];
+	clientEndpoints?: readonly string[];
 	readyMediaLink?: string;
-	staticFallbackText?: string;
+	readyButton?: string;
+	seedSearchSession?: boolean;
+	directBudgetMs: number;
+	reloadBudgetMs: number;
 };
 
 const routeCases: readonly RouteCase[] = [
@@ -47,35 +94,67 @@ const routeCases: readonly RouteCase[] = [
 		name: "global search",
 		path: "/search",
 		heading: "メディア検索",
-		apiEndpoint: "/api/rpc/media/search",
+		ssrText: "検索画面を準備しています...",
+		hydratedEndpoints: searchFilterEndpoints,
+		clientEndpoints: ["/api/rpc/media/search", "/api/rpc/presets/list"],
 		readyMediaLink: E2E_PRIMARY_FILE_NAME,
+		seedSearchSession: true,
+		directBudgetMs: isProduction ? 1_500 : 5_000,
+		reloadBudgetMs: isProduction ? 1_000 : 2_000,
 	},
 	{
 		name: "settings",
 		path: "/config",
 		heading: "Settings",
-		apiEndpoint: "/api/rpc/config/get",
+		ssrText: "Save Changes",
+		hydratedEndpoints: ["/api/rpc/config/get"],
+		readyButton: "Save Changes",
+		directBudgetMs: isProduction ? 1_500 : 2_500,
+		reloadBudgetMs: isProduction ? 1_500 : 2_000,
 	},
 	{
 		name: "entity manager",
 		path: "/manager",
 		heading: "Entity Manager",
+		ssrText: "管理データを準備しています...",
+		hydratedEndpoints: [
+			"/api/rpc/projects/list",
+			"/api/rpc/ips/list",
+			"/api/rpc/characters/list",
+			"/api/rpc/sources/list",
+		],
+		readyButton: "Create New",
+		directBudgetMs: isProduction ? 1_500 : 3_000,
+		reloadBudgetMs: isProduction ? 1_500 : 2_000,
 	},
 	{
 		name: "media sources",
 		path: "/sources",
 		heading: "Media Sources",
+		ssrText: E2E_SOURCE_NAME,
+		ssrMarkup: 'data-testid="source-card"',
+		hydratedEndpoints: ["/api/rpc/sources/list"],
+		directBudgetMs: isProduction ? 1_500 : 2_500,
+		reloadBudgetMs: isProduction ? 1_500 : 2_000,
 	},
 	{
 		name: "seeded source",
 		path: sourcePath(),
 		heading: `Media in Source: ${E2E_SOURCE_ID}`,
+		ssrText: "メディア一覧を準備しています...",
+		hydratedEndpoints: sourceMediaFilterEndpoints,
+		clientEndpoints: ["/api/rpc/media/search"],
+		directBudgetMs: isProduction ? 1_500 : 3_000,
+		reloadBudgetMs: isProduction ? 1_000 : 2_000,
 	},
 	{
 		name: "seeded media detail",
 		path: mediaPath(),
 		heading: E2E_PRIMARY_FILE_NAME,
-		staticFallbackText: "メディア詳細を準備しています...",
+		ssrText: "メディア詳細を準備しています...",
+		hydratedEndpoints: mediaDetailHydratedEndpoints,
+		directBudgetMs: isProduction ? 1_500 : 4_000,
+		reloadBudgetMs: isProduction ? 1_000 : 2_000,
 	},
 ];
 
@@ -85,14 +164,46 @@ test.describe("direct navigation and reload", () => {
 			page,
 			browserHealth,
 		}) => {
-			await expectSsrHtmlHealthy(
-				page,
-				routeCase.path,
-				routeCase.staticFallbackText,
-			);
+			if (routeCase.seedSearchSession) {
+				await page.addInitScript((fileName) => {
+					sessionStorage.setItem(
+						"current-all",
+						JSON.stringify({
+							mode: "simple",
+							selectedSource: "",
+							value: {
+								type: "group",
+								operator: "and",
+								children: [
+									{
+										type: "criterion",
+										target: "keyword",
+										operator: "contains",
+										value: fileName,
+									},
+								],
+							},
+							sort: "date",
+							order: "desc",
+						}),
+					);
+				}, E2E_PRIMARY_FILE_NAME);
+			}
+
+			const directRequestCheckpoint = browserHealth.requestCheckpoint();
 			const directNavigationStartedAt = Date.now();
 			const response = await page.goto(routeCase.path);
 			expect(response?.ok()).toBeTruthy();
+			if (!response) {
+				throw new Error(
+					`Direct navigation did not receive a response for ${routeCase.path}`,
+				);
+			}
+			await expectSsrHtmlHealthy(
+				response,
+				routeCase.ssrText,
+				routeCase.ssrMarkup,
+			);
 			await expect(
 				page.getByRole("heading", { name: routeCase.heading, exact: true }),
 			).toBeVisible();
@@ -103,23 +214,44 @@ test.describe("direct navigation and reload", () => {
 					}),
 				).toBeVisible();
 			}
+			if (routeCase.readyButton) {
+				await expect(
+					page.getByRole("button", {
+						name: routeCase.readyButton,
+						exact: true,
+					}),
+				).toBeVisible();
+			}
+			await waitForAppHydration(page);
 			const directNavigationElapsedMs = Date.now() - directNavigationStartedAt;
-			browserHealth.recordContentReady(
+			browserHealth.recordNavigation(
 				`${routeCase.name} direct navigation`,
 				directNavigationElapsedMs,
+				directRequestCheckpoint,
 			);
-			expect(directNavigationElapsedMs).toBeLessThan(INITIAL_CONTENT_BUDGET_MS);
-			await expectRouteHealthy(page);
-			const apiRequestsBeforeReload = routeCase.apiEndpoint
-				? browserHealth.apiRequestCount(routeCase.apiEndpoint)
-				: 0;
-			if (routeCase.apiEndpoint) {
+			expect(directNavigationElapsedMs).toBeLessThan(routeCase.directBudgetMs);
+			await expectTtfbWithinBudget(page);
+			for (const endpoint of routeCase.hydratedEndpoints) {
 				expect(
-					apiRequestsBeforeReload,
-					`API requests: ${JSON.stringify(browserHealth.apiRequests())}`,
+					browserHealth.apiRequestCountPathSince(
+						directRequestCheckpoint,
+						endpoint,
+					),
+					`Hydrated query refetched in browser: ${endpoint}`,
+				).toBe(0);
+			}
+			for (const endpoint of routeCase.clientEndpoints ?? []) {
+				expect(
+					browserHealth.apiRequestCountPathSince(
+						directRequestCheckpoint,
+						endpoint,
+					),
+					`Client query request budget exceeded: ${endpoint}`,
 				).toBe(1);
 			}
+			await expectRouteHealthy(page);
 
+			const reloadRequestCheckpoint = browserHealth.requestCheckpoint();
 			const reloadStartedAt = Date.now();
 			const reloadResponse = await page.reload();
 			expect(reloadResponse?.ok()).toBeTruthy();
@@ -128,14 +260,11 @@ test.describe("direct navigation and reload", () => {
 					`Reload did not receive a response for ${routeCase.path}`,
 				);
 			}
-			const reloadHtml = await reloadResponse.text();
-			expect(reloadHtml).toContain("Home");
-			if (routeCase.staticFallbackText) {
-				expect(reloadHtml).toContain(routeCase.staticFallbackText);
-			}
-			for (const markup of routeErrorMarkup) {
-				expect(reloadHtml).not.toContain(markup);
-			}
+			await expectSsrHtmlHealthy(
+				reloadResponse,
+				routeCase.ssrText,
+				routeCase.ssrMarkup,
+			);
 			await expect(
 				page.getByRole("heading", { name: routeCase.heading, exact: true }),
 			).toBeVisible();
@@ -146,17 +275,39 @@ test.describe("direct navigation and reload", () => {
 					}),
 				).toBeVisible();
 			}
+			if (routeCase.readyButton) {
+				await expect(
+					page.getByRole("button", {
+						name: routeCase.readyButton,
+						exact: true,
+					}),
+				).toBeVisible();
+			}
+			await waitForAppHydration(page);
 			const reloadElapsedMs = Date.now() - reloadStartedAt;
-			browserHealth.recordContentReady(
+			browserHealth.recordNavigation(
 				`${routeCase.name} reload`,
 				reloadElapsedMs,
+				reloadRequestCheckpoint,
 			);
-			expect(reloadElapsedMs).toBeLessThan(INITIAL_CONTENT_BUDGET_MS);
-			if (routeCase.apiEndpoint) {
+			expect(reloadElapsedMs).toBeLessThan(routeCase.reloadBudgetMs);
+			await expectTtfbWithinBudget(page);
+			for (const endpoint of routeCase.hydratedEndpoints) {
 				expect(
-					browserHealth.apiRequestCount(routeCase.apiEndpoint) -
-						apiRequestsBeforeReload,
-					`API requests: ${JSON.stringify(browserHealth.apiRequests())}`,
+					browserHealth.apiRequestCountPathSince(
+						reloadRequestCheckpoint,
+						endpoint,
+					),
+					`Hydrated query refetched after reload: ${endpoint}`,
+				).toBe(0);
+			}
+			for (const endpoint of routeCase.clientEndpoints ?? []) {
+				expect(
+					browserHealth.apiRequestCountPathSince(
+						reloadRequestCheckpoint,
+						endpoint,
+					),
+					`Client query reload budget exceeded: ${endpoint}`,
 				).toBe(1);
 			}
 			await expectRouteHealthy(page);
@@ -164,39 +315,183 @@ test.describe("direct navigation and reload", () => {
 	}
 });
 
-test("SPA navigation renders the next route without a route error", async ({
+test("full data SSR routes become interactive after hydration", async ({
+	page,
+}) => {
+	await page.goto("/config");
+	await expect(
+		page.getByRole("heading", { name: "Settings", exact: true }),
+	).toBeVisible();
+	await waitForAppHydration(page);
+	await page.getByRole("tab", { name: "AI", exact: true }).click();
+	await expect(
+		page.getByRole("heading", { name: "AI Service", exact: true }),
+	).toBeVisible();
+
+	await page.goto("/sources");
+	await expect(
+		page.getByRole("heading", { name: "Media Sources", exact: true }),
+	).toBeVisible();
+	await waitForAppHydration(page);
+	await page.getByRole("button", { name: "Add Source", exact: true }).click();
+	await expect(page.getByRole("dialog")).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(page.getByRole("dialog")).toHaveCount(0);
+});
+
+test("SPA intent prefetch and cache revisit do not duplicate route queries", async ({
 	page,
 	browserHealth,
 }) => {
 	await page.goto("/");
+
+	const searchCheckpoint = browserHealth.requestCheckpoint();
+	const searchLink = page.getByRole("link", { name: "Search", exact: true });
+	const intentFilterResponse = page.waitForResponse((response) => {
+		const url = new URL(response.url());
+		return url.pathname === "/api/rpc/tags/list" && response.ok();
+	});
+	await searchLink.hover();
+	await intentFilterResponse;
+	await expect(page).toHaveURL(/\/$/);
+	expect(
+		browserHealth.apiRequestCountPathSince(
+			searchCheckpoint,
+			"/api/rpc/tags/list",
+		),
+	).toBe(1);
+
 	const searchNavigationStartedAt = Date.now();
-	await page.getByRole("link", { name: "Search", exact: true }).click();
+	await searchLink.click();
 	await expect(page).toHaveURL(/\/search$/);
-	await expect(
-		page.getByRole("heading", { name: "メディア検索", exact: true }),
-	).toBeVisible();
 	await expect(
 		page.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) }),
 	).toBeVisible();
+	await waitForAppHydration(page);
 	const searchNavigationElapsedMs = Date.now() - searchNavigationStartedAt;
-	browserHealth.recordContentReady(
+	browserHealth.recordNavigation(
 		"search SPA navigation",
 		searchNavigationElapsedMs,
+		searchCheckpoint,
 	);
 	expect(searchNavigationElapsedMs).toBeLessThan(SPA_CONTENT_BUDGET_MS);
+	for (const endpoint of [...searchFilterEndpoints, "/api/rpc/media/search"]) {
+		expect(
+			browserHealth.apiRequestCountPathSince(searchCheckpoint, endpoint),
+			`Search intent prefetch duplicated ${endpoint}`,
+		).toBeLessThanOrEqual(1);
+	}
 	await expectRouteHealthy(page);
 
+	const sourcesCheckpoint = browserHealth.requestCheckpoint();
 	const sourcesNavigationStartedAt = Date.now();
 	await page.getByRole("link", { name: "Sources", exact: true }).click();
 	await expect(page).toHaveURL(/\/sources\/?$/);
 	await expect(
 		page.getByRole("heading", { name: "Media Sources", exact: true }),
 	).toBeVisible();
+	await waitForAppHydration(page);
 	const sourcesNavigationElapsedMs = Date.now() - sourcesNavigationStartedAt;
-	browserHealth.recordContentReady(
+	browserHealth.recordNavigation(
 		"sources SPA navigation",
 		sourcesNavigationElapsedMs,
+		sourcesCheckpoint,
 	);
 	expect(sourcesNavigationElapsedMs).toBeLessThan(SPA_CONTENT_BUDGET_MS);
+	expect(
+		browserHealth.apiRequestCountPathSince(
+			sourcesCheckpoint,
+			"/api/rpc/sources/list",
+		),
+	).toBe(0);
+	await expectRouteHealthy(page);
+
+	const sourceMediaCheckpoint = browserHealth.requestCheckpoint();
+	const sourceMediaNavigationStartedAt = Date.now();
+	await page.getByTestId("source-card").click();
+	await expect(page).toHaveURL(new RegExp(`${sourcePath()}/?$`));
+	await expect(
+		page.getByRole("heading", {
+			name: `Media in Source: ${E2E_SOURCE_ID}`,
+			exact: true,
+		}),
+	).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) }),
+	).toBeVisible();
+	await waitForAppHydration(page);
+	const sourceMediaNavigationElapsedMs =
+		Date.now() - sourceMediaNavigationStartedAt;
+	browserHealth.recordNavigation(
+		"source media SPA navigation",
+		sourceMediaNavigationElapsedMs,
+		sourceMediaCheckpoint,
+	);
+	expect(sourceMediaNavigationElapsedMs).toBeLessThan(SPA_CONTENT_BUDGET_MS);
+	expect(
+		browserHealth.apiRequestCountPathSince(
+			sourceMediaCheckpoint,
+			"/api/rpc/media/search",
+		),
+	).toBeLessThanOrEqual(1);
+	await expectRouteHealthy(page);
+
+	// Intent loaders must not mutate the shared search store while the user is
+	// merely hovering a link from another search-backed route.
+	const sourceSearchInput = page.getByPlaceholder("ファイル名を入力...");
+	await sourceSearchInput.fill(E2E_PRIMARY_FILE_NAME);
+	await page.getByRole("link", { name: "Search", exact: true }).hover();
+	await page.waitForTimeout(300);
+	await expect(sourceSearchInput).toHaveValue(E2E_PRIMARY_FILE_NAME);
+	await expect(
+		page.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) }),
+	).toBeVisible();
+
+	const detailCheckpoint = browserHealth.requestCheckpoint();
+	const detailNavigationStartedAt = Date.now();
+	await page
+		.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) })
+		.click();
+	await expect(page).toHaveURL(new RegExp(`${mediaPath()}/?$`));
+	await expect(
+		page.getByRole("heading", { name: E2E_PRIMARY_FILE_NAME, exact: true }),
+	).toBeVisible();
+	await waitForAppHydration(page);
+	const detailNavigationElapsedMs = Date.now() - detailNavigationStartedAt;
+	browserHealth.recordNavigation(
+		"media detail SPA navigation",
+		detailNavigationElapsedMs,
+		detailCheckpoint,
+	);
+	expect(detailNavigationElapsedMs).toBeLessThan(SPA_CONTENT_BUDGET_MS);
+	for (const endpoint of mediaDetailHydratedEndpoints) {
+		expect(
+			browserHealth.apiRequestCountPathSince(detailCheckpoint, endpoint),
+			`Media detail intent prefetch duplicated ${endpoint}`,
+		).toBeLessThanOrEqual(1);
+	}
+	await expectRouteHealthy(page);
+
+	const revisitCheckpoint = browserHealth.requestCheckpoint();
+	const revisitStartedAt = Date.now();
+	await page.getByRole("link", { name: "Search", exact: true }).click();
+	await expect(page).toHaveURL(/\/search$/);
+	await expect(
+		page.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) }),
+	).toBeVisible();
+	await waitForAppHydration(page);
+	const revisitElapsedMs = Date.now() - revisitStartedAt;
+	browserHealth.recordNavigation(
+		"search cache revisit",
+		revisitElapsedMs,
+		revisitCheckpoint,
+	);
+	expect(revisitElapsedMs).toBeLessThan(SPA_CONTENT_BUDGET_MS);
+	expect(
+		browserHealth.apiRequestCountPathSince(
+			revisitCheckpoint,
+			"/api/rpc/media/search",
+		),
+	).toBeLessThanOrEqual(1);
 	await expectRouteHealthy(page);
 });

--- a/apps/server/src/tests/e2e/support/test.ts
+++ b/apps/server/src/tests/e2e/support/test.ts
@@ -8,8 +8,15 @@ type BrowserHealth = {
 	allowRequestFailure: (matcher: UrlMatcher) => void;
 	allowResponseFailure: (matcher: UrlMatcher) => void;
 	apiRequestCount: (matcher: UrlMatcher) => number;
+	apiRequestCountPathSince: (checkpoint: number, pathname: string) => number;
 	apiRequests: () => readonly string[];
 	recordContentReady: (label: string, elapsedMs: number) => void;
+	recordNavigation: (
+		label: string,
+		elapsedMs: number,
+		requestCheckpoint: number,
+	) => void;
+	requestCheckpoint: () => number;
 };
 
 type BrowserPerformanceMetric = {
@@ -28,6 +35,25 @@ type ContentReadyMetric = {
 	elapsedMs: number;
 };
 
+type NavigationMetric = ContentReadyMetric & {
+	apiRequestCount: number;
+	duplicateApiRequests: Array<{ request: string; count: number }>;
+};
+
+function summarizeRequests(urls: readonly string[]) {
+	const counts = new Map<string, number>();
+	for (const requestUrl of urls) {
+		const url = new URL(requestUrl);
+		counts.set(url.pathname, (counts.get(url.pathname) ?? 0) + 1);
+	}
+	return {
+		apiRequestCount: urls.length,
+		duplicateApiRequests: [...counts.entries()]
+			.filter(([, count]) => count > 1)
+			.map(([request, count]) => ({ request, count })),
+	};
+}
+
 function matches(value: string, matchers: UrlMatcher[]): boolean {
 	return matchers.some((matcher) =>
 		typeof matcher === "string" ? value.includes(matcher) : matcher.test(value),
@@ -40,6 +66,16 @@ export async function expectRouteHealthy(page: Page): Promise<void> {
 	).toHaveCount(0);
 	await expect(page.getByText("[object Object]", { exact: true })).toHaveCount(
 		0,
+	);
+}
+
+export async function waitForAppHydration(page: Page): Promise<void> {
+	await expect(page.locator("html")).toHaveAttribute("data-hydrated", "true");
+	await page.evaluate(
+		() =>
+			new Promise<void>((resolve) => {
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+			}),
 	);
 }
 
@@ -79,6 +115,7 @@ export const test = base.extend<{ browserHealth: BrowserHealth }>({
 			const apiRequestUrls: string[] = [];
 			const apiRequestCounts = new Map<string, number>();
 			const contentReadyMetrics: ContentReadyMetric[] = [];
+			const navigationMetrics: NavigationMetric[] = [];
 			const observedPages = new Set<Page>();
 
 			const observePage = (target: Page) => {
@@ -171,10 +208,27 @@ export const test = base.extend<{ browserHealth: BrowserHealth }>({
 						allowedResponseFailures.push(matcher),
 					apiRequestCount: (matcher) =>
 						apiRequestUrls.filter((url) => matches(url, [matcher])).length,
+					apiRequestCountPathSince: (checkpoint, pathname) =>
+						apiRequestUrls
+							.slice(checkpoint)
+							.filter((requestUrl) => new URL(requestUrl).pathname === pathname)
+							.length,
 					apiRequests: () => apiRequestUrls,
 					recordContentReady: (label, elapsedMs) => {
 						contentReadyMetrics.push({ label, elapsedMs });
 					},
+					recordNavigation: (label, elapsedMs, requestCheckpoint) => {
+						contentReadyMetrics.push({ label, elapsedMs });
+						const requestSummary = summarizeRequests(
+							apiRequestUrls.slice(requestCheckpoint),
+						);
+						navigationMetrics.push({
+							label,
+							elapsedMs,
+							...requestSummary,
+						});
+					},
+					requestCheckpoint: () => apiRequestUrls.length,
 				});
 			} finally {
 				context.off("page", handleNewPage);
@@ -219,6 +273,10 @@ export const test = base.extend<{ browserHealth: BrowserHealth }>({
 				});
 				await testInfo.attach("browser-content-ready-metrics", {
 					body: JSON.stringify(contentReadyMetrics, null, 2),
+					contentType: "application/json",
+				});
+				await testInfo.attach("browser-navigation-metrics", {
+					body: JSON.stringify(navigationMetrics, null, 2),
 					contentType: "application/json",
 				});
 

--- a/apps/tauri/src/hooks/use-current-search-persistence.ts
+++ b/apps/tauri/src/hooks/use-current-search-persistence.ts
@@ -1,4 +1,1 @@
-export {
-	type PresetClientLike,
-	useCurrentSearchPersistence,
-} from "@solid-imager/ui/hooks/use-current-search-persistence";
+export { useCurrentSearchPersistence } from "@solid-imager/ui/hooks/use-current-search-persistence";

--- a/apps/tauri/src/routes/search.tsx
+++ b/apps/tauri/src/routes/search.tsx
@@ -45,7 +45,7 @@ const PresetClient = createPresetClient(rawPresetClient);
 function SearchRoute() {
 	const queryClient = useQueryClient();
 
-	useCurrentSearchPersistence("all", PresetClient);
+	const isSearchStateRestored = useCurrentSearchPersistence("all");
 
 	const page = useSearchPage({
 		searchMedia,
@@ -71,6 +71,7 @@ function SearchRoute() {
 		similarityAnchorMediaId: () => searchState.similarityAnchorMediaId,
 		similarityTopK: () => searchState.similarityTopK,
 		refreshDebounceMs: SEARCH_RESULTS_REFRESH_DEBOUNCE_MS,
+		isSearchStateRestored,
 	});
 
 	useMediaSourceEvents(() => searchState.selectedSource || undefined, {

--- a/docs/design/web-rendering-strategy.md
+++ b/docs/design/web-rendering-strategy.md
@@ -1,0 +1,154 @@
+# Web レンダリング戦略
+
+## 目的
+
+`apps/server` の主要ルートについて、SSR、Solid Query の preload/hydration、SPA 遷移を一貫した方針で運用する。直接アクセスと F5 で意味のある HTML を返しつつ、hydration 後の重複 API リクエストを防ぐことを優先する。
+
+Tauri は `apps/server` の SSR 方針へ含めない。`apps/tauri` は独立した SPA として扱い、共有 UI のみを再利用する。
+
+## ルート分類
+
+| ルート | 方式 | サーバーが返す内容 | hydration 後 |
+|---|---|---|---|
+| Sources (`/sources`) | Full data SSR | ソース一覧を含む完成状態 | hydrate 済み Query cache を利用 |
+| Config (`/config`) | Full data SSR | 設定値を含む完成状態 | hydrate 済み Query cache を利用 |
+| Search (`/search`) | SSR static fallback + Query preload/hydration | 検索画面固有の準備表示 | session 状態を復元後、検索結果を 1 回取得 |
+| Manager (`/manager`) | SSR static fallback + Query preload/hydration | 管理画面固有の準備表示 | preload 済みマスターデータで本体を表示 |
+| Source Media (`/sources/$mediaSourceId`) | SSR static fallback + Query preload/hydration | ソース内一覧固有の準備表示 | session 状態を復元後、検索結果を 1 回取得 |
+| Media Detail (`/sources/$mediaSourceId/$mediaId`) | SSR static fallback + Query preload/hydration | 詳細画面固有の準備表示 | preload 済み詳細データで本体を表示 |
+
+主要な server ルートに pure CSR は置かない。Search、Manager、Source Media、Media Detail も `ssr: true` とし、サーバーとクライアント初回 render で同じ static fallback の component tree を使う。ブラウザ専用 UI は mount 後に表示する。Media Detail 内の Kobalte 依存部分は `ClientOnly` 境界を維持する。
+
+方式の選択基準は次のとおり。
+
+1. request 時点で query key が確定し、component tree が server-safe なら Full data SSR を使う。
+2. 安定した query は server preload できる一方、画面本体がブラウザ API や client-only UI に依存する場合は SSR static fallback + Query hydration を使う。
+3. `data-only` SSR は server/client の hydration tree が一致することを dev と production の E2E で証明できる場合だけ採用する。
+4. Pure CSR は server で意味のある HTML や安定データを返せない場合の最終手段とし、採用時は intent preload とページ固有 pending UI を必須にする。
+
+### `data-only` SSR を採用しない理由
+
+現行の `@tanstack/solid-router` で `ssr: "data-only"` を試したところ、見た目が同じ fallback でもサーバーとクライアントの hydration key 階層が一致せず、`Hydration Mismatch. Unable to find DOM nodes for hydration key` を実測した。このため、現時点では `ssr: true` と同一 component tree の static fallback を採用する。
+
+依存ライブラリ更新後に再検討する場合は、見た目や HTTP status だけで判断せず、dev と production の直接アクセス、F5、SPA 遷移を E2E で検証し、hydration warning が 0 件であることを採用条件とする。
+
+## Router と Query の不変条件
+
+1. server loader が in-process oRPC を呼ぶ前に、service/repository の bootstrap 完了を必ず待つ。初期化は module-scoped Promise で共有する。途中失敗後に部分初期化済みの service graph を配信しないよう、失敗した Promise も保持して fail-fast とし、復旧には process restart を要求する。
+2. server の `QueryClient` は request ごとに新規作成する。request 間で cache や利用者固有データを共有しない。
+3. client の `QueryClient` は singleton とし、SPA 遷移と再訪で cache を再利用する。
+4. router とその context の `QueryClient` に対して `setupRouterSsrQueryIntegration` を設定し、loader が preload した cache を同じ query key で dehydrate/hydrate する。
+5. loader と画面が同じ query を扱う場合は共有 query option builder を使う。query key、page size、検索条件を別々に組み立てない。session 依存 primary query は loader から除外し、画面側の共有 builder だけで組み立てる。
+6. server HTML とクライアント初回 render の component tree を一致させる。hydration error を error component で隠さない。
+7. TanStack Router の intent preload を SPA 遷移の標準とする。独自の hover handler や同一 query の先行 fetch を追加しない。
+8. 初回 hydration の完了は `html[data-hydrated="true"]` で明示する。SSR HTML は `false`、root の `onMount` 後だけ `true` とし、E2E は SSR DOM の可視性を interaction ready の代用にしない。SPA 遷移ではこの marker は既に `true` のため、route 固有の ready 条件も併用する。
+
+## Search と session 状態の例外
+
+Search と Source Media の検索条件は `sessionStorage` から復元するため、cold SSR 時点では最終的な query key を決定できない。server loader はタグ、ソース、プロジェクト、IP、キャラクター、作者など、session 状態に依存しない filter query だけを preload する。
+
+server loader と client intent loader は、共有 store を変更せず filter query だけを preload する。intent hover は navigation ではないため、ここで `sessionStorage` の内容を global search store へ適用してはならない。
+
+実際に画面が mount された後は次の順序を守る。
+
+1. 保存済み検索状態を復元する。
+2. 復元後の条件から primary `media.search` query を組み立てる。
+3. 復元完了 Accessor を条件に結果 query を有効化する。
+
+これにより、初期値での不要な検索と復元後の再検索という二重発火を避ける。filter query は SSR cache を hydrate するため browser では再取得せず、primary `media.search` だけを cold load / reload ごとに 1 回許可する。
+
+保存済み local preset は同期的に適用する。preset 名との照合は画面の Preset Manager が取得する一覧から行い、`presets.list` を primary query の前段に置かない。保存条件がある場合も `media.search` までの waterfall と同一 endpoint の重複取得を増やさない。
+
+## データフローと request budget
+
+### URL 直接アクセス / F5
+
+```text
+request
+  -> server bootstrap 完了
+  -> request-scoped QueryClient で loader preload
+  -> route HTML + dehydrated Query cache
+  -> browser hydrate
+  -> preload 済み query の HTTP 再取得 0 回
+  -> session 依存 primary query のみ 1 回
+```
+
+- SSR HTML に route 固有の内容を含め、汎用 pending/error 表示を含めない。
+- preload/hydrate 対象 endpoint の browser HTTP request は 0 回とする。
+- Search と Source Media の `media.search` はそれぞれ 1 回とする。
+- 保存済み Search session がある場合も `presets.list` は最大 1 回とし、primary query を block しない。
+- 直接アクセスと reload の両方で同じ条件を満たす。
+
+### SPA 遷移 / cache 再訪
+
+```text
+link intent
+  -> route loader がroute-stable queryだけをpreload
+  -> client singleton QueryClient に格納
+  -> navigation
+  -> session復元後にprimary queryを最大1回実行
+  -> preload/cache から render
+  -> 再訪でも stale policy に従い最大 1 request
+```
+
+- SPA 遷移中、対象 endpoint はそれぞれ最大 1 回とする。
+- Search から Sources へ遷移する場合、既存の `sources.list` cache を使い browser request は 0 回とする。
+- Source Media の `media.search`、Media Detail の preload 対象、Search 再訪の `media.search` はそれぞれ最大 1 回とする。
+- duplicate request は navigation 区間ごとに計測し、前の画面の通信と混同しない。
+
+## 性能ベースライン
+
+Issue #594 着手前に isolated E2E fixture で計測した代表値。単位は ms、各セルは `直接アクセス / reload` を表す。
+
+| ルート | dev | production |
+|---|---:|---:|
+| Search | 3067 / 395 | 275 / 197 |
+| Config | 1138 / 1039 | 877 / 845 |
+| Manager | 1102 / 1003 | 882 / 854 |
+| Sources | 1124 / 1044 | 901 / 844 |
+| Source Media | 1124 / 436 | 161 / 93 |
+| Media Detail | 2153 / 539 | 152 / 84 |
+
+計測値はマシン負荷で変動するため、上記そのものを assertion には使わない。回帰検知には次の余裕を持たせた budget を使う。
+
+## E2E budget
+
+`apps/server/src/tests/e2e/route-reload.spec.ts` を性能と重複通信の回帰条件の信頼できる情報源とする。時間 assertion はすべて上限未満を要求する。
+
+直接アクセスの SSR 本文検査には、計測対象の `page.goto()` が返した response 本文をそのまま使う。事前の同一 URL request で route module や DB query を warm-up してから計測してはならない。
+
+| ルート | dev 直接 / reload | production 直接 / reload |
+|---|---:|---:|
+| Search | 5000 / 2000 ms | 1500 / 1000 ms |
+| Config | 2500 / 2000 ms | 1500 / 1500 ms |
+| Manager | 3000 / 2000 ms | 1500 / 1500 ms |
+| Sources | 2500 / 2000 ms | 1500 / 1500 ms |
+| Source Media | 3000 / 2000 ms | 1500 / 1000 ms |
+| Media Detail | 4000 / 2000 ms | 1500 / 1000 ms |
+
+共通 budget は次のとおり。
+
+| 指標 | dev | production |
+|---|---:|---:|
+| TTFB | 1500 ms | 1000 ms |
+| SPA 遷移から content ready | 3000 ms | 1500 ms |
+
+budget を緩和する場合は、遅くなった endpoint と navigation 区間を artifact で特定し、実測根拠を Issue に残す。一時的な CI や開発マシン負荷だけを理由に閾値を引き上げない。
+
+## 検証
+
+レンダリング方式、loader、query key、bootstrap、route fallback を変更した場合は、少なくとも次を確認する。
+
+1. dev と fresh production の両方で直接アクセス、F5、SPA 遷移が成功する。
+2. SSR HTML に route 固有の内容があり、500、汎用 route error、`[object Object]` を含まない。
+   Full data SSR は dehydrated JSON 内の文字列だけでなく、一覧 card や form control の実 DOM markup も確認する。
+3. browser console に Hydration Mismatch がない。
+4. hydrate 済み query と primary query が request budget を超えない。
+   初回 hydration marker と route 固有 content ready を待ち、さらに 2 animation frame 待って、直後に発火する重複 request を計測へ含める。
+5. TTFB、content ready、route 別 budget を満たす。
+6. Full data SSR route は hydration 完了後に form、tab、dialog などの代表操作が成功する。
+
+```bash
+bun run --cwd apps/server test:e2e:dev -- route-reload.spec.ts
+bun run --cwd apps/server test:e2e:production -- route-reload.spec.ts
+```

--- a/packages/core/src/utils/deep-equal.ts
+++ b/packages/core/src/utils/deep-equal.ts
@@ -13,6 +13,13 @@ export function deepEqual(a: unknown, b: unknown): boolean {
 		return a.getTime() === b.getTime();
 	}
 
+	if (Array.isArray(a) || Array.isArray(b)) {
+		if (!(Array.isArray(a) && Array.isArray(b)) || a.length !== b.length) {
+			return false;
+		}
+		return a.every((value, index) => deepEqual(value, b[index]));
+	}
+
 	if (!isRecord(a) || !isRecord(b)) {
 		return false;
 	}

--- a/packages/core/tests/deep-equal.test.ts
+++ b/packages/core/tests/deep-equal.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vite-plus/test";
+import { deepEqual } from "../src/utils/deep-equal";
+
+describe("deepEqual", () => {
+	it("compares nested arrays by value", () => {
+		expect(
+			deepEqual(
+				{
+					type: "group",
+					children: [{ type: "criterion", value: "sample" }],
+				},
+				{
+					type: "group",
+					children: [{ type: "criterion", value: "sample" }],
+				},
+			),
+		).toBe(true);
+	});
+
+	it("rejects arrays with different values or lengths", () => {
+		expect(deepEqual([1, 2], [1, 3])).toBe(false);
+		expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+		expect(deepEqual([1], { 0: 1 })).toBe(false);
+	});
+});

--- a/packages/ui/src/hooks/use-current-search-persistence.test.ts
+++ b/packages/ui/src/hooks/use-current-search-persistence.test.ts
@@ -1,0 +1,250 @@
+import { type Accessor, createRoot, createSignal } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	resetSearchState,
+	searchState,
+	setSearchState,
+} from "../stores/search-store";
+import {
+	type SearchPersistenceSource,
+	useCurrentSearchPersistence,
+} from "./use-current-search-persistence";
+
+vi.mock("solid-js", async () =>
+	vi.importActual<typeof import("solid-js")>("solid-js/dist/solid.js"),
+);
+vi.mock("solid-js/store", async () =>
+	vi.importActual<typeof import("solid-js/store")>(
+		"solid-js/store/dist/store.js",
+	),
+);
+vi.mock("solid-js/web", async () => ({
+	...(await vi.importActual<typeof import("solid-js/web")>(
+		"solid-js/web/dist/web.js",
+	)),
+	isServer: false,
+}));
+
+class MemoryStorage implements Storage {
+	private readonly values = new Map<string, string>();
+
+	get length(): number {
+		return this.values.size;
+	}
+
+	clear(): void {
+		this.values.clear();
+	}
+
+	getItem(key: string): string | null {
+		return this.values.get(key) ?? null;
+	}
+
+	key(index: number): string | null {
+		return [...this.values.keys()][index] ?? null;
+	}
+
+	removeItem(key: string): void {
+		this.values.delete(key);
+	}
+
+	setItem(key: string, value: string): void {
+		this.values.set(key, value);
+	}
+}
+
+interface MountedPersistence {
+	readonly dispose: () => void;
+	readonly initialValue: boolean;
+	readonly isRestored: Accessor<boolean>;
+}
+
+const createPersistedSimpleState = (
+	searchQuery: string,
+	selectedSource = "",
+) => ({
+	mode: "simple",
+	selectedSource,
+	value: {
+		type: "group",
+		operator: "and",
+		children: [
+			{
+				type: "criterion",
+				target: "keyword",
+				operator: "contains",
+				value: searchQuery,
+			},
+		],
+	},
+	sort: "date",
+	order: "desc",
+});
+
+const flushMicrotasks = async () => {
+	await Promise.resolve();
+	await Promise.resolve();
+};
+
+describe("useCurrentSearchPersistence", () => {
+	const mountedRoots: MountedPersistence[] = [];
+
+	const mountPersistence = (
+		sourceId: SearchPersistenceSource,
+	): MountedPersistence => {
+		const mounted = createRoot((dispose) => {
+			const isRestored = useCurrentSearchPersistence(sourceId);
+			return { dispose, initialValue: isRestored(), isRestored };
+		});
+		mountedRoots.push(mounted);
+		return mounted;
+	};
+
+	beforeEach(() => {
+		Object.defineProperty(globalThis, "sessionStorage", {
+			configurable: true,
+			value: new MemoryStorage(),
+		});
+		resetSearchState();
+	});
+
+	afterEach(() => {
+		for (const mounted of mountedRoots.splice(0)) {
+			mounted.dispose();
+		}
+		vi.useRealTimers();
+	});
+
+	it("gates queries until local session state is restored", async () => {
+		sessionStorage.setItem(
+			"current-all",
+			JSON.stringify(createPersistedSimpleState("restored query", "source-1")),
+		);
+
+		const mounted = mountPersistence("all");
+		expect(mounted.initialValue).toBe(false);
+		await flushMicrotasks();
+
+		expect(mounted.isRestored()).toBe(true);
+		expect(searchState.searchQuery).toBe("restored query");
+		expect(searchState.selectedSource).toBe("source-1");
+	});
+
+	it("restores the latest source when the source accessor changes", async () => {
+		const [sourceId, setSourceId] = createSignal("source-a");
+		sessionStorage.setItem(
+			"current-source-a",
+			JSON.stringify(createPersistedSimpleState("source A")),
+		);
+		sessionStorage.setItem(
+			"current-source-b",
+			JSON.stringify(createPersistedSimpleState("source B")),
+		);
+		const mounted = mountPersistence(sourceId);
+		await flushMicrotasks();
+		expect(searchState.searchQuery).toBe("source A");
+
+		setSourceId("source-b");
+		await flushMicrotasks();
+
+		expect(mounted.isRestored()).toBe(true);
+		expect(searchState.searchQuery).toBe("source B");
+	});
+
+	it("resets to defaults for malformed session JSON", async () => {
+		setSearchState({
+			mode: "pro",
+			searchQuery: "previous route",
+			selectedTags: ["stale-tag"],
+			sortBy: "name",
+			sortOrder: "asc",
+		});
+		sessionStorage.setItem("current-all", "not-json");
+
+		const mounted = mountPersistence("all");
+		await flushMicrotasks();
+
+		expect(mounted.isRestored()).toBe(true);
+		expect(searchState.mode).toBe("simple");
+		expect(searchState.searchQuery).toBe("");
+		expect(searchState.selectedTags).toEqual([]);
+		expect(searchState.sortBy).toBe("date");
+		expect(searchState.sortOrder).toBe("desc");
+	});
+
+	it("restores selectedSource from the session payload", async () => {
+		sessionStorage.setItem(
+			"current-all",
+			JSON.stringify(createPersistedSimpleState("saved query", "saved-source")),
+		);
+
+		mountPersistence("all");
+		await flushMicrotasks();
+
+		expect(searchState.searchQuery).toBe("saved query");
+		expect(searchState.selectedSource).toBe("saved-source");
+	});
+
+	it("does not inherit a source for legacy vector sessions", async () => {
+		setSearchState("selectedSource", "stale-source");
+		sessionStorage.setItem(
+			"current-all",
+			JSON.stringify({
+				mode: "vector",
+				similarityAnchorMediaId: "11111111-1111-4111-8111-111111111111",
+				similarityTopK: 100,
+			}),
+		);
+
+		mountPersistence("all");
+		await flushMicrotasks();
+
+		expect(searchState.mode).toBe("vector");
+		expect(searchState.selectedSource).toBe("");
+		expect(searchState.similarityTopK).toBe(100);
+	});
+
+	it("does not save a pending source state under the next source key", async () => {
+		vi.useFakeTimers();
+		const [sourceId, setSourceId] = createSignal("source-a");
+		sessionStorage.setItem(
+			"current-source-a",
+			JSON.stringify(createPersistedSimpleState("initial A")),
+		);
+		const mounted = mountPersistence(sourceId);
+		await flushMicrotasks();
+		expect(mounted.isRestored()).toBe(true);
+
+		setSearchState("searchQuery", "pending A");
+		setSourceId("source-b");
+		await flushMicrotasks();
+		expect(searchState.searchQuery).toBe("");
+
+		await vi.advanceTimersByTimeAsync(1000);
+
+		const persistedForB = JSON.parse(
+			sessionStorage.getItem("current-source-b") ?? "{}",
+		);
+		expect(persistedForB.value?.children).toEqual([]);
+		expect(persistedForB.selectedSource).toBe("");
+		expect(JSON.stringify(persistedForB)).not.toContain("pending A");
+	});
+
+	it("cancels a pending save when its owner is disposed", async () => {
+		vi.useFakeTimers();
+		sessionStorage.setItem(
+			"current-all",
+			JSON.stringify(createPersistedSimpleState("initial")),
+		);
+		const mounted = mountPersistence("all");
+		await flushMicrotasks();
+
+		setSearchState("searchQuery", "pending after unmount");
+		mounted.dispose();
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(sessionStorage.getItem("current-all")).not.toContain(
+			"pending after unmount",
+		);
+	});
+});

--- a/packages/ui/src/hooks/use-current-search-persistence.ts
+++ b/packages/ui/src/hooks/use-current-search-persistence.ts
@@ -1,10 +1,14 @@
-import type {
-	CreatePresetRequest,
-	Preset,
-	UpdatePresetRequest,
+import {
+	type Preset,
+	presetSchema,
 } from "@solid-imager/core/domain/media/schemas";
-import { deepEqual } from "@solid-imager/core/utils/deep-equal";
-import { type Accessor, createEffect, createSignal, onCleanup } from "solid-js";
+import {
+	type Accessor,
+	createEffect,
+	createSignal,
+	onCleanup,
+	untrack,
+} from "solid-js";
 import { isServer } from "solid-js/web";
 import {
 	getSearchCondition,
@@ -14,100 +18,162 @@ import {
 	setSearchState,
 } from "../stores/search-store";
 
-export interface PresetClientLike {
-	list(): Promise<Preset[]>;
-	getByName(name: string): Promise<Preset | null | undefined>;
-	create(data: CreatePresetRequest): Promise<unknown>;
-	update(id: number, data: UpdatePresetRequest): Promise<unknown>;
-}
-
 const DEBOUNCE_MS = 1000;
 
-export function useCurrentSearchPersistence(
-	sourceId: string | Accessor<string | null | undefined> = "current",
-	presetClient: PresetClientLike,
-) {
-	const [isInitialLoad, setIsInitialLoad] = createSignal(true);
-	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+export type SearchPersistenceSource =
+	| string
+	| Accessor<string | null | undefined>;
 
-	const getCurrentPresetName = () => {
-		const id = typeof sourceId === "function" ? sourceId() : sourceId;
-		if (id === "current") {
-			return "current";
+function getCurrentPresetName(sourceId: string | null | undefined) {
+	if (sourceId === "current") {
+		return "current";
+	}
+	if (sourceId === "current-all" || sourceId === "all") {
+		return "current-all";
+	}
+	return sourceId ? `current-${sourceId}` : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function applyPreset(
+	preset: Preset,
+	shouldApply: () => boolean,
+	clearActivePreset: boolean,
+	selectedSource: string,
+) {
+	if (!shouldApply()) {
+		return;
+	}
+	resetSearchState();
+	loadPreset(preset);
+	setSearchState("selectedSource", selectedSource);
+	if (clearActivePreset) {
+		setSearchState("activePresetId", null);
+	}
+}
+
+function restoreCurrentSearchState(
+	sourceId: string | null | undefined,
+	shouldApply: () => boolean,
+) {
+	const presetName = getCurrentPresetName(sourceId);
+	if (!presetName || typeof sessionStorage === "undefined") {
+		return;
+	}
+
+	let sessionDataStr: string | null;
+	try {
+		sessionDataStr = sessionStorage.getItem(presetName);
+	} catch {
+		if (shouldApply()) {
+			resetSearchState();
 		}
-		if (id === "current-all" || id === "all") {
-			return "current-all";
+		return;
+	}
+
+	if (!sessionDataStr) {
+		if (shouldApply()) {
+			resetSearchState();
 		}
-		return id ? `current-${id}` : null;
-	};
+		return;
+	}
+
+	let current: unknown;
+	try {
+		current = JSON.parse(sessionDataStr);
+	} catch {
+		if (shouldApply()) {
+			resetSearchState();
+		}
+		return;
+	}
+
+	if (!isRecord(current)) {
+		if (shouldApply()) {
+			resetSearchState();
+		}
+		return;
+	}
+
+	if (current.mode === "vector") {
+		if (!shouldApply()) {
+			return;
+		}
+		const selectedSource =
+			typeof current.selectedSource === "string" ? current.selectedSource : "";
+		resetSearchState();
+		setSearchState({
+			mode: "vector",
+			selectedSource,
+			similarityAnchorMediaId:
+				typeof current.similarityAnchorMediaId === "string"
+					? current.similarityAnchorMediaId
+					: null,
+			similarityTopK:
+				current.similarityTopK === 20 || current.similarityTopK === 100
+					? current.similarityTopK
+					: 50,
+		});
+		return;
+	}
+
+	const localPresetResult = presetSchema.safeParse({
+		id: -1,
+		name: presetName,
+		value: current.value,
+		sort: current.sort,
+		order: current.order,
+		mode: current.mode,
+		createdAt: new Date(),
+	});
+	if (!localPresetResult.success) {
+		if (shouldApply()) {
+			resetSearchState();
+		}
+		return;
+	}
+	const selectedSource =
+		typeof current.selectedSource === "string"
+			? current.selectedSource
+			: searchState.selectedSource;
+
+	applyPreset(localPresetResult.data, shouldApply, true, selectedSource);
+}
+
+export function useCurrentSearchPersistence(
+	sourceId: SearchPersistenceSource = "current",
+): Accessor<boolean> {
+	const [isRestored, setIsRestored] = createSignal(false);
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	let restoreVersion = 0;
+
+	const getSourceId = () =>
+		typeof sourceId === "function" ? sourceId() : sourceId;
+	const resolvePresetName = () => getCurrentPresetName(getSourceId());
 
 	createEffect(() => {
-		const presetName = getCurrentPresetName();
+		const currentSourceId = getSourceId();
+		const presetName = getCurrentPresetName(currentSourceId);
 		if (!presetName || isServer) {
 			return;
 		}
 
-		if (debounceTimer) {
-			clearTimeout(debounceTimer);
+		const version = restoreVersion + 1;
+		restoreVersion = version;
+		let isCurrentRestore = true;
+		onCleanup(() => {
+			isCurrentRestore = false;
+		});
+		const shouldApply = () => isCurrentRestore && restoreVersion === version;
+		setIsRestored(false);
+
+		untrack(() => restoreCurrentSearchState(currentSourceId, shouldApply));
+		if (shouldApply()) {
+			setIsRestored(true);
 		}
-
-		const init = async () => {
-			setIsInitialLoad(true);
-
-			try {
-				const sessionDataStr = sessionStorage.getItem(presetName);
-				if (sessionDataStr) {
-					const current = JSON.parse(sessionDataStr);
-					if (current.mode === "vector") {
-						resetSearchState();
-						setSearchState({
-							mode: "vector",
-							similarityAnchorMediaId:
-								typeof current.similarityAnchorMediaId === "string"
-									? current.similarityAnchorMediaId
-									: null,
-							similarityTopK:
-								current.similarityTopK === 20 || current.similarityTopK === 100
-									? current.similarityTopK
-									: 50,
-						});
-						return;
-					}
-					const allPresets = await presetClient.list();
-
-					const matchingPreset = allPresets.find(
-						(p) => p.name !== presetName && deepEqual(p.value, current.value),
-					);
-
-					if (matchingPreset) {
-						loadPreset({
-							...matchingPreset,
-							mode: current.mode,
-							sort: current.sort,
-							order: current.order,
-						});
-					} else {
-						loadPreset({
-							id: -1,
-							name: presetName,
-							value: current.value,
-							sort: current.sort,
-							order: current.order,
-							mode: current.mode,
-							createdAt: new Date(),
-						});
-						setSearchState("activePresetId", null);
-					}
-				} else {
-					resetSearchState();
-				}
-			} catch {
-				// silent — persistence errors should not disrupt the UI
-			} finally {
-				setIsInitialLoad(false);
-			}
-		};
-		init();
 	});
 
 	createEffect(() => {
@@ -130,25 +196,13 @@ export function useCurrentSearchPersistence(
 		];
 		void _track;
 
-		if (isInitialLoad() || !getCurrentPresetName() || isServer) {
-			return;
-		}
-
 		if (debounceTimer) {
 			clearTimeout(debounceTimer);
+			debounceTimer = null;
 		}
-		debounceTimer = setTimeout(saveCurrentState, DEBOUNCE_MS);
-	});
 
-	onCleanup(() => {
-		if (debounceTimer) {
-			clearTimeout(debounceTimer);
-		}
-	});
-
-	const saveCurrentState = async () => {
-		const presetName = getCurrentPresetName();
-		if (!presetName || isServer) {
+		const presetName = resolvePresetName();
+		if (!isRestored() || !presetName || isServer) {
 			return;
 		}
 
@@ -157,9 +211,9 @@ export function useCurrentSearchPersistence(
 			operator: "and" as const,
 			children: [],
 		};
-
 		const presetData = {
 			value: condition,
+			selectedSource: searchState.selectedSource,
 			sort: searchState.sortBy,
 			order: searchState.sortOrder,
 			mode: searchState.mode,
@@ -167,10 +221,20 @@ export function useCurrentSearchPersistence(
 			similarityTopK: searchState.similarityTopK,
 		};
 
-		try {
-			sessionStorage.setItem(presetName, JSON.stringify(presetData));
-		} catch {
-			// silent — persistence errors should not disrupt the UI
+		debounceTimer = setTimeout(() => {
+			try {
+				sessionStorage.setItem(presetName, JSON.stringify(presetData));
+			} catch {
+				// Persistence errors must not disrupt the UI.
+			}
+		}, DEBOUNCE_MS);
+	});
+
+	onCleanup(() => {
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
 		}
-	};
+	});
+
+	return isRestored;
 }

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -10,14 +10,19 @@ import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
 import type { QueryClient } from "@tanstack/solid-query";
+import { createInfiniteQuery, createQuery } from "@tanstack/solid-query";
 import {
-	createInfiniteQuery,
-	createQuery,
-	keepPreviousData,
-} from "@tanstack/solid-query";
-import { createEffect, createMemo, createSignal, onCleanup } from "solid-js";
+	type Accessor,
+	createEffect,
+	createMemo,
+	createSignal,
+	onCleanup,
+} from "solid-js";
 import { isServer } from "solid-js/web";
-import { searchQueryKeys } from "../query-options";
+import {
+	buildSearchResultsQueryOptions,
+	searchQueryKeys,
+} from "../query-options";
 import { type QueryUiState, toQueryUiState } from "../query-state";
 
 const DEFAULT_GC_TIME = 1000 * 60 * 5;
@@ -75,6 +80,7 @@ export interface UseSearchPageOptions {
 	similarityTopK?: () => number;
 	gcTime?: number;
 	refreshDebounceMs?: number;
+	isSearchStateRestored?: Accessor<boolean>;
 }
 
 export interface UseSearchPageResult {
@@ -122,6 +128,7 @@ export function useSearchPage(
 		similarityTopK = () => 50,
 		gcTime = DEFAULT_GC_TIME,
 		refreshDebounceMs = DEFAULT_REFRESH_DEBOUNCE_MS,
+		isSearchStateRestored = () => true,
 	} = options;
 
 	const tags = createQuery<TagResponse[]>(() => ({
@@ -153,73 +160,23 @@ export function useSearchPage(
 		JSON.stringify(getSearchCondition() ?? null),
 	);
 
-	const buildSearchParams = (): Pick<
-		MediaSearchRequest,
-		"condition" | "sort" | "order" | "limit"
-	> => {
-		const condition = getSearchCondition();
-		return {
-			condition: condition || undefined,
+	const searchResultQuery = createInfiniteQuery(() =>
+		buildSearchResultsQueryOptions({
+			mode: mode(),
+			sourceId: selectedSource() || undefined,
+			condition: getSearchCondition(),
+			conditionKey: conditionKey(),
 			sort: sortBy(),
 			order: sortOrder(),
 			limit: limit(),
-		};
-	};
-
-	const searchResultQuery = createInfiniteQuery<MediaSearchResponse>(() => {
-		const params = buildSearchParams();
-		const source = selectedSource() || undefined;
-		return {
-			enabled: !isServer,
-			queryKey: searchQueryKeys.results({
-				mode: mode(),
-				sourceId: source,
-				conditionKey: conditionKey(),
-				sort: sortBy(),
-				order: sortOrder(),
-				limit: limit(),
-				similarityAnchorMediaId: similarityAnchorMediaId(),
-				similarityTopK: similarityTopK(),
-			}),
-			queryFn: async ({ pageParam, signal }) => {
-				if (mode() === "vector") {
-					const anchorMediaId = similarityAnchorMediaId();
-					if (!(anchorMediaId && options.searchSimilar)) {
-						return { media: [], total: 0 };
-					}
-					return await options.searchSimilar(
-						{
-							anchorMediaId,
-							mediaSourceId: source,
-							topK: similarityTopK(),
-						},
-						signal,
-					);
-				}
-				return await searchMedia(
-					source,
-					{
-						...params,
-						offset: pageParam as number,
-					},
-					signal,
-				);
-			},
-			initialPageParam: 0,
-			getNextPageParam: (lastPage, allPages) => {
-				if (mode() === "vector") return;
-				const loadedCount = allPages.reduce(
-					(sum, page) => sum + page.media.length,
-					0,
-				);
-				if (loadedCount < lastPage.total) {
-					return loadedCount;
-				}
-			},
-			placeholderData: keepPreviousData,
+			similarityAnchorMediaId: similarityAnchorMediaId(),
+			similarityTopK: similarityTopK(),
+			searchMedia,
+			searchSimilar: options.searchSimilar,
+			enabled: !isServer && isSearchStateRestored(),
 			gcTime,
-		};
-	});
+		}),
+	);
 
 	const searchResults = createMemo(() => {
 		const seen = new Set<string>();

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -15,7 +15,7 @@ import {
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
 import { getErrorMessage } from "@solid-imager/core/utils";
 import type { QueryClient } from "@tanstack/solid-query";
-import { createInfiniteQuery, keepPreviousData } from "@tanstack/solid-query";
+import { createInfiniteQuery } from "@tanstack/solid-query";
 import type { Accessor, Setter } from "solid-js";
 import {
 	createEffect,
@@ -26,16 +26,18 @@ import {
 } from "solid-js";
 import { isServer } from "solid-js/web";
 import { z } from "zod";
-import { sourceMediaQueryKeys } from "../query-options";
+import {
+	buildSourceMediaResultsQueryOptions,
+	sourceMediaQueryKeys,
+} from "../query-options";
 import { type QueryUiState, toQueryUiState } from "../query-state";
 import type { PresetManagerClient } from "../search-control-panel";
 import { toast } from "../toast";
 import { getRestoreImportStrategies } from "./restore-import";
-import type { PresetClientLike } from "./use-current-search-persistence";
 import type { MediaSourceEventTransport } from "./use-media-source-events";
 import { useMediaSourceEvents } from "./use-media-source-events";
 
-const MEDIA_ITEMS_PER_PAGE = 200;
+export const SOURCE_MEDIA_ITEMS_PER_PAGE = 200;
 const SCROLL_RESTORE_DELAY = 100;
 const DEBOUNCE_DELAY_MS = 1000;
 const MEDIA_REFRESH_DEBOUNCE_MS = 300;
@@ -150,8 +152,7 @@ export type SourceMediaPageActions = {
 	parseRestoreFile?: (file: File) => Promise<unknown>;
 };
 
-export type SourceMediaPagePresetClient = PresetManagerClient &
-	PresetClientLike;
+export type SourceMediaPagePresetClient = PresetManagerClient;
 
 export type UseSourceMediaPageOptions = {
 	mediaSourceId: () => string | undefined;
@@ -166,6 +167,7 @@ export type UseSourceMediaPageOptions = {
 	sortOrder: () => "asc" | "desc";
 	itemsPerPage?: number;
 	onThumbnailReady?: (mediaId: string) => void;
+	isSearchStateRestored?: Accessor<boolean>;
 };
 
 export type UseSourceMediaPageResult = {
@@ -230,8 +232,9 @@ export function useSourceMediaPage(
 		getSearchCondition,
 		sortBy,
 		sortOrder,
-		itemsPerPage = MEDIA_ITEMS_PER_PAGE,
+		itemsPerPage = SOURCE_MEDIA_ITEMS_PER_PAGE,
 		onThumbnailReady,
+		isSearchStateRestored = () => true,
 	} = options;
 
 	const id = mediaSourceId;
@@ -250,44 +253,18 @@ export function useSourceMediaPage(
 		JSON.stringify(getSearchCondition() ?? null),
 	);
 
-	const mediaQuery = createInfiniteQuery<MediaSearchResponse>(() => ({
-		queryKey: sourceMediaQueryKeys.results({
+	const mediaQuery = createInfiniteQuery(() =>
+		buildSourceMediaResultsQueryOptions({
 			sourceId: id(),
+			condition: getSearchCondition(),
 			conditionKey: searchConditionKey(),
 			sort: sortBy(),
 			order: sortOrder(),
+			limit: itemsPerPage,
+			searchMedia: actions.searchMedia,
+			enabled: !isServer && isSearchStateRestored() && !!id(),
 		}),
-		queryFn: ({ pageParam, signal }) => {
-			const sourceId = id();
-			if (!sourceId) {
-				throw new Error("Media source ID is required");
-			}
-			return actions.searchMedia(
-				sourceId,
-				{
-					condition: getSearchCondition() || undefined,
-					sort: sortBy(),
-					order: sortOrder(),
-					limit: itemsPerPage,
-					offset: pageParam as number,
-				},
-				signal,
-			);
-		},
-		initialPageParam: 0,
-		getNextPageParam: (lastPage, allPages) => {
-			const loadedCount = allPages.reduce(
-				(sum, page) => sum + page.media.length,
-				0,
-			);
-			if (loadedCount < lastPage.total) {
-				return loadedCount;
-			}
-			return;
-		},
-		placeholderData: keepPreviousData,
-		enabled: !isServer && !!id(),
-	}));
+	);
 
 	// --- Deduplicated results ---
 	const mediaResults = createMemo(() => {

--- a/packages/ui/src/preset-manager.tsx
+++ b/packages/ui/src/preset-manager.tsx
@@ -1,7 +1,9 @@
-import type {
-	Preset,
-	SearchGroup,
+import {
+	type Preset,
+	type SearchGroup,
+	searchGroupSchema,
 } from "@solid-imager/core/domain/media/schemas";
+import { deepEqual } from "@solid-imager/core/utils/deep-equal";
 import { createEffect, createResource, createSignal, Show } from "solid-js";
 import {
 	AlertDialog,
@@ -37,6 +39,7 @@ import {
 	getSearchCondition,
 	loadPreset,
 	searchState,
+	setSearchState,
 } from "./stores/search-store";
 import { toast } from "./toast";
 import { cn } from "./utils/cn";
@@ -53,6 +56,16 @@ export interface PresetManagerClient {
 	delete(id: number): Promise<unknown>;
 }
 
+function normalizeSearchCondition(condition: SearchGroup | undefined) {
+	return searchGroupSchema.parse(
+		condition ?? {
+			type: "group",
+			operator: "and",
+			children: [],
+		},
+	);
+}
+
 export function PresetManager(props: {
 	presetClient: PresetManagerClient;
 	class?: string;
@@ -61,6 +74,20 @@ export function PresetManager(props: {
 	const [data, { refetch }] = createResource(props.presetClient.list);
 
 	const presets = () => data()?.filter((p) => !p.name.startsWith("current"));
+
+	createEffect(() => {
+		const availablePresets = presets();
+		if (!availablePresets || searchState.activePresetId !== null) {
+			return;
+		}
+		const condition = normalizeSearchCondition(getSearchCondition());
+		const matchingPreset = availablePresets.find((preset) =>
+			deepEqual(normalizeSearchCondition(preset.value), condition),
+		);
+		if (matchingPreset) {
+			setSearchState("activePresetId", matchingPreset.id);
+		}
+	});
 
 	const [isSaveDialogOpen, setIsSaveDialogOpen] = createSignal(false);
 	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = createSignal(false);

--- a/packages/ui/src/query-options/index.ts
+++ b/packages/ui/src/query-options/index.ts
@@ -38,8 +38,12 @@ export {
 	QUERY_STALE_TIME_MS,
 } from "./query-client";
 export {
+	buildSearchResultsQueryOptions,
+	buildSourceMediaResultsQueryOptions,
 	type SearchResultsQueryKeyInput,
+	type SearchResultsQueryOptionsInput,
 	type SourceMediaQueryKeyInput,
+	type SourceMediaResultsQueryOptionsInput,
 	searchQueryKeys,
 	sourceMediaQueryKeys,
 } from "./search-query";

--- a/packages/ui/src/query-options/search-query.test.ts
+++ b/packages/ui/src/query-options/search-query.test.ts
@@ -1,5 +1,47 @@
-import { describe, expect, it } from "vitest";
-import { searchQueryKeys, sourceMediaQueryKeys } from "./search-query";
+import type {
+	Media,
+	MediaSearchRequest,
+	MediaSearchResponse,
+} from "@solid-imager/core/domain/media/schemas";
+import { QueryClient } from "@tanstack/solid-query";
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildSearchResultsQueryOptions,
+	buildSourceMediaResultsQueryOptions,
+	searchQueryKeys,
+	sourceMediaQueryKeys,
+} from "./search-query";
+
+const TEST_MEDIA: Media = {
+	id: "11111111-1111-4111-8111-111111111111",
+	mediaSourceId: "22222222-2222-4222-8222-222222222222",
+	filePath: "/images/example.png",
+	fileName: "example.png",
+	mediaType: "image",
+	width: 1024,
+	height: 1024,
+	fileSize: 1024,
+	description: null,
+	createdAt: new Date("2026-01-01T00:00:00.000Z"),
+	modifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+	indexedAt: new Date("2026-01-01T00:00:00.000Z"),
+	status: "active",
+};
+
+const EMPTY_RESPONSE: MediaSearchResponse = { media: [], total: 0 };
+
+const TEST_CONDITION = {
+	type: "group",
+	operator: "and",
+	children: [
+		{
+			type: "criterion",
+			target: "fileName",
+			operator: "contains",
+			value: "sample",
+		},
+	],
+} satisfies MediaSearchRequest["condition"];
 
 describe("query key factories", () => {
 	it("keeps search invalidation as a prefix of result keys", () => {
@@ -22,7 +64,318 @@ describe("query key factories", () => {
 			conditionKey: "{}",
 			sort: "date",
 			order: "desc",
+			limit: 200,
 		});
 		expect(key.slice(0, 2)).toEqual(sourceMediaQueryKeys.forSource("source"));
+	});
+});
+
+describe("buildSearchResultsQueryOptions", () => {
+	it("builds a stable key and forwards paged search input", async () => {
+		const searchMedia = vi.fn(
+			async (): Promise<MediaSearchResponse> => EMPTY_RESPONSE,
+		);
+		const searchSimilar = vi.fn(
+			async (): Promise<MediaSearchResponse> => EMPTY_RESPONSE,
+		);
+		const options = buildSearchResultsQueryOptions({
+			mode: "pro",
+			sourceId: "source-1",
+			condition: TEST_CONDITION,
+			conditionKey: '{"type":"group"}',
+			sort: "rating",
+			order: "asc",
+			limit: 40,
+			similarityAnchorMediaId: null,
+			similarityTopK: 25,
+			searchMedia,
+			searchSimilar,
+			enabled: false,
+			gcTime: 12_345,
+		});
+
+		expect(options.queryKey).toEqual([
+			"searchResults",
+			{
+				mode: "pro",
+				sourceId: "source-1",
+				conditionKey: '{"type":"group"}',
+				sort: "rating",
+				order: "asc",
+				limit: 40,
+				similarityAnchorMediaId: null,
+				similarityTopK: 25,
+			},
+		]);
+		expect(options.initialPageParam).toBe(0);
+		expect(options.enabled).toBe(false);
+		expect(options.gcTime).toBe(12_345);
+
+		const queryFn = options.queryFn;
+		if (typeof queryFn !== "function") {
+			throw new Error("queryFn must be a function");
+		}
+		const signal = new AbortController().signal;
+		await queryFn({
+			client: new QueryClient(),
+			queryKey: options.queryKey,
+			signal,
+			meta: undefined,
+			pageParam: 80,
+			direction: "forward",
+		});
+
+		expect(searchMedia).toHaveBeenCalledOnce();
+		expect(searchMedia).toHaveBeenCalledWith(
+			"source-1",
+			{
+				condition: TEST_CONDITION,
+				sort: "rating",
+				order: "asc",
+				limit: 40,
+				offset: 80,
+			},
+			signal,
+		);
+		expect(searchSimilar).not.toHaveBeenCalled();
+	});
+
+	it("uses loaded media count as the next offset", () => {
+		const options = buildSearchResultsQueryOptions({
+			mode: "simple",
+			sourceId: undefined,
+			condition: undefined,
+			conditionKey: "null",
+			sort: "date",
+			order: "desc",
+			limit: 1,
+			similarityAnchorMediaId: null,
+			similarityTopK: 50,
+			searchMedia: async () => EMPTY_RESPONSE,
+			searchSimilar: undefined,
+		});
+		const getNextPageParam = options.getNextPageParam;
+		if (!getNextPageParam) {
+			throw new Error("getNextPageParam must be defined");
+		}
+		const firstPage = { media: [TEST_MEDIA], total: 3 };
+		const secondPage = { media: [TEST_MEDIA], total: 3 };
+
+		expect(
+			getNextPageParam(secondPage, [firstPage, secondPage], 1, [0, 1]),
+		).toBe(2);
+		expect(
+			getNextPageParam(
+				{ ...secondPage, total: 2 },
+				[firstPage, { ...secondPage, total: 2 }],
+				1,
+				[0, 1],
+			),
+		).toBeUndefined();
+	});
+
+	it("forwards vector search input and disables pagination", async () => {
+		const response = { media: [TEST_MEDIA], total: 10 };
+		const searchMedia = vi.fn(
+			async (): Promise<MediaSearchResponse> => EMPTY_RESPONSE,
+		);
+		const searchSimilar = vi.fn(
+			async (): Promise<MediaSearchResponse> => response,
+		);
+		const options = buildSearchResultsQueryOptions({
+			mode: "vector",
+			sourceId: "source-2",
+			condition: TEST_CONDITION,
+			conditionKey: "vector-condition",
+			sort: "name",
+			order: "desc",
+			limit: 100,
+			similarityAnchorMediaId: "anchor-media",
+			similarityTopK: 10,
+			searchMedia,
+			searchSimilar,
+		});
+		const queryFn = options.queryFn;
+		if (typeof queryFn !== "function") {
+			throw new Error("queryFn must be a function");
+		}
+		const signal = new AbortController().signal;
+
+		await expect(
+			queryFn({
+				client: new QueryClient(),
+				queryKey: options.queryKey,
+				signal,
+				meta: undefined,
+				pageParam: 200,
+				direction: "forward",
+			}),
+		).resolves.toEqual(response);
+		expect(searchSimilar).toHaveBeenCalledWith(
+			{
+				anchorMediaId: "anchor-media",
+				mediaSourceId: "source-2",
+				topK: 10,
+			},
+			signal,
+		);
+		expect(searchMedia).not.toHaveBeenCalled();
+
+		const getNextPageParam = options.getNextPageParam;
+		if (!getNextPageParam) {
+			throw new Error("getNextPageParam must be defined");
+		}
+		expect(getNextPageParam(response, [response], 0, [0])).toBeUndefined();
+	});
+
+	it("returns an empty result when vector search requirements are absent", async () => {
+		const searchMedia = vi.fn(
+			async (): Promise<MediaSearchResponse> => EMPTY_RESPONSE,
+		);
+		const options = buildSearchResultsQueryOptions({
+			mode: "vector",
+			sourceId: undefined,
+			condition: undefined,
+			conditionKey: "null",
+			sort: undefined,
+			order: "desc",
+			limit: 100,
+			similarityAnchorMediaId: null,
+			similarityTopK: 50,
+			searchMedia,
+			searchSimilar: undefined,
+			enabled: false,
+		});
+		const queryFn = options.queryFn;
+		if (typeof queryFn !== "function") {
+			throw new Error("queryFn must be a function");
+		}
+
+		await expect(
+			queryFn({
+				client: new QueryClient(),
+				queryKey: options.queryKey,
+				signal: new AbortController().signal,
+				meta: undefined,
+				pageParam: 0,
+				direction: "forward",
+			}),
+		).resolves.toEqual(EMPTY_RESPONSE);
+		expect(options.enabled).toBe(false);
+		expect(searchMedia).not.toHaveBeenCalled();
+	});
+});
+
+describe("buildSourceMediaResultsQueryOptions", () => {
+	it("builds a source-scoped key and forwards paged search input", async () => {
+		const searchMedia = vi.fn(
+			async (): Promise<MediaSearchResponse> => EMPTY_RESPONSE,
+		);
+		const options = buildSourceMediaResultsQueryOptions({
+			sourceId: "source-3",
+			condition: TEST_CONDITION,
+			conditionKey: "source-condition",
+			sort: "size",
+			order: "desc",
+			limit: 200,
+			searchMedia,
+			enabled: true,
+		});
+
+		expect(options.queryKey).toEqual([
+			"media",
+			"source-3",
+			{
+				sourceId: "source-3",
+				conditionKey: "source-condition",
+				sort: "size",
+				order: "desc",
+				limit: 200,
+			},
+		]);
+		expect(options.initialPageParam).toBe(0);
+		expect(options.enabled).toBe(true);
+
+		const queryFn = options.queryFn;
+		if (typeof queryFn !== "function") {
+			throw new Error("queryFn must be a function");
+		}
+		const signal = new AbortController().signal;
+		await queryFn({
+			client: new QueryClient(),
+			queryKey: options.queryKey,
+			signal,
+			meta: undefined,
+			pageParam: 400,
+			direction: "forward",
+		});
+
+		expect(searchMedia).toHaveBeenCalledWith(
+			"source-3",
+			{
+				condition: TEST_CONDITION,
+				sort: "size",
+				order: "desc",
+				limit: 200,
+				offset: 400,
+			},
+			signal,
+		);
+	});
+
+	it("uses loaded media count as the next source offset", () => {
+		const options = buildSourceMediaResultsQueryOptions({
+			sourceId: "source-3",
+			condition: undefined,
+			conditionKey: "null",
+			sort: undefined,
+			order: "desc",
+			limit: 1,
+			searchMedia: async () => EMPTY_RESPONSE,
+		});
+		const getNextPageParam = options.getNextPageParam;
+		if (!getNextPageParam) {
+			throw new Error("getNextPageParam must be defined");
+		}
+		const firstPage = { media: [TEST_MEDIA], total: 2 };
+		const secondPage = { media: [TEST_MEDIA], total: 2 };
+
+		expect(getNextPageParam(firstPage, [firstPage], 0, [0])).toBe(1);
+		expect(
+			getNextPageParam(secondPage, [firstPage, secondPage], 1, [0, 1]),
+		).toBeUndefined();
+	});
+
+	it("rejects execution when the source ID is unavailable", async () => {
+		const searchMedia = vi.fn(
+			async (): Promise<MediaSearchResponse> => EMPTY_RESPONSE,
+		);
+		const options = buildSourceMediaResultsQueryOptions({
+			sourceId: undefined,
+			condition: undefined,
+			conditionKey: "null",
+			sort: undefined,
+			order: "desc",
+			limit: 200,
+			searchMedia,
+			enabled: false,
+		});
+		const queryFn = options.queryFn;
+		if (typeof queryFn !== "function") {
+			throw new Error("queryFn must be a function");
+		}
+
+		await expect(
+			queryFn({
+				client: new QueryClient(),
+				queryKey: options.queryKey,
+				signal: new AbortController().signal,
+				meta: undefined,
+				pageParam: 0,
+				direction: "forward",
+			}),
+		).rejects.toThrow("Media source ID is required");
+		expect(options.enabled).toBe(false);
+		expect(searchMedia).not.toHaveBeenCalled();
 	});
 });

--- a/packages/ui/src/query-options/search-query.ts
+++ b/packages/ui/src/query-options/search-query.ts
@@ -1,3 +1,9 @@
+import type {
+	MediaSearchRequest,
+	MediaSearchResponse,
+} from "@solid-imager/core/domain/media/schemas";
+import { infiniteQueryOptions, keepPreviousData } from "@tanstack/solid-query";
+
 export type SearchResultsQueryKeyInput = {
 	mode: "simple" | "pro" | "vector";
 	sourceId: string | undefined;
@@ -20,6 +26,7 @@ export type SourceMediaQueryKeyInput = {
 	conditionKey: string;
 	sort: string | undefined;
 	order: "asc" | "desc";
+	limit: number;
 };
 
 export const sourceMediaQueryKeys = {
@@ -28,3 +35,149 @@ export const sourceMediaQueryKeys = {
 	results: (input: SourceMediaQueryKeyInput) =>
 		["media", input.sourceId, input] as const,
 };
+
+type SearchMedia = (
+	sourceId: string | undefined,
+	params: MediaSearchRequest,
+	signal?: AbortSignal,
+) => Promise<MediaSearchResponse>;
+
+type SearchSourceMedia = (
+	sourceId: string,
+	params: MediaSearchRequest,
+	signal?: AbortSignal,
+) => Promise<MediaSearchResponse>;
+
+type SearchSimilar = (
+	input: {
+		anchorMediaId: string;
+		mediaSourceId?: string;
+		topK: number;
+	},
+	signal?: AbortSignal,
+) => Promise<MediaSearchResponse>;
+
+export type SearchResultsQueryOptionsInput = {
+	mode: "simple" | "pro" | "vector";
+	sourceId: string | undefined;
+	condition: MediaSearchRequest["condition"];
+	conditionKey: string;
+	sort: MediaSearchRequest["sort"];
+	order: "asc" | "desc";
+	limit: number;
+	similarityAnchorMediaId: string | null;
+	similarityTopK: number;
+	searchMedia: SearchMedia;
+	searchSimilar: SearchSimilar | undefined;
+	enabled?: boolean;
+	gcTime?: number;
+};
+
+export function buildSearchResultsQueryOptions(
+	input: SearchResultsQueryOptionsInput,
+) {
+	return infiniteQueryOptions({
+		queryKey: searchQueryKeys.results({
+			mode: input.mode,
+			sourceId: input.sourceId,
+			conditionKey: input.conditionKey,
+			sort: input.sort,
+			order: input.order,
+			limit: input.limit,
+			similarityAnchorMediaId: input.similarityAnchorMediaId,
+			similarityTopK: input.similarityTopK,
+		}),
+		queryFn: async ({ pageParam, signal }): Promise<MediaSearchResponse> => {
+			if (input.mode === "vector") {
+				if (!(input.similarityAnchorMediaId && input.searchSimilar)) {
+					return { media: [], total: 0 };
+				}
+				return await input.searchSimilar(
+					{
+						anchorMediaId: input.similarityAnchorMediaId,
+						mediaSourceId: input.sourceId,
+						topK: input.similarityTopK,
+					},
+					signal,
+				);
+			}
+
+			return await input.searchMedia(
+				input.sourceId,
+				{
+					condition: input.condition || undefined,
+					sort: input.sort,
+					order: input.order,
+					limit: input.limit,
+					offset: typeof pageParam === "number" ? pageParam : 0,
+				},
+				signal,
+			);
+		},
+		initialPageParam: 0,
+		getNextPageParam: (lastPage, allPages) => {
+			if (input.mode === "vector") {
+				return;
+			}
+			const loadedCount = allPages.reduce(
+				(sum, page) => sum + page.media.length,
+				0,
+			);
+			return loadedCount < lastPage.total ? loadedCount : undefined;
+		},
+		placeholderData: keepPreviousData,
+		enabled: input.enabled,
+		gcTime: input.gcTime,
+	});
+}
+
+export type SourceMediaResultsQueryOptionsInput = {
+	sourceId: string | undefined;
+	condition: MediaSearchRequest["condition"];
+	conditionKey: string;
+	sort: MediaSearchRequest["sort"];
+	order: "asc" | "desc";
+	limit: number;
+	searchMedia: SearchSourceMedia;
+	enabled?: boolean;
+};
+
+export function buildSourceMediaResultsQueryOptions(
+	input: SourceMediaResultsQueryOptionsInput,
+) {
+	return infiniteQueryOptions({
+		queryKey: sourceMediaQueryKeys.results({
+			sourceId: input.sourceId,
+			conditionKey: input.conditionKey,
+			sort: input.sort,
+			order: input.order,
+			limit: input.limit,
+		}),
+		queryFn: async ({ pageParam, signal }): Promise<MediaSearchResponse> => {
+			if (!input.sourceId) {
+				throw new Error("Media source ID is required");
+			}
+			return await input.searchMedia(
+				input.sourceId,
+				{
+					condition: input.condition || undefined,
+					sort: input.sort,
+					order: input.order,
+					limit: input.limit,
+					offset: typeof pageParam === "number" ? pageParam : 0,
+				},
+				signal,
+			);
+		},
+		initialPageParam: 0,
+		getNextPageParam: (lastPage, allPages) => {
+			const loadedCount = allPages.reduce(
+				(sum, page) => sum + page.media.length,
+				0,
+			);
+			return loadedCount < lastPage.total ? loadedCount : undefined;
+		},
+		placeholderData: keepPreviousData,
+		enabled: input.enabled,
+	});
+}

--- a/packages/ui/src/router-status.tsx
+++ b/packages/ui/src/router-status.tsx
@@ -84,6 +84,32 @@ export function RoutePendingScreen() {
 	);
 }
 
+export type RouteDataPendingScreenProps = {
+	title: string;
+	description: string;
+};
+
+export function RouteDataPendingScreen(props: RouteDataPendingScreenProps) {
+	return (
+		<main class="container mx-auto p-4">
+			<section
+				aria-labelledby="route-data-pending-title"
+				aria-live="polite"
+				class="flex min-h-48 flex-col items-center justify-center gap-2 text-center text-muted-foreground"
+				role="status"
+			>
+				<h1
+					class="font-bold text-2xl text-foreground"
+					id="route-data-pending-title"
+				>
+					{props.title}
+				</h1>
+				<p>{props.description}</p>
+			</section>
+		</main>
+	);
+}
+
 export function RouteErrorScreen(props: ErrorComponentProps) {
 	const router = useRouter();
 

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -11,7 +11,6 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "../dialog";
-import { useCurrentSearchPersistence } from "../hooks/use-current-search-persistence";
 import type {
 	UploadOptions,
 	UseSourceMediaPageResult,
@@ -75,9 +74,6 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 	const page = () => props.page;
 	const filterStates = () => Object.values(page().filterStates());
 	const shouldRenderGrid = () => !props.enableVirtualization || isMounted();
-
-	// Enable auto-save/restore of search conditions
-	useCurrentSearchPersistence(page().mediaSourceId, page().presetClient);
 
 	onMount(() => {
 		setIsMounted(true);

--- a/packages/ui/src/source-card.tsx
+++ b/packages/ui/src/source-card.tsx
@@ -2,6 +2,7 @@ import type {
 	MediaSourceInfo,
 	SafeMediaSource,
 } from "@solid-imager/core/domain/sources/schemas";
+import { Link } from "@tanstack/solid-router";
 import {
 	Card,
 	CardContent,
@@ -65,62 +66,91 @@ export function SourceCard(props: SourceCardProps) {
 		props.onDelete?.(props.mediaSource);
 	};
 
-	return (
-		<a
-			class="block text-current no-underline"
-			href={props.href ?? `/sources/${props.mediaSource.id}`}
-		>
-			<Card class="relative h-full hover:bg-gray-50" data-testid="source-card">
-				<CardHeader>
-					<CardTitle data-testid="source-name">
-						{props.mediaSource.name}
-					</CardTitle>
-				</CardHeader>
-				<CardContent>
-					<CardDescription>{props.mediaSource.description}</CardDescription>
-					<div class="mt-4 space-y-2 text-sm">
-						<p>
-							<span class="font-semibold">Type:</span>{" "}
-							{getTypeLabel(props.mediaSource.type)}
-						</p>
-						<p class="truncate" title={getConnectionDetails(props.mediaSource)}>
-							{getConnectionDetails(props.mediaSource)}
-						</p>
-					</div>
-				</CardContent>
-				<div class="absolute top-2 right-2 z-10 flex gap-1">
-					{props.onSync && (
-						<button
-							class="rounded border bg-white px-2 py-1 text-xs shadow hover:bg-gray-50"
-							data-testid="sync-source-btn"
-							onClick={handleSyncClick}
-							type="button"
-						>
-							Sync
-						</button>
-					)}
-					{props.onEdit && (
-						<button
-							class="rounded border bg-white px-2 py-1 text-xs shadow hover:bg-gray-50"
-							data-testid="edit-source-btn"
-							onClick={handleEditClick}
-							type="button"
-						>
-							Edit
-						</button>
-					)}
-					{props.onDelete && (
-						<button
-							class="rounded bg-red-500 px-2 py-1 text-white text-xs shadow hover:bg-red-600"
-							data-testid="delete-source-btn"
-							onClick={handleDeleteClick}
-							type="button"
-						>
-							Delete
-						</button>
-					)}
+	const content = () => (
+		<>
+			<CardHeader>
+				<CardTitle data-testid="source-name">
+					{props.mediaSource.name}
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<CardDescription>{props.mediaSource.description}</CardDescription>
+				<div class="mt-4 space-y-2 text-sm">
+					<p>
+						<span class="font-semibold">Type:</span>{" "}
+						{getTypeLabel(props.mediaSource.type)}
+					</p>
+					<p class="truncate" title={getConnectionDetails(props.mediaSource)}>
+						{getConnectionDetails(props.mediaSource)}
+					</p>
 				</div>
-			</Card>
-		</a>
+			</CardContent>
+		</>
+	);
+
+	const sourceLink = () => {
+		if (props.href) {
+			return (
+				<a class="block h-full text-current no-underline" href={props.href}>
+					{content()}
+				</a>
+			);
+		}
+
+		if (!props.mediaSource.id) {
+			return (
+				<Link class="block h-full text-current no-underline" to="/sources">
+					{content()}
+				</Link>
+			);
+		}
+
+		return (
+			<Link
+				class="block h-full text-current no-underline"
+				params={{ mediaSourceId: props.mediaSource.id }}
+				to="/sources/$mediaSourceId"
+			>
+				{content()}
+			</Link>
+		);
+	};
+
+	return (
+		<Card class="relative h-full hover:bg-gray-50" data-testid="source-card">
+			{sourceLink()}
+			<div class="absolute top-2 right-2 z-10 flex gap-1">
+				{props.onSync && (
+					<button
+						class="rounded border bg-white px-2 py-1 text-xs shadow hover:bg-gray-50"
+						data-testid="sync-source-btn"
+						onClick={handleSyncClick}
+						type="button"
+					>
+						Sync
+					</button>
+				)}
+				{props.onEdit && (
+					<button
+						class="rounded border bg-white px-2 py-1 text-xs shadow hover:bg-gray-50"
+						data-testid="edit-source-btn"
+						onClick={handleEditClick}
+						type="button"
+					>
+						Edit
+					</button>
+				)}
+				{props.onDelete && (
+					<button
+						class="rounded bg-red-500 px-2 py-1 text-white text-xs shadow hover:bg-red-600"
+						data-testid="delete-source-btn"
+						onClick={handleDeleteClick}
+						type="button"
+					>
+						Delete
+					</button>
+				)}
+			</div>
+		</Card>
 	);
 }

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -9,6 +9,7 @@ import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import type { Accessor, JSX } from "solid-js";
 import { isServer } from "solid-js/web";
+import { useCurrentSearchPersistence } from "./hooks/use-current-search-persistence";
 import type { MediaSourceEventTransport } from "./hooks/use-media-source-events";
 import {
 	type SourceMediaPageActions,
@@ -61,6 +62,9 @@ export type SourceMediaPageProps = {
 
 export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 	const queryClient = useQueryClient();
+	const isSearchStateRestored = useCurrentSearchPersistence(
+		props.mediaSourceId,
+	);
 
 	const tags = createQuery<TagResponse[]>(
 		clientOnlyQueryOptions(props.tagsQueryOptions),
@@ -112,6 +116,7 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 		sortBy: props.sortBy,
 		sortOrder: props.sortOrder,
 		onThumbnailReady: props.onThumbnailReady,
+		isSearchStateRestored,
 	});
 
 	const renderActions: SourceMediaScreenProps["renderActions"] = () => (


### PR DESCRIPTION
## 概要

Web主要routeのSelective SSRとSolid Query hydrationを再設計し、冷間F5の空本文・bootstrap race・hydrate後の重複fetchを解消します。

Fixes #594

## 変更内容

- Sources / ConfigをFull data SSRへ移行
- Search / Manager / Source Media / Media Detailをroute固有static fallback + Query preload/hydrationへ移行
- server bootstrapをloaderより前に完了し、server QueryClientをrequest単位、browserをsingleton化
- Solid Router SSR Query integrationでdehydrate/hydrateを統合
- Search session復元完了までprimary queryをgateし、intent hoverによるstore変更と二重取得を防止
- server / Tauriで共有するinfinite query option builderを追加
- raw SSR、直接URL、F5、SPA intent、cache再訪、API request数、表示時間budgetのE2Eを追加
- Full SSR後の操作可能性とSSE更新後のdialog/input/focus保持を回帰検証
- route分類、baseline、budget、data-only不採用理由を設計文書化

## 技術詳細

- 現行Solid Routerのdata-only SSRはhydration key mismatchを再現したため採用せず、server/clientで同じcomponent treeを使うssr: trueを選択しました
- 初回hydration完了をhtmlのdata-hydrated属性で明示し、SSR DOM可視とinteraction readyを区別します
- session依存のmedia.searchはserver loaderから除外し、復元後条件でcold load/reload各1回だけ実行します
- SourcesのFull SSRはdehydrated JSON内の文字列ではなくsource-card実DOMも検証します

## テスト

- dev E2E: 24 passed
- fresh production build E2E: 24 passed
- server unit: 162 passed
- server integration: 67 passed
- UI: 40 passed
- core: 14 passed
- CLI: 11 passed
- 全workspace typecheck: passed
- 変更ファイルのBiome check / Vite+ lint: passed（既存warningのみ）

## 補足

monorepo全体のvp checkは変更外を含む既存ファイル多数がOxfmt未適用のためformat段階で失敗します。変更ファイルは既存のBiome規約でformat/check済みです。導入済みVite+ 0.1.24にはAGENTS記載のvp env doctorサブコマンドがありません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 主要画面でサーバー側データ取得に対応し、直接アクセスや再読み込み時にも内容を早く表示できるようになりました。
  * 検索条件をセッションに保存・復元し、復元完了後に検索結果を表示するようになりました。
  * 設定、検索、ソース画面などに分かりやすい読み込み中表示を追加しました。
  * ソースカードからの画面遷移が改善されました。

* **バグ修正**
  * 配列を含む検索条件の比較精度を改善しました。
  * SSR後の重複通信や画面遷移時の表示不整合を抑制しました。

* **テスト**
  * 直接アクセス、再読み込み、遅延通信、検索状態復元の検証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->