### PR TITLE
fix(realtime): preserve UI state during SSE updates

### DIFF
--- a/apps/server/src/application/services/directory-sync-service.ts
+++ b/apps/server/src/application/services/directory-sync-service.ts
@@ -72,6 +72,7 @@ async function processDeletions(
 				await deleteThumbnail(mediaSourceId, fileToDelete.id);
 				RealtimeEventBus.publishSource(mediaSourceId, "media-deleted", {
 					filePath: fileToDelete.relativePath,
+					mediaId: fileToDelete.id,
 					timestamp: new Date().toISOString(),
 				});
 				result.deleted++;

--- a/apps/server/src/infrastructure/jobs/file-watcher-service.ts
+++ b/apps/server/src/infrastructure/jobs/file-watcher-service.ts
@@ -100,6 +100,7 @@ async function handleFileDeleted(
 		// Notify
 		RealtimeEventBus.publishSource(mediaSourceId, "media-deleted", {
 			filePath: media.filePath,
+			mediaId: media.id,
 			timestamp: new Date().toISOString(),
 		});
 	} catch (error) {

--- a/apps/server/src/routes/search.tsx
+++ b/apps/server/src/routes/search.tsx
@@ -4,7 +4,6 @@ import { useSearchPage } from "@solid-imager/ui/hooks/use-search-page";
 import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { SearchScreen } from "@solid-imager/ui/screens/search-screen";
-import { useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
 import { createSignal, onMount, Show } from "solid-js";
 import { MediaGridItem } from "~/components/media/media-grid-item";
@@ -76,14 +75,11 @@ function SearchRouteFallback() {
 }
 
 function SearchRoute() {
-	const queryClient = useQueryClient();
-
 	const isSearchStateRestored = useCurrentSearchPersistence("all");
 
 	const page = useSearchPage({
 		searchMedia,
 		searchSimilar,
-		queryClient,
 		queries: {
 			tags: tagsQueryOptions,
 			sources: mediaSourcesQueryOptions,
@@ -107,10 +103,12 @@ function SearchRoute() {
 		isSearchStateRestored,
 	});
 
-	useMediaSourceEvents(() => searchState.selectedSource || undefined, {
+	useMediaSourceEvents(() => searchState.selectedSource || "*", {
 		onMediaAdded: page.refreshSearchResults,
 		onMediaDeleted: page.refreshSearchResults,
 		onMediaChanged: page.refreshSearchResults,
+		onMediaCopied: page.refreshSearchResults,
+		onMediaMoved: page.refreshSearchResults,
 		onAllJobsCompleted: page.refreshSearchResults,
 	});
 

--- a/apps/server/src/tests/e2e/search-realtime-preservation.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/search-realtime-preservation.responsive.spec.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from "node:crypto";
+import { copyFile } from "node:fs/promises";
+import path from "node:path";
+import {
+	E2E_PRIMARY_FILE_NAME,
+	E2E_SOURCE_NAME,
+	getE2eMediaDir,
+	getFixtureMediaPath,
+} from "./support/fixture";
+import { expect, test, waitForAppHydration } from "./support/test";
+
+const sourceEventsEndpoint = /\/api\/rpc\/sources\/events(?:\?|$)/;
+
+test("global search preserves the mobile filter dialog, input value, and focus after an SSE refresh", async ({
+	context,
+	page,
+}, testInfo) => {
+	test.skip(
+		!["responsive-320", "responsive-375"].includes(testInfo.project.name),
+		"The mobile filter dialog is only rendered below the md breakpoint.",
+	);
+
+	const sourceEventsConnected = page.waitForResponse(
+		(response) =>
+			sourceEventsEndpoint.test(new URL(response.url()).pathname) &&
+			response.status() === 200,
+	);
+	await page.goto("/search");
+	await expect(
+		page.getByRole("heading", { name: "メディア検索", exact: true }),
+	).toBeVisible();
+	await waitForAppHydration(page);
+	await sourceEventsConnected;
+
+	await page.getByRole("button", { name: "Filter results" }).click();
+	const filterDialog = page.getByRole("dialog");
+	const fileNameInput = filterDialog.getByPlaceholder("ファイル名を入力...");
+	await expect(filterDialog).toBeVisible();
+	await fileNameInput.fill("e2e");
+	await fileNameInput.focus();
+	await expect(fileNameInput).toBeFocused();
+	await expect(
+		page.locator("p").filter({ hasText: /^2 件の結果$/ }),
+	).toBeVisible();
+
+	const syncedFileName = `e2e-global-sse-${randomUUID()}.png`;
+	await copyFile(
+		getFixtureMediaPath(E2E_PRIMARY_FILE_NAME),
+		path.join(getE2eMediaDir(), syncedFileName),
+	);
+
+	const syncPage = await context.newPage();
+	await syncPage.setViewportSize({ width: 1440, height: 900 });
+	await syncPage.goto("/sources");
+	const sourceCard = syncPage
+		.getByTestId("source-card")
+		.filter({ hasText: E2E_SOURCE_NAME });
+	await expect(sourceCard).toBeVisible();
+	await waitForAppHydration(syncPage);
+	const syncResponse = syncPage.waitForResponse((response) => {
+		const url = new URL(response.url());
+		return url.pathname === "/api/rpc/sources/sync" && response.ok();
+	});
+	await sourceCard.getByTestId("sync-source-btn").click();
+	await syncResponse;
+
+	await expect(
+		page.locator("p").filter({ hasText: /^3 件の結果$/ }),
+	).toBeVisible({ timeout: 30_000 });
+	await expect(filterDialog).toBeVisible();
+	await expect(fileNameInput).toHaveValue("e2e");
+	await expect(fileNameInput).toBeFocused();
+});

--- a/apps/server/src/tests/unit/infrastructure/events/realtime-event-bus.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/events/realtime-event-bus.test.ts
@@ -1,3 +1,4 @@
+import { sourceEventSchema } from "@solid-imager/core/domain/sources/events";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { RealtimeEventBus } from "~/infrastructure/events/realtime-event-bus";
 
@@ -41,6 +42,25 @@ describe("RealtimeEventBus", () => {
 			}),
 		).toThrow();
 		expect(listener).not.toHaveBeenCalled();
+	});
+
+	it("requires a media ID for deletion events", () => {
+		expect(
+			sourceEventSchema.safeParse({
+				event: "media-deleted",
+				data: { filePath: "images/deleted.png" },
+			}).success,
+		).toBe(false);
+
+		expect(
+			sourceEventSchema.safeParse({
+				event: "media-deleted",
+				data: {
+					filePath: "images/deleted.png",
+					mediaId: "11111111-1111-4111-8111-111111111111",
+				},
+			}).success,
+		).toBe(true);
 	});
 
 	it("keeps source, job, and import channels isolated", () => {

--- a/apps/tauri/src/routes/search.tsx
+++ b/apps/tauri/src/routes/search.tsx
@@ -2,7 +2,6 @@ import { Button } from "@solid-imager/ui/button";
 import { useSearchPage } from "@solid-imager/ui/hooks/use-search-page";
 import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { SearchScreen } from "@solid-imager/ui/screens/search-screen";
-import { useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
 import { MediaGridItem } from "~/components/media/media-grid-item";
 import { useCurrentSearchPersistence } from "~/hooks/use-current-search-persistence";
@@ -43,14 +42,11 @@ const SEARCH_RESULTS_REFRESH_DEBOUNCE_MS = 300;
 const PresetClient = createPresetClient(rawPresetClient);
 
 function SearchRoute() {
-	const queryClient = useQueryClient();
-
 	const isSearchStateRestored = useCurrentSearchPersistence("all");
 
 	const page = useSearchPage({
 		searchMedia,
 		searchSimilar,
-		queryClient,
 		queries: {
 			tags: tagsQueryOptions,
 			sources: mediaSourcesQueryOptions,
@@ -74,10 +70,12 @@ function SearchRoute() {
 		isSearchStateRestored,
 	});
 
-	useMediaSourceEvents(() => searchState.selectedSource || undefined, {
+	useMediaSourceEvents(() => searchState.selectedSource || "*", {
 		onMediaAdded: page.refreshSearchResults,
 		onMediaDeleted: page.refreshSearchResults,
 		onMediaChanged: page.refreshSearchResults,
+		onMediaCopied: page.refreshSearchResults,
+		onMediaMoved: page.refreshSearchResults,
 		onAllJobsCompleted: page.refreshSearchResults,
 	});
 

--- a/packages/application/src/services/media-transfer-service.ts
+++ b/packages/application/src/services/media-transfer-service.ts
@@ -419,6 +419,7 @@ export class MediaTransferService {
 			event: "media-deleted",
 			payload: {
 				filePath: media.filePath,
+				mediaId: validatedMediaId,
 				timestamp: new Date().toISOString(),
 			},
 		};

--- a/packages/core/src/domain/sources/events.ts
+++ b/packages/core/src/domain/sources/events.ts
@@ -10,7 +10,9 @@ const sourceScopedEventSchema = z.object({
 export const mediaAddedEventSchema = sourceScopedEventSchema;
 export type MediaAddedEvent = z.infer<typeof mediaAddedEventSchema>;
 
-export const mediaDeletedEventSchema = sourceScopedEventSchema;
+export const mediaDeletedEventSchema = sourceScopedEventSchema.extend({
+	mediaId: z.string().uuid(),
+});
 export type MediaDeletedEvent = z.infer<typeof mediaDeletedEventSchema>;
 
 export const mediaChangedEventSchema = sourceScopedEventSchema;

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -9,7 +9,6 @@ import type {
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
-import type { QueryClient } from "@tanstack/solid-query";
 import { createInfiniteQuery, createQuery } from "@tanstack/solid-query";
 import {
 	type Accessor,
@@ -19,10 +18,7 @@ import {
 	onCleanup,
 } from "solid-js";
 import { isServer } from "solid-js/web";
-import {
-	buildSearchResultsQueryOptions,
-	searchQueryKeys,
-} from "../query-options";
+import { buildSearchResultsQueryOptions } from "../query-options";
 import { type QueryUiState, toQueryUiState } from "../query-state";
 
 const DEFAULT_GC_TIME = 1000 * 60 * 5;
@@ -65,7 +61,6 @@ export interface UseSearchPageOptions {
 		},
 		signal?: AbortSignal,
 	) => Promise<SimilarMediaSearchResponse>;
-	queryClient: QueryClient;
 	queries: SearchPageQueryOptions;
 	selectedSource: () => string | null | undefined;
 	getSearchCondition: () => MediaSearchRequest["condition"];
@@ -114,7 +109,6 @@ export function useSearchPage(
 ): UseSearchPageResult {
 	const {
 		searchMedia,
-		queryClient,
 		queries,
 		selectedSource,
 		getSearchCondition,
@@ -237,13 +231,15 @@ export function useSearchPage(
 			clearTimeout(timer);
 		}
 		if (refreshDebounceMs <= 0) {
-			void queryClient.invalidateQueries({ queryKey: searchQueryKeys.all() });
+			// Refetching the observer targets its current exact query key. Do not
+			// invalidate cached results for other sources, modes, or conditions.
+			void searchResultQuery.refetch();
 			setRefreshTimer(null);
 			return;
 		}
 		setRefreshTimer(
 			setTimeout(() => {
-				void queryClient.invalidateQueries({ queryKey: searchQueryKeys.all() });
+				void searchResultQuery.refetch();
 				setRefreshTimer(null);
 			}, refreshDebounceMs),
 		);

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -15,7 +15,7 @@ import {
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
 import { getErrorMessage } from "@solid-imager/core/utils";
 import type { QueryClient } from "@tanstack/solid-query";
-import { createInfiniteQuery } from "@tanstack/solid-query";
+import { createInfiniteQuery, type InfiniteData } from "@tanstack/solid-query";
 import type { Accessor, Setter } from "solid-js";
 import {
 	createEffect,
@@ -28,6 +28,8 @@ import { isServer } from "solid-js/web";
 import { z } from "zod";
 import {
 	buildSourceMediaResultsQueryOptions,
+	isSourceMediaResultsQueryKey,
+	removeMediaFromInfiniteQueryData,
 	sourceMediaQueryKeys,
 } from "../query-options";
 import { type QueryUiState, toQueryUiState } from "../query-state";
@@ -404,9 +406,6 @@ export function useSourceMediaPage(
 	// --- Refresh helpers ---
 	const refreshMediaQuery = () => {
 		void mediaQuery.refetch();
-		void queryClient.invalidateQueries({
-			queryKey: sourceMediaQueryKeys.forSource(id()),
-		});
 	};
 
 	const [mediaRefreshTimer, setMediaRefreshTimer] = createSignal<ReturnType<
@@ -472,7 +471,18 @@ export function useSourceMediaPage(
 				}, DEBOUNCE_DELAY_MS),
 			);
 		},
-		onMediaDeleted: () => {
+		onMediaDeleted: (data) => {
+			const sourceId = id();
+			if (!sourceId) {
+				return;
+			}
+			queryClient.setQueriesData<InfiniteData<MediaSearchResponse>>(
+				{
+					predicate: (query) =>
+						isSourceMediaResultsQueryKey(query.queryKey, sourceId),
+				},
+				(previous) => removeMediaFromInfiniteQueryData(previous, data.mediaId),
+			);
 			scheduleMediaRefresh();
 		},
 		onMediaChanged: () => {
@@ -488,9 +498,6 @@ export function useSourceMediaPage(
 			if (onThumbnailReady) {
 				onThumbnailReady(data.mediaId);
 			}
-			queryClient.invalidateQueries({
-				queryKey: sourceMediaQueryKeys.forSource(id()),
-			});
 		},
 		onAllJobsCompleted: (data) => {
 			setJobProgress(null);

--- a/packages/ui/src/query-options/index.ts
+++ b/packages/ui/src/query-options/index.ts
@@ -40,6 +40,8 @@ export {
 export {
 	buildSearchResultsQueryOptions,
 	buildSourceMediaResultsQueryOptions,
+	isSourceMediaResultsQueryKey,
+	removeMediaFromInfiniteQueryData,
 	type SearchResultsQueryKeyInput,
 	type SearchResultsQueryOptionsInput,
 	type SourceMediaQueryKeyInput,

--- a/packages/ui/src/query-options/search-query.test.ts
+++ b/packages/ui/src/query-options/search-query.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	buildSearchResultsQueryOptions,
 	buildSourceMediaResultsQueryOptions,
+	isSourceMediaResultsQueryKey,
+	removeMediaFromInfiniteQueryData,
 	searchQueryKeys,
 	sourceMediaQueryKeys,
 } from "./search-query";
@@ -67,6 +69,54 @@ describe("query key factories", () => {
 			limit: 200,
 		});
 		expect(key.slice(0, 2)).toEqual(sourceMediaQueryKeys.forSource("source"));
+	});
+
+	it("matches only source media result keys for local cache updates", () => {
+		const resultKey = sourceMediaQueryKeys.results({
+			sourceId: "source",
+			conditionKey: "null",
+			sort: undefined,
+			order: "desc",
+			limit: 200,
+		});
+
+		expect(isSourceMediaResultsQueryKey(resultKey, "source")).toBe(true);
+		expect(
+			isSourceMediaResultsQueryKey(["media", "source", "media-id"], "source"),
+		).toBe(false);
+	});
+});
+
+describe("removeMediaFromInfiniteQueryData", () => {
+	it("removes a known deleted media item without touching other cached entries", () => {
+		const otherMedia: Media = {
+			...TEST_MEDIA,
+			id: "33333333-3333-4333-8333-333333333333",
+			fileName: "other.png",
+		};
+		const data = {
+			pages: [{ media: [TEST_MEDIA, otherMedia], total: 2 }],
+			pageParams: [0],
+		};
+
+		expect(removeMediaFromInfiniteQueryData(data, TEST_MEDIA.id)).toEqual({
+			pages: [{ media: [otherMedia], total: 1 }],
+			pageParams: [0],
+		});
+	});
+
+	it("preserves the cached object when the deleted media is not loaded", () => {
+		const data = {
+			pages: [{ media: [TEST_MEDIA], total: 1 }],
+			pageParams: [0],
+		};
+
+		expect(
+			removeMediaFromInfiniteQueryData(
+				data,
+				"33333333-3333-4333-8333-333333333333",
+			),
+		).toBe(data);
 	});
 });
 

--- a/packages/ui/src/query-options/search-query.ts
+++ b/packages/ui/src/query-options/search-query.ts
@@ -2,7 +2,11 @@ import type {
 	MediaSearchRequest,
 	MediaSearchResponse,
 } from "@solid-imager/core/domain/media/schemas";
-import { infiniteQueryOptions, keepPreviousData } from "@tanstack/solid-query";
+import {
+	type InfiniteData,
+	infiniteQueryOptions,
+	keepPreviousData,
+} from "@tanstack/solid-query";
 
 export type SearchResultsQueryKeyInput = {
 	mode: "simple" | "pro" | "vector";
@@ -35,6 +39,59 @@ export const sourceMediaQueryKeys = {
 	results: (input: SourceMediaQueryKeyInput) =>
 		["media", input.sourceId, input] as const,
 };
+
+export function isSourceMediaResultsQueryKey(
+	queryKey: readonly unknown[],
+	sourceId: string,
+): boolean {
+	const [scope, querySourceId, input] = queryKey;
+	return (
+		scope === "media" &&
+		querySourceId === sourceId &&
+		typeof input === "object" &&
+		input !== null &&
+		"conditionKey" in input
+	);
+}
+
+/**
+ * Removes a known-deleted media item from cached infinite result pages.
+ *
+ * A source event only identifies the deleted record; it does not contain
+ * enough data to safely insert or replace records for arbitrary filters and
+ * sort orders. Removing an existing item is therefore the only safe local
+ * cache update, with a subsequent background refetch reconciling pagination.
+ */
+export function removeMediaFromInfiniteQueryData(
+	data: InfiniteData<MediaSearchResponse> | undefined,
+	mediaId: string,
+): InfiniteData<MediaSearchResponse> | undefined {
+	if (!data) {
+		return data;
+	}
+
+	let removed = false;
+	const pages = data.pages.map((page) => {
+		const media = page.media.filter((item) => item.id !== mediaId);
+		if (media.length === page.media.length) {
+			return page;
+		}
+		removed = true;
+		return { ...page, media };
+	});
+
+	if (!removed) {
+		return data;
+	}
+
+	return {
+		...data,
+		pages: pages.map((page) => ({
+			...page,
+			total: Math.max(page.total - 1, 0),
+		})),
+	};
+}
 
 type SearchMedia = (
 	sourceId: string | undefined,

--- a/packages/ui/src/screens/media-detail-screen.tsx
+++ b/packages/ui/src/screens/media-detail-screen.tsx
@@ -11,7 +11,6 @@ import {
 	type MediaSourceEventTransport,
 	useMediaSourceEvents,
 } from "../hooks/use-media-source-events";
-import { sourceMediaQueryKeys } from "../query-options";
 import { toQueryUiState } from "../query-state";
 import { LoadingRegion, MediaDetailSkeleton } from "../skeleton";
 
@@ -63,15 +62,7 @@ export function MediaDetailScreen(props: MediaDetailScreenProps) {
 
 	useMediaSourceEvents({
 		transport: props.transport,
-		onMediaAdded: () => {
-			void queryClient.invalidateQueries({
-				queryKey: sourceMediaQueryKeys.forSource(props.mediaSourceId),
-			});
-		},
 		onMediaDeleted: (data: MediaDeletedEvent) => {
-			void queryClient.invalidateQueries({
-				queryKey: sourceMediaQueryKeys.forSource(props.mediaSourceId),
-			});
 			if (
 				data.mediaId === props.mediaId ||
 				data.filePath === mediaDetails.data?.filePath
@@ -80,9 +71,6 @@ export function MediaDetailScreen(props: MediaDetailScreenProps) {
 			}
 		},
 		onMediaChanged: (data: MediaChangedEvent) => {
-			void queryClient.invalidateQueries({
-				queryKey: sourceMediaQueryKeys.forSource(props.mediaSourceId),
-			});
 			if (
 				data.mediaId === props.mediaId ||
 				data.filePath === mediaDetails.data?.filePath


### PR DESCRIPTION
## 概要
SSE更新を現在表示中のQueryへ限定し、Dialog・入力値・focusを背景更新中も保持します。

Closes #580

## 変更内容
- 全ソース検索でwildcard SSEを購読し、表示中の正確なQueryだけを再取得
- 削除イベントへmediaIdを必須化し、一覧キャッシュを局所更新
- Source MediaとMedia Detailの不要なsource-prefix invalidationを削減
- モバイル検索DialogのSSE後の入力値・focus保持をE2Eで追加

## 検証
- bun run typecheck
- bun x biome check（変更ファイル）
- 本番E2E: realtime-preservation、responsive 320px / 375px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * メディア削除イベントに識別情報が含まれ、削除結果が各画面へ正確に反映されるようになりました。
  * メディアのコピー・移動時にも検索結果が自動更新されます。

* **改善**
  * 検索結果の更新が効率化され、不要な再読み込みを抑制しました。
  * メディア削除時、検索結果や一覧から対象が速やかに除去されます。
  * リアルタイム更新後も、検索フィルターのダイアログ、入力内容、フォーカスが維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->