### PR TITLE
fix(tauri): Sources の Query・DB 二重取得を解消 (#588)

### DIFF
--- a/apps/tauri/src/routes/sources/index.tsx
+++ b/apps/tauri/src/routes/sources/index.tsx
@@ -8,9 +8,10 @@ import { SourceCard } from "@solid-imager/ui/source-card";
 import { SourceDeleteModal } from "@solid-imager/ui/source-delete-modal";
 import { SourceFormModal } from "@solid-imager/ui/source-form-modal";
 import { useLiveQuery } from "@tanstack/solid-db";
-import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import { useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
 import { getCollections } from "~/collections";
+import { collectionQueryKeys } from "~/collections/query-keys";
 import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import {
 	createMediaSource,
@@ -18,12 +19,8 @@ import {
 	syncMediaSources,
 	updateMediaSource,
 } from "~/infrastructure/api-clients/sources-api";
-import { mediaSourcesQueryOptions } from "~/queries";
 
 export const Route = createFileRoute("/sources/")({
-	loader: ({ context }) => {
-		void context.queryClient.prefetchQuery(mediaSourcesQueryOptions());
-	},
 	component: SourcesRoute,
 });
 
@@ -38,12 +35,18 @@ function SourcesRoute() {
 	const queryClient = useQueryClient();
 	const { sources } = getCollections();
 	const mediaSources = useLiveQuery(() => sources);
-	const mediaSourcesQuery = createQuery(() => mediaSourcesQueryOptions());
 	const sourceData = () => {
 		const cachedSources = mediaSources();
-		return cachedSources.length > 0 || mediaSources.isReady
+		return cachedSources.length > 0 ||
+			(mediaSources.isReady && !sources.utils.isError)
 			? cachedSources
 			: undefined;
+	};
+	const fetchStatus = () => {
+		if (sources.utils.fetchStatus.includes("paused")) {
+			return "paused" as const;
+		}
+		return sources.utils.isFetching ? ("fetching" as const) : ("idle" as const);
 	};
 
 	const page = useSourcesPage({
@@ -66,7 +69,7 @@ function SourcesRoute() {
 			},
 		},
 		queryClient,
-		invalidateQueryKey: mediaSourcesQueryOptions().queryKey,
+		invalidateQueryKey: collectionQueryKeys.sources(),
 		registerEvents: registerSourceEvents,
 		getSourceIds: () =>
 			(sourceData() ?? [])
@@ -78,23 +81,23 @@ function SourcesRoute() {
 		<SourcesScreen
 			page={page}
 			mediaSources={sourceData}
-			onRetry={async () => {
-				await Promise.all([
-					mediaSourcesQuery.refetch(),
-					sources.utils.refetch(),
-				]);
-			}}
+			onRetry={() => sources.utils.clearError()}
 			state={() =>
 				toQueryUiState(
 					{
 						data: sourceData(),
 						error:
-							mediaSourcesQuery.error ??
+							sources.utils.lastError ??
 							(mediaSources.isError
 								? new Error("保存済みのソースを読み込めませんでした")
 								: undefined),
-						status: mediaSources.isError ? "error" : mediaSourcesQuery.status,
-						fetchStatus: mediaSourcesQuery.fetchStatus,
+						status:
+							mediaSources.isError || sources.utils.isError
+								? "error"
+								: sourceData() === undefined || sources.utils.isLoading
+									? "pending"
+									: "success",
+						fetchStatus: fetchStatus(),
 					},
 					{ isEmpty: (data) => data.length === 0 },
 				)

--- a/docs/design/tauri-spa-architecture.md
+++ b/docs/design/tauri-spa-architecture.md
@@ -1,5 +1,16 @@
 # Tauri対応: apps/tauri/src の SPA 設計方針
 
+## ローカル優先の collection と remote sync（#588）
+
+Tauri の一覧データは、役割を次のように分離する。TanStack DB collection は SQLite に保存した一覧の読込とリアクティブ表示を担当し、TanStack Query integration は collection の remote sync を担当する。画面 route は同じ一覧 API を loader や `createQuery()` で重複取得しない。
+
+| collection | 現在の採用状況 | 移行方針 |
+| --- | --- | --- |
+| sources | collection を表示と同期の唯一のデータ源に採用 | mutation 成功後に `utils.refetch()` で同期する。 |
+| tags / projects / characters / ips / authors | collection を永続化・同期基盤として初期化済み | 対応画面を変更する際、一覧 Query を collection の `useLiveQuery()` に段階移行する。 |
+
+画面状態は `useLiveQuery()` のローカル初期化状態と、collection `utils` の remote 状態を別々に扱う。保存済みデータがあれば remote sync の失敗時も一覧を保持して同期不能を表示する。保存済みデータがなく同期に失敗した場合だけ error state を表示する。mutation は API 呼び出しを維持し、失敗時には collection を再取得しないため、失敗した remote 変更をローカル表示へ反映しない。
+
 ## 背景
 
 `issue-169-tauri-build-bootstrap` ブランチで試みたTauri対応は失敗だった。

--- a/packages/ui/src/async-state.tsx
+++ b/packages/ui/src/async-state.tsx
@@ -210,8 +210,10 @@ export function FilterErrorBanner(props: FilterErrorBannerProps) {
 
 export type QueryStatusProps = {
 	class?: string;
+	errorLabel?: string;
 	fetchState: QueryUiFetchState;
 	hasData: boolean;
+	hasError?: boolean;
 	offlineLabel: string;
 	updatingLabel: string;
 };
@@ -244,6 +246,16 @@ export function QueryStatus(props: QueryStatusProps) {
 							class="size-2 rounded-full bg-warning-foreground"
 						/>
 						{props.offlineLabel}
+					</p>
+				</Match>
+				<Match when={props.hasError && props.hasData}>
+					<p
+						class="flex items-center gap-2 text-warning-foreground text-sm"
+						data-state-ui="cached-sync-error"
+						role="status"
+					>
+						<span aria-hidden="true" class="size-2 rounded-full bg-current" />
+						{props.errorLabel ?? "最新のデータを取得できませんでした"}
 					</p>
 				</Match>
 			</Switch>

--- a/packages/ui/src/screens/sources-screen.tsx
+++ b/packages/ui/src/screens/sources-screen.tsx
@@ -60,8 +60,10 @@ export function SourcesScreen(props: SourcesScreenProps) {
 
 			<QueryStatus
 				class="mb-3"
+				errorLabel="同期できなかったため、保存済みのソースを表示しています"
 				fetchState={props.state().fetchState}
 				hasData={props.state().data !== undefined}
+				hasError={props.state().error !== undefined}
 				offlineLabel="オフラインのため保存済みデータを表示しています"
 				updatingLabel="ソース一覧を更新中..."
 			/>


### PR DESCRIPTION
## 概要

Tauri の Sources 画面を TanStack DB collection を唯一の一覧データ源に変更し、保存済みデータをオフライン時にも表示します。

## 変更内容

- route loader と画面専用 Query を削除し、collection の remote sync に統一
- local read と remote sync の状態を区別し、同期失敗時も保存済み一覧を保持
- 保存済み一覧を表示中の同期失敗を共通状態UIで明示
- collection の採用状況・段階移行方針を設計文書へ記録

## 検証

- `bun run --cwd apps/tauri check`
- `bun run --cwd packages/ui check`
- `bun run --cwd apps/tauri build:web`
- `bun run --cwd packages/ui test`（46 passed）
- `bun run --cwd apps/tauri typecheck` は既存の `ImportMetaEnv.DEV` / CSS module 宣言不足で失敗

fixes #588