### PR TITLE
feat(ui): App Shellとナビゲーションをモバイル対応 (#581)

### DIFF
--- a/apps/server/src/tests/e2e/app-nav.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/app-nav.responsive.spec.ts
@@ -1,0 +1,49 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./support/test";
+
+async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+	const overflow = await page.evaluate(
+		() =>
+			document.documentElement.scrollWidth -
+			document.documentElement.clientWidth,
+	);
+	expect(overflow).toBeLessThanOrEqual(1);
+}
+
+test("app navigation is responsive and accessible", async ({
+	page,
+}, testInfo) => {
+	await page.goto("/about");
+	await expect(page.locator("#main-content")).toBeVisible();
+	await expectNoHorizontalOverflow(page);
+
+	const usesMobileMenu = ["responsive-320", "responsive-375"].includes(
+		testInfo.project.name,
+	);
+	if (!usesMobileMenu) {
+		const aboutLink = page
+			.getByRole("navigation", { name: "主要ナビゲーション" })
+			.getByRole("link", { name: "About", exact: true });
+		await expect(aboutLink).toHaveAttribute("aria-current", "page");
+		await expect(aboutLink).toBeVisible();
+		return;
+	}
+
+	const menuButton = page.getByRole("button", { name: "メニューを開く" });
+	await menuButton.click();
+	const dialog = page.getByRole("dialog");
+	await expect(dialog).toBeVisible();
+	await expect(
+		dialog.getByRole("link", { name: "About", exact: true }),
+	).toHaveAttribute("aria-current", "page");
+
+	await page.keyboard.press("Escape");
+	await expect(dialog).toBeHidden();
+	await expect(menuButton).toBeFocused();
+
+	await menuButton.click();
+	await dialog.getByRole("link", { name: "Search", exact: true }).click();
+	await expect(page).toHaveURL(/\/search$/);
+	await expect(dialog).toBeHidden();
+	await expectNoHorizontalOverflow(page);
+});

--- a/packages/ui/src/layouts/app-nav.tsx
+++ b/packages/ui/src/layouts/app-nav.tsx
@@ -1,23 +1,51 @@
+import {
+	CloseButton as DialogCloseButton,
+	Content as DialogContent,
+	Overlay as DialogOverlay,
+	Portal as DialogPortal,
+	Root as DialogRoot,
+	Title as DialogTitle,
+	Trigger as DialogTrigger,
+} from "@kobalte/core/dialog";
 import { Link, useLocation } from "@tanstack/solid-router";
 import type { JSX } from "solid-js";
-import { createSignal, onCleanup, onMount } from "solid-js";
+import { createSignal, onCleanup, onMount, Show } from "solid-js";
 import { isServer } from "solid-js/web";
 
 type AppNavProps = {
 	pendingDownloadsIndicator?: JSX.Element;
 };
 
