### PR TITLE
fix: Sources・Search・Source Mediaをモバイル対応 (#585)

### DIFF
--- a/apps/server/src/routes/search.tsx
+++ b/apps/server/src/routes/search.tsx
@@ -122,7 +122,7 @@ function SearchRoute() {
 			renderMediaItem={(media) => <MediaGridItem media={media} />}
 			renderNavActions={({ openMobileFilters }) => (
 				<Button
-					class="border-white text-white hover:bg-sky-700 md:hidden"
+					class="size-11 border-input text-foreground hover:bg-accent md:hidden"
 					onClick={openMobileFilters}
 					size="icon"
 					variant="outline"

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -58,13 +58,9 @@ export function SourceMediaPage() {
 	const handleToggleSelect = (mediaId: string) => {
 		setIsBulkSelectMode(true);
 		setSelectedMediaIds((prev) => {
-			const next = prev.includes(mediaId)
+			return prev.includes(mediaId)
 				? prev.filter((id) => id !== mediaId)
 				: [...prev, mediaId];
-			if (next.length === 0) {
-				setIsBulkSelectMode(false);
-			}
-			return next;
 		});
 	};
 
@@ -133,6 +129,7 @@ export function SourceMediaPage() {
 				onBulkAction={() => setIsBulkActionOpen(true)}
 				onClearSelection={handleCancelSelect}
 				selectedCount={() => selectedMediaIds().length}
+				onEnterBulkSelectMode={() => setIsBulkSelectMode(true)}
 				renderItem={(media, options) => (
 					<MediaGridItem
 						media={media}
@@ -148,15 +145,26 @@ export function SourceMediaPage() {
 			/>
 
 			{/* 一括選択ツールバー */}
-			<Show when={isBulkSelectMode() && selectedMediaIds().length > 0}>
-				<div class="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-4 border border-primary/20 bg-background/95 px-6 py-3 shadow-lg backdrop-blur rounded-full">
-					<span class="font-medium text-sm">
+			<Show when={isBulkSelectMode()}>
+				<div
+					class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] left-1/2 z-50 flex w-[calc(100%-2rem)] max-w-md -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-2xl border border-primary/20 bg-background/95 px-3 py-3 shadow-lg backdrop-blur sm:bottom-[calc(1.5rem+env(safe-area-inset-bottom))] sm:w-auto sm:max-w-none sm:flex-nowrap sm:gap-4 sm:rounded-full sm:px-6"
+					data-testid="bulk-actions-bar"
+				>
+					<span class="w-full text-center font-medium text-sm sm:w-auto">
 						{selectedMediaIds().length} 件選択中
 					</span>
-					<Button onClick={() => setIsBulkActionOpen(true)} size="sm">
+					<Button
+						class="flex-1 sm:flex-none"
+						disabled={selectedMediaIds().length === 0}
+						onClick={() => setIsBulkActionOpen(true)}
+					>
 						一括操作を実行
 					</Button>
-					<Button onClick={handleCancelSelect} variant="outline" size="sm">
+					<Button
+						class="flex-1 sm:flex-none"
+						onClick={handleCancelSelect}
+						variant="outline"
+					>
 						解除
 					</Button>
 				</div>

--- a/apps/server/src/tests/e2e/search-realtime-preservation.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/search-realtime-preservation.responsive.spec.ts
@@ -105,7 +105,14 @@ test("source media preserves the mobile filter draft and focus after an SSE refr
 	await fileNameInput.fill("e2e");
 	await fileNameInput.focus();
 	await expect(fileNameInput).toBeFocused();
-	const initialMediaCount = await page.locator("[data-media-id]").count();
+	const resultCount = page.locator("p").filter({
+		hasText: /^\d+ 件の結果$/,
+	});
+	await expect(resultCount).toBeVisible();
+	const initialMediaCount = Number.parseInt(
+		(await resultCount.textContent()) ?? "0",
+		10,
+	);
 
 	const syncedFileName = `e2e-source-filter-sse-${randomUUID()}.png`;
 	await copyFile(
@@ -129,7 +136,10 @@ test("source media preserves the mobile filter draft and focus after an SSE refr
 	await syncResponse;
 
 	await expect
-		.poll(() => page.locator("[data-media-id]").count(), { timeout: 30_000 })
+		.poll(
+			async () => Number.parseInt((await resultCount.textContent()) ?? "0", 10),
+			{ timeout: 30_000 },
+		)
 		.toBeGreaterThan(initialMediaCount);
 	await expect(filterDialog).toBeVisible();
 	await expect(fileNameInput).toHaveValue("e2e");

--- a/apps/server/src/tests/e2e/search-realtime-preservation.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/search-realtime-preservation.responsive.spec.ts
@@ -6,6 +6,7 @@ import {
 	E2E_SOURCE_NAME,
 	getE2eMediaDir,
 	getFixtureMediaPath,
+	sourcePath,
 } from "./support/fixture";
 import { expect, test, waitForAppHydration } from "./support/test";
 
@@ -39,9 +40,12 @@ test("global search preserves the mobile filter dialog, input value, and focus a
 	await fileNameInput.fill("e2e");
 	await fileNameInput.focus();
 	await expect(fileNameInput).toBeFocused();
-	await expect(
-		page.locator("p").filter({ hasText: /^2 件の結果$/ }),
-	).toBeVisible();
+	const resultCount = page.locator("p").filter({ hasText: /^\d+ 件の結果$/ });
+	await expect(resultCount).toBeVisible();
+	const initialResultCount = Number.parseInt(
+		(await resultCount.textContent()) ?? "0",
+		10,
+	);
 
 	const syncedFileName = `e2e-global-sse-${randomUUID()}.png`;
 	await copyFile(
@@ -64,9 +68,69 @@ test("global search preserves the mobile filter dialog, input value, and focus a
 	await sourceCard.getByTestId("sync-source-btn").click();
 	await syncResponse;
 
-	await expect(
-		page.locator("p").filter({ hasText: /^3 件の結果$/ }),
-	).toBeVisible({ timeout: 30_000 });
+	await expect
+		.poll(
+			async () => Number.parseInt((await resultCount.textContent()) ?? "0", 10),
+			{ timeout: 30_000 },
+		)
+		.toBeGreaterThan(initialResultCount);
+	await expect(filterDialog).toBeVisible();
+	await expect(fileNameInput).toHaveValue("e2e");
+	await expect(fileNameInput).toBeFocused();
+});
+
+test("source media preserves the mobile filter draft and focus after an SSE refresh", async ({
+	context,
+	page,
+}, testInfo) => {
+	test.skip(
+		!["responsive-320", "responsive-375"].includes(testInfo.project.name),
+		"The mobile filter dialog is only rendered below the md breakpoint.",
+	);
+
+	const sourceEventsConnected = page.waitForResponse(
+		(response) =>
+			sourceEventsEndpoint.test(new URL(response.url()).pathname) &&
+			response.status() === 200,
+	);
+	await page.goto(sourcePath());
+	await expect(page.getByRole("button", { name: "Add media" })).toBeVisible();
+	await waitForAppHydration(page);
+	await sourceEventsConnected;
+
+	await page.getByRole("button", { name: "Filter results" }).click();
+	const filterDialog = page.getByRole("dialog");
+	const fileNameInput = filterDialog.getByPlaceholder("ファイル名を入力...");
+	await expect(filterDialog).toBeVisible();
+	await fileNameInput.fill("e2e");
+	await fileNameInput.focus();
+	await expect(fileNameInput).toBeFocused();
+	const initialMediaCount = await page.locator("[data-media-id]").count();
+
+	const syncedFileName = `e2e-source-filter-sse-${randomUUID()}.png`;
+	await copyFile(
+		getFixtureMediaPath(E2E_PRIMARY_FILE_NAME),
+		path.join(getE2eMediaDir(), syncedFileName),
+	);
+
+	const syncPage = await context.newPage();
+	await syncPage.setViewportSize({ width: 1440, height: 900 });
+	await syncPage.goto("/sources");
+	const sourceCard = syncPage
+		.getByTestId("source-card")
+		.filter({ hasText: E2E_SOURCE_NAME });
+	await expect(sourceCard).toBeVisible();
+	await waitForAppHydration(syncPage);
+	const syncResponse = syncPage.waitForResponse((response) => {
+		const url = new URL(response.url());
+		return url.pathname === "/api/rpc/sources/sync" && response.ok();
+	});
+	await sourceCard.getByTestId("sync-source-btn").click();
+	await syncResponse;
+
+	await expect
+		.poll(() => page.locator("[data-media-id]").count(), { timeout: 30_000 })
+		.toBeGreaterThan(initialMediaCount);
 	await expect(filterDialog).toBeVisible();
 	await expect(fileNameInput).toHaveValue("e2e");
 	await expect(fileNameInput).toBeFocused();

--- a/apps/server/src/tests/e2e/search.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/search.responsive.spec.ts
@@ -28,13 +28,64 @@ test("search keeps controls usable without horizontal overflow", async ({
 	);
 	if (usesMobileFilterDialog) {
 		await page.getByRole("button", { name: "Filter results" }).click();
-		await expect(page.getByRole("dialog")).toBeVisible();
+		const filterDialog = page.getByRole("dialog");
+		await expect(filterDialog).toBeVisible();
 		await expect(
-			page.getByRole("heading", { name: "検索フィルター", exact: true }),
+			filterDialog.getByRole("heading", {
+				name: "検索フィルター",
+				exact: true,
+			}),
 		).toBeVisible();
 		await expect(
-			page.getByRole("button", { name: "簡易", exact: true }),
+			filterDialog.getByRole("button", { name: "簡易", exact: true }),
 		).toBeVisible();
+		const conditionSummary = filterDialog.getByRole("status");
+		await expect(conditionSummary).toContainText("現在の条件");
+		const resultCount = page.getByText(/^\d+ 件の結果$/);
+		const initialResultCount = await resultCount.textContent();
+
+		let fileNameInput = filterDialog.getByPlaceholder("ファイル名を入力...");
+		await fileNameInput.fill("e2e");
+		await expect(conditionSummary).toContainText("ファイル名: e2e");
+		await page.keyboard.press("Escape");
+		await expect(filterDialog).toBeHidden();
+		await expect(resultCount).toHaveText(initialResultCount ?? "");
+
+		await page.getByRole("button", { name: "Filter results" }).click();
+		await expect(filterDialog).toBeVisible();
+		fileNameInput = filterDialog.getByPlaceholder("ファイル名を入力...");
+		await expect(fileNameInput).toHaveValue("");
+		await expect(filterDialog.getByRole("status")).not.toContainText(
+			"ファイル名:",
+		);
+
+		await fileNameInput.fill("e2e");
+		await filterDialog.getByRole("button", { name: "Dismiss" }).click();
+		await expect(filterDialog).toBeHidden();
+		await expect(resultCount).toHaveText(initialResultCount ?? "");
+
+		await page.getByRole("button", { name: "Filter results" }).click();
+		await expect(filterDialog).toBeVisible();
+		fileNameInput = filterDialog.getByPlaceholder("ファイル名を入力...");
+		await expect(fileNameInput).toHaveValue("");
+		const applyButton = filterDialog.getByRole("button", {
+			name: "適用",
+			exact: true,
+		});
+		await filterDialog
+			.getByRole("button", { name: "ベクトル類似", exact: true })
+			.click();
+		await expect(applyButton).toBeDisabled();
+		await filterDialog
+			.getByRole("button", { name: "条件をクリア", exact: true })
+			.click();
+		await expect(applyButton).toBeEnabled();
+		await expect(fileNameInput).toHaveValue("");
+		await expect(conditionSummary).toContainText("条件は指定されていません。");
+
+		await fileNameInput.fill("e2e");
+		await applyButton.click();
+		await expect(filterDialog).toBeHidden();
 	} else {
 		await expect(
 			page.getByRole("heading", { name: "検索フィルター", exact: true }),

--- a/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
@@ -1,0 +1,176 @@
+import type { Locator, Page } from "@playwright/test";
+import { E2E_SOURCE_ID, E2E_SOURCE_NAME, sourcePath } from "./support/fixture";
+import { expect, test, waitForAppHydration } from "./support/test";
+
+function usesMobileControls(projectName: string): boolean {
+	return ["responsive-320", "responsive-375"].includes(projectName);
+}
+
+async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+	const overflow = await page.evaluate(
+		() =>
+			document.documentElement.scrollWidth -
+			document.documentElement.clientWidth,
+	);
+	expect(overflow).toBeLessThanOrEqual(1);
+}
+
+async function expectTouchTarget(locator: Locator): Promise<void> {
+	const box = await locator.boundingBox();
+	expect(box).not.toBeNull();
+	expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+}
+
+async function expectInsideViewport(
+	page: Page,
+	locator: Locator,
+): Promise<void> {
+	const box = await locator.boundingBox();
+	const viewport = page.viewportSize();
+	expect(box).not.toBeNull();
+	expect(viewport).not.toBeNull();
+	if (!(box && viewport)) {
+		return;
+	}
+	expect(box.x).toBeGreaterThanOrEqual(0);
+	expect(box.y).toBeGreaterThanOrEqual(0);
+	expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);
+	expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
+}
+
+test("sources actions stay operable without horizontal overflow", async ({
+	page,
+}) => {
+	await page.goto("/sources");
+	await expect(
+		page.getByRole("heading", { name: "Media Sources", exact: true }),
+	).toBeVisible();
+	const sourceCard = page
+		.getByTestId("source-card")
+		.filter({ hasText: E2E_SOURCE_NAME });
+	await expect(sourceCard).toBeVisible();
+	await waitForAppHydration(page);
+	await expectNoHorizontalOverflow(page);
+
+	const addSourceButton = page.getByRole("button", {
+		name: "Add Source",
+		exact: true,
+	});
+	const syncAllButton = page.getByRole("button", {
+		name: "Sync All",
+		exact: true,
+	});
+	await expectTouchTarget(addSourceButton);
+	await expectTouchTarget(syncAllButton);
+	await expectTouchTarget(sourceCard.getByTestId("sync-source-btn"));
+	await expectTouchTarget(sourceCard.getByTestId("edit-source-btn"));
+	await expectTouchTarget(sourceCard.getByTestId("delete-source-btn"));
+
+	await addSourceButton.click();
+	await expect(page.getByRole("dialog")).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(page.getByRole("dialog")).toHaveCount(0);
+
+	await sourceCard.getByTestId("edit-source-btn").click();
+	await expect(page.getByRole("dialog")).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(page.getByRole("dialog")).toHaveCount(0);
+
+	await sourceCard.getByTestId("delete-source-btn").click();
+	await expect(page.getByRole("dialog")).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(page.getByRole("dialog")).toHaveCount(0);
+	await expectNoHorizontalOverflow(page);
+});
+
+test("source media exposes mobile filters and touch selection", async ({
+	page,
+}, testInfo) => {
+	await page.goto(sourcePath());
+	await expect(
+		page.getByRole("heading", {
+			name: `Media in Source: ${E2E_SOURCE_ID}`,
+			exact: true,
+		}),
+	).toBeVisible();
+	await expect(page.locator("[data-media-id]").first()).toBeVisible();
+	await waitForAppHydration(page);
+	await expect(page.getByTestId("media-load-more-sentinel")).toBeVisible();
+	await expectNoHorizontalOverflow(page);
+
+	const addMediaButton = page.getByRole("button", { name: "Add media" });
+	await expectTouchTarget(addMediaButton);
+	await expectInsideViewport(page, addMediaButton);
+
+	const selectModeButton = page.getByRole("button", {
+		name: "複数選択",
+		exact: true,
+	});
+	await expectTouchTarget(selectModeButton);
+	await selectModeButton.click();
+	const bulkToolbar = page.getByTestId("bulk-actions-bar");
+	await expect(bulkToolbar).toContainText("0 件選択中");
+	await expect(
+		bulkToolbar.getByRole("button", { name: "一括操作を実行", exact: true }),
+	).toBeDisabled();
+	await page.getByRole("button", { name: "解除", exact: true }).click();
+	await expect(bulkToolbar).toBeHidden();
+	await expect(addMediaButton).toBeVisible();
+
+	await selectModeButton.click();
+	const selectableMedia = page.locator("button[data-media-id]").first();
+	await expect(selectableMedia).toBeVisible();
+	await selectableMedia.click();
+	await expect(bulkToolbar).toContainText("1 件選択中");
+	await expect(addMediaButton).toBeHidden();
+	await expectInsideViewport(page, bulkToolbar);
+	await page.getByRole("button", { name: "解除", exact: true }).click();
+	await expect(addMediaButton).toBeVisible();
+
+	if (usesMobileControls(testInfo.project.name)) {
+		const sourceActionsButton = page.getByRole("button", {
+			name: "ソース操作を開く",
+		});
+		const filterResultsButton = page.getByRole("button", {
+			name: "Filter results",
+		});
+		await expectTouchTarget(sourceActionsButton);
+		await expectTouchTarget(filterResultsButton);
+		await sourceActionsButton.click();
+		const sourceActionsDialog = page.getByRole("dialog");
+		await expect(
+			sourceActionsDialog.getByRole("button", {
+				name: "NDJSON メタデータを書き出す",
+			}),
+		).toBeVisible();
+		await page.keyboard.press("Escape");
+		await expect(sourceActionsDialog).toBeHidden();
+		await sourceActionsButton.click();
+		const restoreFileChooser = page.waitForEvent("filechooser");
+		await sourceActionsDialog
+			.getByRole("button", { name: "ダンプを復元する", exact: true })
+			.click();
+		await restoreFileChooser;
+		await expect(sourceActionsDialog).toBeHidden();
+
+		await filterResultsButton.click();
+		const filterDialog = page.getByRole("dialog");
+		await expect(filterDialog).toBeVisible();
+		await expect(filterDialog.getByRole("status")).toContainText("現在の条件");
+		const fileNameInput = filterDialog.getByPlaceholder("ファイル名を入力...");
+		await fileNameInput.fill("e2e");
+		await expect(filterDialog.getByRole("status")).toContainText(
+			"ファイル名: e2e",
+		);
+		await filterDialog
+			.getByRole("button", { name: "適用", exact: true })
+			.click();
+		await expect(filterDialog).toBeHidden();
+	} else {
+		await expect(
+			page.getByRole("heading", { name: "検索フィルター", exact: true }),
+		).toBeVisible();
+	}
+
+	await expectNoHorizontalOverflow(page);
+});

--- a/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
@@ -18,6 +18,7 @@ async function expectNoHorizontalOverflow(page: Page): Promise<void> {
 async function expectTouchTarget(locator: Locator): Promise<void> {
 	const box = await locator.boundingBox();
 	expect(box).not.toBeNull();
+	expect(box?.width ?? 0).toBeGreaterThanOrEqual(44);
 	expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
 }
 

--- a/apps/tauri/src/routes/search.tsx
+++ b/apps/tauri/src/routes/search.tsx
@@ -94,7 +94,7 @@ function SearchRoute() {
 			)}
 			renderNavActions={({ openMobileFilters }) => (
 				<Button
-					class="border-white text-white hover:bg-sky-700 md:hidden"
+					class="size-11 border-input text-foreground hover:bg-accent md:hidden"
 					onClick={openMobileFilters}
 					size="icon"
 					variant="outline"

--- a/packages/ui/src/media-list-actions.tsx
+++ b/packages/ui/src/media-list-actions.tsx
@@ -1,5 +1,4 @@
 import { ClientOnly } from "@tanstack/solid-router";
-import type { ComponentProps } from "solid-js";
 import { createSignal, onMount, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import { Button } from "./button";
@@ -12,24 +11,27 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "./dialog";
-import {
-	SearchControlPanel,
-	type SearchControlPanelProps,
-} from "./search-control-panel";
-
-type FilterData = ComponentProps<typeof SearchControlPanel>["filterData"];
 
 export type MediaListActionsProps = {
-	filterData: FilterData;
 	onDumpDownload: (mode: "json" | "zip") => void;
-	onSearch: () => void;
-	presetClient: SearchControlPanelProps["presetClient"];
+	onOpenMobileFilters: () => void;
 	onLanceDBDump?: (includeMedia: boolean) => void;
 };
 
+const navButtonClass = "border-white text-white hover:bg-sky-700";
+
 export function MediaListActions(props: MediaListActionsProps) {
 	const [isLanceDBDialogOpen, setIsLanceDBDialogOpen] = createSignal(false);
+	const [isMobileActionsOpen, setIsMobileActionsOpen] = createSignal(false);
 	const [navActions, setNavActions] = createSignal<HTMLElement | null>(null);
+
+	const handleRestore = () => {
+		document.getElementById("restore-input")?.click();
+	};
+	const openLanceDBDialog = () => {
+		setIsMobileActionsOpen(false);
+		setIsLanceDBDialogOpen(true);
+	};
 
 	onMount(() => {
 		setNavActions(document.getElementById("nav-actions"));
@@ -40,146 +42,204 @@ export function MediaListActions(props: MediaListActionsProps) {
 			<Show when={navActions()}>
 				{(mount) => (
 					<Portal mount={mount()}>
-						<Button
-							class="mr-2 border-white text-white hover:bg-sky-700"
-							onClick={() => props.onDumpDownload("json")}
-							size="icon"
-							title="Download NDJSON Metadata Dump"
-							variant="outline"
-						>
-							<svg
-								class="lucide lucide-file-json"
-								fill="none"
-								height="20"
-								stroke="currentColor"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="2"
-								viewBox="0 0 24 24"
-								width="20"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<title>Download NDJSON</title>
-								<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
-								<path d="M14 2v4a2 2 0 0 0 2 2h4" />
-								<path d="M10 12a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1" />
-								<path d="M10 18a1 1 0 0 0-1-1v-1a1 1 0 0 0 1-1" />
-							</svg>
-						</Button>
-						<Button
-							class="mr-2 border-white text-white hover:bg-sky-700"
-							onClick={() => props.onDumpDownload("zip")}
-							size="icon"
-							title="Download TAR Dump (with Images)"
-							variant="outline"
-						>
-							<svg
-								class="lucide lucide-archive"
-								fill="none"
-								height="20"
-								stroke="currentColor"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="2"
-								viewBox="0 0 24 24"
-								width="20"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<title>Download TAR</title>
-								<rect height="5" rx="1" width="20" x="2" y="3" />
-								<path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
-								<path d="M10 12h4" />
-							</svg>
-						</Button>
-						<Button
-							class="mr-2 border-white text-white hover:bg-sky-700"
-							onClick={() => setIsLanceDBDialogOpen(true)}
-							size="icon"
-							title="Download LanceDB Dump"
-							variant="outline"
-						>
-							<svg
-								class="lucide lucide-database"
-								fill="none"
-								height="20"
-								stroke="currentColor"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="2"
-								viewBox="0 0 24 24"
-								width="20"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<title>Download LanceDB</title>
-								<ellipse cx="12" cy="5" rx="9" ry="3" />
-								<path d="M3 5V19A9 3 0 0 0 21 19V5" />
-								<path d="M3 12A9 3 0 0 0 21 12" />
-							</svg>
-						</Button>
-						<Button
-							class="mr-2 border-white text-white hover:bg-sky-700"
-							onClick={() => document.getElementById("restore-input")?.click()}
-							size="icon"
-							title="Import Dump"
-							variant="outline"
-						>
-							<svg
-								class="lucide lucide-upload-cloud"
-								fill="none"
-								height="20"
-								stroke="currentColor"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="2"
-								viewBox="0 0 24 24"
-								width="20"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<title>Import dump</title>
-								<path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" />
-								<path d="M12 12v9" />
-								<path d="m16 16-4-4-4 4" />
-							</svg>
-						</Button>
-						<Dialog>
-							<DialogTrigger
-								as={Button}
-								class="border-white text-white hover:bg-sky-700 md:hidden"
+						<div class="hidden items-center gap-2 md:flex">
+							<Button
+								aria-label="Download NDJSON metadata dump"
+								class={navButtonClass}
+								onClick={() => props.onDumpDownload("json")}
 								size="icon"
+								title="Download NDJSON Metadata Dump"
 								variant="outline"
 							>
 								<svg
-									class="lucide lucide-filter"
+									aria-hidden="true"
+									class="lucide lucide-file-json"
 									fill="none"
-									height="24"
+									height="20"
 									stroke="currentColor"
 									stroke-linecap="round"
 									stroke-linejoin="round"
 									stroke-width="2"
 									viewBox="0 0 24 24"
-									width="24"
+									width="20"
 									xmlns="http://www.w3.org/2000/svg"
 								>
-									<title>Filter results</title>
-									<polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+									<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+									<path d="M14 2v4a2 2 0 0 0 2 2h4" />
+									<path d="M10 12a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1" />
+									<path d="M10 18a1 1 0 0 0-1-1v-1a1 1 0 0 0 1-1" />
+								</svg>
+							</Button>
+							<Button
+								aria-label="Download TAR dump with images"
+								class={navButtonClass}
+								onClick={() => props.onDumpDownload("zip")}
+								size="icon"
+								title="Download TAR Dump (with Images)"
+								variant="outline"
+							>
+								<svg
+									aria-hidden="true"
+									class="lucide lucide-archive"
+									fill="none"
+									height="20"
+									stroke="currentColor"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									viewBox="0 0 24 24"
+									width="20"
+									xmlns="http://www.w3.org/2000/svg"
+								>
+									<rect height="5" rx="1" width="20" x="2" y="3" />
+									<path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
+									<path d="M10 12h4" />
+								</svg>
+							</Button>
+							<Button
+								aria-label="Download LanceDB dump"
+								class={navButtonClass}
+								onClick={() => setIsLanceDBDialogOpen(true)}
+								size="icon"
+								title="Download LanceDB Dump"
+								variant="outline"
+							>
+								<svg
+									aria-hidden="true"
+									class="lucide lucide-database"
+									fill="none"
+									height="20"
+									stroke="currentColor"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									viewBox="0 0 24 24"
+									width="20"
+									xmlns="http://www.w3.org/2000/svg"
+								>
+									<ellipse cx="12" cy="5" rx="9" ry="3" />
+									<path d="M3 5V19A9 3 0 0 0 21 19V5" />
+									<path d="M3 12A9 3 0 0 0 21 12" />
+								</svg>
+							</Button>
+							<Button
+								aria-label="Import source dump"
+								class={navButtonClass}
+								onClick={handleRestore}
+								size="icon"
+								title="Import Dump"
+								variant="outline"
+							>
+								<svg
+									aria-hidden="true"
+									class="lucide lucide-upload-cloud"
+									fill="none"
+									height="20"
+									stroke="currentColor"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									viewBox="0 0 24 24"
+									width="20"
+									xmlns="http://www.w3.org/2000/svg"
+								>
+									<path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" />
+									<path d="M12 12v9" />
+									<path d="m16 16-4-4-4 4" />
+								</svg>
+							</Button>
+						</div>
+
+						<Dialog
+							onOpenChange={setIsMobileActionsOpen}
+							open={isMobileActionsOpen()}
+						>
+							<DialogTrigger
+								aria-label="ソース操作を開く"
+								as={Button}
+								class={`size-11 ${navButtonClass} md:hidden`}
+								size="icon"
+								variant="outline"
+							>
+								<svg
+									aria-hidden="true"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									viewBox="0 0 24 24"
+								>
+									<circle cx="5" cy="12" r="1" />
+									<circle cx="12" cy="12" r="1" />
+									<circle cx="19" cy="12" r="1" />
 								</svg>
 							</DialogTrigger>
-							<DialogContent class="max-h-[80vh] overflow-y-auto">
+							<DialogContent>
 								<DialogHeader>
-									<DialogTitle>検索フィルター</DialogTitle>
+									<DialogTitle>ソース操作</DialogTitle>
+									<DialogDescription>
+										メタデータの書き出しと復元を行えます。
+									</DialogDescription>
 								</DialogHeader>
-								<div class="space-y-4">
-									<SearchControlPanel
-										class="w-full"
-										context="source"
-										filterData={props.filterData}
-										onSearch={props.onSearch}
-										presetClient={props.presetClient}
-									/>
+								<div class="grid gap-2">
+									<Button
+										class="justify-start"
+										onClick={() => props.onDumpDownload("json")}
+										variant="outline"
+									>
+										NDJSON メタデータを書き出す
+									</Button>
+									<Button
+										class="justify-start"
+										onClick={() => props.onDumpDownload("zip")}
+										variant="outline"
+									>
+										画像を含む TAR を書き出す
+									</Button>
+									<Button
+										class="justify-start"
+										onClick={openLanceDBDialog}
+										variant="outline"
+									>
+										LanceDB を書き出す
+									</Button>
+									<Button
+										class="justify-start"
+										onClick={() => {
+											setIsMobileActionsOpen(false);
+											handleRestore();
+										}}
+										variant="outline"
+									>
+										ダンプを復元する
+									</Button>
 								</div>
 							</DialogContent>
 						</Dialog>
 
+						<Button
+							aria-label="Filter results"
+							class={`size-11 ${navButtonClass} md:hidden`}
+							onClick={props.onOpenMobileFilters}
+							size="icon"
+							title="Filter results"
+							variant="outline"
+						>
+							<svg
+								aria-hidden="true"
+								class="lucide lucide-filter"
+								fill="none"
+								height="24"
+								stroke="currentColor"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								viewBox="0 0 24 24"
+								width="24"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+							</svg>
+						</Button>
 						<Dialog
 							onOpenChange={setIsLanceDBDialogOpen}
 							open={isLanceDBDialogOpen()}

--- a/packages/ui/src/mobile-search-filter-dialog.tsx
+++ b/packages/ui/src/mobile-search-filter-dialog.tsx
@@ -1,0 +1,208 @@
+import {
+	defaultState,
+	type SearchState,
+	searchStateSchema,
+} from "@solid-imager/core/domain/search/schema";
+import { createEffect, For, Show } from "solid-js";
+import { createStore } from "solid-js/store";
+import { Button } from "./button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "./dialog";
+import {
+	SearchControlPanel,
+	type SearchControlPanelProps,
+} from "./search-control-panel";
+import { searchState, setSearchState } from "./stores/search-store";
+
+export type MobileSearchFilterDialogProps = Omit<
+	SearchControlPanelProps,
+	"setState" | "showSearchButton" | "state"
+> & {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+};
+
+function copySearchState(state: SearchState): SearchState {
+	return searchStateSchema.parse(state);
+}
+
+function createClearedSearchState(state: SearchState): SearchState {
+	return {
+		...defaultState,
+		// A cleared vector search has no valid anchor, so return to a mode that
+		// can be applied instead of leaving the dialog permanently disabled.
+		mode: state.mode === "vector" ? "simple" : state.mode,
+		selectedSource: state.selectedSource,
+		sortBy: state.sortBy,
+		sortOrder: state.sortOrder,
+		tagMode: state.tagMode,
+	};
+}
+
+function getActiveConditionLabels(
+	props: Pick<MobileSearchFilterDialogProps, "context" | "sources">,
+	state: SearchState,
+) {
+	const labels: string[] = [];
+
+	if (props.context === "global" && state.selectedSource) {
+		const source = props.sources?.find(
+			(item) => item.id === state.selectedSource,
+		);
+		labels.push(`ソース: ${source?.name ?? "選択済み"}`);
+	}
+
+	if (state.mode === "simple") {
+		if (state.searchQuery.trim()) {
+			labels.push(`ファイル名: ${state.searchQuery.trim()}`);
+		}
+		if (state.selectedTags.length > 0) {
+			labels.push(`タグ: ${state.selectedTags.length}件`);
+		}
+		if (state.excludeTags.length > 0) {
+			labels.push(`除外タグ: ${state.excludeTags.length}件`);
+		}
+		if (state.selectedProjects.length > 0) {
+			labels.push(`プロジェクト: ${state.selectedProjects.length}件`);
+		}
+		if (state.selectedIps.length > 0) {
+			labels.push(`IP: ${state.selectedIps.length}件`);
+		}
+		if (state.selectedCharacters.length > 0) {
+			labels.push(`キャラクター: ${state.selectedCharacters.length}件`);
+		}
+		if (state.selectedAuthors.length > 0) {
+			labels.push(`作者: ${state.selectedAuthors.length}件`);
+		}
+		return labels;
+	}
+
+	if (state.mode === "pro") {
+		labels.push(
+			state.advancedCondition ? "詳細条件を設定済み" : "詳細条件は未設定",
+		);
+		return labels;
+	}
+
+	labels.push(
+		state.similarityAnchorMediaId
+			? "類似元メディアを設定済み"
+			: "類似元メディアは未設定",
+	);
+	return labels;
+}
+
+function CurrentSearchConditions(props: {
+	context: MobileSearchFilterDialogProps["context"];
+	sources: MobileSearchFilterDialogProps["sources"];
+	state: SearchState;
+}) {
+	const labels = () => getActiveConditionLabels(props, props.state);
+
+	return (
+		<div
+			aria-live="polite"
+			class="rounded-md border bg-muted/40 p-3 text-sm"
+			data-testid="current-search-conditions"
+			role="status"
+		>
+			<div class="flex items-center justify-between gap-3">
+				<span class="font-medium">現在の条件</span>
+				<span class="text-muted-foreground text-xs">
+					{labels().length > 0 ? `${labels().length}件` : "指定なし"}
+				</span>
+			</div>
+			<Show
+				fallback={
+					<p class="mt-2 text-muted-foreground">条件は指定されていません。</p>
+				}
+				when={labels().length > 0}
+			>
+				<ul class="mt-2 flex flex-wrap gap-1.5">
+					<For each={labels()}>
+						{(label) => (
+							<li class="max-w-full break-words rounded-full bg-background px-2 py-1 text-xs">
+								{label}
+							</li>
+						)}
+					</For>
+				</ul>
+			</Show>
+		</div>
+	);
+}
+
+export function MobileSearchFilterDialog(props: MobileSearchFilterDialogProps) {
+	const [draft, setDraft] = createStore<SearchState>(
+		copySearchState(searchState),
+	);
+	let wasOpen = false;
+
+	createEffect(() => {
+		if (props.open && !wasOpen) {
+			setDraft(copySearchState(searchState));
+		}
+		wasOpen = props.open;
+	});
+
+	const handleApply = () => {
+		setSearchState(copySearchState(draft));
+		props.onSearch();
+		props.onOpenChange(false);
+	};
+	const handleClear = () => {
+		setDraft(createClearedSearchState(draft));
+	};
+	const isApplyDisabled = () =>
+		draft.mode === "vector" && !draft.similarityAnchorMediaId;
+
+	return (
+		<Dialog onOpenChange={props.onOpenChange} open={props.open}>
+			<DialogContent class="max-w-lg gap-4 p-4 sm:p-6">
+				<DialogHeader>
+					<DialogTitle>検索フィルター</DialogTitle>
+					<DialogDescription>
+						条件を確認・変更してから検索結果へ適用できます。
+					</DialogDescription>
+				</DialogHeader>
+				<CurrentSearchConditions
+					context={props.context}
+					sources={props.sources}
+					state={draft}
+				/>
+				<div class="min-w-0 space-y-4">
+					<SearchControlPanel
+						context={props.context}
+						filterData={props.filterData}
+						onSearch={handleApply}
+						presetClient={props.presetClient}
+						selectedSource={draft.selectedSource}
+						setState={setDraft}
+						showSearchButton={false}
+						sources={props.sources}
+						state={draft}
+						usePopover={props.usePopover}
+					/>
+				</div>
+				<DialogFooter class="border-t pt-4">
+					<Button onClick={handleClear} type="button" variant="outline">
+						条件をクリア
+					</Button>
+					<Button
+						disabled={isApplyDisabled()}
+						onClick={handleApply}
+						type="button"
+					>
+						適用
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/ui/src/mobile-search-filter-dialog.tsx
+++ b/packages/ui/src/mobile-search-filter-dialog.tsx
@@ -84,17 +84,15 @@ function getActiveConditionLabels(
 	}
 
 	if (state.mode === "pro") {
-		labels.push(
-			state.advancedCondition ? "詳細条件を設定済み" : "詳細条件は未設定",
-		);
+		if (state.advancedCondition) {
+			labels.push("詳細条件を設定済み");
+		}
 		return labels;
 	}
 
-	labels.push(
-		state.similarityAnchorMediaId
-			? "類似元メディアを設定済み"
-			: "類似元メディアは未設定",
-	);
+	if (state.similarityAnchorMediaId) {
+		labels.push("類似元メディアを設定済み");
+	}
 	return labels;
 }
 
@@ -139,22 +137,29 @@ function CurrentSearchConditions(props: {
 }
 
 export function MobileSearchFilterDialog(props: MobileSearchFilterDialogProps) {
+	const currentSearchState = () =>
+		copySearchState({
+			...searchState,
+			selectedSource: props.selectedSource ?? searchState.selectedSource,
+		});
 	const [draft, setDraft] = createStore<SearchState>(
-		copySearchState(searchState),
+		currentSearchState(),
 	);
 	let wasOpen = false;
 
 	createEffect(() => {
 		if (props.open && !wasOpen) {
-			setDraft(copySearchState(searchState));
+			setDraft(currentSearchState());
 		}
 		wasOpen = props.open;
 	});
 
 	const handleApply = () => {
-		setSearchState(copySearchState(draft));
-		props.onSearch();
+		const nextState = copySearchState(draft);
+		setSearchState(nextState);
+		props.onSelectSource?.(nextState.selectedSource);
 		props.onOpenChange(false);
+		props.onSearch();
 	};
 	const handleClear = () => {
 		setDraft(createClearedSearchState(draft));

--- a/packages/ui/src/preset-manager.tsx
+++ b/packages/ui/src/preset-manager.tsx
@@ -3,8 +3,17 @@ import {
 	type SearchGroup,
 	searchGroupSchema,
 } from "@solid-imager/core/domain/media/schemas";
+import {
+	getSearchConditionFromState,
+	preparePresetState,
+} from "@solid-imager/core/domain/search/logic";
+import {
+	defaultState,
+	type SearchState,
+} from "@solid-imager/core/domain/search/schema";
 import { deepEqual } from "@solid-imager/core/utils/deep-equal";
 import { createEffect, createResource, createSignal, Show } from "solid-js";
+import type { SetStoreFunction } from "solid-js/store";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -34,13 +43,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "./select";
-import {
-	clearPresetFilters,
-	getSearchCondition,
-	loadPreset,
-	searchState,
-	setSearchState,
-} from "./stores/search-store";
+import { searchState, setSearchState } from "./stores/search-store";
 import { toast } from "./toast";
 import { cn } from "./utils/cn";
 
@@ -56,6 +59,14 @@ export interface PresetManagerClient {
 	delete(id: number): Promise<unknown>;
 }
 
+type PresetManagerProps = {
+	presetClient: PresetManagerClient;
+	class?: string;
+	onAction?: () => void;
+	state?: SearchState;
+	setState?: SetStoreFunction<SearchState>;
+};
+
 function normalizeSearchCondition(condition: SearchGroup | undefined) {
 	return searchGroupSchema.parse(
 		condition ?? {
@@ -66,26 +77,39 @@ function normalizeSearchCondition(condition: SearchGroup | undefined) {
 	);
 }
 
-export function PresetManager(props: {
-	presetClient: PresetManagerClient;
-	class?: string;
-	onAction?: () => void;
-}) {
-	const [data, { refetch }] = createResource(props.presetClient.list);
+function createClearedSearchState(state: SearchState): SearchState {
+	return {
+		...defaultState,
+		mode: state.mode,
+		selectedSource: state.selectedSource,
+		sortBy: state.sortBy,
+		sortOrder: state.sortOrder,
+		tagMode: state.tagMode,
+	};
+}
 
-	const presets = () => data()?.filter((p) => !p.name.startsWith("current"));
+export function PresetManager(props: PresetManagerProps) {
+	const [data, { refetch }] = createResource(props.presetClient.list);
+	const currentState = () => props.state ?? searchState;
+	const updateState = props.setState ?? setSearchState;
+
+	const presets = () =>
+		data()?.filter((preset) => !preset.name.startsWith("current"));
 
 	createEffect(() => {
 		const availablePresets = presets();
-		if (!availablePresets || searchState.activePresetId !== null) {
+		const state = currentState();
+		if (!availablePresets || state.activePresetId !== null) {
 			return;
 		}
-		const condition = normalizeSearchCondition(getSearchCondition());
+		const condition = normalizeSearchCondition(
+			getSearchConditionFromState(state),
+		);
 		const matchingPreset = availablePresets.find((preset) =>
 			deepEqual(normalizeSearchCondition(preset.value), condition),
 		);
 		if (matchingPreset) {
-			setSearchState("activePresetId", matchingPreset.id);
+			updateState("activePresetId", matchingPreset.id);
 		}
 	});
 
@@ -98,7 +122,7 @@ export function PresetManager(props: {
 	);
 
 	createEffect(() => {
-		const active = searchState.activePresetId;
+		const active = currentState().activePresetId;
 		if (active) {
 			setSelectedPresetId(String(active));
 		} else {
@@ -112,7 +136,8 @@ export function PresetManager(props: {
 			return;
 		}
 
-		const condition = getSearchCondition();
+		const state = currentState();
+		const condition = getSearchConditionFromState(state);
 		if (!condition) {
 			toast.error("検索条件がありません");
 			return;
@@ -122,9 +147,9 @@ export function PresetManager(props: {
 			await props.presetClient.create({
 				name: newPresetName(),
 				value: condition,
-				sort: searchState.sortBy,
-				order: searchState.sortOrder,
-				mode: searchState.mode === "simple" ? "simple" : "pro",
+				sort: state.sortBy,
+				order: state.sortOrder,
+				mode: state.mode === "simple" ? "simple" : "pro",
 			});
 			setIsSaveDialogOpen(false);
 			setNewPresetName("");
@@ -166,16 +191,16 @@ export function PresetManager(props: {
 		if (!id) {
 			return;
 		}
-		const preset = presets()?.find((p: Preset) => p.id === Number(id));
+		const preset = presets()?.find((item: Preset) => item.id === Number(id));
 		if (preset) {
-			loadPreset(preset);
+			updateState(preparePresetState(preset, currentState()));
 			props.onAction?.();
 		}
 	};
 
 	const handleClearSelection = () => {
 		setSelectedPresetId(null);
-		clearPresetFilters();
+		updateState(createClearedSearchState(currentState()));
 		props.onAction?.();
 	};
 
@@ -209,7 +234,7 @@ export function PresetManager(props: {
 					<Select<string>
 						itemComponent={(itemProps) => {
 							const preset = presets()?.find(
-								(p: Preset) => String(p.id) === itemProps.item.rawValue,
+								(item: Preset) => String(item.id) === itemProps.item.rawValue,
 							);
 							return (
 								<SelectItem
@@ -221,7 +246,9 @@ export function PresetManager(props: {
 							);
 						}}
 						onChange={setSelectedPresetId}
-						options={presets()?.map((p: Preset) => String(p.id)) || []}
+						options={
+							presets()?.map((preset: Preset) => String(preset.id)) || []
+						}
 						placeholder="プリセットを選択..."
 						value={selectedPresetId()}
 					>
@@ -229,7 +256,8 @@ export function PresetManager(props: {
 							<SelectValue<string>>
 								{(state) => {
 									const preset = presets()?.find(
-										(p: Preset) => String(p.id) === state.selectedOption(),
+										(item: Preset) =>
+											String(item.id) === state.selectedOption(),
 									);
 									return (
 										<span class="truncate">

--- a/packages/ui/src/pro-search-dialog.tsx
+++ b/packages/ui/src/pro-search-dialog.tsx
@@ -24,7 +24,7 @@ type Props = {
 	authors?: Author[];
 	value: SearchGroup | null;
 	onChange: (value: SearchGroup | null) => void;
-	onSearch: () => void;
+	onSearch?: () => void;
 };
 
 export function ProSearchDialog(props: Props) {
@@ -53,11 +53,11 @@ export function ProSearchDialog(props: Props) {
 				<DialogFooter>
 					<Button
 						onClick={() => {
-							props.onSearch();
+							props.onSearch?.();
 							setOpen(false);
 						}}
 					>
-						検索
+						{props.onSearch ? "検索" : "完了"}
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/packages/ui/src/screens/search-screen.tsx
+++ b/packages/ui/src/screens/search-screen.tsx
@@ -5,12 +5,12 @@ import type { JSX } from "solid-js";
 import { createSignal, onMount, Show } from "solid-js";
 import { FilterErrorBanner, QueryStatus } from "../async-state";
 import { Card, CardContent, CardHeader, CardTitle } from "../card";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../dialog";
 import type {
 	SearchPageFilterData,
 	UseSearchPageResult,
 } from "../hooks/use-search-page";
 import type { SourceMediaPagePresetClient } from "../hooks/use-source-media-page";
+import { MobileSearchFilterDialog } from "../mobile-search-filter-dialog";
 import { SearchControlPanel } from "../search-control-panel";
 import { LoadingRegion, MediaGridSkeleton } from "../skeleton";
 import { SourceMediaGrid } from "../source-media-grid";
@@ -68,29 +68,32 @@ export function SearchScreen(props: SearchScreenProps) {
 
 	return (
 		<div class="container mx-auto p-4">
-			{props.renderNavActions?.({ openMobileFilters })}
+			<div class="mb-4 flex justify-end">
+				{props.renderNavActions?.({ openMobileFilters })}
+			</div>
 			<ClientOnly>
-				<Dialog
+				<MobileSearchFilterDialog
+					context="global"
+					filterData={props.filterData}
+					onSearch={page().handleSearch}
+					onSelectSource={props.onSelectSource}
 					open={isMobileFilterOpen()}
 					onOpenChange={setIsMobileFilterOpen}
-				>
-					<DialogContent class="max-h-[80vh] overflow-y-auto">
-						<DialogHeader>
-							<DialogTitle>検索フィルター</DialogTitle>
-						</DialogHeader>
-						<div class="space-y-4">{renderPanel()}</div>
-					</DialogContent>
-				</Dialog>
+					presetClient={props.presetClient}
+					selectedSource={props.selectedSource ?? undefined}
+					sources={props.sources}
+					usePopover={false}
+				/>
 			</ClientOnly>
 
-			<div class="mb-8 flex items-center justify-between">
+			<div class="mb-6 sm:mb-8">
 				<div>
-					<h1 class="mb-2 font-bold text-3xl">メディア検索</h1>
+					<h1 class="mb-2 font-bold text-2xl sm:text-3xl">メディア検索</h1>
 					<p class="text-gray-600">タグやファイル名でメディアを検索できます</p>
 				</div>
 			</div>
 
-			<div class="grid gap-6 md:grid-cols-[300px_1fr]">
+			<div class="grid min-w-0 gap-6 md:grid-cols-[minmax(0,300px)_minmax(0,1fr)]">
 				<Card class="sticky top-20 hidden h-fit max-h-[calc(100vh-6rem)] overflow-y-auto md:block">
 					<CardHeader>
 						<CardTitle>検索フィルター</CardTitle>
@@ -98,7 +101,7 @@ export function SearchScreen(props: SearchScreenProps) {
 					<CardContent class="space-y-4">{renderPanel()}</CardContent>
 				</Card>
 
-				<div class="space-y-4">
+				<div class="min-w-0 space-y-4">
 					<Show
 						when={filterStates().some(
 							(state) => state.phase === "error" || state.phase === "offline",

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -1,4 +1,5 @@
 import type { Media } from "@solid-imager/core/domain/media/schemas";
+import { ClientOnly } from "@tanstack/solid-router";
 import type { Component, JSX } from "solid-js";
 import { createSignal, onMount, Show } from "solid-js";
 import { FilterErrorBanner, QueryStatus } from "../async-state";
@@ -16,20 +17,15 @@ import type {
 	UploadOptions,
 	UseSourceMediaPageResult,
 } from "../hooks/use-source-media-page";
+import { MobileSearchFilterDialog } from "../mobile-search-filter-dialog";
 import { SearchControlPanel } from "../search-control-panel";
 import { LoadingRegion, MediaGridSkeleton } from "../skeleton";
 import { SourceMediaGrid } from "../source-media-grid";
 
 export type SourceMediaScreenProps = {
 	page: UseSourceMediaPageResult;
-	renderActions: (props: {
-		isSyncing: boolean;
-		isSyncDisabled: boolean;
-		onDumpDownload: (mode?: "json" | "zip") => void;
-		onSyncLoadedMedia: () => void;
-		onAddMedia: () => void;
-		onRestore: () => void;
-	}) => JSX.Element;
+	/** Render navigation actions without giving them ownership of filter draft state. */
+	renderActions: (props: { onOpenMobileFilters: () => void }) => JSX.Element;
 	/** Render a single media grid item. */
 	renderItem: (
 		media: Media,
@@ -69,11 +65,13 @@ export type SourceMediaScreenProps = {
 	onBulkAction?: () => void;
 	onClearSelection?: () => void;
 	selectedCount?: () => number;
+	onEnterBulkSelectMode?: () => void;
 	onRetryFilters: () => void | Promise<void>;
 };
 
 export function SourceMediaScreen(props: SourceMediaScreenProps) {
 	const [isMounted, setIsMounted] = createSignal(false);
+	const [isMobileFilterOpen, setIsMobileFilterOpen] = createSignal(false);
 	const page = () => props.page;
 	const filterStates = () => Object.values(page().filterStates());
 	const shouldRenderGrid = () => !props.enableVirtualization || isMounted();
@@ -85,19 +83,24 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 	return (
 		<section
 			aria-label="Media upload area"
-			class="container mx-auto min-h-[calc(100vh-2rem)] p-4"
+			class="container mx-auto min-h-[calc(100dvh-2rem)] p-4 pb-[calc(6rem+env(safe-area-inset-bottom))] sm:p-6 sm:pb-[calc(7rem+env(safe-area-inset-bottom))]"
 			onDragOver={page().handleDragOver}
 			onDrop={page().handleDrop}
 		>
 			{props.renderActions({
-				isSyncing: page().isSyncingMedia(),
-				isSyncDisabled:
-					page().isSyncingMedia() || !page().mediaQuery.data?.pages.length,
-				onDumpDownload: page().handleDumpDownload,
-				onSyncLoadedMedia: page().handleSyncLoadedMedia,
-				onAddMedia: page().handleAddButtonClick,
-				onRestore: () => page().restoreInputRef?.click(),
+				onOpenMobileFilters: () => setIsMobileFilterOpen(true),
 			})}
+			<ClientOnly>
+				<MobileSearchFilterDialog
+					context="source"
+					filterData={page().filterData()}
+					onOpenChange={setIsMobileFilterOpen}
+					onSearch={page().handleSearch}
+					open={isMobileFilterOpen()}
+					presetClient={page().presetClient}
+					usePopover={false}
+				/>
+			</ClientOnly>
 
 			<Show when={props.renderJobProgress && page().jobProgress()}>
 				{props.renderJobProgress?.({
@@ -105,19 +108,31 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 				})}
 			</Show>
 
-			<div class="mb-4 flex flex-wrap items-center justify-between gap-4">
-				<h1 class="min-w-0 break-all font-bold text-2xl">
+			<div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+				<h1 class="min-w-0 break-all font-bold text-xl sm:text-2xl">
 					Media in Source: {page().mediaSourceId()}
 				</h1>
-				<Button
-					disabled={
-						page().isSyncingMedia() || !page().mediaQuery.data?.pages.length
-					}
-					onClick={page().handleSyncLoadedMedia}
-					variant="outline"
-				>
-					{page().isSyncingMedia() ? "Syncing..." : "Sync Loaded Media"}
-				</Button>
+				<div class="grid w-full grid-cols-1 gap-2 sm:flex sm:w-auto sm:flex-wrap">
+					<Show when={props.onEnterBulkSelectMode}>
+						<Button
+							class="w-full sm:w-auto"
+							onClick={() => props.onEnterBulkSelectMode?.()}
+							variant="outline"
+						>
+							複数選択
+						</Button>
+					</Show>
+					<Button
+						class="w-full sm:w-auto"
+						disabled={
+							page().isSyncingMedia() || !page().mediaQuery.data?.pages.length
+						}
+						onClick={page().handleSyncLoadedMedia}
+						variant="outline"
+					>
+						{page().isSyncingMedia() ? "Syncing..." : "Sync Loaded Media"}
+					</Button>
+				</div>
 			</div>
 			<Show
 				when={filterStates().some(
@@ -131,7 +146,7 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 				/>
 			</Show>
 
-			<div class="grid gap-6 md:grid-cols-[300px_1fr]">
+			<div class="grid min-w-0 gap-6 md:grid-cols-[minmax(0,300px)_minmax(0,1fr)]">
 				<Card class="sticky top-20 hidden h-fit max-h-[calc(100vh-6rem)] overflow-y-auto md:block">
 					<CardHeader>
 						<CardTitle>検索フィルター</CardTitle>
@@ -148,7 +163,7 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 					</CardContent>
 				</Card>
 
-				<div>
+				<div class="min-w-0">
 					<QueryStatus
 						class="mb-2"
 						fetchState={page().contentState().fetchState}
@@ -213,14 +228,16 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 			/>
 
 			{/* Floating add button */}
-			<button
-				aria-label="Add media"
-				class="fixed right-8 bottom-8 flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg transition-all hover:bg-blue-700 hover:shadow-xl"
-				onClick={page().handleAddButtonClick}
-				type="button"
-			>
-				<span class="text-3xl leading-none">＋</span>
-			</button>
+			<Show when={!props.isBulkSelectMode?.()}>
+				<button
+					aria-label="Add media"
+					class="fixed right-4 bottom-[calc(1rem+env(safe-area-inset-bottom))] z-40 flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg transition-all hover:bg-blue-700 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 sm:right-8 sm:bottom-[calc(2rem+env(safe-area-inset-bottom))]"
+					onClick={page().handleAddButtonClick}
+					type="button"
+				>
+					<span class="text-3xl leading-none">＋</span>
+				</button>
+			</Show>
 
 			{(() => {
 				const UploadModal = props.uploadModalComponent;

--- a/packages/ui/src/screens/sources-screen.tsx
+++ b/packages/ui/src/screens/sources-screen.tsx
@@ -43,18 +43,24 @@ export function SourcesScreen(props: SourcesScreenProps) {
 	};
 
 	return (
-		<div class="container mx-auto p-6">
-			<div class="mb-6 flex flex-wrap items-center justify-between gap-4">
-				<h1 class="font-bold text-3xl">Media Sources</h1>
-				<div class="flex flex-wrap items-center gap-2">
+		<div class="container mx-auto p-4 sm:p-6">
+			<div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+				<h1 class="font-bold text-2xl sm:text-3xl">Media Sources</h1>
+				<div class="grid w-full grid-cols-2 gap-2 sm:flex sm:w-auto sm:flex-wrap">
 					<Button
+						class="w-full sm:w-auto"
 						disabled={page().isSyncing() || !props.mediaSources()?.length}
 						onClick={() => page().handleSyncAll(props.mediaSources())}
 						variant="outline"
 					>
 						{page().isSyncing() ? "Syncing..." : "Sync All"}
 					</Button>
-					<Button onClick={() => page().handleAddSource()}>Add Source</Button>
+					<Button
+						class="w-full sm:w-auto"
+						onClick={() => page().handleAddSource()}
+					>
+						Add Source
+					</Button>
 				</div>
 			</div>
 
@@ -96,7 +102,7 @@ export function SourcesScreen(props: SourcesScreenProps) {
 					</EmptyState>
 				</Match>
 				<Match when={props.state().phase === "data"}>
-					<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+					<div class="grid min-w-0 gap-3 sm:grid-cols-2 sm:gap-4 xl:grid-cols-3">
 						<For each={props.mediaSources()}>
 							{(source) => props.renderSourceCard(source)}
 						</For>

--- a/packages/ui/src/search-control-panel.tsx
+++ b/packages/ui/src/search-control-panel.tsx
@@ -188,7 +188,9 @@ export function SearchControlPanel(props: SearchControlPanelProps) {
 						characters={props.filterData.characters}
 						ips={props.filterData.ips}
 						onChange={(value) => updateState("advancedCondition", value)}
-						onSearch={props.onSearch}
+						onSearch={
+							props.showSearchButton === false ? undefined : props.onSearch
+						}
 						projects={props.filterData.projects}
 						tags={props.filterData.tags}
 						value={currentState().advancedCondition || null}

--- a/packages/ui/src/search-control-panel.tsx
+++ b/packages/ui/src/search-control-panel.tsx
@@ -2,9 +2,12 @@ import type { Author } from "@solid-imager/core/domain/authors/schemas";
 import type { Character } from "@solid-imager/core/domain/characters/schemas";
 import type { Ip } from "@solid-imager/core/domain/ips/schemas";
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
+import { calculateNextModeState } from "@solid-imager/core/domain/search/logic";
+import type { SearchState } from "@solid-imager/core/domain/search/schema";
 import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
 import { Show } from "solid-js";
+import type { SetStoreFunction } from "solid-js/store";
 import { Button } from "./button";
 import { Label } from "./label";
 import { PresetManager, type PresetManagerClient } from "./preset-manager";
@@ -21,7 +24,6 @@ import { SortControls } from "./sort-controls";
 import {
 	clearVectorSearchAnchor,
 	searchState,
-	setSearchMode,
 	setSearchState,
 } from "./stores/search-store";
 
@@ -41,11 +43,44 @@ export type SearchControlPanelProps = {
 	sources?: SafeMediaSource[];
 	selectedSource?: string;
 	onSelectSource?: (id: string) => void;
+	/** Optional isolated state for a draft editing surface. */
+	state?: SearchState;
+	setState?: SetStoreFunction<SearchState>;
+	/** Hide inline submit controls when an enclosing surface supplies Apply. */
+	showSearchButton?: boolean;
 	class?: string;
 	usePopover?: boolean;
 };
 
 export function SearchControlPanel(props: SearchControlPanelProps) {
+	const currentState = () => props.state ?? searchState;
+	const updateState = props.setState ?? setSearchState;
+	const selectedSource = () =>
+		props.state?.selectedSource ??
+		props.selectedSource ??
+		searchState.selectedSource;
+	const handleSelectSource = (id: string) => {
+		if (props.setState) {
+			props.setState("selectedSource", id);
+			return;
+		}
+		props.onSelectSource?.(id);
+	};
+	const handleSetMode = (mode: "simple" | "pro" | "vector") => {
+		updateState(calculateNextModeState(currentState(), mode));
+	};
+	const clearSimilarityAnchor = () => {
+		if (!props.setState) {
+			clearVectorSearchAnchor();
+			return;
+		}
+		props.setState({
+			similarityAnchorMediaId: null,
+			offset: 0,
+			scrollY: 0,
+		});
+	};
+
 	return (
 		<div class={props.class}>
 			<Show when={props.context === "global" && props.sources}>
@@ -59,7 +94,7 @@ export function SearchControlPanel(props: SearchControlPanelProps) {
 						)}
 						onChange={(value) => {
 							const selected = value as { id: string } | undefined;
-							props.onSelectSource?.(selected?.id ?? "");
+							handleSelectSource(selected?.id ?? "");
 						}}
 						options={[
 							{ id: "", name: "すべてのソース" },
@@ -70,7 +105,7 @@ export function SearchControlPanel(props: SearchControlPanelProps) {
 						value={[
 							{ id: "", name: "すべてのソース" },
 							...(props.sources || []),
-						].find((source) => source.id === props.selectedSource)}
+						].find((source) => source.id === selectedSource())}
 					>
 						<SelectTrigger>
 							<SelectValue<{ name: string }>>
@@ -82,90 +117,97 @@ export function SearchControlPanel(props: SearchControlPanelProps) {
 				</div>
 			</Show>
 
-			<div class="mb-4 flex items-center justify-between">
+			<div class="mb-4 flex flex-wrap items-center justify-between gap-2">
 				<Label class="font-medium text-sm">検索モード</Label>
-				<div class="flex gap-2">
+				<div class="flex flex-wrap gap-2">
 					<Button
-						onClick={() => setSearchMode("simple")}
+						class="min-h-11 md:min-h-9"
+						onClick={() => handleSetMode("simple")}
 						size="sm"
-						variant={searchState.mode === "simple" ? "default" : "outline"}
+						variant={currentState().mode === "simple" ? "default" : "outline"}
 					>
 						簡易
 					</Button>
 					<Button
-						onClick={() => setSearchMode("pro")}
+						class="min-h-11 md:min-h-9"
+						onClick={() => handleSetMode("pro")}
 						size="sm"
-						variant={searchState.mode === "pro" ? "default" : "outline"}
+						variant={currentState().mode === "pro" ? "default" : "outline"}
 					>
 						詳細
 					</Button>
 					<Button
-						onClick={() => setSearchMode("vector")}
+						class="min-h-11 md:min-h-9"
+						onClick={() => handleSetMode("vector")}
 						size="sm"
-						variant={searchState.mode === "vector" ? "default" : "outline"}
+						variant={currentState().mode === "vector" ? "default" : "outline"}
 					>
 						ベクトル類似
 					</Button>
 				</div>
 			</div>
 
-			<Show when={searchState.mode !== "vector"}>
+			<Show when={currentState().mode !== "vector"}>
 				<SortControls
 					className="mb-4"
-					onSortByChange={(value) => setSearchState("sortBy", value)}
-					onSortOrderChange={(value) => setSearchState("sortOrder", value)}
-					sortBy={searchState.sortBy}
-					sortOrder={searchState.sortOrder}
+					onSortByChange={(value) => updateState("sortBy", value)}
+					onSortOrderChange={(value) => updateState("sortOrder", value)}
+					sortBy={currentState().sortBy}
+					sortOrder={currentState().sortOrder}
 				/>
 			</Show>
 
 			<div class="my-4 h-px bg-border" />
 
-			<div class={searchState.mode === "simple" ? "block" : "hidden"}>
+			<div class={currentState().mode === "simple" ? "block" : "hidden"}>
 				<SearchFilters
 					authors={props.filterData.authors}
 					characters={props.filterData.characters}
 					ips={props.filterData.ips}
-					onSearch={props.onSearch}
+					onSearch={
+						props.showSearchButton === false ? undefined : props.onSearch
+					}
 					projects={props.filterData.projects}
-					setState={setSearchState}
-					state={searchState}
+					setState={updateState}
+					state={currentState()}
 					tags={props.filterData.tags}
 					usePopover={props.usePopover}
 				/>
 			</div>
 
-			<div class={searchState.mode === "pro" ? "block" : "hidden"}>
+			<div class={currentState().mode === "pro" ? "block" : "hidden"}>
 				<div class="space-y-4">
 					<PresetManager
 						class="w-full flex-col items-stretch"
 						presetClient={props.presetClient}
+						setState={props.setState}
+						state={props.state}
 					/>
 					<ProSearchDialog
 						authors={props.filterData.authors}
 						characters={props.filterData.characters}
 						ips={props.filterData.ips}
-						onChange={(value) => setSearchState("advancedCondition", value)}
+						onChange={(value) => updateState("advancedCondition", value)}
 						onSearch={props.onSearch}
 						projects={props.filterData.projects}
 						tags={props.filterData.tags}
-						value={searchState.advancedCondition || null}
+						value={currentState().advancedCondition || null}
 					/>
 				</div>
 			</div>
 
-			<div class={searchState.mode === "vector" ? "block" : "hidden"}>
+			<div class={currentState().mode === "vector" ? "block" : "hidden"}>
 				<div class="space-y-4">
 					<div class="space-y-2">
 						<Label>類似元メディア</Label>
 						<div class="rounded-md border p-3 text-sm">
-							{searchState.similarityAnchorMediaId ??
+							{currentState().similarityAnchorMediaId ??
 								"メディア個別画面の「Find Similar」から選択してください。"}
 						</div>
-						<Show when={searchState.similarityAnchorMediaId}>
+						<Show when={currentState().similarityAnchorMediaId}>
 							<Button
 								class="w-full"
-								onClick={clearVectorSearchAnchor}
+								onClick={clearSimilarityAnchor}
 								size="sm"
 								variant="outline"
 							>
@@ -178,10 +220,13 @@ export function SearchControlPanel(props: SearchControlPanelProps) {
 						<div class="flex gap-2">
 							{([20, 50, 100] as const).map((value) => (
 								<Button
-									onClick={() => setSearchState("similarityTopK", value)}
+									class="min-h-11 md:min-h-9"
+									onClick={() => updateState("similarityTopK", value)}
 									size="sm"
 									variant={
-										searchState.similarityTopK === value ? "default" : "outline"
+										currentState().similarityTopK === value
+											? "default"
+											: "outline"
 									}
 								>
 									{value}
@@ -189,12 +234,14 @@ export function SearchControlPanel(props: SearchControlPanelProps) {
 							))}
 						</div>
 					</div>
-					<Button
-						disabled={!searchState.similarityAnchorMediaId}
-						onClick={props.onSearch}
-					>
-						類似メディアを検索
-					</Button>
+					<Show when={props.showSearchButton !== false}>
+						<Button
+							disabled={!currentState().similarityAnchorMediaId}
+							onClick={props.onSearch}
+						>
+							類似メディアを検索
+						</Button>
+					</Show>
 					<p class="text-muted-foreground text-xs">
 						CCIPによるキャラクター類似検索です。一般的な画像重複検索とは異なります。
 					</p>

--- a/packages/ui/src/source-card.tsx
+++ b/packages/ui/src/source-card.tsx
@@ -68,13 +68,15 @@ export function SourceCard(props: SourceCardProps) {
 
 	const content = () => (
 		<>
-			<CardHeader>
-				<CardTitle data-testid="source-name">
+			<CardHeader class="min-w-0 p-4 sm:p-6">
+				<CardTitle class="break-words" data-testid="source-name">
 					{props.mediaSource.name}
 				</CardTitle>
 			</CardHeader>
-			<CardContent>
-				<CardDescription>{props.mediaSource.description}</CardDescription>
+			<CardContent class="min-w-0 p-4 pt-0 sm:p-6 sm:pt-0">
+				<CardDescription class="break-words">
+					{props.mediaSource.description}
+				</CardDescription>
 				<div class="mt-4 space-y-2 text-sm">
 					<p>
 						<span class="font-semibold">Type:</span>{" "}
@@ -91,7 +93,7 @@ export function SourceCard(props: SourceCardProps) {
 	const sourceLink = () => {
 		if (props.href) {
 			return (
-				<a class="block h-full text-current no-underline" href={props.href}>
+				<a class="block min-w-0 text-current no-underline" href={props.href}>
 					{content()}
 				</a>
 			);
@@ -99,7 +101,7 @@ export function SourceCard(props: SourceCardProps) {
 
 		if (!props.mediaSource.id) {
 			return (
-				<Link class="block h-full text-current no-underline" to="/sources">
+				<Link class="block min-w-0 text-current no-underline" to="/sources">
 					{content()}
 				</Link>
 			);
@@ -107,7 +109,7 @@ export function SourceCard(props: SourceCardProps) {
 
 		return (
 			<Link
-				class="block h-full text-current no-underline"
+				class="block min-w-0 text-current no-underline"
 				params={{ mediaSourceId: props.mediaSource.id }}
 				to="/sources/$mediaSourceId"
 			>
@@ -117,40 +119,45 @@ export function SourceCard(props: SourceCardProps) {
 	};
 
 	return (
-		<Card class="relative h-full hover:bg-gray-50" data-testid="source-card">
+		<Card
+			class="h-full overflow-hidden hover:bg-gray-50"
+			data-testid="source-card"
+		>
 			{sourceLink()}
-			<div class="absolute top-2 right-2 z-10 flex gap-1">
-				{props.onSync && (
-					<button
-						class="rounded border bg-white px-2 py-1 text-xs shadow hover:bg-gray-50"
-						data-testid="sync-source-btn"
-						onClick={handleSyncClick}
-						type="button"
-					>
-						Sync
-					</button>
-				)}
-				{props.onEdit && (
-					<button
-						class="rounded border bg-white px-2 py-1 text-xs shadow hover:bg-gray-50"
-						data-testid="edit-source-btn"
-						onClick={handleEditClick}
-						type="button"
-					>
-						Edit
-					</button>
-				)}
-				{props.onDelete && (
-					<button
-						class="rounded bg-red-500 px-2 py-1 text-white text-xs shadow hover:bg-red-600"
-						data-testid="delete-source-btn"
-						onClick={handleDeleteClick}
-						type="button"
-					>
-						Delete
-					</button>
-				)}
-			</div>
+			{(props.onSync || props.onEdit || props.onDelete) && (
+				<div class="flex flex-wrap gap-2 border-t bg-muted/30 p-3">
+					{props.onSync && (
+						<button
+							class="min-h-11 min-w-0 flex-1 rounded border bg-background px-3 font-medium text-sm shadow-sm hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							data-testid="sync-source-btn"
+							onClick={handleSyncClick}
+							type="button"
+						>
+							Sync
+						</button>
+					)}
+					{props.onEdit && (
+						<button
+							class="min-h-11 min-w-0 flex-1 rounded border bg-background px-3 font-medium text-sm shadow-sm hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							data-testid="edit-source-btn"
+							onClick={handleEditClick}
+							type="button"
+						>
+							Edit
+						</button>
+					)}
+					{props.onDelete && (
+						<button
+							class="min-h-11 min-w-0 flex-1 rounded bg-red-500 px-3 font-medium text-sm text-white shadow-sm hover:bg-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2"
+							data-testid="delete-source-btn"
+							onClick={handleDeleteClick}
+							type="button"
+						>
+							Delete
+						</button>
+					)}
+				</div>
+			)}
 		</Card>
 	);
 }

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -24,7 +24,7 @@ import type { QueryUiState } from "./query-state";
 import { LoadingRegion, MediaGridSkeleton } from "./skeleton";
 
 const VIRTUALIZATION_THRESHOLD = 100;
-const GRID_GAP_PX = 16;
+const GRID_GAP_PX = 12;
 const GRID_ITEM_ASPECT_RATIO = 4 / 3;
 const VIRTUAL_ROWS_OVERSCAN = 4;
 
@@ -93,9 +93,9 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 	let mediaGridRef: HTMLDivElement | undefined;
 
 	const columnCount = createMemo(() => {
-		const width = windowWidth();
-		if (width >= 1024) return 5;
-		if (width >= 768) return 3;
+		const width = mediaGridWidth() || windowWidth();
+		if (width >= 1100) return 5;
+		if (width >= 640) return 3;
 		return 2;
 	});
 
@@ -202,7 +202,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 
 	const gridContent = (
 		<div
-			class="relative w-full"
+			class="relative min-w-0 w-full"
 			ref={(element) => {
 				mediaGridRef = element;
 				requestAnimationFrame(() => {
@@ -217,7 +217,12 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 		>
 			<Show
 				fallback={
-					<div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5">
+					<div
+						class="grid gap-3"
+						style={{
+							"grid-template-columns": `repeat(${columnCount()}, minmax(0, 1fr))`,
+						}}
+					>
 						<For each={props.mediaResults()}>
 							{(media) =>
 								props.renderItem(media, {
@@ -240,7 +245,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 						const rowMedia = () => mediaRows()[virtualRow.index] || [];
 						return (
 							<div
-								class="absolute left-0 top-0 grid gap-4"
+								class="absolute top-0 left-0 grid gap-3"
 								style={{
 									"grid-template-columns": `repeat(${columnCount()}, minmax(0, 1fr))`,
 									height: `${virtualRow.size}px`,
@@ -270,7 +275,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 	);
 
 	return (
-		<div class="min-h-0 space-y-4">
+		<div class="min-h-0 min-w-0 space-y-4">
 			<Switch>
 				<Match when={props.state().phase === "pending"}>
 					<LoadingRegion label="メディア一覧を読み込んでいます...">
@@ -297,7 +302,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 				>
 					{/* Result count */}
 					<Show when={showResultCount() && props.mediaResults().length > 0}>
-						<div class="mb-4 flex items-center justify-between">
+						<div class="mb-4 flex min-w-0 items-center justify-between gap-3">
 							<p class="text-gray-600 text-sm">{totalCount()} 件の結果</p>
 						</div>
 					</Show>
@@ -305,7 +310,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 					{/* Grid with optional context menu */}
 					<Show fallback={gridContent} when={!disableContextMenu()}>
 						<ContextMenu>
-							<ContextMenuTrigger class="block w-full">
+							<ContextMenuTrigger class="block min-w-0 w-full">
 								{gridContent}
 							</ContextMenuTrigger>
 							<ContextMenuContent>
@@ -426,13 +431,21 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 
 					{/* Load more sentinel */}
 					<div
-						class="flex h-10 w-full items-center justify-center text-gray-500"
+						aria-live="polite"
+						class="flex min-h-11 w-full items-center justify-center py-2 text-gray-500 text-sm"
+						data-testid="media-load-more-sentinel"
 						ref={props.setLoadMoreRef}
+						role="status"
 					>
-						<Show when={props.isFetchingNextPage}>
-							<p class="text-center text-gray-500" role="status">
-								読み込み中...
-							</p>
+						<Show
+							fallback={
+								<Show when={props.hasNextPage}>
+									<p>スクロールしてさらに読み込む</p>
+								</Show>
+							}
+							when={props.isFetchingNextPage}
+						>
+							<p>読み込み中...</p>
 						</Show>
 					</div>
 				</Match>

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -58,6 +58,7 @@ export type SourceMediaPageProps = {
 	onBulkAction?: () => void;
 	onClearSelection?: () => void;
 	selectedCount?: () => number;
+	onEnterBulkSelectMode?: () => void;
 };
 
 export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
@@ -119,13 +120,11 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 		isSearchStateRestored,
 	});
 
-	const renderActions: SourceMediaScreenProps["renderActions"] = () => (
+	const renderActions: SourceMediaScreenProps["renderActions"] = (actions) => (
 		<MediaListActions
-			filterData={page.filterData()}
 			onDumpDownload={page.handleDumpDownload}
 			onLanceDBDump={page.handleLanceDBDump}
-			onSearch={page.handleSearch}
-			presetClient={props.presetClient}
+			onOpenMobileFilters={actions.onOpenMobileFilters}
 		/>
 	);
 
@@ -153,6 +152,7 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 			onBulkAction={props.onBulkAction}
 			onClearSelection={props.onClearSelection}
 			selectedCount={props.selectedCount}
+			onEnterBulkSelectMode={props.onEnterBulkSelectMode}
 		/>
 	);
 }


### PR DESCRIPTION
## 概要

Sources、Search、Source Media を 320px 幅から操作可能なレスポンシブレイアウトへ調整します。

## 変更内容

- Sources のカード・CRUD・同期操作を狭幅向けに再配置
- Search / Source Media のモバイルフィルターを draft + Apply/Cancel に変更
- Escape / 閉じるで未適用条件を破棄し、SSE更新中も入力・フォーカスを保持
- Source Media の操作メニュー、44px操作領域、safe area、0件選択時の解除導線を追加
- コンテナ幅ベースのメディアグリッドと横溢れ対策
- responsive / SSE回帰E2Eを追加・拡張

## 検証

- `bun --filter @solid-imager/ui typecheck`
- `bun --filter @solid-imager/ui test`
- `bun --filter @solid-imager/server lint`
- focused Biome check / `git diff --check`
- responsive E2E（dev / production）— 各 16 passed, 4 mobile-only skipped

## 備考

`apps/server` 単独 typecheck は、生成済み `#route-tree` がない既知の環境要因で失敗します。production E2Eのビルド・実行は成功しています。

Fixes #585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モバイル向け検索フィルターをダイアログで利用できるようになりました。
  * 条件の確認・クリア・適用、入力内容とフォーカスの保持に対応しました。
  * メディアの一括選択・操作をモバイル画面でも使いやすくしました。

* **改善**
  * 検索、ソース、メディア画面のレイアウトを調整し、横方向のはみ出しを防止しました。
  * ボタンや操作領域の視認性、タッチ操作性、レスポンシブ表示を改善しました。
  * リアルタイム更新後も検索条件や表示状態が維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->