### PR TITLE
refactor(ui): FormをTanStack Formへ統合 (#589)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -56,7 +56,6 @@
     "@tanstack/solid-router-devtools": "^1.167.0",
     "@tanstack/solid-router-ssr-query": "^1.167.1",
     "@tanstack/solid-start": "^1.168.19",
-    "@tanstack/zod-form-adapter": "^0.42.1",
     "apache-arrow": "^21.1.0",
     "archiver": "^8.0.0",
     "chokidar": "^5.0.0",

--- a/apps/server/src/tests/e2e/media-detail-manager-config.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/media-detail-manager-config.responsive.spec.ts
@@ -81,6 +81,17 @@ test("media detail, manager, and settings remain usable on narrow screens", asyn
 		page.getByRole("heading", { name: "Settings", exact: true }),
 	).toBeVisible();
 	await waitForAppHydration(page);
+	const saveButton = page.getByRole("button", {
+		name: "Save Changes",
+		exact: true,
+	});
+	const concurrencyInput = page.getByLabel("Concurrency", { exact: true });
+	await concurrencyInput.fill("0");
+	await expect(concurrencyInput).toHaveAttribute("aria-invalid", "true");
+	await expect(saveButton).toBeDisabled();
+	await concurrencyInput.fill("3");
+	await expect(concurrencyInput).toHaveAttribute("aria-invalid", "false");
+	await expect(saveButton).toBeEnabled();
 
 	for (const category of [
 		{ tab: "Jobs", heading: "Job Processing" },

--- a/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
@@ -68,9 +68,30 @@ test("sources actions stay operable without horizontal overflow", async ({
 	await expectTouchTarget(sourceCard.getByTestId("delete-source-btn"));
 
 	await addSourceButton.click();
-	await expect(page.getByRole("dialog")).toBeVisible();
+	const addSourceDialog = page.getByRole("dialog");
+	await expect(addSourceDialog).toBeVisible();
+	await addSourceDialog.getByLabel("Name", { exact: true }).fill("temporary");
+	await addSourceDialog
+		.getByLabel("Directory Path", { exact: true })
+		.fill("/tmp/temporary");
 	await page.keyboard.press("Escape");
 	await expect(page.getByRole("dialog")).toHaveCount(0);
+	await expect(addSourceButton).toBeFocused();
+
+	await addSourceButton.click();
+	await expect(addSourceDialog.getByLabel("Name", { exact: true })).toHaveValue(
+		"",
+	);
+	await expect(
+		addSourceDialog.getByLabel("Directory Path", { exact: true }),
+	).toHaveValue("");
+	await addSourceDialog
+		.getByRole("button", { name: "Add Source", exact: true })
+		.click();
+	await expect(addSourceDialog.getByText("Name is required")).toBeVisible();
+	await expect(addSourceDialog.getByText("Path is required")).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(addSourceDialog).toBeHidden();
 
 	await sourceCard.getByTestId("edit-source-btn").click();
 	await expect(page.getByRole("dialog")).toBeVisible();
@@ -102,6 +123,30 @@ test("source media exposes mobile filters and touch selection", async ({
 	const addMediaButton = page.getByRole("button", { name: "Add media" });
 	await expectTouchTarget(addMediaButton);
 	await expectInsideViewport(page, addMediaButton);
+	await addMediaButton.click();
+	const uploadDialog = page.getByRole("dialog");
+	await expect(
+		uploadDialog.getByRole("heading", {
+			name: "メディアをアップロード",
+			exact: true,
+		}),
+	).toBeVisible();
+	await uploadDialog
+		.getByRole("button", { name: "アップロード", exact: true })
+		.click();
+	await expect(
+		uploadDialog.getByText("アップロードするファイルがありません。"),
+	).toBeVisible();
+	await uploadDialog
+		.getByRole("button", { name: "キャンセル", exact: true })
+		.click();
+	await expect(uploadDialog).toBeHidden();
+	await addMediaButton.click();
+	await expect(
+		uploadDialog.getByText("アップロードするファイルがありません。"),
+	).toHaveCount(0);
+	await page.keyboard.press("Escape");
+	await expect(uploadDialog).toBeHidden();
 
 	const selectModeButton = page.getByRole("button", {
 		name: "複数選択",

--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,6 @@
         "@tanstack/solid-router-devtools": "^1.167.0",
         "@tanstack/solid-router-ssr-query": "^1.167.1",
         "@tanstack/solid-start": "^1.168.19",
-        "@tanstack/zod-form-adapter": "^0.42.1",
         "apache-arrow": "^21.1.0",
         "archiver": "^8.0.0",
         "chokidar": "^5.0.0",
@@ -236,7 +235,6 @@
         "@tanstack/solid-query": "5.99.2",
         "@tanstack/solid-router": "^1.170.11",
         "@tanstack/solid-virtual": "^3.13.26",
-        "@tanstack/zod-form-adapter": "^0.42.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk-solid": "^1.1.2",
@@ -939,8 +937,6 @@
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.1", "", {}, "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
-
-    "@tanstack/zod-form-adapter": ["@tanstack/zod-form-adapter@0.42.1", "", { "dependencies": { "@tanstack/form-core": "0.42.1" }, "peerDependencies": { "zod": "^3.x" } }, "sha512-hPRM0lawVKP64yurW4c6KHZH6altMo2MQN14hfi+GMBTKjO9S7bW1x5LPZ5cayoJE3mBvdlahpSGT5rYZtSbXQ=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.11.1", "", {}, "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA=="],
 
@@ -1926,10 +1922,6 @@
 
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
-    "@tanstack/zod-form-adapter/@tanstack/form-core": ["@tanstack/form-core@0.42.1", "", { "dependencies": { "@tanstack/store": "^0.7.0" } }, "sha512-jTU0jyHqFceujdtPNv3jPVej1dTqBwa8TYdIyWB5BCwRVUBZEp1PiYEBkC9r92xu5fMpBiKc+JKud3eeVjuMiA=="],
-
-    "@tanstack/zod-form-adapter/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "@types/archiver/@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
 
     "@types/fluent-ffmpeg/@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
@@ -2091,8 +2083,6 @@
     "@tanstack/cli/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "@tanstack/start-plugin-core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "@tanstack/zod-form-adapter/@tanstack/form-core/@tanstack/store": ["@tanstack/store@0.7.7", "", {}, "sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ=="],
 
     "@types/archiver/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,6 @@
     "@tanstack/solid-query": "5.99.2",
     "@tanstack/solid-router": "^1.170.11",
     "@tanstack/solid-virtual": "^3.13.26",
-    "@tanstack/zod-form-adapter": "^0.42.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk-solid": "^1.1.2",

--- a/packages/ui/src/form-message.tsx
+++ b/packages/ui/src/form-message.tsx
@@ -1,0 +1,72 @@
+import type { JSX } from "solid-js";
+import { Show } from "solid-js";
+import { cn } from "./utils/cn";
+
+export function getFormErrorMessage(error: unknown): string | undefined {
+	if (typeof error === "string") {
+		return error;
+	}
+	if (
+		typeof error === "object" &&
+		error !== null &&
+		"message" in error &&
+		typeof error.message === "string"
+	) {
+		return error.message;
+	}
+	return undefined;
+}
+
+export function getFormSubmitError(error: unknown): string | undefined {
+	if (typeof error === "object" && error !== null && "form" in error) {
+		return getFormErrorMessage(error.form);
+	}
+	return getFormErrorMessage(error);
+}
+
+export type FormFieldMessageProps = {
+	id: string;
+	message?: string;
+	class?: string;
+};
+
+/** Accessible validation message shared by form fields. */
+export function FormFieldMessage(props: FormFieldMessageProps): JSX.Element {
+	return (
+		<Show when={props.message}>
+			{(message) => (
+				<p
+					aria-live="polite"
+					class={cn("text-destructive text-sm", props.class)}
+					id={props.id}
+				>
+					{message()}
+				</p>
+			)}
+		</Show>
+	);
+}
+
+export type FormErrorProps = {
+	message?: string | null;
+	class?: string;
+};
+
+/** Form-level error for asynchronous submission and server failures. */
+export function FormError(props: FormErrorProps): JSX.Element {
+	return (
+		<Show when={props.message}>
+			{(message) => (
+				<div
+					class={cn(
+						"rounded-md border border-destructive/40 bg-destructive/10 p-3 text-destructive text-sm",
+						props.class,
+					)}
+					role="alert"
+				>
+					{message()}
+				</div>
+			)}
+		</Show>
+	);
+}

--- a/packages/ui/src/form-schemas.test.ts
+++ b/packages/ui/src/form-schemas.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+import {
+	createSourceFormSchema,
+	type SourceFormValues,
+	uploadFormSchema,
+} from "./form-schemas";
+
+const validSourceValues: SourceFormValues = {
+	name: "Pictures",
+	description: "",
+	type: "local",
+	path: "/media/pictures",
+	host: "",
+	port: 22,
+	username: "",
+	password: "",
+	remotePath: "",
+	bucket: "",
+	region: "",
+	accessKeyId: "",
+	secretAccessKey: "",
+	prefix: "",
+};
+
+describe("source form schema", () => {
+	test("derives conditional local and SFTP field errors", () => {
+		const schema = createSourceFormSchema(true);
+		expect(schema.safeParse({ ...validSourceValues, path: "" }).success).toBe(
+			false,
+		);
+		expect(
+			schema.safeParse({
+				...validSourceValues,
+				type: "sftp",
+				path: "",
+			}).success,
+		).toBe(false);
+		expect(schema.safeParse(validSourceValues).success).toBe(true);
+	});
+
+	test("requires S3 secrets only when creating a source", () => {
+		const s3Values: SourceFormValues = {
+			...validSourceValues,
+			type: "s3",
+			path: "",
+			bucket: "images",
+			region: "us-east-1",
+		};
+		expect(createSourceFormSchema(true).safeParse(s3Values).success).toBe(
+			false,
+		);
+		expect(createSourceFormSchema(false).safeParse(s3Values).success).toBe(
+			true,
+		);
+	});
+});
+
+describe("upload form schema", () => {
+	test("validates filename and optional URL through Zod Standard Schema", () => {
+		expect(
+			uploadFormSchema.safeParse({
+				filename: "image.png",
+				description: "",
+				sourceUrl: "",
+				conflictResolution: "skip",
+			}).success,
+		).toBe(true);
+		expect(
+			uploadFormSchema.safeParse({
+				filename: "",
+				description: "",
+				sourceUrl: "not-a-url",
+				conflictResolution: "skip",
+			}).success,
+		).toBe(false);
+	});
+});

--- a/packages/ui/src/form-schemas.test.ts
+++ b/packages/ui/src/form-schemas.test.ts
@@ -53,6 +53,22 @@ describe("source form schema", () => {
 			true,
 		);
 	});
+
+	test("validates the port only for SFTP sources", () => {
+		const localValues = { ...validSourceValues, port: Number.NaN };
+		expect(createSourceFormSchema(true).safeParse(localValues).success).toBe(
+			true,
+		);
+		expect(
+			createSourceFormSchema(true).safeParse({
+				...localValues,
+				type: "sftp",
+				host: "example.com",
+				username: "user",
+				remotePath: "/photos",
+			}).success,
+		).toBe(false);
+	});
 });
 
 describe("upload form schema", () => {

--- a/packages/ui/src/form-schemas.ts
+++ b/packages/ui/src/form-schemas.ts
@@ -8,7 +8,7 @@ export const createSourceFormSchema = (requireSecrets: boolean) =>
 			type: z.enum(["local", "sftp", "s3"]),
 			path: z.string(),
 			host: z.string(),
-			port: z.number().int().positive("Port must be positive"),
+			port: z.number().or(z.nan()),
 			username: z.string(),
 			password: z.string(),
 			remotePath: z.string(),
@@ -39,6 +39,13 @@ export const createSourceFormSchema = (requireSecrets: boolean) =>
 			if (value.type === "local") {
 				requireField("path", "Path is required");
 			} else if (value.type === "sftp") {
+				if (!Number.isInteger(value.port) || value.port <= 0) {
+					context.addIssue({
+						code: "custom",
+						message: "Port must be positive",
+						path: ["port"],
+					});
+				}
 				requireField("host", "Host is required");
 				requireField("username", "Username is required");
 				requireField("remotePath", "Remote path is required");

--- a/packages/ui/src/form-schemas.ts
+++ b/packages/ui/src/form-schemas.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+export const createSourceFormSchema = (requireSecrets: boolean) =>
+	z
+		.object({
+			name: z.string().trim().min(1, "Name is required"),
+			description: z.string(),
+			type: z.enum(["local", "sftp", "s3"]),
+			path: z.string(),
+			host: z.string(),
+			port: z.number().int().positive("Port must be positive"),
+			username: z.string(),
+			password: z.string(),
+			remotePath: z.string(),
+			bucket: z.string(),
+			region: z.string(),
+			accessKeyId: z.string(),
+			secretAccessKey: z.string(),
+			prefix: z.string(),
+		})
+		.superRefine((value, context) => {
+			const requireField = (
+				field:
+					| "path"
+					| "host"
+					| "username"
+					| "remotePath"
+					| "bucket"
+					| "region"
+					| "accessKeyId"
+					| "secretAccessKey",
+				message: string,
+			) => {
+				if (!value[field].trim()) {
+					context.addIssue({ code: "custom", message, path: [field] });
+				}
+			};
+
+			if (value.type === "local") {
+				requireField("path", "Path is required");
+			} else if (value.type === "sftp") {
+				requireField("host", "Host is required");
+				requireField("username", "Username is required");
+				requireField("remotePath", "Remote path is required");
+			} else {
+				requireField("bucket", "Bucket is required");
+				requireField("region", "Region is required");
+				if (requireSecrets) {
+					requireField("accessKeyId", "Access Key ID is required");
+					requireField("secretAccessKey", "Secret Access Key is required");
+				}
+			}
+		});
+
+export type SourceFormValues = z.infer<
+	ReturnType<typeof createSourceFormSchema>
+>;
+
+export const uploadFormSchema = z.object({
+	filename: z.string().trim().min(1, "ファイル名を入力してください。"),
+	description: z.string(),
+	sourceUrl: z.string().url("有効なURLを入力してください。").or(z.literal("")),
+	conflictResolution: z.enum(["overwrite", "skip", "rename"]),
+});
+
+export type UploadFormValues = z.infer<typeof uploadFormSchema>;

--- a/packages/ui/src/hooks/use-sources-page.ts
+++ b/packages/ui/src/hooks/use-sources-page.ts
@@ -99,6 +99,7 @@ export function useSourcesPage(
 			toast.error(
 				`Failed to save source: ${error instanceof Error ? error.message : String(error)}`,
 			);
+			throw error;
 		}
 	};
 

--- a/packages/ui/src/screens/config-screen.tsx
+++ b/packages/ui/src/screens/config-screen.tsx
@@ -1,8 +1,14 @@
 import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
 import { AppConfigSchema } from "@solid-imager/core/domain/config/config-schema";
 import { createForm } from "@tanstack/solid-form";
-import { createSignal, Show } from "solid-js";
+import { createEffect, createSignal } from "solid-js";
+import type { z } from "zod";
 import { Button } from "../button";
+import {
+	FormError,
+	FormFieldMessage,
+	getFormErrorMessage,
+} from "../form-message";
 import { Input } from "../input";
 import { Label } from "../label";
 import { Switch, SwitchControl, SwitchLabel, SwitchThumb } from "../switch";
@@ -10,15 +16,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "../tabs";
 import { Textarea } from "../textarea";
 import { toast } from "../toast";
 
-type DeepFormConfig<T> = T extends number
-	? number | undefined
-	: T extends Array<infer U>
-		? Array<DeepFormConfig<U>>
-		: T extends object
-			? { [K in keyof T]: DeepFormConfig<T[K]> }
-			: T;
+type AppConfigFormValues = z.input<typeof AppConfigSchema>;
 
-type FormConfig = DeepFormConfig<AppConfig>;
+function toFormValues(data: AppConfig): AppConfigFormValues {
+	return data;
+}
 
 function parseNumberInput(val: string): number | undefined {
 	const n = Number(val);
@@ -32,36 +34,60 @@ export type ConfigScreenProps = {
 
 export function ConfigScreen(props: ConfigScreenProps) {
 	const [activeTab, setActiveTab] = createSignal("jobs");
+	const [submitError, setSubmitError] = createSignal<string | null>(null);
 	const form = createForm(() => ({
-		defaultValues: props.data as unknown as FormConfig,
+		defaultValues: toFormValues(props.data),
 		validators: {
-			onChange: AppConfigSchema as never,
+			onChange: AppConfigSchema,
 		},
 		onSubmit: async ({ value }) => {
+			setSubmitError(null);
 			try {
-				await props.onSubmit(value as Partial<AppConfig>);
+				const parsedValue = AppConfigSchema.parse(value);
+				await props.onSubmit(parsedValue);
+				form.reset(parsedValue);
 				props.onSubmitSuccess?.();
 				toast.success("Configuration saved successfully");
-			} catch (_error) {
+			} catch (error) {
+				setSubmitError(
+					getFormErrorMessage(error) ?? "Failed to save configuration",
+				);
 				toast.error("Failed to save configuration");
 			}
 		},
 	}));
 
+	createEffect(() => {
+		const data = props.data;
+		if (!form.state.isDirty) {
+			form.reset(toFormValues(data));
+		}
+	});
+
 	return (
 		<div class="min-w-0 space-y-6 [&_input]:scroll-mt-28 [&_input]:text-base [&_select]:scroll-mt-28 [&_select]:text-base [&_textarea]:scroll-mt-28 [&_textarea]:text-base sm:[&_input]:text-sm sm:[&_select]:text-sm sm:[&_textarea]:text-sm">
 			<div class="sticky top-[calc(4rem+env(safe-area-inset-top))] z-20 -mx-3 flex flex-col gap-3 border-b bg-background px-3 py-3 sm:-mx-6 sm:flex-row sm:items-center sm:justify-between sm:px-6 md:static md:mx-0 md:border-0 md:bg-transparent md:p-0">
 				<h1 class="font-bold text-2xl sm:text-3xl">Settings</h1>
-				<Button
-					class="w-full sm:w-auto"
-					disabled={form.state.isSubmitting}
-					onClick={() => {
-						void form.handleSubmit();
-					}}
+				<form.Subscribe
+					selector={(state) => ({
+						canSubmit: state.canSubmit,
+						isSubmitting: state.isSubmitting,
+					})}
 				>
-					{form.state.isSubmitting ? "Saving..." : "Save Changes"}
-				</Button>
+					{(state) => (
+						<Button
+							class="w-full sm:w-auto"
+							disabled={!state().canSubmit || state().isSubmitting}
+							onClick={() => {
+								void form.handleSubmit();
+							}}
+						>
+							{state().isSubmitting ? "Saving..." : "Save Changes"}
+						</Button>
+					)}
+				</form.Subscribe>
 			</div>
+			<FormError message={submitError()} />
 
 			<Tabs class="min-w-0 w-full" onChange={setActiveTab} value={activeTab()}>
 				<TabsList
@@ -102,6 +128,8 @@ export function ConfigScreen(props: ConfigScreenProps) {
 									<div class="space-y-2">
 										<Label for={field().name}>Concurrency</Label>
 										<Input
+											aria-describedby={`${field().name}-error`}
+											aria-invalid={field().state.meta.errors.length > 0}
 											id={field().name}
 											onBlur={field().handleBlur}
 											onInput={(e) => {
@@ -110,11 +138,12 @@ export function ConfigScreen(props: ConfigScreenProps) {
 											type="number"
 											value={field().state.value ?? ""}
 										/>
-										<Show when={field().state.meta.errors.length}>
-											<div class="text-red-500 text-sm">
-												{field().state.meta.errors[0]}
-											</div>
-										</Show>
+										<FormFieldMessage
+											id={`${field().name}-error`}
+											message={getFormErrorMessage(
+												field().state.meta.errors[0],
+											)}
+										/>
 										<div class="text-muted-foreground text-xs">
 											Number of concurrent downloads/processings.
 										</div>
@@ -127,6 +156,8 @@ export function ConfigScreen(props: ConfigScreenProps) {
 									<div class="space-y-2">
 										<Label for={field().name}>AI Concurrency</Label>
 										<Input
+											aria-describedby={`${field().name}-error`}
+											aria-invalid={field().state.meta.errors.length > 0}
 											id={field().name}
 											onBlur={field().handleBlur}
 											onInput={(e) => {
@@ -135,11 +166,12 @@ export function ConfigScreen(props: ConfigScreenProps) {
 											type="number"
 											value={field().state.value ?? ""}
 										/>
-										<Show when={field().state.meta.errors.length}>
-											<div class="text-red-500 text-sm">
-												{field().state.meta.errors[0]}
-											</div>
-										</Show>
+										<FormFieldMessage
+											id={`${field().name}-error`}
+											message={getFormErrorMessage(
+												field().state.meta.errors[0],
+											)}
+										/>
 										<div class="text-muted-foreground text-xs">
 											Number of concurrent AI tagging jobs.
 										</div>
@@ -152,6 +184,8 @@ export function ConfigScreen(props: ConfigScreenProps) {
 									<div class="space-y-2">
 										<Label for={field().name}>Poll Interval (ms)</Label>
 										<Input
+											aria-describedby={`${field().name}-error`}
+											aria-invalid={field().state.meta.errors.length > 0}
 											id={field().name}
 											onBlur={field().handleBlur}
 											onInput={(e) => {
@@ -160,11 +194,12 @@ export function ConfigScreen(props: ConfigScreenProps) {
 											type="number"
 											value={field().state.value ?? ""}
 										/>
-										<Show when={field().state.meta.errors.length}>
-											<div class="text-red-500 text-sm">
-												{field().state.meta.errors[0]}
-											</div>
-										</Show>
+										<FormFieldMessage
+											id={`${field().name}-error`}
+											message={getFormErrorMessage(
+												field().state.meta.errors[0],
+											)}
+										/>
 									</div>
 								)}
 							</form.Field>
@@ -213,6 +248,8 @@ export function ConfigScreen(props: ConfigScreenProps) {
 											Remote AI Server URL (oRPC)
 										</Label>
 										<Input
+											aria-describedby={`${field().name}-error`}
+											aria-invalid={field().state.meta.errors.length > 0}
 											id={field().name}
 											onBlur={field().handleBlur}
 											onInput={(e) => field().handleChange(e.target.value)}
@@ -281,11 +318,12 @@ export function ConfigScreen(props: ConfigScreenProps) {
 											type="number"
 											value={field().state.value ?? ""}
 										/>
-										<Show when={field().state.meta.errors.length}>
-											<div class="text-red-500 text-sm">
-												{field().state.meta.errors[0]}
-											</div>
-										</Show>
+										<FormFieldMessage
+											id={`${field().name}-error`}
+											message={getFormErrorMessage(
+												field().state.meta.errors[0],
+											)}
+										/>
 									</div>
 								)}
 							</form.Field>

--- a/packages/ui/src/screens/config-screen.tsx
+++ b/packages/ui/src/screens/config-screen.tsx
@@ -256,6 +256,12 @@ export function ConfigScreen(props: ConfigScreenProps) {
 											placeholder="http://power-machine:3000"
 											value={field().state.value ?? ""}
 										/>
+										<FormFieldMessage
+											id={`${field().name}-error`}
+											message={getFormErrorMessage(
+												field().state.meta.errors[0],
+											)}
+										/>
 										<div class="text-muted-foreground text-xs">
 											外部の solid-imager サーバーの oRPC
 											エンドポイントを指定。AI
@@ -308,6 +314,8 @@ export function ConfigScreen(props: ConfigScreenProps) {
 									<div class="space-y-2">
 										<Label for={field().name}>リクエスト間隔 (ms)</Label>
 										<Input
+											aria-describedby={`${field().name}-error`}
+											aria-invalid={field().state.meta.errors.length > 0}
 											id={field().name}
 											max="60000"
 											min="0"

--- a/packages/ui/src/source-form-modal.tsx
+++ b/packages/ui/src/source-form-modal.tsx
@@ -229,7 +229,9 @@ export function SourceFormModal(props: SourceFormModalProps) {
 	};
 	const form = createForm(() => ({
 		defaultValues: defaultValues(),
-		validators: { onSubmit: createSourceFormSchema(!props.editingSource) },
+		validators: {
+			onSubmit: createSourceFormSchema(props.editingSource?.type !== "s3"),
+		},
 		onSubmit: async ({ value }) => {
 			form.setErrorMap({ onSubmit: undefined });
 			try {
@@ -242,10 +244,13 @@ export function SourceFormModal(props: SourceFormModalProps) {
 		},
 	}));
 
+	let wasOpen = false;
 	createEffect(() => {
-		if (props.isOpen) {
+		const isOpen = props.isOpen;
+		if (isOpen && !wasOpen) {
 			form.reset(defaultValues());
 		}
+		wasOpen = isOpen;
 	});
 
 	const selectOptions = () =>
@@ -395,6 +400,8 @@ export function SourceFormModal(props: SourceFormModalProps) {
 												<div class="space-y-2">
 													<Label for={field().name}>Port</Label>
 													<Input
+														aria-describedby={`${field().name}-error`}
+														aria-invalid={field().state.meta.errors.length > 0}
 														id={field().name}
 														min="1"
 														onBlur={field().handleBlur}

--- a/packages/ui/src/source-form-modal.tsx
+++ b/packages/ui/src/source-form-modal.tsx
@@ -2,8 +2,9 @@ import type {
 	MediaSourceInfo,
 	SafeMediaSource,
 } from "@solid-imager/core/domain/sources/schemas";
-import { createEffect, createSignal, Show } from "solid-js";
-import { createStore } from "solid-js/store";
+import { getErrorMessage } from "@solid-imager/core/utils";
+import { createForm } from "@tanstack/solid-form";
+import { createEffect, Show } from "solid-js";
 import { Button } from "./button";
 import {
 	Dialog,
@@ -13,6 +14,13 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "./dialog";
+import {
+	FormError,
+	FormFieldMessage,
+	getFormErrorMessage,
+	getFormSubmitError,
+} from "./form-message";
+import { createSourceFormSchema, type SourceFormValues } from "./form-schemas";
 import { Input } from "./input";
 import { Label } from "./label";
 import {
@@ -46,10 +54,9 @@ export type SourceFormSubmitData = Omit<
 export type SourceFormModalProps = {
 	isOpen: boolean;
 	onClose: () => void;
-	onSubmit: (data: SourceFormSubmitData) => void;
+	onSubmit: (data: SourceFormSubmitData) => void | Promise<void>;
 	editingSource?: MediaSourceInfo | SafeMediaSource | null;
 	initialValues?: SourceFormData;
-	validationRules?: (data: SourceFormData) => Record<string, string>;
 	sourceTypes?: SourceFormType[];
 	description?: string;
 	submitLabel?: string;
@@ -62,122 +69,196 @@ const SOURCE_TYPE_OPTIONS: { value: SourceFormType; label: string }[] = [
 ];
 
 const SOURCE_TYPE_VALUES = SOURCE_TYPE_OPTIONS.map(
-	(o) => o.value,
+	(option) => option.value,
 ) as readonly SourceFormType[];
 
 const getTypeLabel = (type: SourceFormType) =>
 	SOURCE_TYPE_OPTIONS.find((option) => option.value === type)?.label ?? type;
 
-export function defaultSourceFormValidationRules(
-	data: SourceFormData,
-	editingSource?: MediaSourceInfo | SafeMediaSource | null,
-) {
-	const errors: Record<string, string> = {};
-	if (!data.name.trim()) {
-		errors.name = "Name is required";
-	}
+function emptySourceFormValues(type: SourceFormType): SourceFormValues {
+	return {
+		name: "",
+		description: "",
+		type,
+		path: "",
+		host: "",
+		port: DEFAULT_SFTP_PORT,
+		username: "",
+		password: "",
+		remotePath: "",
+		bucket: "",
+		region: "",
+		accessKeyId: "",
+		secretAccessKey: "",
+		prefix: "",
+	};
+}
 
-	if (data.type === "local") {
-		if (!data.connectionInfo.path) {
-			errors.path = "Path is required";
-		}
-	} else if (data.type === "sftp") {
-		if (!data.connectionInfo.host) {
-			errors.host = "Host is required";
-		}
-		if (!data.connectionInfo.username) {
-			errors.username = "Username is required";
-		}
-		if (!data.connectionInfo.remotePath) {
-			errors.remotePath = "Remote path is required";
-		}
-	} else if (data.type === "s3") {
-		if (!data.connectionInfo.bucket) {
-			errors.bucket = "Bucket is required";
-		}
-		if (!data.connectionInfo.region) {
-			errors.region = "Region is required";
-		}
-		if (!editingSource) {
-			if (!data.connectionInfo.accessKeyId) {
-				errors.accessKeyId = "Access Key ID is required";
-			}
-			if (!data.connectionInfo.secretAccessKey) {
-				errors.secretAccessKey = "Secret Access Key is required";
-			}
-		}
+function valuesFromSource(
+	source: MediaSourceInfo | SafeMediaSource,
+): SourceFormValues {
+	const values = emptySourceFormValues(source.type);
+	values.name = source.name;
+	values.description = source.description ?? "";
+	const connection = source.connectionInfo;
+	if ("path" in connection) {
+		values.path = connection.path;
 	}
+	if ("host" in connection) {
+		values.host = connection.host;
+		values.port = connection.port;
+		values.username = connection.username;
+		values.password =
+			"password" in connection ? (connection.password ?? "") : "";
+		values.remotePath = connection.remotePath;
+	}
+	if ("bucket" in connection) {
+		values.bucket = connection.bucket;
+		values.region = connection.region;
+		values.accessKeyId =
+			"accessKeyId" in connection ? connection.accessKeyId : "";
+		values.secretAccessKey =
+			"secretAccessKey" in connection ? connection.secretAccessKey : "";
+		values.prefix = connection.prefix ?? "";
+	}
+	return values;
+}
 
-	return errors;
+function valuesFromInitial(
+	initial: SourceFormData,
+	fallbackType: SourceFormType,
+): SourceFormValues {
+	const values = emptySourceFormValues(initial.type ?? fallbackType);
+	values.name = initial.name;
+	values.description = initial.description;
+	for (const key of [
+		"path",
+		"host",
+		"username",
+		"password",
+		"remotePath",
+		"bucket",
+		"region",
+		"accessKeyId",
+		"secretAccessKey",
+		"prefix",
+	] as const) {
+		const value = initial.connectionInfo[key];
+		values[key] = typeof value === "string" ? value : "";
+	}
+	const port = initial.connectionInfo.port;
+	values.port = typeof port === "number" ? port : DEFAULT_SFTP_PORT;
+	return values;
+}
+
+export function toSourceFormSubmitData(
+	values: SourceFormValues,
+): SourceFormSubmitData {
+	let connectionInfo: Record<string, string | number | undefined>;
+	if (values.type === "local") {
+		connectionInfo = { path: values.path };
+	} else if (values.type === "sftp") {
+		connectionInfo = {
+			host: values.host,
+			port: values.port,
+			username: values.username,
+			password: values.password || undefined,
+			remotePath: values.remotePath,
+		};
+	} else {
+		connectionInfo = {
+			bucket: values.bucket,
+			region: values.region,
+			accessKeyId: values.accessKeyId || undefined,
+			secretAccessKey: values.secretAccessKey || undefined,
+			prefix: values.prefix || undefined,
+		};
+	}
+	return {
+		name: values.name.trim(),
+		description: values.description.trim() || null,
+		type: values.type,
+		connectionInfo,
+	};
+}
+
+type SourceTextInputProps = {
+	id: string;
+	label: string;
+	value: string;
+	errors: unknown[];
+	onBlur: () => void;
+	onChange: (value: string) => void;
+	placeholder?: string;
+	type?: "text" | "password";
+};
+
+function SourceTextInput(props: SourceTextInputProps) {
+	return (
+		<div class="space-y-2">
+			<Label for={props.id}>{props.label}</Label>
+			<Input
+				aria-describedby={`${props.id}-error`}
+				aria-invalid={props.errors.length > 0}
+				id={props.id}
+				onBlur={props.onBlur}
+				onInput={(event) => props.onChange(event.currentTarget.value)}
+				placeholder={props.placeholder}
+				type={props.type ?? "text"}
+				value={props.value}
+			/>
+			<FormFieldMessage
+				id={`${props.id}-error`}
+				message={getFormErrorMessage(props.errors[0])}
+			/>
+		</div>
+	);
 }
 
 export function SourceFormModal(props: SourceFormModalProps) {
 	const sourceTypes = () => props.sourceTypes ?? ["local", "sftp", "s3"];
-	const emptyValues = (): SourceFormData => ({
-		name: "",
-		description: "",
-		type: sourceTypes()[0] ?? "local",
-		connectionInfo: {},
-	});
-
-	const [formData, setFormData] = createStore<SourceFormData>(emptyValues());
-	const [errors, setErrors] = createSignal<Record<string, string>>({});
+	const defaultValues = () => {
+		const fallbackType = sourceTypes()[0] ?? "local";
+		if (props.initialValues) {
+			return valuesFromInitial(props.initialValues, fallbackType);
+		}
+		if (props.editingSource) {
+			return valuesFromSource(props.editingSource);
+		}
+		return emptySourceFormValues(fallbackType);
+	};
+	const form = createForm(() => ({
+		defaultValues: defaultValues(),
+		validators: { onSubmit: createSourceFormSchema(!props.editingSource) },
+		onSubmit: async ({ value }) => {
+			form.setErrorMap({ onSubmit: undefined });
+			try {
+				await props.onSubmit(toSourceFormSubmitData(value));
+			} catch (error) {
+				form.setErrorMap({
+					onSubmit: { form: getErrorMessage(error), fields: {} },
+				});
+			}
+		},
+	}));
 
 	createEffect(() => {
-		if (props.initialValues) {
-			setFormData(props.initialValues);
-		} else if (props.editingSource) {
-			setFormData({
-				name: props.editingSource.name,
-				description: props.editingSource.description || "",
-				type: props.editingSource.type as SourceFormType,
-				connectionInfo:
-					(props.editingSource.connectionInfo as Record<
-						string,
-						string | number
-					>) || {},
-			});
-		} else {
-			setFormData(emptyValues());
+		if (props.isOpen) {
+			form.reset(defaultValues());
 		}
-		setErrors({});
 	});
-
-	const validate = () => {
-		const nextErrors = props.validationRules
-			? props.validationRules(formData)
-			: defaultSourceFormValidationRules(formData, props.editingSource);
-
-		setErrors(nextErrors);
-		return Object.keys(nextErrors).length === 0;
-	};
-
-	const handleSubmit = (event: Event) => {
-		event.preventDefault();
-		if (!validate()) {
-			return;
-		}
-		const connectionInfo: Record<string, string | number | undefined> = {
-			...formData.connectionInfo,
-			port: formData.connectionInfo.port
-				? Number(formData.connectionInfo.port)
-				: undefined,
-		};
-
-		props.onSubmit({
-			...formData,
-			description: formData.description || null,
-			connectionInfo,
-		});
-	};
 
 	const selectOptions = () =>
 		SOURCE_TYPE_OPTIONS.filter((option) =>
 			sourceTypes().includes(option.value),
 		);
+	const fieldError = (errors: unknown[]) => getFormErrorMessage(errors[0]);
 
 	return (
-		<Dialog onOpenChange={() => props.onClose()} open={props.isOpen}>
+		<Dialog
+			onOpenChange={(open) => !open && props.onClose()}
+			open={props.isOpen}
+		>
 			<DialogContent class="sm:max-w-[500px]">
 				<DialogHeader>
 					<DialogTitle>
@@ -189,288 +270,291 @@ export function SourceFormModal(props: SourceFormModalProps) {
 					</DialogDescription>
 				</DialogHeader>
 
-				<form class="space-y-4" onSubmit={handleSubmit}>
-					<div class="space-y-2">
-						<Label for="name">Name</Label>
-						<Input
-							id="name"
-							onInput={(event) =>
-								setFormData("name", event.currentTarget.value)
-							}
-							placeholder="My Media Source"
-							value={formData.name}
-						/>
-						<Show when={errors().name}>
-							<p class="text-red-500 text-sm">{errors().name}</p>
-						</Show>
-					</div>
+				<form
+					class="space-y-4"
+					onSubmit={(event) => {
+						event.preventDefault();
+						event.stopPropagation();
+						void form.handleSubmit();
+					}}
+				>
+					<form.Field name="name">
+						{(field) => (
+							<div class="space-y-2">
+								<Label for={field().name}>Name</Label>
+								<Input
+									aria-describedby={`${field().name}-error`}
+									aria-invalid={field().state.meta.errors.length > 0}
+									id={field().name}
+									onBlur={field().handleBlur}
+									onInput={(event) =>
+										field().handleChange(event.currentTarget.value)
+									}
+									placeholder="My Media Source"
+									value={field().state.value}
+								/>
+								<FormFieldMessage
+									id={`${field().name}-error`}
+									message={fieldError(field().state.meta.errors)}
+								/>
+							</div>
+						)}
+					</form.Field>
 
-					<div class="space-y-2">
-						<Label for="description">Description (Optional)</Label>
-						<Input
-							id="description"
-							onInput={(event) =>
-								setFormData("description", event.currentTarget.value)
-							}
-							placeholder="Photos from my camera"
-							value={formData.description}
-						/>
-					</div>
+					<form.Field name="description">
+						{(field) => (
+							<div class="space-y-2">
+								<Label for={field().name}>Description (Optional)</Label>
+								<Input
+									id={field().name}
+									onBlur={field().handleBlur}
+									onInput={(event) =>
+										field().handleChange(event.currentTarget.value)
+									}
+									placeholder="Photos from my camera"
+									value={field().state.value}
+								/>
+							</div>
+						)}
+					</form.Field>
 
 					<Show when={sourceTypes().length > 1}>
-						<div class="space-y-2">
-							<Label>Type</Label>
-							<Select
-								itemComponent={(itemProps) => (
-									<SelectItem item={itemProps.item}>
-										{itemProps.item.rawValue.label}
-									</SelectItem>
-								)}
-								onChange={(value) =>
-									setFormData(
-										"type",
-										parseSelectValue(value?.value, SOURCE_TYPE_VALUES, "local"),
-									)
-								}
-								options={selectOptions()}
-								value={{
-									value: formData.type,
-									label: getTypeLabel(formData.type),
-								}}
-							>
-								<SelectTrigger>
-									<SelectValue<{ value: string; label: string }>>
-										{(state) => state.selectedOption().label}
-									</SelectValue>
-								</SelectTrigger>
-								<SelectContent />
-							</Select>
-						</div>
+						<form.Field name="type">
+							{(field) => (
+								<div class="space-y-2">
+									<Label>Type</Label>
+									<Select
+										itemComponent={(itemProps) => (
+											<SelectItem item={itemProps.item}>
+												{itemProps.item.rawValue.label}
+											</SelectItem>
+										)}
+										onChange={(value) =>
+											field().handleChange(
+												parseSelectValue(
+													value?.value,
+													SOURCE_TYPE_VALUES,
+													"local",
+												),
+											)
+										}
+										options={selectOptions()}
+										value={{
+											value: field().state.value,
+											label: getTypeLabel(field().state.value),
+										}}
+									>
+										<SelectTrigger>
+											<SelectValue<{ value: string; label: string }>>
+												{(state) => state.selectedOption().label}
+											</SelectValue>
+										</SelectTrigger>
+										<SelectContent />
+									</Select>
+								</div>
+							)}
+						</form.Field>
 					</Show>
 
-					<div class="space-y-4 rounded-md border p-4">
-						<h4 class="font-medium text-sm">Connection Details</h4>
+					<form.Subscribe selector={(state) => state.values.type}>
+						{(type) => (
+							<div class="space-y-4 rounded-md border p-4">
+								<h4 class="font-medium text-sm">Connection Details</h4>
+								<Show when={type() === "local"}>
+									<form.Field name="path">
+										{(field) => (
+											<SourceTextInput
+												errors={field().state.meta.errors}
+												id={field().name}
+												label="Directory Path"
+												onBlur={field().handleBlur}
+												onChange={field().handleChange}
+												placeholder="/mnt/data/photos"
+												value={field().state.value}
+											/>
+										)}
+									</form.Field>
+								</Show>
+								<Show when={type() === "sftp"}>
+									<div class="grid gap-4 sm:grid-cols-2">
+										<form.Field name="host">
+											{(field) => (
+												<SourceTextInput
+													errors={field().state.meta.errors}
+													id={field().name}
+													label="Host"
+													onBlur={field().handleBlur}
+													onChange={field().handleChange}
+													placeholder="192.168.1.10"
+													value={field().state.value}
+												/>
+											)}
+										</form.Field>
+										<form.Field name="port">
+											{(field) => (
+												<div class="space-y-2">
+													<Label for={field().name}>Port</Label>
+													<Input
+														id={field().name}
+														min="1"
+														onBlur={field().handleBlur}
+														onInput={(event) =>
+															field().handleChange(
+																event.currentTarget.valueAsNumber,
+															)
+														}
+														type="number"
+														value={field().state.value}
+													/>
+													<FormFieldMessage
+														id={`${field().name}-error`}
+														message={fieldError(field().state.meta.errors)}
+													/>
+												</div>
+											)}
+										</form.Field>
+									</div>
+									<form.Field name="username">
+										{(field) => (
+											<SourceTextInput
+												errors={field().state.meta.errors}
+												id={field().name}
+												label="Username"
+												onBlur={field().handleBlur}
+												onChange={field().handleChange}
+												placeholder="user"
+												value={field().state.value}
+											/>
+										)}
+									</form.Field>
+									<form.Field name="password">
+										{(field) => (
+											<SourceTextInput
+												errors={field().state.meta.errors}
+												id={field().name}
+												label="Password (Optional)"
+												onBlur={field().handleBlur}
+												onChange={field().handleChange}
+												placeholder="********"
+												type="password"
+												value={field().state.value}
+											/>
+										)}
+									</form.Field>
+									<form.Field name="remotePath">
+										{(field) => (
+											<SourceTextInput
+												errors={field().state.meta.errors}
+												id={field().name}
+												label="Remote Path"
+												onBlur={field().handleBlur}
+												onChange={field().handleChange}
+												placeholder="/home/user/photos"
+												value={field().state.value}
+											/>
+										)}
+									</form.Field>
+								</Show>
+								<Show when={type() === "s3"}>
+									<div class="grid gap-4 sm:grid-cols-2">
+										<form.Field name="bucket">
+											{(field) => (
+												<SourceTextInput
+													errors={field().state.meta.errors}
+													id={field().name}
+													label="Bucket"
+													onBlur={field().handleBlur}
+													onChange={field().handleChange}
+													placeholder="my-bucket"
+													value={field().state.value}
+												/>
+											)}
+										</form.Field>
+										<form.Field name="region">
+											{(field) => (
+												<SourceTextInput
+													errors={field().state.meta.errors}
+													id={field().name}
+													label="Region"
+													onBlur={field().handleBlur}
+													onChange={field().handleChange}
+													placeholder="us-east-1"
+													value={field().state.value}
+												/>
+											)}
+										</form.Field>
+									</div>
+									<form.Field name="accessKeyId">
+										{(field) => (
+											<SourceTextInput
+												errors={field().state.meta.errors}
+												id={field().name}
+												label="Access Key ID"
+												onBlur={field().handleBlur}
+												onChange={field().handleChange}
+												placeholder="AKIA..."
+												value={field().state.value}
+											/>
+										)}
+									</form.Field>
+									<form.Field name="secretAccessKey">
+										{(field) => (
+											<SourceTextInput
+												errors={field().state.meta.errors}
+												id={field().name}
+												label="Secret Access Key"
+												onBlur={field().handleBlur}
+												onChange={field().handleChange}
+												placeholder="********"
+												type="password"
+												value={field().state.value}
+											/>
+										)}
+									</form.Field>
+									<form.Field name="prefix">
+										{(field) => (
+											<SourceTextInput
+												errors={field().state.meta.errors}
+												id={field().name}
+												label="Prefix (Optional)"
+												onBlur={field().handleBlur}
+												onChange={field().handleChange}
+												placeholder="photos/"
+												value={field().state.value}
+											/>
+										)}
+									</form.Field>
+								</Show>
+							</div>
+						)}
+					</form.Subscribe>
 
-						<Show when={formData.type === "local"}>
-							<div class="space-y-2">
-								<Label for="path">Directory Path</Label>
-								<Input
-									id="path"
-									onInput={(event) =>
-										setFormData(
-											"connectionInfo",
-											"path",
-											event.currentTarget.value,
-										)
-									}
-									placeholder="/mnt/data/photos"
-									value={(formData.connectionInfo.path as string) || ""}
-								/>
-								<Show when={errors().path}>
-									<p class="text-red-500 text-sm">{errors().path}</p>
-								</Show>
-							</div>
-						</Show>
-
-						<Show when={formData.type === "sftp"}>
-							<div class="grid gap-4 sm:grid-cols-2">
-								<div class="space-y-2">
-									<Label for="host">Host</Label>
-									<Input
-										id="host"
-										onInput={(event) =>
-											setFormData(
-												"connectionInfo",
-												"host",
-												event.currentTarget.value,
-											)
-										}
-										placeholder="192.168.1.10"
-										value={(formData.connectionInfo.host as string) || ""}
-									/>
-									<Show when={errors().host}>
-										<p class="text-red-500 text-sm">{errors().host}</p>
-									</Show>
-								</div>
-								<div class="space-y-2">
-									<Label for="port">Port</Label>
-									<Input
-										id="port"
-										onInput={(event) =>
-											setFormData(
-												"connectionInfo",
-												"port",
-												event.currentTarget.value,
-											)
-										}
-										placeholder="22"
-										type="number"
-										value={formData.connectionInfo.port || DEFAULT_SFTP_PORT}
-									/>
-								</div>
-							</div>
-							<div class="space-y-2">
-								<Label for="username">Username</Label>
-								<Input
-									id="username"
-									onInput={(event) =>
-										setFormData(
-											"connectionInfo",
-											"username",
-											event.currentTarget.value,
-										)
-									}
-									placeholder="user"
-									value={(formData.connectionInfo.username as string) || ""}
-								/>
-								<Show when={errors().username}>
-									<p class="text-red-500 text-sm">{errors().username}</p>
-								</Show>
-							</div>
-							<div class="space-y-2">
-								<Label for="password">Password (Optional)</Label>
-								<Input
-									id="password"
-									onInput={(event) =>
-										setFormData(
-											"connectionInfo",
-											"password",
-											event.currentTarget.value,
-										)
-									}
-									placeholder="********"
-									type="password"
-									value={(formData.connectionInfo.password as string) || ""}
-								/>
-							</div>
-							<div class="space-y-2">
-								<Label for="remotePath">Remote Path</Label>
-								<Input
-									id="remotePath"
-									onInput={(event) =>
-										setFormData(
-											"connectionInfo",
-											"remotePath",
-											event.currentTarget.value,
-										)
-									}
-									placeholder="/home/user/photos"
-									value={(formData.connectionInfo.remotePath as string) || ""}
-								/>
-								<Show when={errors().remotePath}>
-									<p class="text-red-500 text-sm">{errors().remotePath}</p>
-								</Show>
-							</div>
-						</Show>
-
-						<Show when={formData.type === "s3"}>
-							<div class="grid gap-4 sm:grid-cols-2">
-								<div class="space-y-2">
-									<Label for="bucket">Bucket</Label>
-									<Input
-										id="bucket"
-										onInput={(event) =>
-											setFormData(
-												"connectionInfo",
-												"bucket",
-												event.currentTarget.value,
-											)
-										}
-										placeholder="my-bucket"
-										value={(formData.connectionInfo.bucket as string) || ""}
-									/>
-									<Show when={errors().bucket}>
-										<p class="text-red-500 text-sm">{errors().bucket}</p>
-									</Show>
-								</div>
-								<div class="space-y-2">
-									<Label for="region">Region</Label>
-									<Input
-										id="region"
-										onInput={(event) =>
-											setFormData(
-												"connectionInfo",
-												"region",
-												event.currentTarget.value,
-											)
-										}
-										placeholder="us-east-1"
-										value={(formData.connectionInfo.region as string) || ""}
-									/>
-									<Show when={errors().region}>
-										<p class="text-red-500 text-sm">{errors().region}</p>
-									</Show>
-								</div>
-							</div>
-							<div class="space-y-2">
-								<Label for="accessKeyId">Access Key ID</Label>
-								<Input
-									id="accessKeyId"
-									onInput={(event) =>
-										setFormData(
-											"connectionInfo",
-											"accessKeyId",
-											event.currentTarget.value,
-										)
-									}
-									placeholder="AKIA..."
-									value={(formData.connectionInfo.accessKeyId as string) || ""}
-								/>
-								<Show when={errors().accessKeyId}>
-									<p class="text-red-500 text-sm">{errors().accessKeyId}</p>
-								</Show>
-							</div>
-							<div class="space-y-2">
-								<Label for="secretAccessKey">Secret Access Key</Label>
-								<Input
-									id="secretAccessKey"
-									onInput={(event) =>
-										setFormData(
-											"connectionInfo",
-											"secretAccessKey",
-											event.currentTarget.value,
-										)
-									}
-									placeholder="********"
-									type="password"
-									value={
-										(formData.connectionInfo.secretAccessKey as string) || ""
-									}
-								/>
-								<Show when={errors().secretAccessKey}>
-									<p class="text-red-500 text-sm">{errors().secretAccessKey}</p>
-								</Show>
-							</div>
-							<div class="space-y-2">
-								<Label for="prefix">Prefix (Optional)</Label>
-								<Input
-									id="prefix"
-									onInput={(event) =>
-										setFormData(
-											"connectionInfo",
-											"prefix",
-											event.currentTarget.value,
-										)
-									}
-									placeholder="photos/"
-									value={(formData.connectionInfo.prefix as string) || ""}
-								/>
-							</div>
-						</Show>
-					</div>
+					<form.Subscribe selector={(state) => state.errorMap.onSubmit}>
+						{(error) => <FormError message={getFormSubmitError(error())} />}
+					</form.Subscribe>
 
 					<DialogFooter>
-						<Button
-							onClick={() => props.onClose()}
-							type="button"
-							variant="outline"
-						>
+						<Button onClick={props.onClose} type="button" variant="outline">
 							Cancel
 						</Button>
-						<Button type="submit">
-							{props.submitLabel ??
-								(props.editingSource ? "Save Changes" : "Add Source")}
-						</Button>
+						<form.Subscribe
+							selector={(state) => ({
+								canSubmit: state.canSubmit,
+								isSubmitting: state.isSubmitting,
+							})}
+						>
+							{(state) => (
+								<Button
+									disabled={!state().canSubmit || state().isSubmitting}
+									type="submit"
+								>
+									{state().isSubmitting
+										? "Saving..."
+										: (props.submitLabel ??
+											(props.editingSource ? "Save Changes" : "Add Source"))}
+								</Button>
+							)}
+						</form.Subscribe>
 					</DialogFooter>
 				</form>
 			</DialogContent>

--- a/packages/ui/src/upload-media-modal.tsx
+++ b/packages/ui/src/upload-media-modal.tsx
@@ -1,4 +1,5 @@
 import { getErrorMessage } from "@solid-imager/core/utils";
+import { createForm } from "@tanstack/solid-form";
 import { createEffect, createSignal, For, on, onCleanup, Show } from "solid-js";
 import { z } from "zod";
 import { Button } from "./button";
@@ -10,6 +11,13 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "./dialog";
+import {
+	FormError,
+	FormFieldMessage,
+	getFormErrorMessage,
+	getFormSubmitError,
+} from "./form-message";
+import { type UploadFormValues, uploadFormSchema } from "./form-schemas";
 import { Input } from "./input";
 import { Label } from "./label";
 
@@ -72,6 +80,13 @@ const resolutionOptions: Array<{
 	},
 ];
 
+const EMPTY_UPLOAD_FORM: UploadFormValues = {
+	filename: "",
+	description: "",
+	sourceUrl: "",
+	conflictResolution: "skip",
+};
+
 function fileSizeLabel(file: File) {
 	if (file.size < 1024) {
 		return `${file.size} B`;
@@ -84,24 +99,58 @@ function fileSizeLabel(file: File) {
 
 export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
 	const [selectedFiles, setSelectedFiles] = createSignal<File[]>([]);
-	const [filename, setFilename] = createSignal("");
-	const [description, setDescription] = createSignal("");
-	const [sourceUrl, setSourceUrl] = createSignal("");
-	const [conflictResolution, setConflictResolution] =
-		createSignal<UploadConflictResolution>("skip");
 	const [isDragging, setIsDragging] = createSignal(false);
 	const [isFetchingUrl, setIsFetchingUrl] = createSignal(false);
 	const [lastFetchedUrl, setLastFetchedUrl] = createSignal<string | null>(null);
 	const [previewUrl, setPreviewUrl] = createSignal<string | null>(null);
-	const [error, setError] = createSignal<string | null>(null);
-	const [isSubmitting, setIsSubmitting] = createSignal(false);
+	const [asyncError, setAsyncError] = createSignal<string | null>(null);
 	let fileInputRef: HTMLInputElement | undefined;
+
+	const form = createForm(() => ({
+		defaultValues: EMPTY_UPLOAD_FORM,
+		validators: { onSubmit: uploadFormSchema },
+		onSubmit: async ({ value }) => {
+			const files = selectedFiles();
+			if (files.length === 0) {
+				form.setErrorMap({
+					onSubmit: {
+						form: "アップロードするファイルがありません。",
+						fields: {},
+					},
+				});
+				return;
+			}
+
+			form.setErrorMap({ onSubmit: undefined });
+			setAsyncError(null);
+			try {
+				const resolution = value.conflictResolution;
+				await props.onUploadStart({
+					files,
+					filename: value.filename,
+					description: value.description,
+					sourceUrl: value.sourceUrl || undefined,
+					conflictResolution: resolution,
+					overwrite: resolution === "overwrite",
+					autoIncrement: resolution === "rename",
+				});
+				props.onClose();
+			} catch (submitError) {
+				form.setErrorMap({
+					onSubmit: {
+						form: getErrorMessage(submitError),
+						fields: {},
+					},
+				});
+			}
+		},
+	}));
 
 	const setFiles = (files: File[]) => {
 		setSelectedFiles(files);
 		props.onFilesSelected(files);
-		if (files[0] && !filename()) {
-			setFilename(files[0].name);
+		if (files[0] && !form.getFieldValue("filename")) {
+			form.setFieldValue("filename", files[0].name);
 		}
 	};
 
@@ -122,8 +171,8 @@ export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
 			(file) => {
 				if (file) {
 					setSelectedFiles([file]);
-					if (!filename()) {
-						setFilename(file.name);
+					if (!form.getFieldValue("filename")) {
+						form.setFieldValue("filename", file.name);
 					}
 				} else {
 					setSelectedFiles([]);
@@ -137,13 +186,13 @@ export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
 		on(
 			() => props.pastedUrl,
 			(url) => {
-				setSourceUrl(url || "");
+				form.setFieldValue("sourceUrl", url || "");
 			},
 		),
 	);
 
 	createEffect(() => {
-		const url = sourceUrl();
+		const url = form.state.values.sourceUrl;
 		if (
 			!(url && props.onFetchUrl && z.string().url().safeParse(url).success) ||
 			url === lastFetchedUrl()
@@ -159,17 +208,17 @@ export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
 		}
 		setIsFetchingUrl(true);
 		setLastFetchedUrl(url);
-		setError(null);
+		setAsyncError(null);
 		try {
 			const file = await props.onFetchUrl?.(url);
 			if (!file) {
 				return;
 			}
-			setFilename(file.name);
+			form.setFieldValue("filename", file.name);
 			setFiles([file]);
 			updatePreview(file);
 		} catch (fetchError) {
-			setError(getErrorMessage(fetchError));
+			setAsyncError(getErrorMessage(fetchError));
 		} finally {
 			setIsFetchingUrl(false);
 		}
@@ -179,45 +228,28 @@ export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
 		if (!(files && files.length > 0)) {
 			return;
 		}
-		setError(null);
+		setAsyncError(null);
 		const nextFiles = Array.from(files);
 		setFiles(nextFiles);
 		updatePreview(nextFiles[0] ?? null);
 	};
 
-	const handleSubmit = async () => {
-		const files = selectedFiles();
-		if (files.length === 0) {
-			setError("アップロードするファイルがありません。");
+	createEffect(() => {
+		if (!props.isOpen) {
 			return;
 		}
-
-		const resolvedFilename = filename() || files[0]?.name || "";
-		if (!resolvedFilename) {
-			setError("ファイル名を入力してください。");
-			return;
-		}
-
-		const resolution = conflictResolution();
-		setIsSubmitting(true);
-		setError(null);
-		try {
-			await props.onUploadStart({
-				files,
-				filename: resolvedFilename,
-				description: description(),
-				sourceUrl: sourceUrl() || undefined,
-				conflictResolution: resolution,
-				overwrite: resolution === "overwrite",
-				autoIncrement: resolution === "rename",
-			});
-			props.onClose();
-		} catch (submitError) {
-			setError(getErrorMessage(submitError));
-		} finally {
-			setIsSubmitting(false);
-		}
-	};
+		const initialFiles = props.initialFile ? [props.initialFile] : [];
+		setSelectedFiles(initialFiles);
+		props.onFilesSelected(initialFiles);
+		updatePreview(props.initialFile);
+		setLastFetchedUrl(null);
+		form.reset({
+			...EMPTY_UPLOAD_FORM,
+			filename: props.initialFile?.name ?? "",
+			sourceUrl: props.pastedUrl ?? "",
+		});
+		setAsyncError(null);
+	});
 
 	onCleanup(() => {
 		const currentPreview = previewUrl();
@@ -237,212 +269,279 @@ export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
 						</DialogDescription>
 					</DialogHeader>
 
-					<div class="grid gap-4 py-4">
-						<button
-							class={`rounded-lg border-2 border-dashed p-6 text-center transition-colors ${
-								isDragging() ? "border-primary bg-primary/5" : "border-muted"
-							}`}
-							onClick={() => fileInputRef?.click()}
-							onKeyDown={(event) => {
-								if (event.key === "Enter" || event.key === " ") {
+					<form
+						onSubmit={(event) => {
+							event.preventDefault();
+							event.stopPropagation();
+							void form.handleSubmit();
+						}}
+					>
+						<div class="grid gap-4 py-4">
+							<button
+								class={`rounded-lg border-2 border-dashed p-6 text-center transition-colors ${
+									isDragging() ? "border-primary bg-primary/5" : "border-muted"
+								}`}
+								onClick={() => fileInputRef?.click()}
+								onKeyDown={(event) => {
+									if (event.key === "Enter" || event.key === " ") {
+										event.preventDefault();
+										fileInputRef?.click();
+									}
+								}}
+								onDragEnter={(event) => {
 									event.preventDefault();
-									fileInputRef?.click();
-								}
-							}}
-							onDragEnter={(event) => {
-								event.preventDefault();
-								setIsDragging(true);
-							}}
-							onDragLeave={(event) => {
-								event.preventDefault();
-								setIsDragging(false);
-							}}
-							onDragOver={(event) => event.preventDefault()}
-							onDrop={(event) => {
-								event.preventDefault();
-								setIsDragging(false);
-								handleDroppedFiles(event.dataTransfer?.files);
-							}}
-							type="button"
-						>
-							<p class="font-medium text-sm">ファイルをドラッグ&ドロップ</p>
-							<p class="mt-1 text-muted-foreground text-xs">
-								またはファイル選択ダイアログから追加します。
-							</p>
-							<span class="mt-3 inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 font-medium text-sm ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50">
-								ファイルを選択
-							</span>
-						</button>
-						<input
-							class="hidden"
-							multiple
-							onChange={(event) => {
-								handleDroppedFiles(event.currentTarget.files);
-								event.currentTarget.value = "";
-							}}
-							ref={(element) => {
-								fileInputRef = element;
-							}}
-							type="file"
-						/>
-
-						<Show when={selectedFiles().length > 0}>
-							<div class="rounded-md border p-3">
-								<p class="mb-2 font-medium text-sm">選択中のファイル</p>
-								<ul class="space-y-2">
-									<For each={selectedFiles()}>
-										{(file) => (
-											<li class="flex items-center justify-between gap-3 text-sm">
-												<span class="truncate">{file.name}</span>
-												<span class="shrink-0 text-muted-foreground text-xs">
-													{fileSizeLabel(file)}
-												</span>
-											</li>
-										)}
-									</For>
-								</ul>
-							</div>
-						</Show>
-
-						<div class="grid gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
-							<Label class="sm:text-right" for="filename">
-								ファイル名
-							</Label>
-							<Input
-								class="sm:col-span-3"
-								id="filename"
-								onInput={(event) => setFilename(event.currentTarget.value)}
-								value={filename()}
+									setIsDragging(true);
+								}}
+								onDragLeave={(event) => {
+									event.preventDefault();
+									setIsDragging(false);
+								}}
+								onDragOver={(event) => event.preventDefault()}
+								onDrop={(event) => {
+									event.preventDefault();
+									setIsDragging(false);
+									handleDroppedFiles(event.dataTransfer?.files);
+								}}
+								type="button"
+							>
+								<p class="font-medium text-sm">ファイルをドラッグ&ドロップ</p>
+								<p class="mt-1 text-muted-foreground text-xs">
+									またはファイル選択ダイアログから追加します。
+								</p>
+								<span class="mt-3 inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 font-medium text-sm ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50">
+									ファイルを選択
+								</span>
+							</button>
+							<input
+								class="hidden"
+								multiple
+								onChange={(event) => {
+									handleDroppedFiles(event.currentTarget.files);
+									event.currentTarget.value = "";
+								}}
+								ref={(element) => {
+									fileInputRef = element;
+								}}
+								type="file"
 							/>
-						</div>
 
-						<div class="grid gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
-							<Label class="sm:text-right" for="description">
-								説明
-							</Label>
-							<Input
-								class="sm:col-span-3"
-								id="description"
-								onInput={(event) => setDescription(event.currentTarget.value)}
-								value={description()}
-							/>
-						</div>
-
-						<div class="grid gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
-							<Label class="sm:text-right" for="sourceUrl">
-								ソースURL
-							</Label>
-							<div class="relative sm:col-span-3">
-								<Input
-									disabled={isFetchingUrl()}
-									id="sourceUrl"
-									onInput={(event) => setSourceUrl(event.currentTarget.value)}
-									value={sourceUrl()}
-								/>
-								<Show when={isFetchingUrl()}>
-									<div class="-translate-y-1/2 absolute top-1/2 right-2 text-muted-foreground text-xs">
-										Loading...
-									</div>
-								</Show>
-							</div>
-							<Show when={previewUrl()}>
-								<div class="mt-2 flex justify-center sm:col-span-4">
-									<img
-										alt="Fetched preview"
-										class="max-h-48 rounded-md object-contain"
-										src={previewUrl() || undefined}
-									/>
+							<Show when={selectedFiles().length > 0}>
+								<div class="rounded-md border p-3">
+									<p class="mb-2 font-medium text-sm">選択中のファイル</p>
+									<ul class="space-y-2">
+										<For each={selectedFiles()}>
+											{(file) => (
+												<li class="flex items-center justify-between gap-3 text-sm">
+													<span class="truncate">{file.name}</span>
+													<span class="shrink-0 text-muted-foreground text-xs">
+														{fileSizeLabel(file)}
+													</span>
+												</li>
+											)}
+										</For>
+									</ul>
 								</div>
 							</Show>
-						</div>
 
-						<div class="space-y-2">
-							<Label>競合時の処理</Label>
-							<div class="grid gap-2 sm:grid-cols-3">
-								<For each={resolutionOptions}>
-									{(option) => (
-										<label class="rounded-md border p-3 text-sm has-[:checked]:border-primary has-[:checked]:bg-primary/5">
-											<div class="flex items-center gap-2">
-												<input
-													checked={conflictResolution() === option.value}
-													onChange={() => setConflictResolution(option.value)}
-													type="radio"
-												/>
-												<span class="font-medium">{option.label}</span>
-											</div>
-											<p class="mt-1 text-muted-foreground text-xs">
-												{option.description}
-											</p>
-										</label>
-									)}
-								</For>
-							</div>
-						</div>
-
-						<Show when={(props.conflicts?.length ?? 0) > 0}>
-							<div class="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-950 text-sm">
-								<p class="font-medium">同名ファイルがあります</p>
-								<ul class="mt-2 list-disc space-y-1 pl-5">
-									<For each={props.conflicts}>
-										{(conflict) => (
-											<li>
-												{conflict.filename}
-												<Show when={conflict.suggestedName}>
-													<span> → {conflict.suggestedName}</span>
-												</Show>
-											</li>
-										)}
-									</For>
-								</ul>
-							</div>
-						</Show>
-
-						<Show when={props.uploadProgress}>
-							{(progress) => (
-								<div class="rounded-md border p-3 text-sm">
-									<div class="flex justify-between gap-3">
-										<span>{progress().filename || "アップロード中"}</span>
-										<span class="text-muted-foreground">
-											{progress().status ||
-												(progress().total
-													? `${progress().current ?? 0}/${progress().total}`
-													: "処理中")}
-										</span>
+							<form.Field name="filename">
+								{(field) => (
+									<div class="grid gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
+										<Label class="sm:text-right" for={field().name}>
+											ファイル名
+										</Label>
+										<div class="space-y-2 sm:col-span-3">
+											<Input
+												aria-describedby={`${field().name}-error`}
+												aria-invalid={field().state.meta.errors.length > 0}
+												id={field().name}
+												onBlur={field().handleBlur}
+												onInput={(event) =>
+													field().handleChange(event.currentTarget.value)
+												}
+												value={field().state.value}
+											/>
+											<FormFieldMessage
+												id={`${field().name}-error`}
+												message={getFormErrorMessage(
+													field().state.meta.errors[0],
+												)}
+											/>
+										</div>
 									</div>
-									<div class="mt-2 h-2 overflow-hidden rounded bg-muted">
-										<div
-											class="h-full bg-primary transition-all"
-											style={{
-												width: (() => {
-													const total = progress().total;
-													return total
-														? `${Math.min(100, ((progress().current ?? 0) / total) * 100)}%`
-														: "35%";
-												})(),
-											}}
+								)}
+							</form.Field>
+
+							<form.Field name="description">
+								{(field) => (
+									<div class="grid gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
+										<Label class="sm:text-right" for={field().name}>
+											説明
+										</Label>
+										<Input
+											class="sm:col-span-3"
+											id={field().name}
+											onBlur={field().handleBlur}
+											onInput={(event) =>
+												field().handleChange(event.currentTarget.value)
+											}
+											value={field().state.value}
 										/>
 									</div>
+								)}
+							</form.Field>
+
+							<form.Field name="sourceUrl">
+								{(field) => (
+									<div class="grid gap-2 sm:grid-cols-4 sm:items-center sm:gap-4">
+										<Label class="sm:text-right" for={field().name}>
+											ソースURL
+										</Label>
+										<div class="relative space-y-2 sm:col-span-3">
+											<Input
+												aria-describedby={`${field().name}-error`}
+												aria-invalid={field().state.meta.errors.length > 0}
+												disabled={isFetchingUrl()}
+												id={field().name}
+												onBlur={field().handleBlur}
+												onInput={(event) =>
+													field().handleChange(event.currentTarget.value)
+												}
+												value={field().state.value}
+											/>
+											<Show when={isFetchingUrl()}>
+												<div class="-translate-y-1/2 absolute top-1/2 right-2 text-muted-foreground text-xs">
+													Loading...
+												</div>
+											</Show>
+											<FormFieldMessage
+												id={`${field().name}-error`}
+												message={getFormErrorMessage(
+													field().state.meta.errors[0],
+												)}
+											/>
+										</div>
+										<Show when={previewUrl()}>
+											<div class="mt-2 flex justify-center sm:col-span-4">
+												<img
+													alt="Fetched preview"
+													class="max-h-48 rounded-md object-contain"
+													src={previewUrl() || undefined}
+												/>
+											</div>
+										</Show>
+									</div>
+								)}
+							</form.Field>
+
+							<form.Field name="conflictResolution">
+								{(field) => (
+									<div class="space-y-2">
+										<Label>競合時の処理</Label>
+										<div class="grid gap-2 sm:grid-cols-3">
+											<For each={resolutionOptions}>
+												{(option) => (
+													<label class="rounded-md border p-3 text-sm has-[:checked]:border-primary has-[:checked]:bg-primary/5">
+														<div class="flex items-center gap-2">
+															<input
+																checked={field().state.value === option.value}
+																onChange={() =>
+																	field().handleChange(option.value)
+																}
+																type="radio"
+															/>
+															<span class="font-medium">{option.label}</span>
+														</div>
+														<p class="mt-1 text-muted-foreground text-xs">
+															{option.description}
+														</p>
+													</label>
+												)}
+											</For>
+										</div>
+									</div>
+								)}
+							</form.Field>
+
+							<Show when={(props.conflicts?.length ?? 0) > 0}>
+								<div class="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-950 text-sm">
+									<p class="font-medium">同名ファイルがあります</p>
+									<ul class="mt-2 list-disc space-y-1 pl-5">
+										<For each={props.conflicts}>
+											{(conflict) => (
+												<li>
+													{conflict.filename}
+													<Show when={conflict.suggestedName}>
+														<span> → {conflict.suggestedName}</span>
+													</Show>
+												</li>
+											)}
+										</For>
+									</ul>
 								</div>
-							)}
-						</Show>
+							</Show>
 
-						<Show when={error()}>
-							<p class="text-center text-red-500 text-sm">{error()}</p>
-						</Show>
-					</div>
+							<Show when={props.uploadProgress}>
+								{(progress) => (
+									<div class="rounded-md border p-3 text-sm">
+										<div class="flex justify-between gap-3">
+											<span>{progress().filename || "アップロード中"}</span>
+											<span class="text-muted-foreground">
+												{progress().status ||
+													(progress().total
+														? `${progress().current ?? 0}/${progress().total}`
+														: "処理中")}
+											</span>
+										</div>
+										<div class="mt-2 h-2 overflow-hidden rounded bg-muted">
+											<div
+												class="h-full bg-primary transition-all"
+												style={{
+													width: (() => {
+														const total = progress().total;
+														return total
+															? `${Math.min(100, ((progress().current ?? 0) / total) * 100)}%`
+															: "35%";
+													})(),
+												}}
+											/>
+										</div>
+									</div>
+								)}
+							</Show>
 
-					<DialogFooter>
-						<Button onClick={props.onClose} type="button" variant="outline">
-							キャンセル
-						</Button>
-						<Button
-							disabled={isSubmitting() || isFetchingUrl()}
-							onClick={() => void handleSubmit()}
-							type="button"
-						>
-							{isSubmitting() ? "アップロード中..." : "アップロード"}
-						</Button>
-					</DialogFooter>
+							<FormError message={asyncError()} />
+							<form.Subscribe selector={(state) => state.errorMap.onSubmit}>
+								{(error) => <FormError message={getFormSubmitError(error())} />}
+							</form.Subscribe>
+						</div>
+
+						<DialogFooter>
+							<Button onClick={props.onClose} type="button" variant="outline">
+								キャンセル
+							</Button>
+							<form.Subscribe
+								selector={(state) => ({
+									canSubmit: state.canSubmit,
+									isSubmitting: state.isSubmitting,
+								})}
+							>
+								{(state) => (
+									<Button
+										disabled={
+											!state().canSubmit ||
+											state().isSubmitting ||
+											isFetchingUrl()
+										}
+										type="submit"
+									>
+										{state().isSubmitting
+											? "アップロード中..."
+											: "アップロード"}
+									</Button>
+								)}
+							</form.Subscribe>
+						</DialogFooter>
+					</form>
 				</DialogContent>
 			</Show>
 		</Dialog>

--- a/packages/ui/src/upload-media-modal.tsx
+++ b/packages/ui/src/upload-media-modal.tsx
@@ -147,9 +147,11 @@ export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
 	}));
 
 	const setFiles = (files: File[]) => {
+		const previousAutoName = selectedFiles()[0]?.name;
 		setSelectedFiles(files);
 		props.onFilesSelected(files);
-		if (files[0] && !form.getFieldValue("filename")) {
+		const filename = form.getFieldValue("filename");
+		if (files[0] && (!filename || filename === previousAutoName)) {
 			form.setFieldValue("filename", files[0].name);
 		}
 	};
@@ -444,6 +446,7 @@ export function UploadMediaModalContent(props: UploadMediaModalContentProps) {
 														<div class="flex items-center gap-2">
 															<input
 																checked={field().state.value === option.value}
+																name={field().name}
 																onChange={() =>
 																	field().handleChange(option.value)
 																}


### PR DESCRIPTION
## 概要

Source・Upload・Config FormをTanStack Form v1とZod 4 Standard Schemaへ統合します。field、submit、server error、reset、dirty stateの扱いを共有化しました。

## 変更内容

- Configの型アサーションを除去し、AppConfigSchemaからvalidationを導出
- Source Formをtype別Zod schemaとTanStack Formへ移行
- Upload Formのmetadata・競合処理・submit stateをTanStack Formへ移行
- field error / form errorのaccessibleな共有表示を追加
- modal再オープン時reset、二重送信防止、server error表示を追加
- 未使用のTanStack Zod Form Adapterと旧Zod 3依存を削除
- schema unit testとSource / Upload / Config E2E assertionを追加

## 検証

- bun run --cwd packages/ui typecheck
- bun run --cwd packages/ui test（11 files / 49 tests）
- bun x biome check 対象変更ファイル
- git diff --check

focused E2Eは既存のNitro vite対話インストール問題によりapp起動前に停止しました。Vite+ checkとServer/Tauri typecheckの既知のroute tree・環境型問題もIssueコメントへ記録しています。

fixes #589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ソース追加・メディアアップロード画面の入力フォームを刷新し、入力内容に応じたバリデーションを追加しました。
  - フィールドごとのエラーや送信エラーを、より分かりやすく表示します。
  - ソース種別に応じて必要な入力項目を自動的に確認します。
- **改善**
  - 設定保存時の入力チェックを強化し、不正な値では保存できないようにしました。
  - フォームの再表示時に、入力内容やエラー状態が適切にリセットされます。
  - 保存・アップロード失敗時の通知とエラー表示を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->