### PR TITLE
fix(ui): モバイルのDialog・Form操作を改善 (#587)

### DIFF
--- a/packages/ui/src/ai-tagging-modal.tsx
+++ b/packages/ui/src/ai-tagging-modal.tsx
@@ -70,7 +70,7 @@ export function AiTaggingModal(props: AiTaggingModalProps) {
 			onOpenChange={(open: boolean) => !open && props.onClose()}
 			open={props.isOpen}
 		>
-			<DialogContent class="max-h-[80vh] overflow-y-auto sm:max-w-[600px]">
+			<DialogContent class="sm:max-w-[600px]">
 				<DialogHeader>
 					<DialogTitle>AI Tagging Results</DialogTitle>
 					<DialogDescription>

--- a/packages/ui/src/alert-dialog.tsx
+++ b/packages/ui/src/alert-dialog.tsx
@@ -53,7 +53,7 @@ const AlertDialogContent: Component<
 			<AlertDialogOverlay />
 			<AlertDialogPrimitiveContent
 				class={cn(
-					"-translate-x-1/2 -translate-y-1/2 data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 data-[closed]:slide-out-to-left-1/2 data-[closed]:slide-out-to-top-[48%] data-[expanded]:slide-in-from-left-1/2 data-[expanded]:slide-in-from-top-[48%] fixed top-1/2 left-1/2 z-50 grid max-h-screen w-full max-w-lg gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[closed]:animate-out data-[expanded]:animate-in sm:rounded-lg",
+					"-translate-x-1/2 -translate-y-1/2 data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 data-[closed]:slide-out-to-left-1/2 data-[closed]:slide-out-to-top-[48%] data-[expanded]:slide-in-from-left-1/2 data-[expanded]:slide-in-from-top-[48%] fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] w-[calc(100%-2rem)] max-w-lg gap-4 overflow-y-auto overscroll-contain border bg-background p-6 shadow-lg duration-200 data-[closed]:animate-out data-[expanded]:animate-in sm:max-h-[calc(100dvh-4rem)] sm:rounded-lg",
 					props.class,
 				)}
 				{...rest}
@@ -69,7 +69,7 @@ const AlertDialogHeader: Component<ComponentProps<"div">> = (props) => {
 	return (
 		<div
 			class={cn(
-				"flex flex-col space-y-2 text-center sm:text-left",
+				"sticky top-0 z-10 shrink-0 space-y-2 bg-background text-center sm:text-left",
 				props.class,
 			)}
 			{...rest}
@@ -82,7 +82,7 @@ const AlertDialogFooter: Component<ComponentProps<"div">> = (props) => {
 	return (
 		<div
 			class={cn(
-				"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+				"sticky bottom-0 z-10 flex shrink-0 flex-col-reverse gap-2 bg-background sm:flex-row sm:justify-end [&>button]:min-h-11 [&>button]:w-full sm:[&>button]:w-auto",
 				props.class,
 			)}
 			{...rest}

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -30,7 +30,7 @@ const buttonVariants = cva(
 				link: "text-primary underline-offset-4 hover:underline",
 			},
 			size: {
-				default: "h-10 px-4 py-2",
+				default: "h-11 px-4 py-2",
 				sm: "h-9 px-3 text-xs",
 				lg: "h-11 px-8",
 				icon: "size-10",

--- a/packages/ui/src/character-crop-modal.tsx
+++ b/packages/ui/src/character-crop-modal.tsx
@@ -63,7 +63,7 @@ export function CharacterCropModal(props: CharacterCropModalProps) {
 			onOpenChange={(open) => !open && props.onClose()}
 			open={props.isOpen}
 		>
-			<DialogContent class="max-h-[90vh] overflow-y-auto sm:max-w-[900px]">
+			<DialogContent class="sm:max-w-[900px]">
 				<DialogHeader>
 					<DialogTitle class="flex items-center gap-2">
 						<span class="i-lucide-scan text-indigo-600" />

--- a/packages/ui/src/combobox.tsx
+++ b/packages/ui/src/combobox.tsx
@@ -29,7 +29,7 @@ const ComboboxItem = <T extends ValidComponent = "li">(
 	return (
 		<ComboboxPrimitive.Item
 			class={cn(
-				"relative flex cursor-default select-none items-center justify-between rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50",
+				"relative flex min-h-11 cursor-default select-none items-center justify-between rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50",
 				local.class,
 			)}
 			{...others}
@@ -147,7 +147,10 @@ const ComboboxTrigger = <T extends ValidComponent = "button">(
 	]);
 	return (
 		<ComboboxPrimitive.Trigger
-			class={cn("size-4 opacity-50", local.class)}
+			class={cn(
+				"flex min-h-11 min-w-11 items-center justify-center opacity-50",
+				local.class,
+			)}
 			{...others}
 		>
 			<ComboboxPrimitive.Icon>
@@ -189,7 +192,7 @@ const ComboboxContent = <T extends ValidComponent = "div">(
 		<ComboboxPrimitive.Portal>
 			<ComboboxPrimitive.Content
 				class={cn(
-					"fade-in-80 relative z-50 min-w-32 animate-in overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+					"fade-in-80 relative z-50 max-h-[min(24rem,calc(100dvh-2rem))] min-w-32 max-w-[calc(100dvw-2rem)] animate-in overflow-y-auto overflow-x-hidden overscroll-contain rounded-md border bg-popover text-popover-foreground shadow-md",
 					local.class,
 				)}
 				{...others}
@@ -220,7 +223,7 @@ const VirtualComboboxContent = <T extends ValidComponent = "div">(
 		<ComboboxPrimitive.Portal>
 			<ComboboxPrimitive.Content
 				class={cn(
-					"fade-in-80 relative z-50 min-w-32 animate-in overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+					"fade-in-80 relative z-50 max-h-[min(24rem,calc(100dvh-2rem))] min-w-32 max-w-[calc(100dvw-2rem)] animate-in overflow-x-hidden overscroll-contain rounded-md border bg-popover text-popover-foreground shadow-md",
 					local.class,
 				)}
 				{...others}
@@ -276,7 +279,7 @@ const VirtualComboboxContent = <T extends ValidComponent = "div">(
 											>
 												<ComboboxPrimitive.Item
 													item={item}
-													class="relative flex cursor-default select-none items-center justify-between rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50"
+													class="relative flex min-h-11 cursor-default select-none items-center justify-between rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50"
 												>
 													<ComboboxPrimitive.ItemLabel>
 														{item.textValue}

--- a/packages/ui/src/combobox.tsx
+++ b/packages/ui/src/combobox.tsx
@@ -203,7 +203,7 @@ const ComboboxContent = <T extends ValidComponent = "div">(
 	);
 };
 
-const ITEM_HEIGHT_PX = 32;
+const ITEM_HEIGHT_PX = 44;
 const VIRTUAL_OVERSCAN = 5;
 
 const VirtualComboboxContent = <T extends ValidComponent = "div">(

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -68,7 +68,7 @@ const DialogContent = <T extends ValidComponent = "div">(
 			<DialogOverlay />
 			<DialogPrimitiveContent
 				class={cn(
-					"-translate-x-1/2 -translate-y-1/2 data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 data-[closed]:slide-out-to-left-1/2 data-[closed]:slide-out-to-top-[48%] data-[expanded]:slide-in-from-left-1/2 data-[expanded]:slide-in-from-top-[48%] fixed top-1/2 left-1/2 z-50 grid max-h-screen w-full max-w-lg gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[closed]:animate-out data-[expanded]:animate-in sm:rounded-lg",
+					"-translate-x-1/2 -translate-y-1/2 data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 data-[closed]:slide-out-to-left-1/2 data-[closed]:slide-out-to-top-[48%] data-[expanded]:slide-in-from-left-1/2 data-[expanded]:slide-in-from-top-[48%] fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))] w-[calc(100%-2rem)] max-w-lg gap-4 overflow-y-auto overscroll-contain border bg-background p-6 shadow-lg duration-200 data-[closed]:animate-out data-[expanded]:animate-in sm:max-h-[calc(100dvh-4rem)] sm:rounded-lg",
 					props.class,
 				)}
 				{...rest}
@@ -101,7 +101,7 @@ const DialogHeader: Component<ComponentProps<"div">> = (props) => {
 	return (
 		<div
 			class={cn(
-				"flex flex-col space-y-1.5 text-center sm:text-left",
+				"sticky top-0 z-10 shrink-0 space-y-1.5 bg-background text-center sm:text-left",
 				props.class,
 			)}
 			{...rest}
@@ -114,7 +114,7 @@ const DialogFooter: Component<ComponentProps<"div">> = (props) => {
 	return (
 		<div
 			class={cn(
-				"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+				"sticky bottom-0 z-10 flex shrink-0 flex-col-reverse gap-2 bg-background sm:flex-row sm:justify-end [&>button]:min-h-11 [&>button]:w-full sm:[&>button]:w-auto",
 				props.class,
 			)}
 			{...rest}

--- a/packages/ui/src/input.tsx
+++ b/packages/ui/src/input.tsx
@@ -18,7 +18,7 @@ export function Input(props: InputProps) {
 	return (
 		<input
 			class={cn(
-				"flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:font-medium file:text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+				"flex min-h-11 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:font-medium file:text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
 				local.class,
 			)}
 			{...rest}

--- a/packages/ui/src/popover.tsx
+++ b/packages/ui/src/popover.tsx
@@ -22,7 +22,7 @@ const PopoverContent = <T extends ValidComponent = "div">(
 		<PopoverPrimitive.Portal>
 			<PopoverPrimitive.Content
 				class={cn(
-					"data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 z-50 w-72 origin-[var(--kb-popover-content-transform-origin)] rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[closed]:animate-out data-[expanded]:animate-in",
+					"data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 z-50 max-h-[calc(100dvh-2rem)] w-[min(18rem,calc(100dvw-2rem))] overflow-auto overscroll-contain origin-[var(--kb-popover-content-transform-origin)] rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[closed]:animate-out data-[expanded]:animate-in",
 					local.class,
 				)}
 				{...others}

--- a/packages/ui/src/select.tsx
+++ b/packages/ui/src/select.tsx
@@ -47,7 +47,7 @@ const SelectTrigger = <T extends ValidComponent = "button">(
 	return (
 		<SelectPrimitiveTrigger
 			class={cn(
-				"flex h-10 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+				"flex min-h-11 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
 				local.class,
 			)}
 			{...others}
@@ -84,7 +84,7 @@ const SelectContent = <T extends ValidComponent = "div">(
 		<SelectPrimitivePortal>
 			<SelectPrimitiveContent
 				class={cn(
-					"fade-in-80 relative z-50 min-w-32 animate-in overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+					"fade-in-80 relative z-50 max-h-[min(24rem,calc(100dvh-2rem))] min-w-32 max-w-[calc(100dvw-2rem)] animate-in overflow-y-auto overflow-x-hidden overscroll-contain rounded-md border bg-popover text-popover-foreground shadow-md",
 					local.class,
 				)}
 				{...others}
@@ -111,7 +111,7 @@ const SelectItem = <T extends ValidComponent = "li">(
 	return (
 		<SelectPrimitiveItem
 			class={cn(
-				"relative mt-0 flex w-full cursor-default select-none items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+				"relative mt-0 flex min-h-11 w-full cursor-default select-none items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 				local.class,
 			)}
 			{...others}

--- a/packages/ui/src/source-form-modal.tsx
+++ b/packages/ui/src/source-form-modal.tsx
@@ -178,7 +178,7 @@ export function SourceFormModal(props: SourceFormModalProps) {
 
 	return (
 		<Dialog onOpenChange={() => props.onClose()} open={props.isOpen}>
-			<DialogContent class="max-h-[80vh] overflow-y-auto sm:max-w-[500px]">
+			<DialogContent class="sm:max-w-[500px]">
 				<DialogHeader>
 					<DialogTitle>
 						{props.editingSource ? "Edit Source" : "Add New Source"}
@@ -273,7 +273,7 @@ export function SourceFormModal(props: SourceFormModalProps) {
 						</Show>
 
 						<Show when={formData.type === "sftp"}>
-							<div class="grid grid-cols-2 gap-4">
+							<div class="grid gap-4 sm:grid-cols-2">
 								<div class="space-y-2">
 									<Label for="host">Host</Label>
 									<Input
@@ -364,7 +364,7 @@ export function SourceFormModal(props: SourceFormModalProps) {
 						</Show>
 
 						<Show when={formData.type === "s3"}>
-							<div class="grid grid-cols-2 gap-4">
+							<div class="grid gap-4 sm:grid-cols-2">
 								<div class="space-y-2">
 									<Label for="bucket">Bucket</Label>
 									<Input

--- a/packages/ui/src/upload-media-modal.tsx
+++ b/packages/ui/src/upload-media-modal.tsx
@@ -304,35 +304,35 @@ export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
 							</div>
 						</Show>
 
-						<div class="grid grid-cols-4 items-center gap-4">
-							<Label class="text-right" for="filename">
+						<div class="grid gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
+							<Label class="sm:text-right" for="filename">
 								ファイル名
 							</Label>
 							<Input
-								class="col-span-3"
+								class="sm:col-span-3"
 								id="filename"
 								onInput={(event) => setFilename(event.currentTarget.value)}
 								value={filename()}
 							/>
 						</div>
 
-						<div class="grid grid-cols-4 items-center gap-4">
-							<Label class="text-right" for="description">
+						<div class="grid gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
+							<Label class="sm:text-right" for="description">
 								説明
 							</Label>
 							<Input
-								class="col-span-3"
+								class="sm:col-span-3"
 								id="description"
 								onInput={(event) => setDescription(event.currentTarget.value)}
 								value={description()}
 							/>
 						</div>
 
-						<div class="grid grid-cols-4 items-center gap-4">
-							<Label class="text-right" for="sourceUrl">
+						<div class="grid gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
+							<Label class="sm:text-right" for="sourceUrl">
 								ソースURL
 							</Label>
-							<div class="relative col-span-3">
+							<div class="relative sm:col-span-3">
 								<Input
 									disabled={isFetchingUrl()}
 									id="sourceUrl"
@@ -346,7 +346,7 @@ export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
 								</Show>
 							</div>
 							<Show when={previewUrl()}>
-								<div class="col-span-4 mt-2 flex justify-center">
+								<div class="mt-2 flex justify-center sm:col-span-4">
 									<img
 										alt="Fetched preview"
 										class="max-h-48 rounded-md object-contain"


### PR DESCRIPTION
## 概要

モバイル画面でのDialog、Popover、Select、Combobox、フォーム操作を viewport と safe area に収め、十分なタッチターゲットを提供します。

## 変更内容

- Dialog / AlertDialog に dynamic viewport・safe area・内部スクロール・sticky header/footerを適用
- Popover / Select / Combobox の狭幅・高さ制限と内部スクロールを追加
- Input、Button、Select、Combobox の主要操作を44px以上へ統一
- Source Form と Upload Form を狭幅で1列レイアウトへ変更

## 検証

- bun run --cwd packages/ui typecheck
- bun x biome check packages/ui/src
- git diff --check

production E2E は Nitro が未定義の vite パッケージを対話インストールしようとして build 前に停止します。server typecheck は #route-tree 未生成により既存route型エラーで停止します。

fixes #587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ダイアログやモーダルの表示幅・高さ、スクロール動作を画面サイズに合わせて調整しました。
  * ヘッダーとフッターを固定表示し、操作性を改善しました。
  * コンボボックスやセレクト項目、入力欄、ボタンの最小サイズを拡大しました。
  * ポップオーバーや選択リストが画面内に収まりやすくなりました。
  * 各種フォームのレイアウトをレスポンシブ対応に改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->