### PR TITLE
fix: Media Detail・Manager・Configをモバイル対応 (#586)

### DIFF
--- a/apps/server/src/components/media/media-sidebar.tsx
+++ b/apps/server/src/components/media/media-sidebar.tsx
@@ -68,7 +68,7 @@ function formatBytes(bytes: number, decimals = 2) {
 }
 
 const CodeBlock = (props: { content: string }) => (
-	<pre class="mt-2 max-h-96 overflow-y-auto rounded-md bg-gray-100 p-2">
+	<pre class="mt-2 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-md bg-gray-100 p-2">
 		<code class="text-sm">{props.content}</code>
 	</pre>
 );
@@ -377,7 +377,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 	};
 
 	return (
-		<aside class="h-full space-y-4 overflow-y-auto rounded-lg border bg-gray-50 p-4">
+		<aside class="min-w-0 space-y-4 rounded-lg border bg-gray-50 p-3 sm:p-4 lg:h-full lg:overflow-y-auto lg:overscroll-contain">
 			<div>
 				<h1 class="font-bold text-xl break-all">{props.media.fileName}</h1>
 				<p class="text-gray-500 text-sm break-all">{props.media.filePath}</p>
@@ -385,7 +385,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 
 			<div class="flex flex-col gap-2">
 				<button
-					class="flex w-full items-center justify-center gap-2 rounded-md bg-purple-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-purple-700"
+					class="flex min-h-11 w-full items-center justify-center gap-2 rounded-md bg-purple-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-purple-700"
 					onClick={() => setIsAiTaggingModalOpen(true)}
 					type="button"
 				>
@@ -393,7 +393,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 					Extract Tags (AI)
 				</button>
 				<button
-					class="flex w-full items-center justify-center gap-2 rounded-md bg-teal-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-teal-700"
+					class="flex min-h-11 w-full items-center justify-center gap-2 rounded-md bg-teal-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-teal-700"
 					onClick={() => setIsCharacterCropModalOpen(true)}
 					type="button"
 				>
@@ -401,7 +401,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 					Detect &amp; Crop Characters
 				</button>
 				<button
-					class="flex w-full items-center justify-center gap-2 rounded-md border px-3 py-2 font-medium text-sm transition-colors hover:bg-gray-100 disabled:opacity-50"
+					class="flex min-h-11 w-full items-center justify-center gap-2 rounded-md border px-3 py-2 font-medium text-sm transition-colors hover:bg-gray-100 disabled:opacity-50"
 					disabled={isExtractingCcip() || isCcipJobPending()}
 					onClick={handleCcipExtraction}
 					type="button"
@@ -415,7 +415,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 				</button>
 				<Show when={ccipStatus() === "ready"}>
 					<button
-						class="flex w-full items-center justify-center gap-2 rounded-md border px-3 py-2 font-medium text-sm transition-colors hover:bg-gray-100"
+						class="flex min-h-11 w-full items-center justify-center gap-2 rounded-md border px-3 py-2 font-medium text-sm transition-colors hover:bg-gray-100"
 						onClick={() => {
 							activateVectorSearch(props.media.id);
 							void navigate({ to: "/search" });
@@ -444,7 +444,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 
 			<div class="space-y-2">
 				<h2 class="font-semibold text-lg">Details</h2>
-				<dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+				<dl class="grid grid-cols-1 gap-1 text-sm sm:grid-cols-2 sm:gap-x-4 sm:gap-y-2">
 					<dt class="font-medium text-gray-600">Resolution</dt>
 					<dd class="text-gray-800">
 						{props.media.width} x {props.media.height}
@@ -458,11 +458,11 @@ export function MediaSidebar(props: MediaSidebarProps) {
 
 			{/* Description Section */}
 			<div class="space-y-2">
-				<div class="flex items-center justify-between">
+				<div class="flex items-start justify-between gap-2">
 					<h2 class="font-semibold text-lg">Description</h2>
 					<Show when={!isEditingDescription()}>
 						<button
-							class="text-blue-600 text-sm hover:underline"
+							class="min-h-11 px-2 text-blue-600 text-sm hover:underline"
 							onClick={() => setIsEditingDescription(true)}
 							type="button"
 						>
@@ -487,22 +487,22 @@ export function MediaSidebar(props: MediaSidebarProps) {
 						when={isEditingDescription()}
 					>
 						<textarea
-							class="w-full rounded-md border border-gray-300 p-2 text-sm"
+							class="w-full scroll-mb-24 rounded-md border border-gray-300 p-2 text-base sm:text-sm"
 							onInput={(e) => setDescriptionValue(e.currentTarget.value)}
 							placeholder="Enter description..."
 							rows={6}
 							value={descriptionValue()}
 						/>
-						<div class="flex gap-2">
+						<div class="sticky bottom-0 z-10 -mx-3 flex flex-col gap-2 border-t bg-gray-50 px-3 py-3 sm:-mx-4 sm:px-4 lg:static lg:mx-0 lg:flex-row lg:border-0 lg:bg-transparent lg:p-0">
 							<button
-								class="rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700"
+								class="min-h-11 w-full rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 lg:w-auto"
 								onClick={handleSaveDescription}
 								type="button"
 							>
 								Save
 							</button>
 							<button
-								class="rounded-md bg-gray-300 px-3 py-1 text-gray-700 text-sm hover:bg-gray-400"
+								class="min-h-11 w-full rounded-md bg-gray-300 px-3 py-1 text-gray-700 text-sm hover:bg-gray-400 lg:w-auto"
 								onClick={handleCancelEdit}
 								type="button"
 							>
@@ -544,10 +544,10 @@ export function MediaSidebar(props: MediaSidebarProps) {
 						<For each={props.media.authors}>
 							{(author) => (
 								<li>
-									<div class="flex items-center gap-2">
-										<span class="font-medium">{author.name}</span>
+									<div class="flex min-w-0 items-center gap-2">
+										<span class="break-words font-medium">{author.name}</span>
 										<Show when={author.accountId}>
-											<span class="text-gray-500 text-xs">
+											<span class="break-all text-gray-500 text-xs">
 												({author.accountId})
 											</span>
 										</Show>

--- a/apps/server/src/tests/e2e/media-detail-manager-config.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/media-detail-manager-config.responsive.spec.ts
@@ -1,0 +1,120 @@
+import type { Page } from "@playwright/test";
+import { E2E_PRIMARY_FILE_NAME, mediaPath } from "./support/fixture";
+import { expect, test, waitForAppHydration } from "./support/test";
+
+const mobileProjects = ["responsive-320", "responsive-375"];
+
+async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+	const overflow = await page.evaluate(
+		() =>
+			document.documentElement.scrollWidth -
+			document.documentElement.clientWidth,
+	);
+	expect(overflow).toBeLessThanOrEqual(1);
+}
+
+test("media detail, manager, and settings remain usable on narrow screens", async ({
+	page,
+}, testInfo) => {
+	await page.goto(mediaPath());
+	await expect(
+		page.getByRole("heading", { name: E2E_PRIMARY_FILE_NAME, exact: true }),
+	).toBeVisible();
+	await waitForAppHydration(page);
+	await expect(
+		page.getByRole("img", { name: E2E_PRIMARY_FILE_NAME, exact: true }),
+	).toBeVisible();
+	const detailsHeading = page.getByRole("heading", {
+		name: "Details",
+		exact: true,
+	});
+	await detailsHeading.scrollIntoViewIfNeeded();
+	await expect(detailsHeading).toBeInViewport();
+	await expectNoHorizontalOverflow(page);
+
+	await page.goto("/manager");
+	await expect(
+		page.getByRole("heading", { name: "Entity Manager", exact: true }),
+	).toBeVisible();
+	await waitForAppHydration(page);
+	await expectNoHorizontalOverflow(page);
+
+	const projectName = `Responsive project ${testInfo.project.name}`;
+	await page.getByRole("button", { name: "Create New", exact: true }).click();
+	const projectDialog = page.getByRole("dialog");
+	await expect(projectDialog).toBeVisible();
+	await projectDialog.getByLabel("Name", { exact: true }).fill(projectName);
+	await projectDialog
+		.getByRole("button", { name: "Save", exact: true })
+		.click();
+	await expect(projectDialog).toBeHidden();
+	await expect(
+		page.getByRole("heading", { name: projectName, exact: true }),
+	).toBeVisible();
+
+	await page
+		.getByRole("button", { name: `Edit ${projectName}`, exact: true })
+		.click();
+	await expect(projectDialog).toBeVisible();
+	await expect(
+		projectDialog.getByLabel("Name", { exact: true }),
+	).toBeInViewport();
+	await page.keyboard.press("Escape");
+	await expect(projectDialog).toBeHidden();
+
+	await page
+		.getByRole("button", { name: "Batch Tagging", exact: true })
+		.click();
+	await expect(
+		page.getByRole("heading", { name: "Batch AI Tagging", exact: true }),
+	).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: "Scan for Targets", exact: true }),
+	).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: "Start Batch Tagging", exact: true }),
+	).toBeVisible();
+	await expectNoHorizontalOverflow(page);
+
+	await page.goto("/config");
+	await expect(
+		page.getByRole("heading", { name: "Settings", exact: true }),
+	).toBeVisible();
+	await waitForAppHydration(page);
+
+	for (const category of [
+		{ tab: "Jobs", heading: "Job Processing" },
+		{ tab: "AI", heading: "AI Service" },
+		{ tab: "Downloads", heading: "Downloads" },
+		{ tab: "Storage", heading: "Storage" },
+		{ tab: "Media", heading: "Media Extensions" },
+		{ tab: "Logging", heading: "Logging" },
+	]) {
+		await page.getByRole("tab", { name: category.tab, exact: true }).click();
+		await expect(
+			page.getByRole("heading", { name: category.heading, exact: true }),
+		).toBeVisible();
+	}
+
+	await page.getByRole("tab", { name: "Storage", exact: true }).click();
+	const thumbnailDirectory = page.getByLabel("Thumbnail Directory", {
+		exact: true,
+	});
+	await expect(thumbnailDirectory).toBeVisible();
+	await expectNoHorizontalOverflow(page);
+
+	if (mobileProjects.includes(testInfo.project.name)) {
+		const fontSize = await thumbnailDirectory.evaluate((input) =>
+			Number.parseFloat(getComputedStyle(input).fontSize),
+		);
+		expect(fontSize).toBeGreaterThanOrEqual(16);
+
+		await page.getByRole("tab", { name: "Media", exact: true }).click();
+		await page
+			.getByLabel("Negative Tags", { exact: true })
+			.scrollIntoViewIfNeeded();
+		await expect(
+			page.getByRole("button", { name: "Save Changes", exact: true }),
+		).toBeInViewport();
+	}
+});

--- a/packages/ui/src/media-sidebar.tsx
+++ b/packages/ui/src/media-sidebar.tsx
@@ -290,16 +290,16 @@ export function MediaSidebar(props: MediaSidebarProps) {
 	};
 
 	return (
-		<aside class="h-full space-y-4 overflow-y-auto rounded-lg border bg-gray-50 p-4">
+		<aside class="min-w-0 space-y-4 rounded-lg border bg-gray-50 p-3 sm:p-4 lg:h-full lg:overflow-y-auto lg:overscroll-contain">
 			<div>
-				<h1 class="font-bold text-xl">{props.media.fileName}</h1>
-				<p class="text-gray-500 text-sm">{props.media.filePath}</p>
+				<h1 class="break-words font-bold text-xl">{props.media.fileName}</h1>
+				<p class="break-all text-gray-500 text-sm">{props.media.filePath}</p>
 			</div>
 
 			<Show when={props.aiTaggingModal}>
 				<div class="flex flex-col gap-2">
 					<button
-						class="flex w-full items-center justify-center gap-2 rounded-md bg-purple-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-purple-700"
+						class="flex min-h-11 w-full items-center justify-center gap-2 rounded-md bg-purple-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-purple-700"
 						onClick={() => setIsAiTaggingModalOpen(true)}
 						type="button"
 					>
@@ -309,7 +309,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 
 					<Show when={props.characterCropModal}>
 						<button
-							class="flex w-full items-center justify-center gap-2 rounded-md bg-teal-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-teal-700"
+							class="flex min-h-11 w-full items-center justify-center gap-2 rounded-md bg-teal-600 px-3 py-2 font-medium text-sm text-white transition-colors hover:bg-teal-700"
 							onClick={() => setIsCharacterCropModalOpen(true)}
 							type="button"
 						>
@@ -351,7 +351,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 
 			<div class="space-y-2">
 				<h2 class="font-semibold text-lg">Details</h2>
-				<dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+				<dl class="grid grid-cols-1 gap-1 text-sm sm:grid-cols-2 sm:gap-x-4 sm:gap-y-2">
 					<dt class="font-medium text-gray-600">Resolution</dt>
 					<dd class="text-gray-800">
 						{props.media.width} x {props.media.height}
@@ -364,11 +364,11 @@ export function MediaSidebar(props: MediaSidebarProps) {
 			</div>
 
 			<div class="space-y-2">
-				<div class="flex items-center justify-between">
+				<div class="flex items-start justify-between gap-2">
 					<h2 class="font-semibold text-lg">Description</h2>
 					<Show when={!isEditingDescription()}>
 						<button
-							class="text-blue-600 text-sm hover:underline"
+							class="min-h-11 px-2 text-blue-600 text-sm hover:underline"
 							onClick={() => setIsEditingDescription(true)}
 							type="button"
 						>
@@ -393,14 +393,15 @@ export function MediaSidebar(props: MediaSidebarProps) {
 						when={isEditingDescription()}
 					>
 						<textarea
-							class="w-full rounded-md border border-gray-300 p-2 text-sm"
+							class="w-full scroll-mb-24 rounded-md border border-gray-300 p-2 text-base sm:text-sm"
 							onInput={(e) => setDescriptionValue(e.currentTarget.value)}
 							placeholder="Enter description..."
 							rows={6}
 							value={descriptionValue()}
 						/>
-						<div class="flex gap-2">
+						<div class="sticky bottom-0 z-10 -mx-3 flex flex-col gap-2 border-t bg-gray-50 px-3 py-3 sm:-mx-4 sm:px-4 lg:static lg:mx-0 lg:flex-row lg:border-0 lg:bg-transparent lg:p-0">
 							<Button
+								class="w-full lg:w-auto"
 								onClick={() => {
 									void handleSaveDescription();
 								}}
@@ -408,7 +409,12 @@ export function MediaSidebar(props: MediaSidebarProps) {
 							>
 								Save
 							</Button>
-							<Button onClick={handleCancelEdit} size="sm" variant="outline">
+							<Button
+								class="w-full lg:w-auto"
+								onClick={handleCancelEdit}
+								size="sm"
+								variant="outline"
+							>
 								Cancel
 							</Button>
 						</div>
@@ -445,10 +451,10 @@ export function MediaSidebar(props: MediaSidebarProps) {
 						<For each={props.media.authors}>
 							{(author) => (
 								<li>
-									<div class="flex items-center gap-2">
-										<span class="font-medium">{author.name}</span>
+									<div class="flex min-w-0 items-center gap-2">
+										<span class="break-words font-medium">{author.name}</span>
 										<Show when={author.accountId}>
-											<span class="text-gray-500 text-xs">
+											<span class="break-all text-gray-500 text-xs">
 												({author.accountId})
 											</span>
 										</Show>

--- a/packages/ui/src/media-viewer.tsx
+++ b/packages/ui/src/media-viewer.tsx
@@ -53,7 +53,7 @@ export function MediaViewer(props: MediaViewerProps) {
 	});
 
 	return (
-		<div class="flex h-full w-full items-center justify-center bg-black/5">
+		<div class="flex h-full min-h-0 min-w-0 w-full items-center justify-center overflow-hidden rounded-lg bg-black/5 p-2 sm:p-4">
 			<Switch>
 				<Match when={props.source.type === "video"}>
 					<Show
@@ -65,7 +65,11 @@ export function MediaViewer(props: MediaViewerProps) {
 						when={mediaUrl()}
 					>
 						{(url) => (
-							<video class="max-h-full max-w-full" controls src={url()}>
+							<video
+								class="max-h-full max-w-full rounded-md"
+								controls
+								src={url()}
+							>
 								<track kind="captions" />
 							</video>
 						)}
@@ -81,7 +85,7 @@ export function MediaViewer(props: MediaViewerProps) {
 						when={mediaUrl()}
 					>
 						{(url) => (
-							<audio controls src={url()}>
+							<audio class="max-w-full" controls src={url()}>
 								<track kind="captions" />
 							</audio>
 						)}
@@ -107,7 +111,7 @@ export function MediaViewer(props: MediaViewerProps) {
 						{(url) => (
 							<img
 								alt={props.fileName}
-								class="max-h-full max-w-full object-contain"
+								class="max-h-full max-w-full rounded-md object-contain"
 								height={props.height}
 								src={url()}
 								width={props.width}

--- a/packages/ui/src/screens/config-screen.tsx
+++ b/packages/ui/src/screens/config-screen.tsx
@@ -1,7 +1,7 @@
 import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
 import { AppConfigSchema } from "@solid-imager/core/domain/config/config-schema";
 import { createForm } from "@tanstack/solid-form";
-import { Show } from "solid-js";
+import { createSignal, Show } from "solid-js";
 import { Button } from "../button";
 import { Input } from "../input";
 import { Label } from "../label";
@@ -31,6 +31,7 @@ export type ConfigScreenProps = {
 };
 
 export function ConfigScreen(props: ConfigScreenProps) {
+	const [activeTab, setActiveTab] = createSignal("jobs");
 	const form = createForm(() => ({
 		defaultValues: props.data as unknown as FormConfig,
 		validators: {
@@ -48,30 +49,52 @@ export function ConfigScreen(props: ConfigScreenProps) {
 	}));
 
 	return (
-		<>
-			<div class="mb-6 flex items-center justify-between">
-				<h1 class="font-bold text-3xl">Settings</h1>
+		<div class="min-w-0 space-y-6 [&_input]:scroll-mt-28 [&_input]:text-base [&_select]:scroll-mt-28 [&_select]:text-base [&_textarea]:scroll-mt-28 [&_textarea]:text-base sm:[&_input]:text-sm sm:[&_select]:text-sm sm:[&_textarea]:text-sm">
+			<div class="sticky top-[calc(4rem+env(safe-area-inset-top))] z-20 -mx-3 flex flex-col gap-3 border-b bg-background px-3 py-3 sm:-mx-6 sm:flex-row sm:items-center sm:justify-between sm:px-6 md:static md:mx-0 md:border-0 md:bg-transparent md:p-0">
+				<h1 class="font-bold text-2xl sm:text-3xl">Settings</h1>
 				<Button
+					class="w-full sm:w-auto"
 					disabled={form.state.isSubmitting}
-					onClick={() => form.handleSubmit()}
+					onClick={() => {
+						void form.handleSubmit();
+					}}
 				>
 					{form.state.isSubmitting ? "Saving..." : "Save Changes"}
 				</Button>
 			</div>
 
-			<Tabs class="w-full" defaultValue="jobs">
-				<TabsList class="grid w-full grid-cols-6">
-					<TabsTrigger value="jobs">Jobs</TabsTrigger>
-					<TabsTrigger value="ai">AI</TabsTrigger>
-					<TabsTrigger value="downloads">Downloads</TabsTrigger>
-					<TabsTrigger value="storage">Storage</TabsTrigger>
-					<TabsTrigger value="media">Media</TabsTrigger>
-					<TabsTrigger value="logging">Logging</TabsTrigger>
+			<Tabs class="min-w-0 w-full" onChange={setActiveTab} value={activeTab()}>
+				<TabsList
+					aria-label="Settings categories"
+					class="flex h-auto w-full justify-start gap-1 overflow-x-auto rounded-md p-1 md:grid md:grid-cols-6 md:overflow-visible"
+				>
+					<TabsTrigger class="min-h-11 shrink-0" type="button" value="jobs">
+						Jobs
+					</TabsTrigger>
+					<TabsTrigger class="min-h-11 shrink-0" type="button" value="ai">
+						AI
+					</TabsTrigger>
+					<TabsTrigger
+						class="min-h-11 shrink-0"
+						type="button"
+						value="downloads"
+					>
+						Downloads
+					</TabsTrigger>
+					<TabsTrigger class="min-h-11 shrink-0" type="button" value="storage">
+						Storage
+					</TabsTrigger>
+					<TabsTrigger class="min-h-11 shrink-0" type="button" value="media">
+						Media
+					</TabsTrigger>
+					<TabsTrigger class="min-h-11 shrink-0" type="button" value="logging">
+						Logging
+					</TabsTrigger>
 				</TabsList>
 
-				<div class="mt-6 space-y-6">
+				<div class="mt-4 space-y-4 sm:mt-6 sm:space-y-6">
 					<TabsContent value="jobs">
-						<div class="space-y-4 rounded-md border p-4">
+						<div class="space-y-4 rounded-md border p-3 sm:p-4">
 							<h2 class="mb-4 font-semibold text-xl">Job Processing</h2>
 
 							<form.Field name="jobs.concurrency">
@@ -181,7 +204,7 @@ export function ConfigScreen(props: ConfigScreenProps) {
 					</TabsContent>
 
 					<TabsContent value="ai">
-						<div class="space-y-4 rounded-md border p-4">
+						<div class="space-y-4 rounded-md border p-3 sm:p-4">
 							<h2 class="mb-4 font-semibold text-xl">AI Service</h2>
 							<form.Field name="ai.baseUrl">
 								{(field) => (
@@ -224,7 +247,7 @@ export function ConfigScreen(props: ConfigScreenProps) {
 					</TabsContent>
 
 					<TabsContent value="downloads">
-						<div class="space-y-4 rounded-md border p-4">
+						<div class="space-y-4 rounded-md border p-3 sm:p-4">
 							<h2 class="mb-4 font-semibold text-xl">Downloads</h2>
 
 							<form.Field name="downloads.rateLimitEnabled">
@@ -270,7 +293,7 @@ export function ConfigScreen(props: ConfigScreenProps) {
 					</TabsContent>
 
 					<TabsContent value="storage">
-						<div class="space-y-4 rounded-md border p-4">
+						<div class="space-y-4 rounded-md border p-3 sm:p-4">
 							<h2 class="mb-4 font-semibold text-xl">Storage</h2>
 							<form.Field name="storage.thumbnailDir">
 								{(field) => (
@@ -286,7 +309,7 @@ export function ConfigScreen(props: ConfigScreenProps) {
 								)}
 							</form.Field>
 
-							<div class="grid grid-cols-2 gap-4">
+							<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
 								<form.Field name="storage.thumbnailSize">
 									{(field) => (
 										<div class="space-y-2">
@@ -330,10 +353,10 @@ export function ConfigScreen(props: ConfigScreenProps) {
 					</TabsContent>
 
 					<TabsContent value="media">
-						<div class="space-y-4 rounded-md border p-4">
+						<div class="space-y-4 rounded-md border p-3 sm:p-4">
 							<h2 class="mb-4 font-semibold text-xl">Media Extensions</h2>
 
-							<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+							<div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
 								<form.Field name="media.supportedExtensions.image">
 									{(field) => (
 										<div class="space-y-2">
@@ -471,7 +494,7 @@ export function ConfigScreen(props: ConfigScreenProps) {
 					</TabsContent>
 
 					<TabsContent value="logging">
-						<div class="space-y-4 rounded-md border p-4">
+						<div class="space-y-4 rounded-md border p-3 sm:p-4">
 							<h2 class="mb-4 font-semibold text-xl">Logging</h2>
 							<form.Field name="logging.level">
 								{(field) => (
@@ -507,6 +530,6 @@ export function ConfigScreen(props: ConfigScreenProps) {
 					</TabsContent>
 				</div>
 			</Tabs>
-		</>
+		</div>
 	);
 }

--- a/packages/ui/src/screens/config-state-screen.tsx
+++ b/packages/ui/src/screens/config-state-screen.tsx
@@ -20,7 +20,7 @@ export function ConfigStateScreen(props: ConfigStateScreenProps) {
 	const hasData = () => props.data !== undefined;
 
 	return (
-		<div class={cn("container mx-auto max-w-4xl p-6", props.class)}>
+		<div class={cn("container mx-auto max-w-4xl p-3 sm:p-6", props.class)}>
 			<Show when={hasData()}>
 				<QueryStatus
 					class="mb-2"

--- a/packages/ui/src/screens/manager-screen.tsx
+++ b/packages/ui/src/screens/manager-screen.tsx
@@ -126,24 +126,27 @@ export function ManagerScreen(props: ManagerScreenProps) {
 			characterIpState().phase === "offline");
 
 	return (
-		<div class="container mx-auto p-4 sm:p-8">
-			<div class="mb-8 flex flex-wrap items-center justify-between gap-4">
-				<h1 class="font-bold text-3xl">Entity Manager</h1>
+		<div class="container mx-auto px-3 py-4 sm:p-8">
+			<div class="mb-6 flex flex-col gap-3 sm:mb-8 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+				<h1 class="font-bold text-2xl sm:text-3xl">Entity Manager</h1>
 				<Show
 					when={
 						isCrudTab(manager().activeTab()) &&
 						activeQueryState().phase !== "empty"
 					}
 				>
-					<Button onClick={manager().openCreateDialog}>Create New</Button>
+					<Button class="w-full sm:w-auto" onClick={manager().openCreateDialog}>
+						Create New
+					</Button>
 				</Show>
 			</div>
 
-			<div class="mb-6 flex gap-4 overflow-x-auto border-b">
+			<div class="-mx-3 mb-6 flex gap-1 overflow-x-auto border-b px-3 sm:mx-0 sm:gap-4 sm:px-0">
 				<For each={managerTabs}>
 					{(tab) => (
 						<button
-							class={`shrink-0 border-b-2 px-4 py-2 font-medium transition-colors ${
+							aria-pressed={manager().activeTab() === tab}
+							class={`min-h-11 shrink-0 border-b-2 px-3 py-2 font-medium transition-colors sm:px-4 ${
 								manager().activeTab() === tab
 									? "border-primary text-primary"
 									: "border-transparent text-muted-foreground hover:text-foreground"
@@ -297,9 +300,12 @@ export function ManagerScreen(props: ManagerScreenProps) {
 									: "If checked, existing AI tags will be ignored and images will be re-analyzed."}
 							</p>
 
-							<div class="flex items-center gap-x-2 pt-2">
-								<Button onClick={manager().handleScan}>Scan for Targets</Button>
+							<div class="sticky bottom-0 z-10 -mx-2 flex flex-col gap-2 border-t bg-card px-2 py-3 sm:static sm:mx-0 sm:flex-row sm:border-0 sm:bg-transparent sm:p-0">
+								<Button class="w-full sm:w-auto" onClick={manager().handleScan}>
+									Scan for Targets
+								</Button>
 								<Button
+									class="w-full sm:w-auto"
 									onClick={
 										manager().activeTab() === "vectors"
 											? manager().handleStartBatchCcipExtraction
@@ -313,13 +319,19 @@ export function ManagerScreen(props: ManagerScreenProps) {
 							</div>
 
 							<Show when={manager().taggingStatus()}>
-								<div class="mt-4 rounded bg-gray-100 p-2 text-sm">
+								<div class="mt-4 break-words rounded bg-gray-100 p-2 text-sm">
 									{manager().taggingStatus()}
 								</div>
 							</Show>
 							<Show when={manager().jobProgress()}>
 								{(progress) => (
-									<div class="mt-4">
+									<div class="mt-4 space-y-2" role="status">
+										<div class="flex flex-wrap justify-between gap-x-3 gap-y-1 text-muted-foreground text-sm">
+											<span>Batch progress</span>
+											<span>
+												{progress().processed} / {progress().total}
+											</span>
+										</div>
 										<Progress
 											value={(progress().processed / progress().total) * 100}
 										/>
@@ -388,8 +400,11 @@ export function ManagerScreen(props: ManagerScreenProps) {
 								</Select>
 							</div>
 
-							<div class="flex items-center gap-x-2 pt-2">
-								<Button onClick={manager().handleScanDuplicates}>
+							<div class="sticky bottom-0 z-10 -mx-2 flex flex-col gap-2 border-t bg-card px-2 py-3 sm:static sm:mx-0 sm:flex-row sm:border-0 sm:bg-transparent sm:p-0">
+								<Button
+									class="w-full sm:w-auto"
+									onClick={manager().handleScanDuplicates}
+								>
 									Scan for Duplicates
 								</Button>
 							</div>
@@ -403,12 +418,13 @@ export function ManagerScreen(props: ManagerScreenProps) {
 					</Card>
 
 					<Show when={manager().duplicateGroups().length > 0}>
-						<div class="flex items-center justify-between">
+						<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 							<h3 class="font-bold text-lg">
 								Duplicate Groups ({manager().duplicateGroups().length})
 							</h3>
-							<div class="flex gap-2">
+							<div class="grid grid-cols-2 gap-2 sm:flex">
 								<Button
+									class="w-full sm:w-auto"
 									onClick={manager().selectKeepOldest}
 									size="sm"
 									variant="outline"
@@ -416,6 +432,7 @@ export function ManagerScreen(props: ManagerScreenProps) {
 									Keep Oldest
 								</Button>
 								<Button
+									class="w-full sm:w-auto"
 									onClick={manager().selectKeepLargest}
 									size="sm"
 									variant="outline"
@@ -423,6 +440,7 @@ export function ManagerScreen(props: ManagerScreenProps) {
 									Keep Largest
 								</Button>
 								<Button
+									class="col-span-2 w-full sm:col-auto sm:w-auto"
 									onClick={manager().handleDeleteDuplicates}
 									variant="destructive"
 								>
@@ -535,8 +553,8 @@ export function ManagerScreen(props: ManagerScreenProps) {
 					<For each={manager().getActiveItems()}>
 						{(item) => (
 							<Card>
-								<CardHeader>
-									<CardTitle>{item.name}</CardTitle>
+								<CardHeader class="min-w-0">
+									<CardTitle class="break-words">{item.name}</CardTitle>
 									<Show when={item.description}>
 										<CardDescription>{item.description}</CardDescription>
 									</Show>
@@ -556,8 +574,10 @@ export function ManagerScreen(props: ManagerScreenProps) {
 									</Show>
 								</CardHeader>
 								<CardContent>
-									<div class="flex justify-end space-x-2">
+									<div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
 										<Button
+											aria-label={`Edit ${item.name}`}
+											class="w-full sm:w-auto"
 											onClick={() => manager().openEditDialog(item)}
 											size="sm"
 											variant="outline"
@@ -565,6 +585,7 @@ export function ManagerScreen(props: ManagerScreenProps) {
 											Edit
 										</Button>
 										<Button
+											class="w-full sm:w-auto"
 											onClick={() => {
 												manager().setItemToDelete(item);
 												manager().setIsDeleteDialogOpen(true);
@@ -602,10 +623,13 @@ export function ManagerScreen(props: ManagerScreenProps) {
 						</DialogDescription>
 					</DialogHeader>
 					<div class="grid gap-4 py-4">
-						<div class="grid grid-cols-4 items-center gap-4">
-							<Label class="text-right">Name</Label>
+						<div class="grid grid-cols-1 gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
+							<Label class="sm:text-right" for="manager-entity-name">
+								Name
+							</Label>
 							<Input
-								class="col-span-3"
+								class="w-full text-base sm:col-span-3 sm:text-sm"
+								id="manager-entity-name"
 								onInput={(event) =>
 									manager().setFormData({
 										...manager().formData(),
@@ -615,10 +639,13 @@ export function ManagerScreen(props: ManagerScreenProps) {
 								value={manager().formData().name}
 							/>
 						</div>
-						<div class="grid grid-cols-4 items-center gap-4">
-							<Label class="text-right">Description</Label>
+						<div class="grid grid-cols-1 gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
+							<Label class="sm:text-right" for="manager-entity-description">
+								Description
+							</Label>
 							<Input
-								class="col-span-3"
+								class="w-full text-base sm:col-span-3 sm:text-sm"
+								id="manager-entity-description"
 								onInput={(event) =>
 									manager().setFormData({
 										...manager().formData(),
@@ -629,9 +656,11 @@ export function ManagerScreen(props: ManagerScreenProps) {
 							/>
 						</div>
 						<Show when={manager().activeTab() === "characters"}>
-							<div class="grid grid-cols-4 items-center gap-4">
-								<Label class="text-right">IPs</Label>
-								<div class="col-span-3">
+							<div class="grid grid-cols-1 gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
+								<Label class="sm:text-right" for="manager-entity-ips">
+									IPs
+								</Label>
+								<div class="w-full sm:col-span-3">
 									<Combobox<Ip>
 										itemComponent={(comboboxProps) => (
 											<ComboboxItem item={comboboxProps.item}>
@@ -659,7 +688,10 @@ export function ManagerScreen(props: ManagerScreenProps) {
 											)}
 									>
 										<ComboboxControl>
-											<ComboboxInput placeholder="Select IPs..." />
+											<ComboboxInput
+												id="manager-entity-ips"
+												placeholder="Select IPs..."
+											/>
 											<ComboboxTrigger />
 										</ComboboxControl>
 										<ComboboxContent />

--- a/packages/ui/src/screens/media-detail-screen.tsx
+++ b/packages/ui/src/screens/media-detail-screen.tsx
@@ -86,7 +86,7 @@ export function MediaDetailScreen(props: MediaDetailScreenProps) {
 	});
 
 	return (
-		<div class="container mx-auto p-4">
+		<div class="container mx-auto px-3 py-4 sm:p-4">
 			<QueryStatus
 				fetchState={state().fetchState}
 				hasData={state().data !== undefined}
@@ -96,11 +96,11 @@ export function MediaDetailScreen(props: MediaDetailScreenProps) {
 			<Switch>
 				<Match when={state().data}>
 					{(details) => (
-						<div class="flex h-[calc(100vh-80px)] flex-col gap-4 lg:flex-row">
-							<div class="flex-grow">
+						<div class="flex flex-col gap-4 lg:h-[calc(100dvh-5rem)] lg:flex-row">
+							<div class="aspect-[4/3] min-h-64 min-w-0 overflow-hidden rounded-lg lg:aspect-auto lg:min-h-0 lg:flex-1">
 								{props.renderMediaViewer(details(), props.sourceRootPath)}
 							</div>
-							<div class="w-full shrink-0 lg:w-96">
+							<div class="min-w-0 shrink-0 lg:w-96 lg:max-w-[40%]">
 								{props.renderMediaSidebar(
 									details(),
 									mediaDetails.isRefetching,

--- a/packages/ui/src/tabs.tsx
+++ b/packages/ui/src/tabs.tsx
@@ -26,7 +26,7 @@ const TabsList = <T extends ValidComponent = "div">(
 	return (
 		<TabsListPrimitive
 			class={cn(
-				"inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+				"inline-flex min-h-10 max-w-full items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
 				local.class,
 			)}
 			{...others}


### PR DESCRIPTION
## 概要

Media Detail、Entity Manager、Config を 320px 幅から操作可能なレスポンシブレイアウトへ調整します。

## 変更内容

- 詳細ビュー／サイドバーの縦積み、長いメタデータの折返し、編集CTAを改善
- Manager のタブ・カード・バッチ操作・CRUDダイアログを狭幅対応
- Config の制御済みタブ、横スクロール、1列フォーム、sticky Saveを追加
- 4 viewport を検証する E2E を追加

## 検証

- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/ui test` — 46 passed
- `bun run --cwd apps/server check`
- responsive E2E（dev / production）— 各 4 passed
- `git diff --check`

## 備考

`apps/server` 単独 typecheck は、生成済み `#route-tree` がない既知の環境要因で失敗します。E2Eハーネス上でのビルド・実行は成功しています。

Fixes #586