### PR TITLE
feat(ui): 共通の非同期状態UIを整備する (#579)

### DIFF
--- a/apps/server/src/components/api-activity-indicator.tsx
+++ b/apps/server/src/components/api-activity-indicator.tsx
@@ -69,13 +69,22 @@ export function ApiActivityIndicator() {
 
 	return (
 		<Show when={isVisible()}>
-			<div class="fixed top-3 left-1/2 z-[60] -translate-x-1/2 rounded-md border border-border bg-background px-3 py-2 text-sm shadow-lg">
+			<div
+				class="fixed top-3 left-1/2 z-[60] -translate-x-1/2 rounded-md border border-border bg-background px-3 py-2 text-sm shadow-lg"
+				role="status"
+			>
 				<div class="flex items-center gap-2">
 					<Show when={isOnline()}>
-						<span class="inline-block size-2 animate-pulse rounded-full bg-warning-foreground" />
+						<span
+							aria-hidden="true"
+							class="inline-block size-2 animate-pulse rounded-full bg-warning-foreground motion-reduce:animate-none"
+						/>
 					</Show>
 					<Show when={!isOnline()}>
-						<span class="inline-block size-2 rounded-full bg-destructive" />
+						<span
+							aria-hidden="true"
+							class="inline-block size-2 rounded-full bg-destructive"
+						/>
 					</Show>
 					<span class="text-foreground">
 						{getStatusText(isOnline(), activeCount())}

--- a/apps/server/src/routes/config.tsx
+++ b/apps/server/src/routes/config.tsx
@@ -1,10 +1,9 @@
 import { configQueryKeys } from "@solid-imager/ui/query-options";
 import { toQueryUiState } from "@solid-imager/ui/query-state";
 import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
-import { ConfigScreen } from "@solid-imager/ui/screens/config-screen";
+import { ConfigStateScreen } from "@solid-imager/ui/screens/config-state-screen";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
-import { Show } from "solid-js";
 import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import { configQueryOptions } from "~/infrastructure/api-clients/queries";
 
@@ -16,7 +15,10 @@ export const Route = createFileRoute("/config")({
 	},
 	pendingComponent: () => (
 		<RouteDataPendingScreen
+			class="max-w-4xl p-6"
 			description="設定を準備しています..."
+			layout="config"
+			showAction
 			title="Settings"
 		/>
 	),
@@ -32,51 +34,18 @@ function ConfigPageContent() {
 	const config = () => configQuery.data ?? loaderData().config;
 
 	return (
-		<div class="container mx-auto max-w-4xl p-6">
-			<Show when={state().phase === "pending" && config() === undefined}>
-				<div class="py-10 text-center" role="status">
-					Loading settings...
-				</div>
-			</Show>
-
-			<Show
-				when={
-					(state().phase === "error" || state().phase === "offline") &&
-					config() === undefined
-				}
-			>
-				<div class="py-10 text-red-500" role="alert">
-					{state().phase === "offline"
-						? "Offline. Settings will load after reconnecting."
-						: "Error loading settings."}
-				</div>
-			</Show>
-			<Show when={state().fetchState === "background-fetching"}>
-				<p class="mb-2 text-muted-foreground text-sm" role="status">
-					Updating settings...
-				</p>
-			</Show>
-			<Show
-				when={state().fetchState === "paused" && state().data !== undefined}
-			>
-				<p class="mb-2 text-muted-foreground text-sm" role="status">
-					Offline. Showing cached settings.
-				</p>
-			</Show>
-
-			<Show when={config()}>
-				{(data) => (
-					<ConfigScreen
-						data={data()}
-						onSubmit={async (value) => {
-							await orpc.config.update(value);
-							await queryClient.invalidateQueries({
-								queryKey: configQueryKeys.all(),
-							});
-						}}
-					/>
-				)}
-			</Show>
-		</div>
+		<ConfigStateScreen
+			data={config()}
+			onRetry={async () => {
+				await configQuery.refetch();
+			}}
+			onSubmit={async (value) => {
+				await orpc.config.update(value);
+				await queryClient.invalidateQueries({
+					queryKey: configQueryKeys.all(),
+				});
+			}}
+			state={state()}
+		/>
 	);
 }

--- a/apps/server/src/routes/manager.tsx
+++ b/apps/server/src/routes/manager.tsx
@@ -80,7 +80,10 @@ export const Route = createFileRoute("/manager")({
 function ManagerRouteFallback() {
 	return (
 		<RouteDataPendingScreen
+			class="p-4 sm:p-8"
 			description="管理データを準備しています..."
+			layout="manager"
+			showAction
 			title="Entity Manager"
 		/>
 	);

--- a/apps/server/src/routes/search.tsx
+++ b/apps/server/src/routes/search.tsx
@@ -2,6 +2,7 @@ import { Button } from "@solid-imager/ui/button";
 import { useCurrentSearchPersistence } from "@solid-imager/ui/hooks/use-current-search-persistence";
 import { useSearchPage } from "@solid-imager/ui/hooks/use-search-page";
 import { createPresetClient } from "@solid-imager/ui/preset-client";
+import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { SearchScreen } from "@solid-imager/ui/screens/search-screen";
 import { useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
@@ -65,16 +66,12 @@ function SearchRouteBoundary() {
 
 function SearchRouteFallback() {
 	return (
-		<main class="container mx-auto p-4">
-			<section
-				aria-live="polite"
-				class="flex min-h-48 flex-col items-center justify-center gap-2 text-muted-foreground"
-				role="status"
-			>
-				<h1 class="font-bold text-2xl text-foreground">メディア検索</h1>
-				<p>検索画面を準備しています...</p>
-			</section>
-		</main>
+		<RouteDataPendingScreen
+			description="検索画面を準備しています..."
+			layout="media-grid"
+			showDescription
+			title="メディア検索"
+		/>
 	);
 }
 

--- a/apps/server/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
@@ -1,3 +1,4 @@
+import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { MediaDetailScreen } from "@solid-imager/ui/screens/media-detail-screen";
 import { ClientOnly, createFileRoute, useParams } from "@tanstack/solid-router";
 import { createSignal, onMount, Show } from "solid-js";
@@ -48,16 +49,12 @@ function Media() {
 
 function MediaRouteFallback() {
 	return (
-		<main class="container mx-auto p-4">
-			<section
-				aria-live="polite"
-				class="flex min-h-48 flex-col items-center justify-center gap-2 text-muted-foreground"
-				role="status"
-			>
-				<h1 class="font-bold text-2xl text-foreground">メディア詳細</h1>
-				<p>メディア詳細を準備しています...</p>
-			</section>
-		</main>
+		<RouteDataPendingScreen
+			description="メディア詳細を準備しています..."
+			layout="media-detail"
+			showDescription
+			title="メディア詳細"
+		/>
 	);
 }
 

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@solid-imager/ui/button";
 import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { sourceMediaQueryKeys } from "@solid-imager/ui/query-options";
+import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { SourceMediaPage as SourceMediaPageComponent } from "@solid-imager/ui/source-media-page";
 import { useQueryClient } from "@tanstack/solid-query";
 import { useParams } from "@tanstack/solid-router";
@@ -89,9 +90,12 @@ export function SourceMediaPage() {
 	return (
 		<Show
 			fallback={
-				<div class="flex min-h-[60vh] items-center justify-center text-muted-foreground">
-					メディア一覧を読み込んでいます...
-				</div>
+				<RouteDataPendingScreen
+					description="メディア一覧を読み込んでいます..."
+					layout="media-grid"
+					showAction
+					title="メディア一覧"
+				/>
 			}
 			when={isMounted()}
 		>

--- a/apps/server/src/routes/sources/$mediaSourceId/index.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/index.tsx
@@ -30,6 +30,8 @@ function SourceMediaRouteFallback() {
 	return (
 		<RouteDataPendingScreen
 			description="メディア一覧を準備しています..."
+			layout="media-grid"
+			showAction
 			title="メディア一覧"
 		/>
 	);

--- a/apps/server/src/routes/sources/index.tsx
+++ b/apps/server/src/routes/sources/index.tsx
@@ -29,7 +29,10 @@ export const Route = createFileRoute("/sources/")({
 	},
 	pendingComponent: () => (
 		<RouteDataPendingScreen
+			class="p-6"
 			description="ソース一覧を準備しています..."
+			layout="cards"
+			showAction
 			title="Media Sources"
 		/>
 	),
@@ -72,12 +75,18 @@ function SourcesRouteContent() {
 			page={page}
 			mediaSources={sourceData}
 			state={() =>
-				toQueryUiState(mediaSources, {
-					isEmpty: (data) => data.length === 0,
-				})
+				toQueryUiState(
+					{
+						data: sourceData(),
+						error: mediaSources.error,
+						fetchStatus: mediaSources.fetchStatus,
+						status: mediaSources.status,
+					},
+					{ isEmpty: (data) => data.length === 0 },
+				)
 			}
-			onRetry={() => {
-				void mediaSources.refetch();
+			onRetry={async () => {
+				await mediaSources.refetch();
 			}}
 			renderSourceCard={(source) => (
 				<SourceCard

--- a/apps/server/src/tests/e2e/loading-recovery.spec.ts
+++ b/apps/server/src/tests/e2e/loading-recovery.spec.ts
@@ -34,6 +34,7 @@ test.describe("loading and recovery", () => {
 	test("keeps the app shell visible while the initial search response is delayed", async ({
 		page,
 	}) => {
+		await page.emulateMedia({ reducedMotion: "reduce" });
 		let releaseRequest: () => void = () => {};
 		const requestGate = new Promise<void>((resolve) => {
 			releaseRequest = resolve;
@@ -45,9 +46,23 @@ test.describe("loading and recovery", () => {
 
 		const navigation = page.goto("/search", { waitUntil: "commit" });
 		await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
+		const screenSkeleton = page.locator('[data-screen-skeleton="media-grid"]');
+		await expect(screenSkeleton).toBeVisible();
 		await expect(
-			page.getByText("検索画面を準備しています...", { exact: true }),
+			screenSkeleton.locator(':scope > [aria-busy="true"]'),
 		).toBeVisible();
+		await expect(
+			screenSkeleton
+				.locator("p:not(.sr-only)")
+				.filter({ hasText: "検索画面を準備しています..." }),
+		).toBeVisible();
+		await expect(screenSkeleton.locator('[role="status"]')).toHaveCount(1);
+		await page.waitForLoadState("load");
+		await expect(
+			screenSkeleton
+				.locator('[data-skeleton="media-grid"] [aria-hidden="true"]')
+				.first(),
+		).toHaveCSS("animation-name", "none");
 		await expect(
 			page.getByText("APIの応答を待っています...", { exact: true }),
 		).toBeVisible();
@@ -57,6 +72,7 @@ test.describe("loading and recovery", () => {
 		await expect(
 			page.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) }),
 		).toBeVisible();
+		await expect(screenSkeleton).toHaveCount(0);
 	});
 
 	test("keeps existing results and form input during a background refresh", async ({
@@ -82,17 +98,26 @@ test.describe("loading and recovery", () => {
 
 		holdBackgroundRequest = true;
 		const searchInput = page.getByPlaceholder("ファイル名を入力...");
+		await primaryLink.evaluate((element) => {
+			element.setAttribute("data-existing-result", "true");
+		});
 		await searchInput.fill(E2E_PRIMARY_FILE_NAME);
 		await expect(
 			page.getByText("検索結果を更新中...", { exact: true }),
 		).toBeVisible();
 		await expect(searchInput).toHaveValue(E2E_PRIMARY_FILE_NAME);
+		await expect(searchInput).toBeFocused();
 		await expect(primaryLink).toBeVisible();
+		await expect(page.locator('[data-existing-result="true"]')).toBeVisible();
+		await expect(page.locator("[data-screen-skeleton]")).toHaveCount(0);
 
 		releaseRequest();
 		await expect(
 			page.getByText("検索結果を更新中...", { exact: true }),
 		).toHaveCount(0);
+		await expect(searchInput).toHaveValue(E2E_PRIMARY_FILE_NAME);
+		await expect(searchInput).toBeFocused();
+		await expect(primaryLink).toBeVisible();
 	});
 
 	test("keeps route content visible while SPA media-detail preload is delayed", async ({
@@ -134,7 +159,7 @@ test.describe("loading and recovery", () => {
 		).toBeVisible();
 	});
 
-	test("shows a recoverable SPA error and reload recovery when media detail is unavailable", async ({
+	test("recovers a SPA media-detail error with the keyboard retry action", async ({
 		page,
 		browserHealth,
 	}) => {
@@ -156,11 +181,15 @@ test.describe("loading and recovery", () => {
 			.click();
 		await expect(page).toHaveURL(new RegExp(`${mediaPath()}/?$`));
 		await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
-		await expect(page.getByRole("alert")).toContainText("Error:");
+		await expect(page.getByRole("alert")).toContainText(
+			"メディア情報を読み込めませんでした",
+		);
 
 		await page.unroute(mediaDetailsEndpoint);
-		const recoveryResponse = await page.reload();
-		expect(recoveryResponse?.ok()).toBeTruthy();
+		const retryButton = page.getByRole("button", { name: "再試行" });
+		await retryButton.focus();
+		await expect(retryButton).toBeFocused();
+		await retryButton.press("Enter");
 		await expect(
 			page.getByRole("heading", { name: E2E_PRIMARY_FILE_NAME, exact: true }),
 		).toBeVisible();
@@ -183,7 +212,7 @@ test.describe("loading and recovery", () => {
 			).toBeVisible();
 
 			await page.unroute(searchEndpoint);
-			await page.reload();
+			await page.getByRole("button", { name: "再試行" }).click();
 			await expect(
 				page.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) }),
 			).toBeVisible();
@@ -212,10 +241,24 @@ test.describe("loading and recovery", () => {
 		).toBeVisible();
 
 		await page.unroute(searchEndpoint);
-		await page.reload();
+		await page.getByRole("button", { name: "再試行" }).click();
 		await expect(
 			page.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) }),
 		).toBeVisible();
+	});
+
+	test("shows the shared empty state for an unmatched search", async ({
+		page,
+	}) => {
+		await page.goto("/search");
+		await page
+			.getByPlaceholder("ファイル名を入力...")
+			.fill("__issue_579_no_matching_media__");
+
+		const emptyState = page.locator('[data-state-ui="empty"]');
+		await expect(emptyState).toBeVisible();
+		await expect(emptyState).toContainText("検索結果が見つかりませんでした");
+		await expect(emptyState.locator('[role="alert"]')).toHaveCount(0);
 	});
 
 	test("shows and clears the offline API status without replacing existing content", async ({

--- a/apps/tauri/src/main.tsx
+++ b/apps/tauri/src/main.tsx
@@ -74,13 +74,13 @@ function App() {
 				<AppShell nav={<BootstrapNav />}>
 					<BootstrapStatusScreen
 						error={bootstrapError()}
-						onRetry={() => void initialize()}
+						onRetry={initialize}
 					/>
 				</AppShell>
 			</Match>
 			<Match when={state().status === "loading"}>
 				<AppShell nav={<BootstrapNav />}>
-					<BootstrapStatusScreen onRetry={() => void initialize()} />
+					<BootstrapStatusScreen onRetry={initialize} />
 				</AppShell>
 			</Match>
 		</Switch>

--- a/apps/tauri/src/routes/config.tsx
+++ b/apps/tauri/src/routes/config.tsx
@@ -1,9 +1,8 @@
 import { configQueryKeys } from "@solid-imager/ui/query-options";
 import { toQueryUiState } from "@solid-imager/ui/query-state";
-import { ConfigScreen } from "@solid-imager/ui/screens/config-screen";
+import { ConfigStateScreen } from "@solid-imager/ui/screens/config-state-screen";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
-import { Show } from "solid-js";
 import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import { configQueryOptions } from "~/queries";
 
@@ -20,46 +19,18 @@ function ConfigPage() {
 	const state = () => toQueryUiState(configQuery);
 
 	return (
-		<div class="container mx-auto max-w-4xl p-6">
-			<Show when={state().phase === "pending"}>
-				<div class="py-10 text-center" role="status">
-					Loading settings...
-				</div>
-			</Show>
-
-			<Show when={state().phase === "error" || state().phase === "offline"}>
-				<div class="py-10 text-red-500" role="alert">
-					{state().phase === "offline"
-						? "Offline. Settings will load after reconnecting."
-						: "Error loading settings."}
-				</div>
-			</Show>
-			<Show when={state().fetchState === "background-fetching"}>
-				<p class="mb-2 text-muted-foreground text-sm" role="status">
-					Updating settings...
-				</p>
-			</Show>
-			<Show
-				when={state().fetchState === "paused" && state().data !== undefined}
-			>
-				<p class="mb-2 text-muted-foreground text-sm" role="status">
-					Offline. Showing cached settings.
-				</p>
-			</Show>
-
-			<Show when={state().data}>
-				{(data) => (
-					<ConfigScreen
-						data={data()}
-						onSubmit={async (value) => {
-							await orpc.config.update(value);
-							await queryClient.invalidateQueries({
-								queryKey: configQueryKeys.all(),
-							});
-						}}
-					/>
-				)}
-			</Show>
-		</div>
+		<ConfigStateScreen
+			data={state().data}
+			onRetry={async () => {
+				await configQuery.refetch();
+			}}
+			onSubmit={async (value) => {
+				await orpc.config.update(value);
+				await queryClient.invalidateQueries({
+					queryKey: configQueryKeys.all(),
+				});
+			}}
+			state={state()}
+		/>
 	);
 }

--- a/apps/tauri/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
+++ b/apps/tauri/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
@@ -1,5 +1,6 @@
 import { useSourceRootPath } from "@solid-imager/ui/hooks/use-source-root-path";
 import { projectsQueryKeys } from "@solid-imager/ui/query-options";
+import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { MediaDetailScreen } from "@solid-imager/ui/screens/media-detail-screen";
 import { useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute, useParams } from "@tanstack/solid-router";
@@ -9,12 +10,20 @@ import { createTauriTransport } from "~/hooks/use-media-source-events";
 import { mediaDetailsQueryOptions, mediaSourcesQueryOptions } from "~/queries";
 
 export const Route = createFileRoute("/sources/$mediaSourceId/$mediaId/")({
-	loader: async ({ context, params }) => {
+	loader: ({ context, params }) => {
 		void context.queryClient.prefetchQuery(mediaSourcesQueryOptions());
-		await context.queryClient.ensureQueryData(
+		void context.queryClient.prefetchQuery(
 			mediaDetailsQueryOptions(params.mediaSourceId, params.mediaId),
 		);
 	},
+	pendingComponent: () => (
+		<RouteDataPendingScreen
+			description="メディア詳細を準備しています..."
+			layout="media-detail"
+			showDescription
+			title="メディア詳細"
+		/>
+	),
 	component: MediaDetailRoute,
 });
 

--- a/apps/tauri/src/routes/sources/index.tsx
+++ b/apps/tauri/src/routes/sources/index.tsx
@@ -39,6 +39,12 @@ function SourcesRoute() {
 	const { sources } = getCollections();
 	const mediaSources = useLiveQuery(() => sources);
 	const mediaSourcesQuery = createQuery(() => mediaSourcesQueryOptions());
+	const sourceData = () => {
+		const cachedSources = mediaSources();
+		return cachedSources.length > 0 || mediaSources.isReady
+			? cachedSources
+			: undefined;
+	};
 
 	const page = useSourcesPage({
 		actions: {
@@ -63,21 +69,31 @@ function SourcesRoute() {
 		invalidateQueryKey: mediaSourcesQueryOptions().queryKey,
 		registerEvents: registerSourceEvents,
 		getSourceIds: () =>
-			mediaSources()
-				?.map((s) => s.id ?? s.name)
+			(sourceData() ?? [])
+				.map((s) => s.id ?? s.name)
 				.filter((id): id is string => Boolean(id)) ?? [],
 	});
 
 	return (
 		<SourcesScreen
 			page={page}
-			mediaSources={() => mediaSources()}
+			mediaSources={sourceData}
+			onRetry={async () => {
+				await Promise.all([
+					mediaSourcesQuery.refetch(),
+					sources.utils.refetch(),
+				]);
+			}}
 			state={() =>
 				toQueryUiState(
 					{
-						data: mediaSources(),
-						error: mediaSourcesQuery.error,
-						status: mediaSourcesQuery.status,
+						data: sourceData(),
+						error:
+							mediaSourcesQuery.error ??
+							(mediaSources.isError
+								? new Error("保存済みのソースを読み込めませんでした")
+								: undefined),
+						status: mediaSources.isError ? "error" : mediaSourcesQuery.status,
 						fetchStatus: mediaSourcesQuery.fetchStatus,
 					},
 					{ isEmpty: (data) => data.length === 0 },

--- a/packages/ui/src/async-state.tsx
+++ b/packages/ui/src/async-state.tsx
@@ -1,0 +1,223 @@
+import type { JSX, ParentProps } from "solid-js";
+import { createSignal, Match, Show, Switch } from "solid-js";
+import { Dynamic } from "solid-js/web";
+import { Button } from "./button";
+import type { QueryUiFetchState } from "./query-state";
+import { cn } from "./utils/cn";
+
+export type RetryButtonProps = {
+	class?: string;
+	label?: string;
+	onRetry: () => void | Promise<void>;
+};
+
+export function RetryButton(props: RetryButtonProps) {
+	const [isRetrying, setIsRetrying] = createSignal(false);
+
+	const retry = async () => {
+		if (isRetrying()) {
+			return;
+		}
+
+		setIsRetrying(true);
+		try {
+			await props.onRetry();
+		} catch {
+			// The query state renders the retry failure. Keep the control usable.
+		} finally {
+			setIsRetrying(false);
+		}
+	};
+
+	return (
+		<Button
+			aria-busy={isRetrying()}
+			class={props.class}
+			disabled={isRetrying()}
+			onClick={() => void retry()}
+			type="button"
+		>
+			{isRetrying() ? "再試行中..." : (props.label ?? "再試行")}
+		</Button>
+	);
+}
+
+type StatePanelProps = ParentProps<{
+	class?: string;
+	description?: JSX.Element;
+	headingLevel?: 1 | 2;
+	icon: JSX.Element;
+	role?: "alert" | "status";
+	state: "empty" | "error" | "offline";
+	title: string;
+}>;
+
+function StatePanel(props: StatePanelProps) {
+	return (
+		<section
+			class={cn(
+				"flex min-h-48 flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-6 text-center",
+				props.state === "error" && "border-destructive/40 bg-error/60",
+				props.state === "offline" &&
+					"border-warning-foreground/40 bg-warning/60",
+				props.state === "empty" && "bg-muted/30",
+				props.class,
+			)}
+			data-state-ui={props.state}
+		>
+			<div
+				aria-hidden="true"
+				class={cn(
+					"flex size-10 items-center justify-center rounded-full text-lg",
+					props.state === "error" && "bg-destructive/15 text-destructive",
+					props.state === "offline" &&
+						"bg-warning-foreground/15 text-warning-foreground",
+					props.state === "empty" && "bg-muted text-muted-foreground",
+				)}
+			>
+				{props.icon}
+			</div>
+			<div class="max-w-lg space-y-2" role={props.role}>
+				<Dynamic
+					class="font-semibold text-lg"
+					component={props.headingLevel === 1 ? "h1" : "h2"}
+				>
+					{props.title}
+				</Dynamic>
+				<Show when={props.description}>
+					<p class="text-muted-foreground text-sm">{props.description}</p>
+				</Show>
+			</div>
+			<Show when={props.children}>
+				<div class="flex flex-wrap items-center justify-center gap-2">
+					{props.children}
+				</div>
+			</Show>
+		</section>
+	);
+}
+
+export type EmptyStateProps = ParentProps<{
+	class?: string;
+	description?: JSX.Element;
+	headingLevel?: 1 | 2;
+	title: string;
+}>;
+
+export function EmptyState(props: EmptyStateProps) {
+	return (
+		<StatePanel
+			class={props.class}
+			description={props.description}
+			headingLevel={props.headingLevel}
+			icon="–"
+			state="empty"
+			title={props.title}
+		>
+			{props.children}
+		</StatePanel>
+	);
+}
+
+export type ErrorStateProps = ParentProps<{
+	class?: string;
+	description?: JSX.Element;
+	headingLevel?: 1 | 2;
+	onRetry?: () => void | Promise<void>;
+	retryLabel?: string;
+	title: string;
+}>;
+
+export function ErrorState(props: ErrorStateProps) {
+	return (
+		<StatePanel
+			class={props.class}
+			description={props.description}
+			headingLevel={props.headingLevel}
+			icon="!"
+			role="alert"
+			state="error"
+			title={props.title}
+		>
+			<Show when={props.onRetry}>
+				{(onRetry) => (
+					<RetryButton label={props.retryLabel} onRetry={onRetry()} />
+				)}
+			</Show>
+			{props.children}
+		</StatePanel>
+	);
+}
+
+export type OfflineStateProps = ParentProps<{
+	class?: string;
+	description?: JSX.Element;
+	headingLevel?: 1 | 2;
+	onRetry?: () => void | Promise<void>;
+	retryLabel?: string;
+	title?: string;
+}>;
+
+export function OfflineState(props: OfflineStateProps) {
+	return (
+		<StatePanel
+			class={props.class}
+			description={props.description}
+			headingLevel={props.headingLevel}
+			icon="×"
+			role="status"
+			state="offline"
+			title={props.title ?? "オフラインです"}
+		>
+			<Show when={props.onRetry}>
+				{(onRetry) => (
+					<RetryButton label={props.retryLabel} onRetry={onRetry()} />
+				)}
+			</Show>
+			{props.children}
+		</StatePanel>
+	);
+}
+
+export type QueryStatusProps = {
+	class?: string;
+	fetchState: QueryUiFetchState;
+	hasData: boolean;
+	offlineLabel: string;
+	updatingLabel: string;
+};
+
+export function QueryStatus(props: QueryStatusProps) {
+	return (
+		<div class={cn("min-h-6", props.class)} data-state-ui-slot="query-status">
+			<Switch>
+				<Match when={props.fetchState === "background-fetching"}>
+					<p
+						class="flex items-center gap-2 text-muted-foreground text-sm"
+						data-state-ui="background-fetching"
+						role="status"
+					>
+						<span
+							aria-hidden="true"
+							class="size-2 animate-pulse rounded-full bg-current motion-reduce:animate-none"
+						/>
+						{props.updatingLabel}
+					</p>
+				</Match>
+				<Match when={props.fetchState === "paused" && props.hasData}>
+					<p
+						class="flex items-center gap-2 text-muted-foreground text-sm"
+						data-state-ui="cached-offline"
+						role="status"
+					>
+						<span
+							aria-hidden="true"
+							class="size-2 rounded-full bg-warning-foreground"
+						/>
+						{props.offlineLabel}
+					</p>
+				</Match>
+			</Switch>
+		</div>
+	);
+}

--- a/packages/ui/src/async-state.tsx
+++ b/packages/ui/src/async-state.tsx
@@ -179,6 +179,35 @@ export function OfflineState(props: OfflineStateProps) {
 	);
 }
 
+export type FilterErrorBannerProps = {
+	class?: string;
+	message: string;
+	onRetry: () => void | Promise<void>;
+	retryLabel?: string;
+};
+
+/** Keeps usable content visible when only supplementary search filters fail. */
+export function FilterErrorBanner(props: FilterErrorBannerProps) {
+	return (
+		<div
+			class={cn(
+				"flex flex-wrap items-center justify-between gap-2 rounded-md border border-warning-foreground/30 bg-warning/40 p-3",
+				props.class,
+			)}
+			data-state-ui="filter-error"
+		>
+			<p class="text-muted-foreground text-sm" role="status">
+				{props.message}
+			</p>
+			<RetryButton
+				class="h-8 px-3 text-xs"
+				label={props.retryLabel ?? "フィルターを再取得"}
+				onRetry={props.onRetry}
+			/>
+		</div>
+	);
+}
+
 export type QueryStatusProps = {
 	class?: string;
 	fetchState: QueryUiFetchState;

--- a/packages/ui/src/hooks/use-manager-page.ts
+++ b/packages/ui/src/hooks/use-manager-page.ts
@@ -164,6 +164,7 @@ export type UseManagerPageResult = {
 		characters: QueryUiState<Character[]>;
 		sources: QueryUiState<SafeMediaSource[]>;
 	}>;
+	retryQueries: () => Promise<void>;
 	openCreateDialog: () => void;
 	openEditDialog: (item: ManagerEntity) => void;
 	handleSave: () => Promise<void>;
@@ -329,6 +330,15 @@ export function useManagerPage(
 			isEmpty: (data) => data.length === 0,
 		}),
 	});
+
+	const retryQueries = async () => {
+		await Promise.all([
+			projects.refetch(),
+			ipsQuery.refetch(),
+			characters.refetch(),
+			sourcesQuery.refetch(),
+		]);
+	};
 
 	const invalidateActive = () => {
 		const tab = activeCrudTab(activeTab());
@@ -727,6 +737,7 @@ export function useManagerPage(
 		ips,
 		getActiveItems,
 		queryStates,
+		retryQueries,
 		openCreateDialog,
 		openEditDialog,
 		handleSave: () => (editingItem() ? handleUpdate() : handleCreate()),

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -102,6 +102,7 @@ export interface UseSearchPageResult {
 	getSourceRootPath: (mediaSourceId: string) => string | undefined;
 	isRestored: () => boolean;
 	handleSearch: () => void;
+	retryFilters: () => Promise<void>;
 	refreshSearchResults: () => void;
 	loadMoreRef: () => HTMLDivElement | undefined;
 	setLoadMoreRef: (el: HTMLDivElement | undefined) => void;
@@ -206,6 +207,16 @@ export function useSearchPage(
 		status: "pending" | "error" | "success";
 		fetchStatus: "idle" | "fetching" | "paused";
 	}) => toQueryUiState(query, { isEmpty: (data) => data.length === 0 });
+	const retryFilters = async () => {
+		await Promise.all([
+			tags.refetch(),
+			sources.refetch(),
+			allProjects.refetch(),
+			allIps.refetch(),
+			allCharacters.refetch(),
+			allAuthors.refetch(),
+		]);
+	};
 
 	const getSourceRootPath = (mediaSourceId: string) => {
 		const source = sources.data?.find((item) => item.id === mediaSourceId);
@@ -332,6 +343,7 @@ export function useSearchPage(
 		getSourceRootPath,
 		isRestored,
 		handleSearch,
+		retryFilters,
 		refreshSearchResults,
 		loadMoreRef,
 		setLoadMoreRef,

--- a/packages/ui/src/query-state.test.ts
+++ b/packages/ui/src/query-state.test.ts
@@ -48,6 +48,19 @@ describe("toQueryUiState", () => {
 		).toMatchObject({ phase: "offline", fetchState: "paused" });
 	});
 
+	it("maps an unavailable network without data to offline", () => {
+		expect(
+			toQueryUiState(
+				{
+					data: undefined,
+					status: "error",
+					fetchStatus: "idle",
+				},
+				{ isOnline: false },
+			),
+		).toMatchObject({ phase: "offline", fetchState: "idle" });
+	});
+
 	it("preserves cached data during a background fetch", () => {
 		expect(
 			toQueryUiState({
@@ -90,6 +103,32 @@ describe("toQueryUiState", () => {
 			phase: "data",
 			fetchState: "paused",
 			data: ["cached"],
+		});
+	});
+
+	it("preserves an empty result during a background fetch", () => {
+		expect(
+			toQueryUiState(
+				{ data: [], status: "success", fetchStatus: "fetching" },
+				{ isEmpty: (data) => data.length === 0 },
+			),
+		).toMatchObject({
+			phase: "empty",
+			fetchState: "background-fetching",
+			data: [],
+		});
+	});
+
+	it("preserves an empty cached result while paused", () => {
+		expect(
+			toQueryUiState(
+				{ data: [], status: "success", fetchStatus: "paused" },
+				{ isEmpty: (data) => data.length === 0 },
+			),
+		).toMatchObject({
+			phase: "empty",
+			fetchState: "paused",
+			data: [],
 		});
 	});
 });

--- a/packages/ui/src/router-status.tsx
+++ b/packages/ui/src/router-status.tsx
@@ -1,6 +1,8 @@
 import type { ErrorComponentProps } from "@tanstack/solid-router";
 import { Link, useRouter, useRouterState } from "@tanstack/solid-router";
 import { createEffect, createSignal, onCleanup, Show, untrack } from "solid-js";
+import { ErrorState } from "./async-state";
+import { ScreenSkeleton, type ScreenSkeletonLayout } from "./screen-skeleton";
 
 export const ROUTE_PENDING_DELAY_MS = 300;
 export const ROUTE_PENDING_MIN_DURATION_MS = 500;
@@ -62,7 +64,7 @@ export function RouteTransitionIndicator() {
 				class="fixed inset-x-0 top-0 z-[70] h-1 overflow-hidden bg-primary/20"
 				role="progressbar"
 			>
-				<div class="h-full w-1/2 animate-pulse rounded-full bg-primary" />
+				<div class="h-full w-1/2 animate-pulse rounded-full bg-primary motion-reduce:animate-none" />
 			</div>
 		</Show>
 	);
@@ -70,131 +72,92 @@ export function RouteTransitionIndicator() {
 
 export function RoutePendingScreen() {
 	return (
-		<section
-			aria-live="polite"
-			class="mx-auto flex min-h-48 max-w-xl items-center justify-center gap-3 p-6 text-muted-foreground"
-			role="status"
-		>
-			<span
-				aria-hidden="true"
-				class="size-5 animate-spin rounded-full border-2 border-current border-r-transparent"
-			/>
-			<span>画面を読み込んでいます...</span>
-		</section>
+		<ScreenSkeleton
+			layout="cards"
+			loadingLabel="画面を読み込んでいます..."
+			title="画面を読み込んでいます"
+		/>
 	);
 }
 
 export type RouteDataPendingScreenProps = {
+	class?: string;
 	title: string;
 	description: string;
+	layout?: ScreenSkeletonLayout;
+	showAction?: boolean;
+	showDescription?: boolean;
 };
 
 export function RouteDataPendingScreen(props: RouteDataPendingScreenProps) {
 	return (
-		<main class="container mx-auto p-4">
-			<section
-				aria-labelledby="route-data-pending-title"
-				aria-live="polite"
-				class="flex min-h-48 flex-col items-center justify-center gap-2 text-center text-muted-foreground"
-				role="status"
-			>
-				<h1
-					class="font-bold text-2xl text-foreground"
-					id="route-data-pending-title"
-				>
-					{props.title}
-				</h1>
-				<p>{props.description}</p>
-			</section>
-		</main>
+		<ScreenSkeleton
+			class={props.class}
+			description={props.description}
+			layout={props.layout ?? "cards"}
+			loadingLabel={props.description}
+			showAction={props.showAction}
+			showDescription={props.showDescription}
+			title={props.title}
+		/>
 	);
 }
 
 export function RouteErrorScreen(props: ErrorComponentProps) {
 	const router = useRouter();
 
-	const retry = () => {
-		void router.invalidate().finally(() => {
+	const retry = async () => {
+		await router.invalidate().finally(() => {
 			props.reset();
 		});
 	};
 
 	return (
-		<section
-			aria-labelledby="route-error-title"
-			class="mx-auto flex min-h-64 max-w-xl flex-col items-center justify-center gap-4 p-6 text-center"
-			role="alert"
-		>
-			<div>
-				<h1 class="text-xl font-semibold" id="route-error-title">
-					画面を表示できませんでした
-				</h1>
-				<p class="mt-2 text-sm text-muted-foreground">
-					通信状態を確認して、もう一度お試しください。
-				</p>
-			</div>
-			<div class="flex flex-wrap justify-center gap-2">
-				<button
-					class="rounded-md bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
-					onClick={retry}
-					type="button"
-				>
-					再試行
-				</button>
+		<div class="container mx-auto p-4">
+			<ErrorState
+				class="mx-auto max-w-xl"
+				description="通信状態を確認して、もう一度お試しください。"
+				headingLevel={1}
+				onRetry={retry}
+				title="画面を表示できませんでした"
+			>
 				<Link
 					class="rounded-md border border-border px-4 py-2 hover:bg-muted"
 					to="/"
 				>
 					ホームへ戻る
 				</Link>
-			</div>
-		</section>
+			</ErrorState>
+		</div>
 	);
 }
 
 interface BootstrapStatusScreenProps {
 	error?: Error;
-	onRetry: () => void;
+	onRetry: () => void | Promise<void>;
 }
 
 export function BootstrapStatusScreen(props: BootstrapStatusScreenProps) {
 	return (
-		<section
-			aria-live={props.error ? undefined : "polite"}
-			class="mx-auto flex min-h-64 max-w-xl flex-col items-center justify-center gap-4 p-6 text-center"
-			role={props.error ? "alert" : "status"}
+		<Show
+			fallback={
+				<ScreenSkeleton
+					description="保存済みデータを読み込んでいます。"
+					layout="cards"
+					loadingLabel="アプリを準備しています..."
+					showDescription
+					title="アプリを準備しています"
+				/>
+			}
+			when={props.error}
 		>
-			<Show
-				fallback={
-					<>
-						<span
-							aria-hidden="true"
-							class="size-6 animate-spin rounded-full border-2 border-current border-r-transparent text-primary"
-						/>
-						<div>
-							<h1 class="font-semibold">アプリを準備しています</h1>
-							<p class="mt-2 text-sm text-muted-foreground">
-								保存済みデータを読み込んでいます。
-							</p>
-						</div>
-					</>
-				}
-				when={props.error}
-			>
-				<div>
-					<h1 class="text-xl font-semibold">アプリを起動できませんでした</h1>
-					<p class="mt-2 text-sm text-muted-foreground">
-						ローカルデータの初期化に失敗しました。
-					</p>
-				</div>
-				<button
-					class="rounded-md bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
-					onClick={props.onRetry}
-					type="button"
-				>
-					再試行
-				</button>
-			</Show>
-		</section>
+			<ErrorState
+				class="mx-auto max-w-xl"
+				description="ローカルデータの初期化に失敗しました。"
+				headingLevel={1}
+				onRetry={props.onRetry}
+				title="アプリを起動できませんでした"
+			/>
+		</Show>
 	);
 }

--- a/packages/ui/src/screen-skeleton.tsx
+++ b/packages/ui/src/screen-skeleton.tsx
@@ -1,0 +1,102 @@
+import { Match, Show, Switch } from "solid-js";
+import {
+	CardGridSkeleton,
+	CardSkeleton,
+	ConfigSkeleton,
+	ManagerSkeleton,
+	MediaDetailSkeleton,
+	MediaGridSkeleton,
+	Skeleton,
+} from "./skeleton";
+import { cn } from "./utils/cn";
+
+export type ScreenSkeletonLayout =
+	| "cards"
+	| "config"
+	| "manager"
+	| "media-detail"
+	| "media-grid";
+
+export type ScreenSkeletonProps = {
+	class?: string;
+	description?: string;
+	layout: ScreenSkeletonLayout;
+	loadingLabel: string;
+	showAction?: boolean;
+	showDescription?: boolean;
+	title: string;
+};
+
+/** Static, SSR-safe screen fallback that reserves the main content dimensions. */
+export function ScreenSkeleton(props: ScreenSkeletonProps) {
+	return (
+		<div
+			class={cn("container mx-auto p-4", props.class)}
+			data-screen-skeleton={props.layout}
+			data-state-ui="pending"
+		>
+			<p class="sr-only" role="status">
+				{props.loadingLabel}
+			</p>
+			<div aria-busy="true">
+				<div
+					class={cn(
+						"flex flex-wrap items-start justify-between gap-4",
+						props.layout === "media-detail"
+							? "mb-2"
+							: props.layout === "manager"
+								? "mb-8"
+								: "mb-6",
+					)}
+				>
+					<div>
+						<h1
+							class={cn(
+								"font-bold text-3xl",
+								props.layout === "media-detail" && "sr-only",
+							)}
+						>
+							{props.title}
+						</h1>
+						<Show when={props.showDescription && props.description}>
+							{(description) => (
+								<p
+									aria-hidden={description() === props.loadingLabel}
+									class={cn(
+										"text-muted-foreground",
+										props.layout !== "media-detail" && "mt-2",
+									)}
+								>
+									{description()}
+								</p>
+							)}
+						</Show>
+					</div>
+					<Show when={props.showAction}>
+						<Skeleton class="h-10 w-28" />
+					</Show>
+				</div>
+				<Switch>
+					<Match when={props.layout === "cards"}>
+						<CardGridSkeleton />
+					</Match>
+					<Match when={props.layout === "manager"}>
+						<ManagerSkeleton />
+					</Match>
+					<Match when={props.layout === "media-grid"}>
+						<div class="grid gap-6 md:grid-cols-[300px_1fr]">
+							<CardSkeleton class="hidden min-h-96 md:block" />
+							<MediaGridSkeleton />
+						</div>
+					</Match>
+					<Match when={props.layout === "media-detail"}>
+						<MediaDetailSkeleton />
+					</Match>
+					<Match when={props.layout === "config"}>
+						<ConfigSkeleton />
+					</Match>
+				</Switch>
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/src/screens/config-state-screen.tsx
+++ b/packages/ui/src/screens/config-state-screen.tsx
@@ -1,0 +1,75 @@
+import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
+import { Match, Show, Switch } from "solid-js";
+import { ErrorState, OfflineState, QueryStatus } from "../async-state";
+import type { QueryUiState } from "../query-state";
+import { ConfigSkeleton, LoadingRegion, Skeleton } from "../skeleton";
+import { cn } from "../utils/cn";
+import { ConfigScreen } from "./config-screen";
+
+export type ConfigStateScreenProps = {
+	class?: string;
+	data?: AppConfig;
+	onRetry: () => void | Promise<void>;
+	onSubmit: (value: Partial<AppConfig>) => Promise<void>;
+	onSubmitSuccess?: () => void;
+	state: QueryUiState<AppConfig>;
+};
+
+/** Shared server/Tauri query-state wrapper for the settings form. */
+export function ConfigStateScreen(props: ConfigStateScreenProps) {
+	const hasData = () => props.data !== undefined;
+
+	return (
+		<div class={cn("container mx-auto max-w-4xl p-6", props.class)}>
+			<Show when={hasData()}>
+				<QueryStatus
+					class="mb-2"
+					fetchState={props.state.fetchState}
+					hasData
+					offlineLabel="オフラインのため保存済みの設定を表示しています。"
+					updatingLabel="設定を更新中..."
+				/>
+			</Show>
+
+			<Switch>
+				<Match when={props.data}>
+					{(data) => (
+						<ConfigScreen
+							data={data()}
+							onSubmit={props.onSubmit}
+							onSubmitSuccess={props.onSubmitSuccess}
+						/>
+					)}
+				</Match>
+				<Match when={props.state.phase === "pending"}>
+					<LoadingRegion label="設定を読み込んでいます...">
+						<div class="mb-6 flex items-center justify-between">
+							<h1 class="font-bold text-3xl">Settings</h1>
+							<Skeleton class="h-10 w-32" />
+						</div>
+						<ConfigSkeleton />
+					</LoadingRegion>
+				</Match>
+				<Match when={props.state.phase === "offline"}>
+					<div class="space-y-6">
+						<h1 class="font-bold text-3xl">Settings</h1>
+						<OfflineState
+							description="接続が戻ったら、この画面から設定を再取得できます。"
+							onRetry={props.onRetry}
+						/>
+					</div>
+				</Match>
+				<Match when={props.state.phase === "error"}>
+					<div class="space-y-6">
+						<h1 class="font-bold text-3xl">Settings</h1>
+						<ErrorState
+							description="接続を確認して、もう一度お試しください。"
+							onRetry={props.onRetry}
+							title="設定を取得できませんでした"
+						/>
+					</div>
+				</Match>
+			</Switch>
+		</div>
+	);
+}

--- a/packages/ui/src/screens/manager-screen.tsx
+++ b/packages/ui/src/screens/manager-screen.tsx
@@ -1,6 +1,6 @@
 import type { Ip } from "@solid-imager/core/domain/ips/schemas";
 import type { DuplicateGroup } from "@solid-imager/core/domain/media/schemas";
-import { For, Show } from "solid-js";
+import { For, Match, Show, Switch } from "solid-js";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -11,6 +11,13 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "../alert-dialog";
+import {
+	EmptyState,
+	ErrorState,
+	OfflineState,
+	QueryStatus,
+	RetryButton,
+} from "../async-state";
 import { Button } from "../button";
 import {
 	Card,
@@ -53,6 +60,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "../select";
+import { CardGridSkeleton, LoadingRegion } from "../skeleton";
 
 export type ManagerScreenProps = {
 	manager: UseManagerPageResult;
@@ -87,32 +95,55 @@ function isCharacter(item: ManagerEntity) {
 	return "ips" in item;
 }
 
+function isCrudTab(tab: ManagerEntityType) {
+	return tab === "projects" || tab === "ips" || tab === "characters";
+}
+
 const ALL_SOURCES_OPTION = { id: "__all__", name: "All Sources" };
 
 export function ManagerScreen(props: ManagerScreenProps) {
 	const manager = () => props.manager;
-	const queryStates = () => Object.values(manager().queryStates());
+	const activeQueryState = () => {
+		const states = manager().queryStates();
+		switch (manager().activeTab()) {
+			case "projects":
+				return states.projects;
+			case "ips":
+				return states.ips;
+			case "characters":
+				return states.characters;
+			default:
+				return states.sources;
+		}
+	};
+	const canRenderActiveTab = () =>
+		activeQueryState().phase === "data" ||
+		(activeQueryState().phase === "empty" && !isCrudTab(manager().activeTab()));
+	const characterIpState = () => manager().queryStates().ips;
+	const hasCharacterIpError = () =>
+		manager().activeTab() === "characters" &&
+		(characterIpState().phase === "error" ||
+			characterIpState().phase === "offline");
 
 	return (
-		<div class="container mx-auto p-8">
-			<div class="mb-8 flex items-center justify-between">
+		<div class="container mx-auto p-4 sm:p-8">
+			<div class="mb-8 flex flex-wrap items-center justify-between gap-4">
 				<h1 class="font-bold text-3xl">Entity Manager</h1>
 				<Show
 					when={
-						manager().activeTab() !== "tagging" &&
-						manager().activeTab() !== "vectors" &&
-						manager().activeTab() !== "duplicates"
+						isCrudTab(manager().activeTab()) &&
+						activeQueryState().phase !== "empty"
 					}
 				>
 					<Button onClick={manager().openCreateDialog}>Create New</Button>
 				</Show>
 			</div>
 
-			<div class="mb-6 flex space-x-4 border-b">
+			<div class="mb-6 flex gap-4 overflow-x-auto border-b">
 				<For each={managerTabs}>
 					{(tab) => (
 						<button
-							class={`border-b-2 px-4 py-2 font-medium transition-colors ${
+							class={`shrink-0 border-b-2 px-4 py-2 font-medium transition-colors ${
 								manager().activeTab() === tab
 									? "border-primary text-primary"
 									: "border-transparent text-muted-foreground hover:text-foreground"
@@ -125,45 +156,66 @@ export function ManagerScreen(props: ManagerScreenProps) {
 					)}
 				</For>
 			</div>
-			<Show when={queryStates().some((state) => state.phase === "pending")}>
-				<p class="mb-4 text-muted-foreground text-sm" role="status">
-					管理データを読み込み中...
-				</p>
+
+			<QueryStatus
+				class="mb-4"
+				fetchState={activeQueryState().fetchState}
+				hasData={activeQueryState().data !== undefined}
+				offlineLabel="オフラインのため保存済みの管理データを表示しています。"
+				updatingLabel="管理データを更新中..."
+			/>
+			<Show when={hasCharacterIpError()}>
+				<div class="mb-4 flex flex-wrap items-center justify-between gap-2 rounded-md border border-warning-foreground/30 bg-warning/40 p-3">
+					<p class="text-muted-foreground text-sm" role="status">
+						IP候補を取得できませんでした。Characters一覧は引き続き利用できます。
+					</p>
+					<RetryButton
+						class="h-8 px-3 text-xs"
+						label="IP候補を再取得"
+						onRetry={manager().retryQueries}
+					/>
+				</div>
 			</Show>
-			<Show
-				when={queryStates().some(
-					(state) =>
-						(state.phase === "error" || state.phase === "offline") &&
-						state.data === undefined,
-				)}
-			>
-				<p class="mb-4 text-destructive text-sm" role="alert">
-					一部の管理データを取得できませんでした。接続後に再試行します。
-				</p>
-			</Show>
-			<Show
-				when={queryStates().some(
-					(state) => state.fetchState === "background-fetching",
-				)}
-			>
-				<p class="mb-4 text-muted-foreground text-sm" role="status">
-					管理データを更新中...
-				</p>
-			</Show>
-			<Show
-				when={queryStates().some(
-					(state) => state.fetchState === "paused" && state.data !== undefined,
-				)}
-			>
-				<p class="mb-4 text-muted-foreground text-sm" role="status">
-					オフラインのため保存済みデータを表示しています。
-				</p>
-			</Show>
+
+			<Switch>
+				<Match when={activeQueryState().phase === "pending"}>
+					<LoadingRegion label="管理データを読み込んでいます...">
+						<CardGridSkeleton />
+					</LoadingRegion>
+				</Match>
+				<Match when={activeQueryState().phase === "error"}>
+					<ErrorState
+						description="接続を確認して、もう一度お試しください。"
+						onRetry={manager().retryQueries}
+						title="管理データを取得できませんでした"
+					/>
+				</Match>
+				<Match when={activeQueryState().phase === "offline"}>
+					<OfflineState
+						description="接続が戻ったら、この画面から再試行できます。"
+						onRetry={manager().retryQueries}
+					/>
+				</Match>
+				<Match
+					when={
+						activeQueryState().phase === "empty" &&
+						isCrudTab(manager().activeTab())
+					}
+				>
+					<EmptyState
+						description="最初の項目を作成すると、ここに表示されます。"
+						title={`登録された ${tabLabel(manager().activeTab())} はありません`}
+					>
+						<Button onClick={manager().openCreateDialog}>Create New</Button>
+					</EmptyState>
+				</Match>
+			</Switch>
 
 			<Show
 				when={
-					manager().activeTab() === "tagging" ||
-					manager().activeTab() === "vectors"
+					(manager().activeTab() === "tagging" ||
+						manager().activeTab() === "vectors") &&
+					canRenderActiveTab()
 				}
 			>
 				<div class="space-y-6">
@@ -279,7 +331,9 @@ export function ManagerScreen(props: ManagerScreenProps) {
 				</div>
 			</Show>
 
-			<Show when={manager().activeTab() === "duplicates"}>
+			<Show
+				when={manager().activeTab() === "duplicates" && canRenderActiveTab()}
+			>
 				<div class="space-y-6">
 					<Card>
 						<CardHeader>
@@ -473,9 +527,8 @@ export function ManagerScreen(props: ManagerScreenProps) {
 
 			<Show
 				when={
-					manager().activeTab() !== "tagging" &&
-					manager().activeTab() !== "vectors" &&
-					manager().activeTab() !== "duplicates"
+					isCrudTab(manager().activeTab()) &&
+					activeQueryState().phase === "data"
 				}
 			>
 				<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/packages/ui/src/screens/media-detail-screen.tsx
+++ b/packages/ui/src/screens/media-detail-screen.tsx
@@ -6,12 +6,14 @@ import type {
 } from "@solid-imager/core/domain/sources/events";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { type JSX, Match, Switch } from "solid-js";
+import { ErrorState, OfflineState, QueryStatus } from "../async-state";
 import {
 	type MediaSourceEventTransport,
 	useMediaSourceEvents,
 } from "../hooks/use-media-source-events";
 import { sourceMediaQueryKeys } from "../query-options";
 import { toQueryUiState } from "../query-state";
+import { LoadingRegion, MediaDetailSkeleton } from "../skeleton";
 
 export type MediaDetailScreenProps = {
 	mediaSourceId: string;
@@ -97,20 +99,12 @@ export function MediaDetailScreen(props: MediaDetailScreenProps) {
 
 	return (
 		<div class="container mx-auto p-4">
-			<Switch>
-				<Match when={state().fetchState === "background-fetching"}>
-					<p class="mb-2 text-muted-foreground text-sm" role="status">
-						メディア情報を更新中...
-					</p>
-				</Match>
-				<Match
-					when={state().fetchState === "paused" && state().data !== undefined}
-				>
-					<p class="mb-2 text-muted-foreground text-sm" role="status">
-						オフラインのため保存済みデータを表示しています
-					</p>
-				</Match>
-			</Switch>
+			<QueryStatus
+				fetchState={state().fetchState}
+				hasData={state().data !== undefined}
+				offlineLabel="オフラインのため保存済みデータを表示しています"
+				updatingLabel="メディア情報を更新中..."
+			/>
 			<Switch>
 				<Match when={state().data}>
 					{(details) => (
@@ -130,19 +124,24 @@ export function MediaDetailScreen(props: MediaDetailScreenProps) {
 					)}
 				</Match>
 				<Match when={state().phase === "offline"}>
-					<div class="text-muted-foreground" role="status">
-						Offline. Media details will load after reconnecting.
-					</div>
+					<OfflineState
+						description="接続が戻ったらメディア情報を再取得できます。"
+						headingLevel={1}
+						onRetry={() => mediaDetails.refetch().then(() => undefined)}
+					/>
 				</Match>
 				<Match when={state().phase === "error"}>
-					<div class="text-red-500" role="alert">
-						Error: {errorMessage()}
-					</div>
+					<ErrorState
+						description={errorMessage()}
+						headingLevel={1}
+						onRetry={() => mediaDetails.refetch().then(() => undefined)}
+						title="メディア情報を読み込めませんでした"
+					/>
 				</Match>
 				<Match when={state().phase === "pending"}>
-					<div class="text-muted-foreground" role="status">
-						Loading media details...
-					</div>
+					<LoadingRegion label="メディア情報を読み込んでいます...">
+						<MediaDetailSkeleton />
+					</LoadingRegion>
 				</Match>
 			</Switch>
 		</div>

--- a/packages/ui/src/screens/search-screen.tsx
+++ b/packages/ui/src/screens/search-screen.tsx
@@ -3,7 +3,7 @@ import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas"
 import { ClientOnly } from "@tanstack/solid-router";
 import type { JSX } from "solid-js";
 import { createSignal, onMount, Show } from "solid-js";
-import { QueryStatus, RetryButton } from "../async-state";
+import { FilterErrorBanner, QueryStatus } from "../async-state";
 import { Card, CardContent, CardHeader, CardTitle } from "../card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../dialog";
 import type {
@@ -104,16 +104,10 @@ export function SearchScreen(props: SearchScreenProps) {
 							(state) => state.phase === "error" || state.phase === "offline",
 						)}
 					>
-						<div class="flex flex-wrap items-center justify-between gap-2 rounded-md border border-warning-foreground/30 bg-warning/40 p-3">
-							<p class="text-muted-foreground text-sm" role="status">
-								一部の検索フィルターを取得できませんでした。検索結果は引き続き利用できます。
-							</p>
-							<RetryButton
-								class="h-8 px-3 text-xs"
-								label="フィルターを再取得"
-								onRetry={page().retryFilters}
-							/>
-						</div>
+						<FilterErrorBanner
+							message="一部の検索フィルターを取得できませんでした。検索結果は引き続き利用できます。"
+							onRetry={page().retryFilters}
+						/>
 					</Show>
 					<QueryStatus
 						fetchState={page().contentState().fetchState}

--- a/packages/ui/src/screens/search-screen.tsx
+++ b/packages/ui/src/screens/search-screen.tsx
@@ -3,6 +3,7 @@ import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas"
 import { ClientOnly } from "@tanstack/solid-router";
 import type { JSX } from "solid-js";
 import { createSignal, onMount, Show } from "solid-js";
+import { QueryStatus, RetryButton } from "../async-state";
 import { Card, CardContent, CardHeader, CardTitle } from "../card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../dialog";
 import type {
@@ -11,6 +12,7 @@ import type {
 } from "../hooks/use-search-page";
 import type { SourceMediaPagePresetClient } from "../hooks/use-source-media-page";
 import { SearchControlPanel } from "../search-control-panel";
+import { LoadingRegion, MediaGridSkeleton } from "../skeleton";
 import { SourceMediaGrid } from "../source-media-grid";
 
 export type SearchScreenNavActions = {
@@ -62,18 +64,10 @@ export function SearchScreen(props: SearchScreenProps) {
 		/>
 	);
 
-	const showResults = () => {
-		const hasRenderableState =
-			page().contentState().phase === "data" ||
-			page().contentState().phase === "empty";
-		if (props.ssrGuard) {
-			return hasRenderableState && isMounted();
-		}
-		return hasRenderableState;
-	};
+	const canRenderContent = () => !props.ssrGuard || isMounted();
 
 	return (
-		<main class="container mx-auto p-4">
+		<div class="container mx-auto p-4">
 			{props.renderNavActions?.({ openMobileFilters })}
 			<ClientOnly>
 				<Dialog
@@ -110,68 +104,53 @@ export function SearchScreen(props: SearchScreenProps) {
 							(state) => state.phase === "error" || state.phase === "offline",
 						)}
 					>
-						<p class="text-muted-foreground text-sm" role="status">
-							一部の検索フィルターを取得できませんでした。検索結果は引き続き利用できます。
-						</p>
+						<div class="flex flex-wrap items-center justify-between gap-2 rounded-md border border-warning-foreground/30 bg-warning/40 p-3">
+							<p class="text-muted-foreground text-sm" role="status">
+								一部の検索フィルターを取得できませんでした。検索結果は引き続き利用できます。
+							</p>
+							<RetryButton
+								class="h-8 px-3 text-xs"
+								label="フィルターを再取得"
+								onRetry={page().retryFilters}
+							/>
+						</div>
 					</Show>
-					<Show
-						when={page().contentState().fetchState === "background-fetching"}
-					>
-						<p class="text-muted-foreground text-sm" role="status">
-							検索結果を更新中...
-						</p>
-					</Show>
-					<Show
-						when={
-							page().contentState().fetchState === "paused" &&
-							page().contentState().data !== undefined
-						}
-					>
-						<p class="text-muted-foreground text-sm" role="status">
-							オフラインのため保存済みの検索結果を表示しています
-						</p>
-					</Show>
+					<QueryStatus
+						fetchState={page().contentState().fetchState}
+						hasData={page().contentState().data !== undefined}
+						offlineLabel="オフラインのため保存済みの検索結果を表示しています"
+						updatingLabel="検索結果を更新中..."
+					/>
 					<Show
 						fallback={
-							<div
-								class="py-8 text-center"
-								role={
-									page().contentState().phase === "error" ? "alert" : "status"
-								}
-							>
-								{page().contentState().phase === "offline"
-									? "オフラインです。接続後に検索を再開します"
-									: page().contentState().phase === "error"
-										? "検索結果を取得できませんでした"
-										: "読み込み中..."}
-							</div>
+							<LoadingRegion label="検索結果を読み込んでいます...">
+								<MediaGridSkeleton />
+							</LoadingRegion>
 						}
-						when={showResults()}
+						when={canRenderContent()}
 					>
 						<SourceMediaGrid
 							disableContextMenu
 							enableVirtualization={props.enableVirtualization}
-							isError={page().contentState().phase === "error"}
+							errorTitle="検索結果を取得できませんでした"
 							isFetchingNextPage={page().searchResultQuery.isFetchingNextPage}
-							isPending={page().contentState().phase === "pending"}
 							mediaResults={page().searchResults}
 							mediaSourceId={() => undefined}
 							onLoadMore={() => page().searchResultQuery.fetchNextPage()}
+							onRetry={async () => {
+								await page().searchResultQuery.refetch();
+							}}
 							hasNextPage={page().searchResultQuery.hasNextPage}
-							queryError={
-								page().searchResultQuery.error instanceof Error
-									? page().searchResultQuery.error
-									: null
-							}
 							renderItem={(media, _options) => props.renderMediaItem(media)}
 							setLoadMoreRef={page().setLoadMoreRef}
 							showEmptyState
 							showResultCount
+							state={page().contentState}
 							totalCount={page().searchResultQuery.data?.pages[0]?.total}
 						/>
 					</Show>
 				</div>
 			</div>
-		</main>
+		</div>
 	);
 }

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -1,6 +1,7 @@
 import type { Media } from "@solid-imager/core/domain/media/schemas";
 import type { Component, JSX } from "solid-js";
 import { createSignal, onMount, Show } from "solid-js";
+import { QueryStatus, RetryButton } from "../async-state";
 import { Button } from "../button";
 import { Card, CardContent, CardHeader, CardTitle } from "../card";
 import {
@@ -16,6 +17,7 @@ import type {
 	UseSourceMediaPageResult,
 } from "../hooks/use-source-media-page";
 import { SearchControlPanel } from "../search-control-panel";
+import { LoadingRegion, MediaGridSkeleton } from "../skeleton";
 import { SourceMediaGrid } from "../source-media-grid";
 
 export type SourceMediaScreenProps = {
@@ -67,6 +69,7 @@ export type SourceMediaScreenProps = {
 	onBulkAction?: () => void;
 	onClearSelection?: () => void;
 	selectedCount?: () => number;
+	onRetryFilters: () => void | Promise<void>;
 };
 
 export function SourceMediaScreen(props: SourceMediaScreenProps) {
@@ -102,8 +105,8 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 				})}
 			</Show>
 
-			<div class="mb-4 flex items-center justify-between">
-				<h1 class="font-bold text-2xl">
+			<div class="mb-4 flex flex-wrap items-center justify-between gap-4">
+				<h1 class="min-w-0 break-all font-bold text-2xl">
 					Media in Source: {page().mediaSourceId()}
 				</h1>
 				<Button
@@ -121,9 +124,16 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 					(state) => state.phase === "error" || state.phase === "offline",
 				)}
 			>
-				<p class="mb-3 text-muted-foreground text-sm" role="status">
-					一部の検索フィルターを取得できませんでした。メディア一覧は引き続き利用できます。
-				</p>
+				<div class="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-warning-foreground/30 bg-warning/40 p-3">
+					<p class="text-muted-foreground text-sm" role="status">
+						一部の検索フィルターを取得できませんでした。メディア一覧は引き続き利用できます。
+					</p>
+					<RetryButton
+						class="h-8 px-3 text-xs"
+						label="フィルターを再取得"
+						onRetry={props.onRetryFilters}
+					/>
+				</div>
 			</Show>
 
 			<div class="grid gap-6 md:grid-cols-[300px_1fr]">
@@ -144,49 +154,32 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 				</Card>
 
 				<div>
-					<Show
-						when={page().contentState().fetchState === "background-fetching"}
-					>
-						<p class="mb-2 text-muted-foreground text-sm" role="status">
-							メディア一覧を更新中...
-						</p>
-					</Show>
-					<Show
-						when={
-							page().contentState().fetchState === "paused" &&
-							page().contentState().data !== undefined
-						}
-					>
-						<p class="mb-2 text-muted-foreground text-sm" role="status">
-							オフラインのため保存済みデータを表示しています
-						</p>
-					</Show>
-					<Show when={page().contentState().phase === "offline"}>
-						<p class="mb-2 text-muted-foreground text-sm" role="status">
-							オフラインです。接続後にメディア一覧を読み込みます
-						</p>
-					</Show>
+					<QueryStatus
+						class="mb-2"
+						fetchState={page().contentState().fetchState}
+						hasData={page().contentState().data !== undefined}
+						offlineLabel="オフラインのため保存済みデータを表示しています"
+						updatingLabel="メディア一覧を更新中..."
+					/>
 					<Show
 						fallback={
-							<div class="flex h-64 items-center justify-center text-muted-foreground">
-								メディア一覧を読み込んでいます...
-							</div>
+							<LoadingRegion label="メディア一覧を読み込んでいます...">
+								<MediaGridSkeleton />
+							</LoadingRegion>
 						}
 						when={shouldRenderGrid()}
 					>
 						<SourceMediaGrid
 							contextMenuMediaId={page().contextMenuMediaId}
 							enableVirtualization={props.enableVirtualization}
-							isError={page().contentState().phase === "error"}
 							isFetchingNextPage={page().mediaQuery.isFetchingNextPage}
-							isPending={page().contentState().phase === "pending"}
 							mediaResults={page().mediaResults}
 							mediaSourceId={page().mediaSourceId}
 							onCopyMove={page().handleCopyMove}
 							onDelete={page().handleDelete}
 							onLoadMore={() => page().mediaQuery.fetchNextPage()}
-							onRetry={() => {
-								void page().mediaQuery.refetch();
+							onRetry={async () => {
+								await page().mediaQuery.refetch();
 							}}
 							onSyncSingleMedia={page().handleSyncSingleMedia}
 							onToggleSelect={props.onToggleSelect}
@@ -196,11 +189,11 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 							onClearSelection={props.onClearSelection}
 							selectedCount={props.selectedCount}
 							hasNextPage={page().mediaQuery.hasNextPage}
-							queryError={page().mediaQuery.error ?? null}
 							renderItem={props.renderItem}
 							setContextMenuMediaId={page().setContextMenuMediaId}
 							setLoadMoreRef={page().setLoadMoreRef}
 							showOpenInNewTab={props.showOpenInNewTab}
+							state={page().contentState}
 							totalCount={page().mediaQuery.data?.pages[0]?.total}
 						/>
 					</Show>

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -1,7 +1,7 @@
 import type { Media } from "@solid-imager/core/domain/media/schemas";
 import type { Component, JSX } from "solid-js";
 import { createSignal, onMount, Show } from "solid-js";
-import { QueryStatus, RetryButton } from "../async-state";
+import { FilterErrorBanner, QueryStatus } from "../async-state";
 import { Button } from "../button";
 import { Card, CardContent, CardHeader, CardTitle } from "../card";
 import {
@@ -124,16 +124,11 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 					(state) => state.phase === "error" || state.phase === "offline",
 				)}
 			>
-				<div class="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-warning-foreground/30 bg-warning/40 p-3">
-					<p class="text-muted-foreground text-sm" role="status">
-						一部の検索フィルターを取得できませんでした。メディア一覧は引き続き利用できます。
-					</p>
-					<RetryButton
-						class="h-8 px-3 text-xs"
-						label="フィルターを再取得"
-						onRetry={props.onRetryFilters}
-					/>
-				</div>
+				<FilterErrorBanner
+					class="mb-3"
+					message="一部の検索フィルターを取得できませんでした。メディア一覧は引き続き利用できます。"
+					onRetry={props.onRetryFilters}
+				/>
 			</Show>
 
 			<div class="grid gap-6 md:grid-cols-[300px_1fr]">

--- a/packages/ui/src/screens/sources-screen.tsx
+++ b/packages/ui/src/screens/sources-screen.tsx
@@ -3,15 +3,23 @@ import type {
 	SafeMediaSource,
 } from "@solid-imager/core/domain/sources/schemas";
 import type { JSX } from "solid-js";
-import { For, Show } from "solid-js";
+import { For, Match, Switch } from "solid-js";
+import {
+	EmptyState,
+	ErrorState,
+	OfflineState,
+	QueryStatus,
+} from "../async-state";
+import { Button } from "../button";
 import type { UseSourcesPageResult } from "../hooks/use-sources-page";
 import type { QueryUiState } from "../query-state";
+import { CardGridSkeleton, LoadingRegion } from "../skeleton";
 
 export type SourcesScreenProps = {
 	page: UseSourcesPageResult;
 	mediaSources: () => (SafeMediaSource | MediaSourceInfo)[] | undefined;
 	state: () => QueryUiState<(SafeMediaSource | MediaSourceInfo)[]>;
-	onRetry?: () => void;
+	onRetry?: () => void | Promise<void>;
 	renderSourceCard: (source: SafeMediaSource | MediaSourceInfo) => JSX.Element;
 	renderFormModal: (props: {
 		editingSource: SafeMediaSource | MediaSourceInfo | null;
@@ -36,83 +44,63 @@ export function SourcesScreen(props: SourcesScreenProps) {
 
 	return (
 		<div class="container mx-auto p-6">
-			<div class="mb-6 flex items-center justify-between">
+			<div class="mb-6 flex flex-wrap items-center justify-between gap-4">
 				<h1 class="font-bold text-3xl">Media Sources</h1>
-				<div class="flex items-center gap-2">
-					<button
-						class="rounded bg-green-500 px-4 py-2 text-white shadow hover:bg-green-600 disabled:cursor-not-allowed disabled:opacity-50"
+				<div class="flex flex-wrap items-center gap-2">
+					<Button
 						disabled={page().isSyncing() || !props.mediaSources()?.length}
 						onClick={() => page().handleSyncAll(props.mediaSources())}
-						type="button"
+						variant="outline"
 					>
 						{page().isSyncing() ? "Syncing..." : "Sync All"}
-					</button>
-					<button
-						class="rounded bg-blue-500 px-4 py-2 text-white shadow hover:bg-blue-600"
-						onClick={() => page().handleAddSource()}
-						type="button"
+					</Button>
+					<Button onClick={() => page().handleAddSource()}>Add Source</Button>
+				</div>
+			</div>
+
+			<QueryStatus
+				class="mb-3"
+				fetchState={props.state().fetchState}
+				hasData={props.state().data !== undefined}
+				offlineLabel="オフラインのため保存済みデータを表示しています"
+				updatingLabel="ソース一覧を更新中..."
+			/>
+
+			<Switch>
+				<Match when={props.state().phase === "pending"}>
+					<LoadingRegion label="ソースを読み込んでいます...">
+						<CardGridSkeleton />
+					</LoadingRegion>
+				</Match>
+				<Match when={props.state().phase === "error"}>
+					<ErrorState
+						description={errorMessage()}
+						onRetry={props.onRetry}
+						title="ソース一覧を読み込めませんでした"
+					/>
+				</Match>
+				<Match when={props.state().phase === "offline"}>
+					<OfflineState
+						description="接続を確認してから再試行してください。"
+						onRetry={props.onRetry}
+					/>
+				</Match>
+				<Match when={props.state().phase === "empty"}>
+					<EmptyState
+						description="画像を管理するメディアソースを追加してください。"
+						title="メディアソースがありません"
 					>
-						Add Source
-					</button>
-				</div>
-			</div>
-
-			<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-				<For each={props.mediaSources()}>
-					{(source) => props.renderSourceCard(source)}
-				</For>
-			</div>
-
-			<Show when={props.state().phase === "pending"}>
-				<div class="mt-8 text-center" role="status">
-					<p class="text-muted-foreground">ソースを読み込んでいます...</p>
-				</div>
-			</Show>
-
-			<Show
-				when={
-					props.state().phase === "error" || props.state().phase === "offline"
-				}
-			>
-				<div
-					class="mt-8 rounded-md border border-destructive/30 bg-error p-4 text-center"
-					role="alert"
-				>
-					<p class="font-medium text-error-foreground">
-						ソース一覧を読み込めませんでした
-					</p>
-					<p class="mt-1 text-muted-foreground text-sm">
-						{props.state().phase === "offline"
-							? "オフラインです。接続後に再試行します"
-							: errorMessage()}
-					</p>
-					<Show when={props.onRetry}>
-						<button
-							class="mt-3 rounded border border-input bg-background px-3 py-1.5 text-sm hover:bg-accent"
-							onClick={props.onRetry}
-							type="button"
-						>
-							再試行
-						</button>
-					</Show>
-				</div>
-			</Show>
-
-			<Show when={props.state().fetchState === "background-fetching"}>
-				<p class="mt-3 text-muted-foreground text-sm" role="status">
-					ソース一覧を更新中...
-				</p>
-			</Show>
-			<Show
-				when={
-					props.state().fetchState === "paused" &&
-					props.state().data !== undefined
-				}
-			>
-				<p class="mt-3 text-muted-foreground text-sm" role="status">
-					オフラインのため保存済みデータを表示しています
-				</p>
-			</Show>
+						<Button onClick={() => page().handleAddSource()}>Add Source</Button>
+					</EmptyState>
+				</Match>
+				<Match when={props.state().phase === "data"}>
+					<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+						<For each={props.mediaSources()}>
+							{(source) => props.renderSourceCard(source)}
+						</For>
+					</div>
+				</Match>
+			</Switch>
 
 			{props.renderFormModal({
 				editingSource: page().editingSource(),

--- a/packages/ui/src/skeleton.tsx
+++ b/packages/ui/src/skeleton.tsx
@@ -1,0 +1,197 @@
+import type { ComponentProps, ParentProps } from "solid-js";
+import { For, splitProps } from "solid-js";
+import { Card, CardContent, CardHeader } from "./card";
+import { cn } from "./utils/cn";
+
+export type SkeletonProps = Omit<ComponentProps<"div">, "aria-hidden">;
+
+/** Decorative placeholder. Announce loading once on the containing region. */
+export function Skeleton(props: SkeletonProps) {
+	const [local, others] = splitProps(props, ["class"]);
+
+	return (
+		<div
+			aria-hidden="true"
+			class={cn(
+				"animate-pulse rounded-md bg-muted motion-reduce:animate-none",
+				local.class,
+			)}
+			{...others}
+		/>
+	);
+}
+
+export type LoadingRegionProps = ParentProps<{
+	class?: string;
+	label: string;
+}>;
+
+/** Owns the single loading announcement for a group of decorative skeletons. */
+export function LoadingRegion(props: LoadingRegionProps) {
+	return (
+		<>
+			<p class="sr-only" role="status">
+				{props.label}
+			</p>
+			<section aria-busy="true" class={props.class} data-state-ui="pending">
+				{props.children}
+			</section>
+		</>
+	);
+}
+
+export type CardSkeletonProps = {
+	class?: string;
+};
+
+export function CardSkeleton(props: CardSkeletonProps) {
+	return (
+		<Card class={cn("min-h-44", props.class)} aria-hidden="true">
+			<CardHeader class="space-y-3">
+				<Skeleton class="h-5 w-2/3" />
+				<Skeleton class="h-4 w-5/6" />
+			</CardHeader>
+			<CardContent class="space-y-2">
+				<Skeleton class="h-4 w-1/2" />
+				<Skeleton class="h-4 w-3/4" />
+			</CardContent>
+		</Card>
+	);
+}
+
+export type CardGridSkeletonProps = {
+	class?: string;
+	count?: number;
+};
+
+export function CardGridSkeleton(props: CardGridSkeletonProps) {
+	return (
+		<div
+			aria-hidden="true"
+			class={cn("grid gap-4 md:grid-cols-2 lg:grid-cols-3", props.class)}
+			data-skeleton="card-grid"
+		>
+			<For each={Array.from({ length: props.count ?? 6 })}>
+				{() => <CardSkeleton />}
+			</For>
+		</div>
+	);
+}
+
+export type ListSkeletonProps = {
+	class?: string;
+	count?: number;
+};
+
+export function ListSkeleton(props: ListSkeletonProps) {
+	return (
+		<div
+			aria-hidden="true"
+			class={cn("space-y-4", props.class)}
+			data-skeleton="list"
+		>
+			<For each={Array.from({ length: props.count ?? 5 })}>
+				{() => (
+					<div class="space-y-2">
+						<Skeleton class="h-4 w-1/3" />
+						<Skeleton class="h-10 w-full" />
+					</div>
+				)}
+			</For>
+		</div>
+	);
+}
+
+export type MediaGridSkeletonProps = {
+	class?: string;
+	count?: number;
+};
+
+export function MediaGridSkeleton(props: MediaGridSkeletonProps) {
+	return (
+		<div
+			aria-hidden="true"
+			class={cn(
+				"grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5",
+				props.class,
+			)}
+			data-skeleton="media-grid"
+		>
+			<For each={Array.from({ length: props.count ?? 10 })}>
+				{() => <Skeleton class="aspect-[3/4] w-full rounded-lg" />}
+			</For>
+		</div>
+	);
+}
+
+export type MediaDetailSkeletonProps = {
+	class?: string;
+};
+
+export function MediaDetailSkeleton(props: MediaDetailSkeletonProps) {
+	return (
+		<div
+			aria-hidden="true"
+			class={cn(
+				"flex min-h-[calc(100dvh-5rem)] flex-col gap-4 lg:flex-row",
+				props.class,
+			)}
+			data-skeleton="media-detail"
+		>
+			<Skeleton class="min-h-80 flex-1 rounded-lg lg:min-h-0" />
+			<div class="w-full shrink-0 space-y-4 rounded-lg border p-4 lg:w-96">
+				<Skeleton class="h-7 w-3/4" />
+				<Skeleton class="h-4 w-1/2" />
+				<Skeleton class="h-24 w-full" />
+				<Skeleton class="h-10 w-full" />
+				<Skeleton class="h-10 w-full" />
+			</div>
+		</div>
+	);
+}
+
+export type ConfigSkeletonProps = {
+	class?: string;
+};
+
+export type ManagerSkeletonProps = {
+	class?: string;
+};
+
+export function ManagerSkeleton(props: ManagerSkeletonProps) {
+	return (
+		<div
+			aria-hidden="true"
+			class={cn("space-y-6", props.class)}
+			data-skeleton="manager"
+		>
+			<div class="flex gap-4 overflow-hidden border-b">
+				<For each={Array.from({ length: 6 })}>
+					{() => <Skeleton class="h-10 w-24 shrink-0 rounded-none" />}
+				</For>
+			</div>
+			<div class="min-h-6" />
+			<CardGridSkeleton />
+		</div>
+	);
+}
+
+export function ConfigSkeleton(props: ConfigSkeletonProps) {
+	return (
+		<div
+			aria-hidden="true"
+			class={cn("space-y-6", props.class)}
+			data-skeleton="config"
+		>
+			<div class="grid h-10 grid-cols-6 gap-1">
+				<For each={Array.from({ length: 6 })}>
+					{() => <Skeleton class="h-10 w-full" />}
+				</For>
+			</div>
+			<div class="space-y-5 rounded-md border p-4">
+				<Skeleton class="h-7 w-1/3" />
+				<ListSkeleton count={4} />
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -6,10 +6,13 @@ import {
 	createMemo,
 	createSignal,
 	For,
+	Match,
 	onCleanup,
 	onMount,
 	Show,
+	Switch,
 } from "solid-js";
+import { EmptyState, ErrorState, OfflineState } from "./async-state";
 import {
 	ContextMenu,
 	ContextMenuContent,
@@ -17,6 +20,8 @@ import {
 	ContextMenuSeparator,
 	ContextMenuTrigger,
 } from "./context-menu";
+import type { QueryUiState } from "./query-state";
+import { LoadingRegion, MediaGridSkeleton } from "./skeleton";
 
 const VIRTUALIZATION_THRESHOLD = 100;
 const GRID_GAP_PX = 16;
@@ -26,11 +31,9 @@ const VIRTUAL_ROWS_OVERSCAN = 4;
 type SourceMediaGridProps = {
 	mediaResults: Accessor<Media[]>;
 	mediaSourceId: Accessor<string | undefined>;
-	isPending: boolean;
-	isError: boolean;
+	state: Accessor<QueryUiState<Media[]>>;
 	isFetchingNextPage: boolean;
-	queryError: Error | null;
-	onRetry?: () => void;
+	onRetry?: () => void | Promise<void>;
 	contextMenuMediaId?: Accessor<string | null>;
 	setContextMenuMediaId?: Setter<string | null>;
 	onDelete?: (mediaId: string) => void;
@@ -68,6 +71,8 @@ type SourceMediaGridProps = {
 	showOpenInNewTab?: boolean;
 	/** Total result count. If omitted, uses mediaResults().length (may not reflect total). */
 	totalCount?: number;
+	/** Screen-specific copy for the initial error state. */
+	errorTitle?: string;
 };
 
 export function SourceMediaGrid(props: SourceMediaGridProps) {
@@ -77,6 +82,10 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 	const enableVirtualization = () => props.enableVirtualization ?? false;
 	const disableContextMenu = () => props.disableContextMenu ?? false;
 	const totalCount = () => props.totalCount ?? props.mediaResults().length;
+	const errorMessage = () => {
+		const error = props.state().error;
+		return error instanceof Error ? error.message : "API接続に失敗しました";
+	};
 
 	// --- Virtual grid setup ---
 	const [windowWidth, setWindowWidth] = createSignal(0);
@@ -262,177 +271,172 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 
 	return (
 		<div class="min-h-0 space-y-4">
-			{/* Loading state */}
-			<Show when={props.isPending && props.mediaResults().length === 0}>
-				<div class="flex h-64 items-center justify-center">
-					<div class="animate-pulse text-lg text-muted-foreground">
-						Loading media...
-					</div>
-				</div>
-			</Show>
-
-			{/* Error state */}
-			<Show when={props.isError}>
-				<div class="rounded-md border border-destructive/30 bg-error p-4">
-					<p class="font-medium text-error-foreground">
-						メディア一覧を読み込めませんでした
-					</p>
-					<p class="mt-1 text-muted-foreground text-sm">
-						{props.queryError?.message ?? "API connection failed"}
-					</p>
-					<Show when={props.onRetry}>
-						<button
-							class="mt-3 rounded border border-input bg-background px-3 py-1.5 text-sm hover:bg-accent"
-							onClick={props.onRetry}
-							type="button"
-						>
-							再試行
-						</button>
+			<Switch>
+				<Match when={props.state().phase === "pending"}>
+					<LoadingRegion label="メディア一覧を読み込んでいます...">
+						<MediaGridSkeleton />
+					</LoadingRegion>
+				</Match>
+				<Match when={props.state().phase === "error"}>
+					<ErrorState
+						description={errorMessage()}
+						onRetry={props.onRetry}
+						title={props.errorTitle ?? "メディア一覧を読み込めませんでした"}
+					/>
+				</Match>
+				<Match when={props.state().phase === "offline"}>
+					<OfflineState
+						description="接続を確認してから再試行してください。"
+						onRetry={props.onRetry}
+					/>
+				</Match>
+				<Match
+					when={
+						props.state().phase === "data" || props.state().phase === "empty"
+					}
+				>
+					{/* Result count */}
+					<Show when={showResultCount() && props.mediaResults().length > 0}>
+						<div class="mb-4 flex items-center justify-between">
+							<p class="text-gray-600 text-sm">{totalCount()} 件の結果</p>
+						</div>
 					</Show>
-				</div>
-			</Show>
 
-			{/* Result count */}
-			<Show when={showResultCount() && props.mediaResults().length > 0}>
-				<div class="mb-4 flex items-center justify-between">
-					<p class="text-gray-600 text-sm">{totalCount()} 件の結果</p>
-				</div>
-			</Show>
-
-			{/* Grid with optional context menu */}
-			<Show fallback={gridContent} when={!disableContextMenu()}>
-				<ContextMenu>
-					<ContextMenuTrigger class="block w-full">
-						{gridContent}
-					</ContextMenuTrigger>
-					<ContextMenuContent>
-						<Show
-							fallback={
-								<ContextMenuItem disabled>No media selected</ContextMenuItem>
-							}
-							when={contextMenuMediaId()}
-						>
-							<ContextMenuItem
-								onSelect={() => {
-									const id = contextMenuMediaId();
-									if (id) props.onToggleSelect?.(id);
-								}}
-							>
-								{(() => {
-									const id = contextMenuMediaId();
-									return id &&
-										props.isBulkSelectMode?.() &&
-										props.isSelected?.(id)
-										? "選択解除"
-										: "選択";
-								})()}
-							</ContextMenuItem>
-
-							<ContextMenuSeparator />
-
-							<Show
-								when={
-									props.isBulkSelectMode?.() &&
-									(props.selectedCount?.() ?? 0) > 0
-								}
-							>
-								<ContextMenuItem
-									onSelect={() => {
-										props.onBulkAction?.();
-									}}
+					{/* Grid with optional context menu */}
+					<Show fallback={gridContent} when={!disableContextMenu()}>
+						<ContextMenu>
+							<ContextMenuTrigger class="block w-full">
+								{gridContent}
+							</ContextMenuTrigger>
+							<ContextMenuContent>
+								<Show
+									fallback={
+										<ContextMenuItem disabled>
+											No media selected
+										</ContextMenuItem>
+									}
+									when={contextMenuMediaId()}
 								>
-									一括操作を実行 ({props.selectedCount?.()}件選択中)
-								</ContextMenuItem>
-								<ContextMenuItem
-									onSelect={() => {
-										props.onClearSelection?.();
-									}}
-								>
-									選択をクリア
-								</ContextMenuItem>
-								<ContextMenuSeparator />
-							</Show>
+									<ContextMenuItem
+										onSelect={() => {
+											const id = contextMenuMediaId();
+											if (id) props.onToggleSelect?.(id);
+										}}
+									>
+										{(() => {
+											const id = contextMenuMediaId();
+											return id &&
+												props.isBulkSelectMode?.() &&
+												props.isSelected?.(id)
+												? "選択解除"
+												: "選択";
+										})()}
+									</ContextMenuItem>
 
-							<Show when={showOpenInNewTab()}>
-								<ContextMenuItem
-									onSelect={() => {
-										const id = contextMenuMediaId();
-										const sourceId = props.mediaSourceId();
-										if (id && sourceId) {
-											window.open(`/sources/${sourceId}/${id}`, "_blank");
+									<ContextMenuSeparator />
+
+									<Show
+										when={
+											props.isBulkSelectMode?.() &&
+											(props.selectedCount?.() ?? 0) > 0
 										}
-									}}
-								>
-									新しいタブで開く
-								</ContextMenuItem>
-							</Show>
+									>
+										<ContextMenuItem
+											onSelect={() => {
+												props.onBulkAction?.();
+											}}
+										>
+											一括操作を実行 ({props.selectedCount?.()}件選択中)
+										</ContextMenuItem>
+										<ContextMenuItem
+											onSelect={() => {
+												props.onClearSelection?.();
+											}}
+										>
+											選択をクリア
+										</ContextMenuItem>
+										<ContextMenuSeparator />
+									</Show>
 
-							<ContextMenuItem
-								class="text-red-600 focus:text-red-600"
-								onSelect={() => {
-									const id = contextMenuMediaId();
-									if (id) props.onDelete?.(id);
-								}}
-							>
-								削除
-							</ContextMenuItem>
+									<Show when={showOpenInNewTab()}>
+										<ContextMenuItem
+											onSelect={() => {
+												const id = contextMenuMediaId();
+												const sourceId = props.mediaSourceId();
+												if (id && sourceId) {
+													window.open(`/sources/${sourceId}/${id}`, "_blank");
+												}
+											}}
+										>
+											新しいタブで開く
+										</ContextMenuItem>
+									</Show>
 
-							<ContextMenuSeparator />
+									<ContextMenuItem
+										class="text-red-600 focus:text-red-600"
+										onSelect={() => {
+											const id = contextMenuMediaId();
+											if (id) props.onDelete?.(id);
+										}}
+									>
+										削除
+									</ContextMenuItem>
 
-							<ContextMenuItem
-								onSelect={() => {
-									const id = contextMenuMediaId();
-									if (id) props.onCopyMove?.(id, "copy");
-								}}
-							>
-								他のソースへコピー
-							</ContextMenuItem>
-							<ContextMenuItem
-								onSelect={() => {
-									const id = contextMenuMediaId();
-									if (id) props.onCopyMove?.(id, "move");
-								}}
-							>
-								他のソースへ移動
-							</ContextMenuItem>
+									<ContextMenuSeparator />
 
-							<ContextMenuSeparator />
+									<ContextMenuItem
+										onSelect={() => {
+											const id = contextMenuMediaId();
+											if (id) props.onCopyMove?.(id, "copy");
+										}}
+									>
+										他のソースへコピー
+									</ContextMenuItem>
+									<ContextMenuItem
+										onSelect={() => {
+											const id = contextMenuMediaId();
+											if (id) props.onCopyMove?.(id, "move");
+										}}
+									>
+										他のソースへ移動
+									</ContextMenuItem>
 
-							<ContextMenuItem
-								onSelect={() => {
-									const id = contextMenuMediaId();
-									if (id) props.onSyncSingleMedia?.(id);
-								}}
-							>
-								メタデータを同期 (再処理)
-							</ContextMenuItem>
+									<ContextMenuSeparator />
+
+									<ContextMenuItem
+										onSelect={() => {
+											const id = contextMenuMediaId();
+											if (id) props.onSyncSingleMedia?.(id);
+										}}
+									>
+										メタデータを同期 (再処理)
+									</ContextMenuItem>
+								</Show>
+							</ContextMenuContent>
+						</ContextMenu>
+					</Show>
+
+					{/* Empty state */}
+					<Show when={showEmptyState() && props.state().phase === "empty"}>
+						<EmptyState
+							description="検索条件を変更して、もう一度お試しください。"
+							title="検索結果が見つかりませんでした"
+						/>
+					</Show>
+
+					{/* Load more sentinel */}
+					<div
+						class="flex h-10 w-full items-center justify-center text-gray-500"
+						ref={props.setLoadMoreRef}
+					>
+						<Show when={props.isFetchingNextPage}>
+							<p class="text-center text-gray-500" role="status">
+								読み込み中...
+							</p>
 						</Show>
-					</ContextMenuContent>
-				</ContextMenu>
-			</Show>
-
-			{/* Empty state */}
-			<Show
-				when={
-					showEmptyState() &&
-					props.mediaResults().length === 0 &&
-					!props.isPending
-				}
-			>
-				<div class="py-12 text-center text-gray-500">
-					検索結果が見つかりませんでした
-				</div>
-			</Show>
-
-			{/* Load more sentinel */}
-			<div
-				class="flex h-10 w-full items-center justify-center text-gray-500"
-				ref={props.setLoadMoreRef}
-			>
-				<Show when={props.isFetchingNextPage}>
-					<div class="text-center text-gray-500">読み込み中...</div>
-				</Show>
-			</div>
+					</div>
+				</Match>
+			</Switch>
 		</div>
 	);
 }

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -132,6 +132,15 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 	return (
 		<SourceMediaScreen
 			enableVirtualization={props.enableVirtualization}
+			onRetryFilters={async () => {
+				await Promise.all([
+					tags.refetch(),
+					allProjects.refetch(),
+					allIps.refetch(),
+					allCharacters.refetch(),
+					allAuthors.refetch(),
+				]);
+			}}
 			page={page}
 			renderActions={renderActions}
 			renderItem={props.renderItem}


### PR DESCRIPTION
## 概要

Issue #579 の共通Skeleton・Empty・Error・Offline・Retry UIを実装し、Server/Tauriの主要6画面へ適用しました。初回loadingだけをSkeletonにし、background fetchでは既存コンテンツと入力・focusを維持します。

## 変更内容

- card / list / media grid / detail / manager / config用の共有Skeletonを追加
- Empty / Error / Offline / Retry / background・cached-offline statusを共有化
- aria-busy、status/alert、reduced motion、読み上げ通知を整理
- Sources、Search、Source Media、Media Detail、Manager、Configへ状態UIを適用
- Server/Tauri Config wrapperを共通化し、Tauriのoffline/error retry経路を修正
- #594 のFull data SSR / static fallback / ClientOnly境界を維持
- background DOM保持、retry、empty、offline、network failure、responsive回帰のE2Eを拡充

## 検証

- Biome: 変更28ファイル成功
- 全workspace typecheck: 成功
- UI unit: 43 tests
- Server unit: 162 tests
- Server integration: 67 tests
- dev loading-recovery E2E: 11 tests
- fresh production build +主要E2E: 23 tests
- Tauri Web build: 成功

## 補足

rootの vp check / vp test は既存のVite+ root解決問題で解析開始前に失敗するため、package別check/testとfresh production buildで検証しています。詳細はIssueのReview Checklistに記録しました。

Closes #579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 設定・検索・メディア・管理画面に、統一された読み込み中／空状態／エラー／オフライン表示を追加しました。
  * 画面ごとのスケルトン表示と、データ準備中の案内を改善しました。
  * エラーや通信停止時に、画面上の「再試行」操作で復旧できるようになりました。
* **アクセシビリティ**
  * スクリーンリーダー向けの状態通知を改善し、アニメーション抑制設定にも対応しました。
* **品質改善**
  * 読み込み、再試行、空状態、更新中の表示に関する自動テストを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->