+const navigationItems = [
+	{ label: "Home", to: "/" },
+	{ label: "Sources", to: "/sources" },
+	{ label: "Search", to: "/search" },
+	{ label: "Manager", to: "/manager" },
+	{ label: "About", to: "/about" },
+	{ label: "Settings", to: "/config" },
+] as const;
+
 export function AppNav(props: AppNavProps) {
 	const location = useLocation();
-	const active = (path: string) =>
-		path === location().pathname
-			? "border-sky-600"
-			: "border-transparent hover:border-sky-600";
+	const [isMenuOpen, setIsMenuOpen] = createSignal(false);
+	const [isClient, setIsClient] = createSignal(false);
+	const isActive = (path: string) => path === location().pathname;
+	const linkClass = (path: string) =>
+		`rounded-md px-3 py-2 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-sky-800 ${
+			isActive(path)
+				? "bg-sky-700 text-white"
+				: "text-sky-50 hover:bg-sky-700 hover:text-white"
+		}`;
 
 	const [isVisible, setIsVisible] = createSignal(true);
 	const [lastScrollY, setLastScrollY] = createSignal(0);
 
 	const handleScroll = () => {
+		if (!window.matchMedia("(min-width: 768px)").matches) {
+			setIsVisible(true);
+			return;
+		}
+
 		const currentScrollY = window.scrollY;
 
 		if (currentScrollY < 0) {
@@ -39,6 +67,7 @@ export function AppNav(props: AppNavProps) {
 	};
 
 	onMount(() => {
+		setIsClient(true);
 		window.addEventListener("scroll", handleScroll, { passive: true });
 	});
 
@@ -51,30 +80,40 @@ export function AppNav(props: AppNavProps) {
 
 	return (
 		<>
+			<a
+				class="sr-only fixed top-2 left-2 z-[60] rounded-md bg-background px-4 py-2 text-foreground shadow focus:not-sr-only focus:outline-none focus:ring-2 focus:ring-ring"
+				href="#main-content"
+			>
+				メインコンテンツへ移動
+			</a>
 			<nav
+				aria-label="主要ナビゲーション"
 				class={`fixed top-0 right-0 left-0 z-50 w-full bg-sky-800 transition-transform duration-300 ${
 					isVisible() ? "translate-y-0" : "-translate-y-full"
 				}`}
 			>
-				<div class="container relative flex items-center p-3">
-					<ul class="flex items-center text-gray-200">
-						<li class={`border-b-2 ${active("/")} mx-1.5 sm:mx-6`}>
-							<Link to="/">Home</Link>
-						</li>
-						<li class={`border-b-2 ${active("/about")} mx-1.5 sm:mx-6`}>
-							<Link to="/about">About</Link>
-						</li>
-						<li class={`border-b-2 ${active("/sources")} mx-1.5 sm:mx-6`}>
-							<Link to="/sources">Sources</Link>
-						</li>
-						<li class={`border-b-2 ${active("/search")} mx-1.5 sm:mx-6`}>
-							<Link to="/search">Search</Link>
-						</li>
-						<li class={`border-b-2 ${active("/manager")} mx-1.5 sm:mx-6`}>
-							<Link to="/manager">Manager</Link>
-						</li>
-						<li class={`border-b-2 ${active("/docs")} mx-1.5 sm:mx-6`}>
+				<div class="container flex min-h-16 items-center gap-2 px-3 pt-[env(safe-area-inset-top)] sm:px-4">
+					<Link
+						class="rounded-md px-2 py-2 font-semibold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+						to="/"
+					>
+						Solid Imager
+					</Link>
+					<ul class="hidden items-center gap-1 md:flex">
+						{navigationItems.map((item) => (
+							<li>
+								<Link
+									aria-current={isActive(item.to) ? "page" : undefined}
+									class={linkClass(item.to)}
+									to={item.to}
+								>
+									{item.label}
+								</Link>
+							</li>
+						))}
+						<li>
 							<a
+								class={linkClass("/docs")}
 								href="/docs/index.html"
 								rel="noopener noreferrer"
 								target="_blank"
@@ -82,16 +121,95 @@ export function AppNav(props: AppNavProps) {
 								Docs
 							</a>
 						</li>
-						<li class={`border-b-2 ${active("/config")} mx-1.5 sm:mx-6`}>
-							<Link to="/config">Settings</Link>
-						</li>
 					</ul>
 					<div class="ml-auto flex items-center gap-2" id="nav-actions">
 						{props.pendingDownloadsIndicator}
+						<DialogRoot onOpenChange={setIsMenuOpen} open={isMenuOpen()}>
+							<DialogTrigger
+								aria-label="メニューを開く"
+								class="inline-flex size-11 items-center justify-center rounded-md text-white hover:bg-sky-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:hidden"
+							>
+								<svg
+									aria-hidden="true"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									viewBox="0 0 24 24"
+								>
+									<path d="M4 6h16M4 12h16M4 18h16" />
+								</svg>
+							</DialogTrigger>
+							<Show when={isClient()}>
+								<DialogPortal>
+									<DialogOverlay class="fixed inset-0 z-[60] bg-black/50 data-[closed]:animate-out data-[expanded]:animate-in" />
+									<DialogContent
+										aria-labelledby="mobile-navigation-title"
+										class="fixed inset-y-0 right-0 z-[70] flex w-[min(20rem,calc(100vw-1rem))] flex-col bg-background pb-[env(safe-area-inset-bottom)] shadow-xl outline-none data-[closed]:animate-out data-[closed]:slide-out-to-right data-[expanded]:animate-in data-[expanded]:slide-in-from-right"
+									>
+										<div class="flex min-h-16 items-center justify-between border-b px-4 pt-[env(safe-area-inset-top)]">
+											<DialogTitle
+												class="font-semibold text-lg"
+												id="mobile-navigation-title"
+											>
+												メニュー
+											</DialogTitle>
+											<DialogCloseButton
+												aria-label="メニューを閉じる"
+												class="inline-flex size-11 items-center justify-center rounded-md hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+											>
+												<svg
+													aria-hidden="true"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="2"
+													viewBox="0 0 24 24"
+												>
+													<path d="M18 6 6 18M6 6l12 12" />
+												</svg>
+											</DialogCloseButton>
+										</div>
+										<nav
+											aria-label="モバイルナビゲーション"
+											class="overflow-y-auto p-3"
+										>
+											<ul class="space-y-1">
+												{navigationItems.map((item) => (
+													<li>
+														<Link
+															aria-current={
+																isActive(item.to) ? "page" : undefined
+															}
+															class={`block min-h-11 ${linkClass(item.to)}`}
+															onClick={() => setIsMenuOpen(false)}
+															to={item.to}
+														>
+															{item.label}
+														</Link>
+													</li>
+												))}
+												<li>
+													<a
+														class={`block min-h-11 ${linkClass("/docs")}`}
+														href="/docs/index.html"
+														rel="noopener noreferrer"
+														target="_blank"
+													>
+														Docs
+													</a>
+												</li>
+											</ul>
+										</nav>
+									</DialogContent>
+								</DialogPortal>
+							</Show>
+						</DialogRoot>
 					</div>
 				</div>
 			</nav>
-			<div class="h-[52px]" />
+			<div
+				aria-hidden="true"
+				class="h-[calc(4rem+env(safe-area-inset-top))] shrink-0"
+			/>
 		</>
 	);
 }

--- a/packages/ui/src/layouts/app-shell.tsx
+++ b/packages/ui/src/layouts/app-shell.tsx
@@ -7,10 +7,12 @@ interface AppShellProps {
 
 export function AppShell(props: ParentProps<AppShellProps>) {
 	return (
-		<div class="flex min-h-screen flex-col bg-background text-foreground">
+		<div class="flex min-h-screen min-h-[100dvh] flex-col bg-background pb-[env(safe-area-inset-bottom)] text-foreground">
 			{props.statusIndicator}
 			{props.nav}
-			<main class="flex-1">{props.children}</main>
+			<div class="flex-1" id="main-content" tabIndex={-1}>
+				{props.children}
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## 概要

App Shellとグローバルナビゲーションを320px幅から使えるレスポンシブ構成へ更新します。

## 変更内容

- モバイル用ドロワーナビゲーションと安全なフォーカス管理を追加
- 現在地表示、skip link、44pxタッチターゲットを追加
- dvhとsafe-area insetに対応した共有App Shellへ更新
- 320px/375px/768pxを含むレスポンシブE2Eを追加

## 検証

- bun run --cwd packages/ui typecheck
- bun run --cwd packages/ui check
- bun run --cwd apps/server check
- bun run --cwd apps/server test:e2e:production -- app-nav.responsive.spec.ts

fixes #581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モバイル画面向けのスライド式ナビゲーションメニューを追加しました。
  * メニュー内で現在のページを確認でき、Escキーで閉じた際はメニューボタンへフォーカスが戻ります。
  * ナビゲーションから検索ページへスムーズに移動できます。
  * スキップリンクを追加し、キーボード操作による本文への移動に対応しました。

* **改善**
  * 画面幅に応じてナビゲーションを最適化し、横方向のはみ出しを防止しました。
  * モバイル表示ではナビゲーションが常に利用しやすくなりました。
  * ノッチなどのセーフエリアに配慮した表示に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->