### PR TITLE
feat(search): move CCIP similarity to pgvector

### DIFF
--- a/apps/server/drizzle/0018_charming_korvac.sql
+++ b/apps/server/drizzle/0018_charming_korvac.sql
@@ -1,0 +1,44 @@
+CREATE EXTENSION IF NOT EXISTS vector;--> statement-breakpoint
+CREATE TYPE "public"."media_region_kind" AS ENUM('full', 'person', 'manual');--> statement-breakpoint
+CREATE TABLE "ccip_embeddings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"region_id" uuid NOT NULL,
+	"embedding" vector(768) NOT NULL,
+	"model" text NOT NULL,
+	"embedding_version" integer NOT NULL,
+	"media_modified_at" timestamp NOT NULL,
+	"extracted_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_ccip_embeddings_region_model_version" UNIQUE("region_id","model","embedding_version")
+);
+--> statement-breakpoint
+CREATE TABLE "media_regions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"media_id" uuid NOT NULL,
+	"kind" "media_region_kind" NOT NULL,
+	"x" real,
+	"y" real,
+	"width" real,
+	"height" real,
+	"source_modified_at" timestamp NOT NULL,
+	"detector" text,
+	"detector_version" text,
+	"score" real,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "media_regions_bbox_by_kind" CHECK ((
+				("media_regions"."kind" = 'full' AND "media_regions"."x" IS NULL AND "media_regions"."y" IS NULL AND "media_regions"."width" IS NULL AND "media_regions"."height" IS NULL)
+				OR
+				("media_regions"."kind" <> 'full' AND "media_regions"."x" IS NOT NULL AND "media_regions"."y" IS NOT NULL AND "media_regions"."width" IS NOT NULL AND "media_regions"."height" IS NOT NULL
+					AND "media_regions"."x" >= 0 AND "media_regions"."y" >= 0 AND "media_regions"."width" > 0 AND "media_regions"."height" > 0
+					AND "media_regions"."x" + "media_regions"."width" <= 1 AND "media_regions"."y" + "media_regions"."height" <= 1)
+			)),
+	CONSTRAINT "media_regions_score_range" CHECK ("media_regions"."score" IS NULL OR ("media_regions"."score" >= 0 AND "media_regions"."score" <= 1))
+);
+--> statement-breakpoint
+ALTER TABLE "ccip_embeddings" ADD CONSTRAINT "ccip_embeddings_region_id_media_regions_id_fk" FOREIGN KEY ("region_id") REFERENCES "public"."media_regions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "media_regions" ADD CONSTRAINT "media_regions_media_id_media_id_fk" FOREIGN KEY ("media_id") REFERENCES "public"."media"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_ccip_embeddings_region_id" ON "ccip_embeddings" USING btree ("region_id");--> statement-breakpoint
+CREATE INDEX "idx_media_regions_media_id" ON "media_regions" USING btree ("media_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_media_regions_full_media_id" ON "media_regions" USING btree ("media_id") WHERE "media_regions"."kind" = 'full';

--- a/apps/server/drizzle/meta/0018_snapshot.json
+++ b/apps/server/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,3278 @@
+{
+  "id": "2453ddc4-ac38-4eb3-bbb2-5a74f621fbfa",
+  "prevId": "1928bf68-5088-4c28-9755-00116d14c19c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.author_accounts": {
+      "name": "author_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "author_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_author_accounts_author_id": {
+          "name": "idx_author_accounts_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_author_accounts_platform_account_unique": {
+          "name": "idx_author_accounts_platform_account_unique",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "author_accounts_author_id_authors_id_fk": {
+          "name": "author_accounts_author_id_authors_id_fk",
+          "tableFrom": "author_accounts",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_authors_account_id": {
+          "name": "idx_authors_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authors_name": {
+          "name": "idx_authors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#808080'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ccip_embeddings": {
+      "name": "ccip_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_version": {
+          "name": "embedding_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_modified_at": {
+          "name": "media_modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ccip_embeddings_region_id": {
+          "name": "idx_ccip_embeddings_region_id",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ccip_embeddings_region_id_media_regions_id_fk": {
+          "name": "ccip_embeddings_region_id_media_regions_id_fk",
+          "tableFrom": "ccip_embeddings",
+          "tableTo": "media_regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_ccip_embeddings_region_model_version": {
+          "name": "uq_ccip_embeddings_region_model_version",
+          "nullsNotDistinct": false,
+          "columns": [
+            "region_id",
+            "model",
+            "embedding_version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_ips": {
+      "name": "character_ips",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_id": {
+          "name": "ip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_character_ips_ip_id_character_id": {
+          "name": "idx_character_ips_ip_id_character_id",
+          "columns": [
+            {
+              "expression": "ip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_ips_character_id_characters_id_fk": {
+          "name": "character_ips_character_id_characters_id_fk",
+          "tableFrom": "character_ips",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_ips_ip_id_ips_id_fk": {
+          "name": "character_ips_ip_id_ips_id_fk",
+          "tableFrom": "character_ips",
+          "tableTo": "ips",
+          "columnsFrom": [
+            "ip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "character_ips_character_id_ip_id_pk": {
+          "name": "character_ips_character_id_ip_id_pk",
+          "columns": [
+            "character_id",
+            "ip_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "characters_name_unique": {
+          "name": "characters_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ips": {
+      "name": "ips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ips_name_unique": {
+          "name": "ips_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_pending_created": {
+          "name": "idx_jobs_pending_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending' AND \"jobs\".\"type\" <> 'import_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_pending_type_created": {
+          "name": "idx_jobs_pending_type_created",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending' AND \"jobs\".\"type\" <> 'import_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_pending_lancedb_source": {
+          "name": "idx_jobs_pending_lancedb_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending'\n\t\t\t\t\tAND \"jobs\".\"type\" IN ('sync_lancedb', 'sync_lancedb_full', 'sync_lancedb_delta')\n\t\t\t\t\tAND \"jobs\".\"source_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_active_lancedb_source": {
+          "name": "idx_jobs_active_lancedb_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'in_progress'\n\t\t\t\t\tAND \"jobs\".\"type\" IN ('sync_lancedb', 'sync_lancedb_full', 'sync_lancedb_delta')\n\t\t\t\t\tAND \"jobs\".\"source_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_source_id_media_sources_id_fk": {
+          "name": "jobs_source_id_media_sources_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "jobs_parent_id_jobs_id_fk": {
+          "name": "jobs_parent_id_jobs_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lancedb_sync_dirty": {
+      "name": "lancedb_sync_dirty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upsert'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_lancedb_sync_dirty_source_updated": {
+          "name": "idx_lancedb_sync_dirty_source_updated",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lancedb_sync_dirty_source_id_media_sources_id_fk": {
+          "name": "lancedb_sync_dirty_source_id_media_sources_id_fk",
+          "tableFrom": "lancedb_sync_dirty",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lancedb_sync_dirty_source_media_unique": {
+          "name": "lancedb_sync_dirty_source_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "media_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_authors": {
+      "name": "media_authors",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_authors_author_id_media_id": {
+          "name": "idx_media_authors_author_id_media_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_authors_media_id_media_id_fk": {
+          "name": "media_authors_media_id_media_id_fk",
+          "tableFrom": "media_authors",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_authors_author_id_authors_id_fk": {
+          "name": "media_authors_author_id_authors_id_fk",
+          "tableFrom": "media_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_authors_media_id_author_id_pk": {
+          "name": "media_authors_media_id_author_id_pk",
+          "columns": [
+            "media_id",
+            "author_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_categories": {
+      "name": "media_categories",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_categories_category_id_media_id": {
+          "name": "idx_media_categories_category_id_media_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_categories_media_id_media_id_fk": {
+          "name": "media_categories_media_id_media_id_fk",
+          "tableFrom": "media_categories",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_categories_category_id_categories_id_fk": {
+          "name": "media_categories_category_id_categories_id_fk",
+          "tableFrom": "media_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_categories_media_id_category_id_pk": {
+          "name": "media_categories_media_id_category_id_pk",
+          "columns": [
+            "media_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_characters": {
+      "name": "media_characters",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_characters_character_id_media_id": {
+          "name": "idx_media_characters_character_id_media_id",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_characters_media_id_media_id_fk": {
+          "name": "media_characters_media_id_media_id_fk",
+          "tableFrom": "media_characters",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_characters_character_id_characters_id_fk": {
+          "name": "media_characters_character_id_characters_id_fk",
+          "tableFrom": "media_characters",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_characters_media_id_character_id_pk": {
+          "name": "media_characters_media_id_character_id_pk",
+          "columns": [
+            "media_id",
+            "character_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_collections": {
+      "name": "media_collections",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_collections_media_id": {
+          "name": "idx_media_collections_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_collections_collection_id_collections_id_fk": {
+          "name": "media_collections_collection_id_collections_id_fk",
+          "tableFrom": "media_collections",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_collections_media_id_media_id_fk": {
+          "name": "media_collections_media_id_media_id_fk",
+          "tableFrom": "media_collections",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_collections_collection_id_media_id_pk": {
+          "name": "media_collections_collection_id_media_id_pk",
+          "columns": [
+            "collection_id",
+            "media_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_details": {
+      "name": "media_details",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1970-01-01 00:00:00'"
+        }
+      },
+      "indexes": {
+        "idx_media_details_rating": {
+          "name": "idx_media_details_rating",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_details_favorite": {
+          "name": "idx_media_details_favorite",
+          "columns": [
+            {
+              "expression": "favorite",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_details_view_count": {
+          "name": "idx_media_details_view_count",
+          "columns": [
+            {
+              "expression": "view_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_details_media_id_media_id_fk": {
+          "name": "media_details_media_id_media_id_fk",
+          "tableFrom": "media_details",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_generation_info": {
+      "name": "media_generation_info",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negative_prompt": {
+          "name": "negative_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loras": {
+          "name": "loras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vae": {
+          "name": "vae",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hypernetworks": {
+          "name": "hypernetworks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddings": {
+          "name": "embeddings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "seed": {
+          "name": "seed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": -1
+        },
+        "cfg_scale": {
+          "name": "cfg_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_media_generation_info_metadata": {
+          "name": "idx_media_generation_info_metadata",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_generation_info_ai_generated": {
+          "name": "idx_media_generation_info_ai_generated",
+          "columns": [
+            {
+              "expression": "ai_generated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_generation_info_model_name": {
+          "name": "idx_media_generation_info_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_generation_info_media_id_media_id_fk": {
+          "name": "media_generation_info_media_id_media_id_fk",
+          "tableFrom": "media_generation_info",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_ips": {
+      "name": "media_ips",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_id": {
+          "name": "ip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_ips_ip_id_media_id": {
+          "name": "idx_media_ips_ip_id_media_id",
+          "columns": [
+            {
+              "expression": "ip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_ips_media_id_media_id_fk": {
+          "name": "media_ips_media_id_media_id_fk",
+          "tableFrom": "media_ips",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_ips_ip_id_ips_id_fk": {
+          "name": "media_ips_ip_id_ips_id_fk",
+          "tableFrom": "media_ips",
+          "tableTo": "ips",
+          "columnsFrom": [
+            "ip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_ips_media_id_ip_id_pk": {
+          "name": "media_ips_media_id_ip_id_pk",
+          "columns": [
+            "media_id",
+            "ip_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_projects": {
+      "name": "media_projects",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_projects_project_id_media_id": {
+          "name": "idx_media_projects_project_id_media_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_projects_media_id_media_id_fk": {
+          "name": "media_projects_media_id_media_id_fk",
+          "tableFrom": "media_projects",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_projects_project_id_projects_id_fk": {
+          "name": "media_projects_project_id_projects_id_fk",
+          "tableFrom": "media_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_projects_media_id_project_id_pk": {
+          "name": "media_projects_media_id_project_id_pk",
+          "columns": [
+            "media_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_regions": {
+      "name": "media_regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "media_region_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detector": {
+          "name": "detector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detector_version": {
+          "name": "detector_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_regions_media_id": {
+          "name": "idx_media_regions_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_media_regions_full_media_id": {
+          "name": "uq_media_regions_full_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"media_regions\".\"kind\" = 'full'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_regions_media_id_media_id_fk": {
+          "name": "media_regions_media_id_media_id_fk",
+          "tableFrom": "media_regions",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_regions_bbox_by_kind": {
+          "name": "media_regions_bbox_by_kind",
+          "value": "(\n\t\t\t\t(\"media_regions\".\"kind\" = 'full' AND \"media_regions\".\"x\" IS NULL AND \"media_regions\".\"y\" IS NULL AND \"media_regions\".\"width\" IS NULL AND \"media_regions\".\"height\" IS NULL)\n\t\t\t\tOR\n\t\t\t\t(\"media_regions\".\"kind\" <> 'full' AND \"media_regions\".\"x\" IS NOT NULL AND \"media_regions\".\"y\" IS NOT NULL AND \"media_regions\".\"width\" IS NOT NULL AND \"media_regions\".\"height\" IS NOT NULL\n\t\t\t\t\tAND \"media_regions\".\"x\" >= 0 AND \"media_regions\".\"y\" >= 0 AND \"media_regions\".\"width\" > 0 AND \"media_regions\".\"height\" > 0\n\t\t\t\t\tAND \"media_regions\".\"x\" + \"media_regions\".\"width\" <= 1 AND \"media_regions\".\"y\" + \"media_regions\".\"height\" <= 1)\n\t\t\t)"
+        },
+        "media_regions_score_range": {
+          "name": "media_regions_score_range",
+          "value": "\"media_regions\".\"score\" IS NULL OR (\"media_regions\".\"score\" >= 0 AND \"media_regions\".\"score\" <= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_relations": {
+      "name": "media_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_media_id": {
+          "name": "parent_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_media_id": {
+          "name": "child_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "media_relation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_relations_child": {
+          "name": "idx_media_relations_child",
+          "columns": [
+            {
+              "expression": "child_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_relations_type": {
+          "name": "idx_media_relations_type",
+          "columns": [
+            {
+              "expression": "relation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_relations_parent_media_id_media_id_fk": {
+          "name": "media_relations_parent_media_id_media_id_fk",
+          "tableFrom": "media_relations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "parent_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_relations_child_media_id_media_id_fk": {
+          "name": "media_relations_child_media_id_media_id_fk",
+          "tableFrom": "media_relations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "child_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_child_type_unique": {
+          "name": "parent_child_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "parent_media_id",
+            "child_media_id",
+            "relation_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_sources": {
+      "name": "media_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "media_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_info": {
+          "name": "connection_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_sync": {
+      "name": "media_sync",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "media_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'synced'"
+        },
+        "backup_urls": {
+          "name": "backup_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_attempts": {
+          "name": "sync_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_sync_media_id_media_id_fk": {
+          "name": "media_sync_media_id_media_id_fk",
+          "tableFrom": "media_sync",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_tags": {
+      "name": "media_tags",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_type": {
+          "name": "tag_type",
+          "type": "tag_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'positive'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_tags_tag_id_tag_type_media_id": {
+          "name": "idx_media_tags_tag_id_tag_type_media_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_tags_media_id_media_id_fk": {
+          "name": "media_tags_media_id_media_id_fk",
+          "tableFrom": "media_tags",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_tags_tag_id_tags_id_fk": {
+          "name": "media_tags_tag_id_tags_id_fk",
+          "tableFrom": "media_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_tags_media_id_tag_id_tag_type_pk": {
+          "name": "media_tags_media_id_tag_id_tag_type_pk",
+          "columns": [
+            "media_id",
+            "tag_id",
+            "tag_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_technical_info": {
+      "name": "media_technical_info",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color_profile": {
+          "name": "color_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "exif_data": {
+          "name": "exif_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "hash_md5": {
+          "name": "hash_md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hash_perceptual": {
+          "name": "hash_perceptual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frame_rate": {
+          "name": "frame_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitrate_kbps": {
+          "name": "bitrate_kbps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_codec": {
+          "name": "video_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_technical_info_hash_md5": {
+          "name": "idx_media_technical_info_hash_md5",
+          "columns": [
+            {
+              "expression": "hash_md5",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_technical_info_media_id_media_id_fk": {
+          "name": "media_technical_info_media_id_media_id_fk",
+          "tableFrom": "media_technical_info",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_urls": {
+      "name": "media_urls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_urls_media_id": {
+          "name": "idx_media_urls_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_urls_url": {
+          "name": "idx_media_urls_url",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_urls_media_id_url_unique": {
+          "name": "idx_media_urls_media_id_url_unique",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_urls_media_id_media_id_fk": {
+          "name": "media_urls_media_id_media_id_fk",
+          "tableFrom": "media_urls",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "media_organization_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "idx_media_source_id": {
+          "name": "idx_media_source_id",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_file_size": {
+          "name": "idx_media_file_size",
+          "columns": [
+            {
+              "expression": "file_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_file_name": {
+          "name": "idx_media_file_name",
+          "columns": [
+            {
+              "expression": "file_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_created_at": {
+          "name": "idx_media_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_description": {
+          "name": "idx_media_description",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_source_id_media_sources_id_fk": {
+          "name": "media_source_id_media_sources_id_fk",
+          "tableFrom": "media",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_id_file_path_unique": {
+          "name": "source_id_file_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "file_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presets": {
+      "name": "presets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort": {
+          "name": "sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "presets_name_unique": {
+          "name": "presets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.similar_media": {
+      "name": "similar_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media1_id": {
+          "name": "media1_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media2_id": {
+          "name": "media2_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "similarity_score": {
+          "name": "similarity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'perceptual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_similar_media_score": {
+          "name": "idx_similar_media_score",
+          "columns": [
+            {
+              "expression": "similarity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "similar_media_media1_id_media_id_fk": {
+          "name": "similar_media_media1_id_media_id_fk",
+          "tableFrom": "similar_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "similar_media_media2_id_media_id_fk": {
+          "name": "similar_media_media2_id_media_id_fk",
+          "tableFrom": "similar_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media1Id_media2Id_algorithm_unique": {
+          "name": "media1Id_media2Id_algorithm_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "media1_id",
+            "media2_id",
+            "algorithm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tags_author_id": {
+          "name": "idx_tags_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_author_id_authors_id_fk": {
+          "name": "tags_author_id_authors_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.view_history": {
+      "name": "view_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "view_history_media_id_media_id_fk": {
+          "name": "view_history_media_id_media_id_fk",
+          "tableFrom": "view_history",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.author_platform": {
+      "name": "author_platform",
+      "schema": "public",
+      "values": [
+        "twitter",
+        "pixiv-fanbox",
+        "danbooru"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.media_organization_status": {
+      "name": "media_organization_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived",
+        "deleted"
+      ]
+    },
+    "public.media_region_kind": {
+      "name": "media_region_kind",
+      "schema": "public",
+      "values": [
+        "full",
+        "person",
+        "manual"
+      ]
+    },
+    "public.media_relation_type": {
+      "name": "media_relation_type",
+      "schema": "public",
+      "values": [
+        "variant",
+        "version",
+        "page",
+        "derivative",
+        "edit",
+        "source"
+      ]
+    },
+    "public.media_source_type": {
+      "name": "media_source_type",
+      "schema": "public",
+      "values": [
+        "local",
+        "sftp",
+        "s3"
+      ]
+    },
+    "public.media_sync_status": {
+      "name": "media_sync_status",
+      "schema": "public",
+      "values": [
+        "synced",
+        "pending",
+        "failed"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "video",
+        "audio"
+      ]
+    },
+    "public.tag_type": {
+      "name": "tag_type",
+      "schema": "public",
+      "values": [
+        "positive",
+        "negative"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1782830770400,
       "tag": "0017_ambitious_gideon",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1784367056664,
+      "tag": "0018_charming_korvac",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/get-media-ids.ts
+++ b/apps/server/get-media-ids.ts
@@ -1,11 +1,11 @@
-import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { medias } from "./src/infrastructure/db/schema";
+import { createPglite } from "./src/infrastructure/db/pglite";
 
 async function getMediaIds() {
-  let pglite: PGlite | undefined;
+  let pglite: ReturnType<typeof createPglite> | undefined;
   try {
-    pglite = new PGlite("./.data/pglite");
+    pglite = createPglite("./.data/pglite");
     const db = drizzle(pglite, { schema: { medias } });
 
     const media = await db.query.medias.findFirst();

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -17,6 +17,7 @@
     "db:drop": "drizzle-kit drop",
     "db:dump": "bun scripts/dump-db.ts",
     "db:restore": "bun scripts/restore-db.ts",
+	"ccip:migrate-from-lancedb": "bun scripts/migrate-ccip-lancedb.ts",
     "lancedb:sync-slow": "bun scripts/sync-lancedb-slow.ts",
     "measure:dev-startup": "bun scripts/measure-dev-startup.ts",
     "db:studio": "drizzle-kit studio",
@@ -35,7 +36,8 @@
     "docs:generate": "typedoc"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.5.2",
+    "@electric-sql/pglite": "0.5.3",
+    "@electric-sql/pglite-pgvector": "0.0.4",
     "@lancedb/lancedb": "^0.30.0",
     "@orpc/client": "^1.14.4",
     "@orpc/contract": "^1.14.4",

--- a/apps/server/scripts/isolated-runtime.ts
+++ b/apps/server/scripts/isolated-runtime.ts
@@ -1,11 +1,11 @@
 import { mkdir, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { PGlite } from '@electric-sql/pglite';
 import { defaultAppConfig } from '@solid-imager/core/domain/config/config-schema';
 import { mediaGenerationInfo, medias, mediaSources } from '@solid-imager/db/schema';
 import { drizzle } from 'drizzle-orm/pglite';
 import { migrate } from 'drizzle-orm/pglite/migrator';
 import sharp from 'sharp';
+import { createPglite } from '../src/infrastructure/db/pglite';
 import {
 	E2E_PRIMARY_FILE_NAME,
 	E2E_PRIMARY_MEDIA_ID,
@@ -73,7 +73,7 @@ async function seedMediaFixtures(runtimeDir: string): Promise<void> {
 		stat(similarPath),
 	]);
 	const pgliteDir = path.join(runtimeDir, 'pglite');
-	const client = new PGlite(pgliteDir);
+	const client = createPglite(pgliteDir);
 	const db = drizzle(client);
 
 	try {

--- a/apps/server/scripts/migrate-ccip-lancedb.ts
+++ b/apps/server/scripts/migrate-ccip-lancedb.ts
@@ -1,0 +1,154 @@
+import type { CcipVectorRecord } from "@solid-imager/application/ports/ccip-vector-store";
+import { z } from "zod";
+import { services } from "../src/application/registry";
+import { PostgresCcipVectorStore } from "../src/infrastructure/ai/postgres-ccip-vector-store";
+import { LanceDbCcipVectorStore } from "../src/infrastructure/ai/lancedb-ccip-vector-store";
+import { initServices } from "../src/infrastructure/bootstrap";
+import { db } from "../src/infrastructure/db";
+import { logger } from "../src/infrastructure/logger";
+
+const usage =
+	"Usage: bun scripts/migrate-ccip-lancedb.ts [--dry-run] [--source-id <uuid>] [--batch-size <positive integer>]";
+const uuidSchema = z.string().uuid();
+
+type MigrationOptions = {
+	dryRun: boolean;
+	mediaSourceId?: string;
+	batchSize: number;
+};
+
+function parsePositiveInteger(value: string, name: string): number {
+	if (!/^\d+$/.test(value)) {
+		throw new Error(`${name} must be a positive integer`);
+	}
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isSafeInteger(parsed) || parsed < 1) {
+		throw new Error(`${name} must be a positive integer`);
+	}
+	return parsed;
+}
+
+function parseOptions(args: string[]): MigrationOptions {
+	const options: MigrationOptions = { dryRun: false, batchSize: 100 };
+	for (let index = 0; index < args.length; index += 1) {
+		const argument = args[index];
+		if (argument === "--dry-run") {
+			options.dryRun = true;
+			continue;
+		}
+		if (argument === "--source-id") {
+			const value = args[index + 1];
+			if (!value) throw new Error("--source-id requires a UUID");
+			options.mediaSourceId = uuidSchema.parse(value);
+			index += 1;
+			continue;
+		}
+		if (argument === "--batch-size") {
+			const value = args[index + 1];
+			if (!value) throw new Error("--batch-size requires a value");
+			options.batchSize = parsePositiveInteger(value, "--batch-size");
+			index += 1;
+			continue;
+		}
+		throw new Error(`Unknown argument: ${argument}`);
+	}
+	return options;
+}
+
+function migrationKey(record: CcipVectorRecord): string {
+	return `${record.mediaId}:${record.model}:${record.embeddingVersion}`;
+}
+
+function recordsMatch(left: CcipVectorRecord, right: CcipVectorRecord): boolean {
+	return (
+		left.mediaSourceId === right.mediaSourceId &&
+		left.mediaModifiedAt.getTime() === right.mediaModifiedAt.getTime() &&
+		left.vector.length === right.vector.length &&
+		left.vector.every((value, index) => value === right.vector[index])
+	);
+}
+
+function collapseRecords(records: CcipVectorRecord[]): {
+	records: CcipVectorRecord[];
+	collapsedDuplicates: number;
+} {
+	const byKey = new Map<string, CcipVectorRecord>();
+	let collapsedDuplicates = 0;
+	for (const record of records) {
+		const key = migrationKey(record);
+		const existing = byKey.get(key);
+		if (!existing) {
+			byKey.set(key, record);
+			continue;
+		}
+		if (!recordsMatch(existing, record)) {
+			throw new Error(`Conflicting LanceDB CCIP records for ${key}`);
+		}
+		collapsedDuplicates += 1;
+		if (record.extractedAt.getTime() > existing.extractedAt.getTime()) {
+			byKey.set(key, record);
+		}
+	}
+	return { records: [...byKey.values()], collapsedDuplicates };
+}
+
+async function main(): Promise<void> {
+	const args = process.argv.slice(2);
+	if (args.includes("--help") || args.includes("-h")) {
+		process.stdout.write(`${usage}\n`);
+		return;
+	}
+	const options = parseOptions(args);
+	initServices();
+	const config = services.getConfigService().getConfig();
+	const legacyStore = new LanceDbCcipVectorStore(config.lancedb.ccipVectorDir, {
+		readOnly: true,
+	});
+	const rawRecords = await legacyStore.list({
+		mediaSourceId: options.mediaSourceId,
+	});
+	const collapsed = collapseRecords(rawRecords);
+
+	logger.info(
+		{
+			dryRun: options.dryRun,
+			mediaSourceId: options.mediaSourceId,
+			rawRows: rawRecords.length,
+			uniqueLogicalRows: collapsed.records.length,
+			collapsedDuplicates: collapsed.collapsedDuplicates,
+			batchSize: options.batchSize,
+		},
+		"CCIP LanceDB migration prepared",
+	);
+
+	if (options.dryRun) {
+		return;
+	}
+
+	const targetStore = new PostgresCcipVectorStore(db);
+	for (let start = 0; start < collapsed.records.length; start += options.batchSize) {
+		const batch = collapsed.records.slice(start, start + options.batchSize);
+		await targetStore.upsertMany(batch);
+		logger.info(
+			{
+				migrated: Math.min(start + batch.length, collapsed.records.length),
+				total: collapsed.records.length,
+			},
+			"CCIP LanceDB migration batch completed",
+		);
+	}
+
+	logger.info(
+		{
+			rawRows: rawRecords.length,
+			uniqueLogicalRows: collapsed.records.length,
+			collapsedDuplicates: collapsed.collapsedDuplicates,
+		},
+		"CCIP LanceDB migration completed",
+	);
+}
+
+main().catch((error: unknown) => {
+	logger.error({ err: error }, "CCIP LanceDB migration failed");
+	process.exitCode = 1;
+});

--- a/apps/server/scripts/migrate-ccip-lancedb.ts
+++ b/apps/server/scripts/migrate-ccip-lancedb.ts
@@ -68,30 +68,6 @@ function recordsMatch(left: CcipVectorRecord, right: CcipVectorRecord): boolean 
 	);
 }
 
-function collapseRecords(records: CcipVectorRecord[]): {
-	records: CcipVectorRecord[];
-	collapsedDuplicates: number;
-} {
-	const byKey = new Map<string, CcipVectorRecord>();
-	let collapsedDuplicates = 0;
-	for (const record of records) {
-		const key = migrationKey(record);
-		const existing = byKey.get(key);
-		if (!existing) {
-			byKey.set(key, record);
-			continue;
-		}
-		if (!recordsMatch(existing, record)) {
-			throw new Error(`Conflicting LanceDB CCIP records for ${key}`);
-		}
-		collapsedDuplicates += 1;
-		if (record.extractedAt.getTime() > existing.extractedAt.getTime()) {
-			byKey.set(key, record);
-		}
-	}
-	return { records: [...byKey.values()], collapsedDuplicates };
-}
-
 async function main(): Promise<void> {
 	const args = process.argv.slice(2);
 	if (args.includes("--help") || args.includes("-h")) {
@@ -104,45 +80,74 @@ async function main(): Promise<void> {
 	const legacyStore = new LanceDbCcipVectorStore(config.lancedb.ccipVectorDir, {
 		readOnly: true,
 	});
-	const rawRecords = await legacyStore.list({
+	const targetStore = options.dryRun
+		? null
+		: new PostgresCcipVectorStore(db);
+	let rawRows = 0;
+	let uniqueLogicalRows = 0;
+	let collapsedDuplicates = 0;
+	let migrated = 0;
+	let current: CcipVectorRecord | null = null;
+	let pending: CcipVectorRecord[] = [];
+
+	const flush = async (): Promise<void> => {
+		if (pending.length === 0) return;
+		const batch = pending;
+		pending = [];
+		if (targetStore) {
+			await targetStore.upsertMany(batch);
+			migrated += batch.length;
+			logger.info(
+				{ migrated, batchSize: batch.length },
+				"CCIP LanceDB migration batch completed",
+			);
+		}
+	};
+
+	for await (const records of legacyStore.listBatches(options.batchSize, {
 		mediaSourceId: options.mediaSourceId,
-	});
-	const collapsed = collapseRecords(rawRecords);
+	})) {
+		rawRows += records.length;
+		for (const record of records) {
+			if (!current) {
+				current = record;
+				continue;
+			}
+			if (migrationKey(current) === migrationKey(record)) {
+				if (!recordsMatch(current, record)) {
+					throw new Error(
+						`Conflicting LanceDB CCIP records for ${migrationKey(record)}`,
+					);
+				}
+				collapsedDuplicates += 1;
+				if (record.extractedAt.getTime() > current.extractedAt.getTime()) {
+					current = record;
+				}
+				continue;
+			}
+			pending.push(current);
+			uniqueLogicalRows += 1;
+			current = record;
+			if (pending.length >= options.batchSize) {
+				await flush();
+			}
+		}
+	}
+	if (current) {
+		pending.push(current);
+		uniqueLogicalRows += 1;
+	}
+	await flush();
 
 	logger.info(
 		{
 			dryRun: options.dryRun,
 			mediaSourceId: options.mediaSourceId,
-			rawRows: rawRecords.length,
-			uniqueLogicalRows: collapsed.records.length,
-			collapsedDuplicates: collapsed.collapsedDuplicates,
+			rawRows,
+			uniqueLogicalRows,
+			collapsedDuplicates,
+			migrated,
 			batchSize: options.batchSize,
-		},
-		"CCIP LanceDB migration prepared",
-	);
-
-	if (options.dryRun) {
-		return;
-	}
-
-	const targetStore = new PostgresCcipVectorStore(db);
-	for (let start = 0; start < collapsed.records.length; start += options.batchSize) {
-		const batch = collapsed.records.slice(start, start + options.batchSize);
-		await targetStore.upsertMany(batch);
-		logger.info(
-			{
-				migrated: Math.min(start + batch.length, collapsed.records.length),
-				total: collapsed.records.length,
-			},
-			"CCIP LanceDB migration batch completed",
-		);
-	}
-
-	logger.info(
-		{
-			rawRows: rawRecords.length,
-			uniqueLogicalRows: collapsed.records.length,
-			collapsedDuplicates: collapsed.collapsedDuplicates,
 		},
 		"CCIP LanceDB migration completed",
 	);

--- a/apps/server/scripts/migrate-pglite-fresh.ts
+++ b/apps/server/scripts/migrate-pglite-fresh.ts
@@ -1,11 +1,13 @@
 import { migrate } from "drizzle-orm/pglite/migrator";
 import { drizzle } from "drizzle-orm/pglite";
-import { PGlite } from "@electric-sql/pglite";
 import path from "path";
 import fs from "fs";
+import { createPglite } from "../src/infrastructure/db/pglite";
 
 async function main() {
-  const dataDir = path.join(process.cwd(), ".data", "pglite-fresh");
+	const dataDir =
+		process.env.PGLITE_DATA_DIR ??
+		path.join(process.cwd(), ".data", "pglite-fresh");
   console.log("Using PGlite data directory:", dataDir);
 
   // Ensure the data directory exists
@@ -13,7 +15,7 @@ async function main() {
     fs.mkdirSync(dataDir, { recursive: true });
   }
 
-  const client = new PGlite(dataDir);
+  const client = createPglite(dataDir);
   const db = drizzle(client);
 
   try {

--- a/apps/server/scripts/migrate-pglite.ts
+++ b/apps/server/scripts/migrate-pglite.ts
@@ -1,11 +1,12 @@
 import { migrate } from "drizzle-orm/pglite/migrator";
 import { drizzle } from "drizzle-orm/pglite";
-import { PGlite } from "@electric-sql/pglite";
 import path from "path";
 import fs from "fs";
+import { createPglite } from "../src/infrastructure/db/pglite";
 
 async function main() {
-  const dataDir = path.join(process.cwd(), ".data", "pglite");
+	const dataDir =
+		process.env.PGLITE_DATA_DIR ?? path.join(process.cwd(), ".data", "pglite");
   console.log("Using PGlite data directory:", dataDir);
 
   // Ensure the data directory exists
@@ -13,7 +14,7 @@ async function main() {
     fs.mkdirSync(dataDir, { recursive: true });
   }
 
-  const client = new PGlite(dataDir);
+  const client = createPglite(dataDir);
   const db = drizzle(client);
 
   try {

--- a/apps/server/scripts/test-pglite-dir.ts
+++ b/apps/server/scripts/test-pglite-dir.ts
@@ -1,11 +1,11 @@
-import { PGlite } from "@electric-sql/pglite";
 import path from "path";
+import { createPglite } from "../src/infrastructure/db/pglite";
 
 async function test() {
   const dataDir = path.join(process.cwd(), ".data", "test-pglite");
   console.log("Starting PGlite test with directory:", dataDir);
   try {
-    const db = new PGlite(dataDir);
+    const db = createPglite(dataDir);
     await db.waitReady;
     const res = await db.query("SELECT 1 as one");
     console.log("Query result:", res);

--- a/apps/server/scripts/test-pglite.ts
+++ b/apps/server/scripts/test-pglite.ts
@@ -1,9 +1,9 @@
-import { PGlite } from "@electric-sql/pglite";
+import { createPglite } from "../src/infrastructure/db/pglite";
 
 async function test() {
   console.log("Starting PGlite test...");
   try {
-    const db = new PGlite();
+    const db = createPglite();
     await db.waitReady;
     const res = await db.query("SELECT 1 as one");
     console.log("Query result:", res);

--- a/apps/server/src/application/services/ccip-vector-service.ts
+++ b/apps/server/src/application/services/ccip-vector-service.ts
@@ -1,18 +1,18 @@
 import { CcipVectorService } from "@solid-imager/application/services/ccip-vector-service";
 import { services } from "~/application/registry";
 import { taggingService } from "~/application/services/tagging-service";
-import { LanceDbCcipVectorStore } from "~/infrastructure/ai/lancedb-ccip-vector-store";
+import { PostgresCcipVectorStore } from "~/infrastructure/ai/postgres-ccip-vector-store";
+import { db } from "~/infrastructure/db";
 
 let service: CcipVectorService | null = null;
 
 export function getCcipVectorService(): CcipVectorService {
 	if (!service) {
-		const config = services.getConfigService().getConfig();
 		service = new CcipVectorService({
 			mediaRepository: services.getMediaRepository(),
 			sourceRepository: services.getSourceRepository(),
 			taggingService,
-			vectorStore: new LanceDbCcipVectorStore(config.lancedb.ccipVectorDir),
+			vectorStore: new PostgresCcipVectorStore(db),
 		});
 	}
 	return service;

--- a/apps/server/src/infrastructure/ai/lancedb-ccip-vector-store.ts
+++ b/apps/server/src/infrastructure/ai/lancedb-ccip-vector-store.ts
@@ -3,6 +3,7 @@ import type { Connection, Table } from "@lancedb/lancedb";
 import type {
 	CcipVectorCandidate,
 	CcipVectorMetadata,
+	CcipVectorQuery,
 	CcipVectorRecord,
 	ICcipVectorStore,
 } from "@solid-imager/application/ports/ccip-vector-store";
@@ -43,6 +44,22 @@ function escapeSqlString(value: string): string {
 	return value.replaceAll("'", "''");
 }
 
+function queryPredicates(query?: CcipVectorQuery): string[] {
+	const predicates: string[] = [];
+	if (query?.mediaSourceId) {
+		predicates.push(
+			`mediaSourceId = '${escapeSqlString(query.mediaSourceId)}'`,
+		);
+	}
+	if (query?.model) {
+		predicates.push(`model = '${escapeSqlString(query.model)}'`);
+	}
+	if (query?.embeddingVersion !== undefined) {
+		predicates.push(`embeddingVersion = ${query.embeddingVersion}`);
+	}
+	return predicates;
+}
+
 function toRecord(value: unknown): CcipVectorRecord {
 	const row = rowSchema.parse(value);
 	return {
@@ -66,7 +83,10 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 	private writeQueue: Promise<void> = Promise.resolve();
 	private writeOperationsSinceOptimize = 0;
 
-	constructor(private readonly directory: string) {}
+	constructor(
+		private readonly directory: string,
+		private readonly options: { readOnly?: boolean } = {},
+	) {}
 
 	private async connection(): Promise<Connection> {
 		if (!this.connectionPromise) {
@@ -102,7 +122,13 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 		let table: Table;
 		try {
 			table = await db.openTable(TABLE_NAME);
-		} catch {
+		} catch (error) {
+			if (this.options.readOnly) {
+				throw new Error(
+					`CCIP LanceDB table ${TABLE_NAME} is unavailable in read-only mode`,
+					{ cause: error },
+				);
+			}
 			const arrow = await import("apache-arrow");
 			const schema = new arrow.Schema([
 				new arrow.Field("mediaId", new arrow.Utf8(), false),
@@ -126,7 +152,9 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 			]);
 			table = await db.createTable(TABLE_NAME, [], { schema });
 		}
-		await this.ensureMediaIdIndex(table);
+		if (!this.options.readOnly) {
+			await this.ensureMediaIdIndex(table);
+		}
 		return table;
 	}
 
@@ -143,27 +171,36 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 	}
 
 	private async serializeWrite(operation: () => Promise<void>): Promise<void> {
+		if (this.options.readOnly) {
+			throw new Error("CCIP LanceDB store is read-only");
+		}
 		const next = this.writeQueue.then(operation, operation);
 		this.writeQueue = next.catch(() => undefined);
 		await next;
 	}
 
-	async get(mediaId: string): Promise<CcipVectorRecord | null> {
-		return (await this.getMany([mediaId])).get(mediaId) ?? null;
+	async get(
+		mediaId: string,
+		query?: CcipVectorQuery,
+	): Promise<CcipVectorRecord | null> {
+		return (await this.getMany([mediaId], query)).get(mediaId) ?? null;
 	}
 
-	async getMany(mediaIds: string[]): Promise<Map<string, CcipVectorRecord>> {
+	async getMany(
+		mediaIds: string[],
+		query?: CcipVectorQuery,
+	): Promise<Map<string, CcipVectorRecord>> {
 		if (mediaIds.length === 0) {
 			return new Map();
 		}
-		const predicate = mediaIds
-			.map((mediaId) => `'${escapeSqlString(mediaId)}'`)
-			.join(", ");
+		const predicates = [
+			`mediaId IN (${mediaIds
+				.map((mediaId) => `'${escapeSqlString(mediaId)}'`)
+				.join(", ")})`,
+			...queryPredicates(query),
+		];
 		const table = await this.table();
-		const rows = await table
-			.query()
-			.where(`mediaId IN (${predicate})`)
-			.toArray();
+		const rows = await table.query().where(predicates.join(" AND ")).toArray();
 		return new Map(
 			rows.map((row) => {
 				const record = toRecord(row);
@@ -174,13 +211,17 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 
 	async getMetadataMany(
 		mediaIds: string[],
+		query?: CcipVectorQuery,
 	): Promise<Map<string, CcipVectorMetadata>> {
 		if (mediaIds.length === 0) {
 			return new Map();
 		}
-		const predicate = mediaIds
-			.map((mediaId) => `'${escapeSqlString(mediaId)}'`)
-			.join(", ");
+		const predicates = [
+			`mediaId IN (${mediaIds
+				.map((mediaId) => `'${escapeSqlString(mediaId)}'`)
+				.join(", ")})`,
+			...queryPredicates(query),
+		];
 		const table = await this.table();
 		const rows = await table
 			.query()
@@ -192,7 +233,7 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 				"mediaModifiedAt",
 				"extractedAt",
 			])
-			.where(`mediaId IN (${predicate})`)
+			.where(predicates.join(" AND "))
 			.toArray();
 		return new Map(
 			rows.map((row) => {
@@ -240,43 +281,46 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 		});
 	}
 
-	async listMediaIds(mediaSourceId?: string): Promise<string[]> {
+	async listMediaIds(query?: CcipVectorQuery): Promise<string[]> {
 		const table = await this.table();
-		const query = table.query().select(["mediaId"]);
-		if (mediaSourceId) {
-			query.where(`mediaSourceId = '${escapeSqlString(mediaSourceId)}'`);
+		const tableQuery = table.query().select(["mediaId"]);
+		const predicates = queryPredicates(query);
+		if (predicates.length > 0) {
+			tableQuery.where(predicates.join(" AND "));
 		}
-		const rows = await query.toArray();
+		const rows = await tableQuery.toArray();
 		return rows.flatMap((row) => {
 			const result = z.object({ mediaId: z.string().uuid() }).safeParse(row);
 			return result.success ? [result.data.mediaId] : [];
 		});
 	}
 
-	async list(mediaSourceId?: string): Promise<CcipVectorRecord[]> {
+	async list(query?: CcipVectorQuery): Promise<CcipVectorRecord[]> {
 		const table = await this.table();
-		const query = table.query();
-		if (mediaSourceId) {
-			query.where(`mediaSourceId = '${escapeSqlString(mediaSourceId)}'`);
+		const tableQuery = table.query();
+		const predicates = queryPredicates(query);
+		if (predicates.length > 0) {
+			tableQuery.where(predicates.join(" AND "));
 		}
-		const rows = await query.toArray();
+		const rows = await tableQuery.toArray();
 		return rows.map(toRecord);
 	}
 
 	async search(
 		vector: number[],
 		limit: number,
-		mediaSourceId?: string,
+		query?: CcipVectorQuery,
 	): Promise<CcipVectorCandidate[]> {
 		const table = await this.table();
-		const query = table
+		const tableQuery = table
 			.vectorSearch(vector)
 			.distanceType("cosine")
 			.limit(limit);
-		if (mediaSourceId) {
-			query.where(`mediaSourceId = '${escapeSqlString(mediaSourceId)}'`);
+		const predicates = queryPredicates(query);
+		if (predicates.length > 0) {
+			tableQuery.where(predicates.join(" AND "));
 		}
-		const rows = await query.toArray();
+		const rows = await tableQuery.toArray();
 		return rows.map((value) => {
 			const row = rowSchema.parse(value);
 			return {

--- a/apps/server/src/infrastructure/ai/lancedb-ccip-vector-store.ts
+++ b/apps/server/src/infrastructure/ai/lancedb-ccip-vector-store.ts
@@ -4,6 +4,7 @@ import type {
 	CcipVectorCandidate,
 	CcipVectorMetadata,
 	CcipVectorQuery,
+	CcipVectorReadQuery,
 	CcipVectorRecord,
 	ICcipVectorStore,
 } from "@solid-imager/application/ports/ccip-vector-store";
@@ -181,14 +182,14 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 
 	async get(
 		mediaId: string,
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<CcipVectorRecord | null> {
 		return (await this.getMany([mediaId], query)).get(mediaId) ?? null;
 	}
 
 	async getMany(
 		mediaIds: string[],
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<Map<string, CcipVectorRecord>> {
 		if (mediaIds.length === 0) {
 			return new Map();
@@ -211,7 +212,7 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 
 	async getMetadataMany(
 		mediaIds: string[],
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<Map<string, CcipVectorMetadata>> {
 		if (mediaIds.length === 0) {
 			return new Map();
@@ -306,10 +307,51 @@ export class LanceDbCcipVectorStore implements ICcipVectorStore {
 		return rows.map(toRecord);
 	}
 
+	/**
+	 * Reads legacy rows in bounded pages for the one-time PostgreSQL migration.
+	 * Ordering groups duplicate logical embeddings next to one another so the
+	 * caller can resolve them without retaining the complete table in memory.
+	 */
+	async *listBatches(
+		batchSize: number,
+		query?: CcipVectorQuery,
+	): AsyncGenerator<CcipVectorRecord[]> {
+		if (!Number.isSafeInteger(batchSize) || batchSize < 1) {
+			throw new Error("batchSize must be a positive integer");
+		}
+		const table = await this.table();
+		const predicates = queryPredicates(query);
+		let offset = 0;
+		while (true) {
+			const tableQuery = table
+				.query()
+				.orderBy([
+					{ columnName: "mediaId" },
+					{ columnName: "model" },
+					{ columnName: "embeddingVersion" },
+					{ columnName: "extractedAt" },
+				])
+				.limit(batchSize)
+				.offset(offset);
+			if (predicates.length > 0) {
+				tableQuery.where(predicates.join(" AND "));
+			}
+			const rows = await tableQuery.toArray();
+			if (rows.length === 0) {
+				return;
+			}
+			yield rows.map(toRecord);
+			offset += rows.length;
+			if (rows.length < batchSize) {
+				return;
+			}
+		}
+	}
+
 	async search(
 		vector: number[],
 		limit: number,
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<CcipVectorCandidate[]> {
 		const table = await this.table();
 		const tableQuery = table

--- a/apps/server/src/infrastructure/ai/postgres-ccip-vector-store.ts
+++ b/apps/server/src/infrastructure/ai/postgres-ccip-vector-store.ts
@@ -2,6 +2,7 @@ import type {
 	CcipVectorCandidate,
 	CcipVectorMetadata,
 	CcipVectorQuery,
+	CcipVectorReadQuery,
 	CcipVectorRecord,
 	ICcipVectorStore,
 } from "@solid-imager/application/ports/ccip-vector-store";
@@ -110,14 +111,14 @@ export class PostgresCcipVectorStore implements ICcipVectorStore {
 
 	async get(
 		mediaId: string,
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<CcipVectorRecord | null> {
 		return (await this.getMany([mediaId], query)).get(mediaId) ?? null;
 	}
 
 	async getMany(
 		mediaIds: string[],
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<Map<string, CcipVectorRecord>> {
 		if (mediaIds.length === 0) {
 			return new Map();
@@ -138,7 +139,7 @@ export class PostgresCcipVectorStore implements ICcipVectorStore {
 
 	async getMetadataMany(
 		mediaIds: string[],
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<Map<string, CcipVectorMetadata>> {
 		if (mediaIds.length === 0) {
 			return new Map();
@@ -169,41 +170,74 @@ export class PostgresCcipVectorStore implements ICcipVectorStore {
 	}
 
 	async upsertMany(records: CcipVectorRecord[]): Promise<void> {
+		if (records.length === 0) {
+			return;
+		}
+		const regionsByMediaId = new Map<string, CcipVectorRecord>();
+		const embeddingsByKey = new Map<string, CcipVectorRecord>();
 		for (const record of records) {
 			vectorLiteral(record.vector);
-			const [region] = await this.database
+			const existingRegion = regionsByMediaId.get(record.mediaId);
+			if (
+				!existingRegion ||
+				record.mediaModifiedAt.getTime() >
+					existingRegion.mediaModifiedAt.getTime()
+			) {
+				regionsByMediaId.set(record.mediaId, record);
+			}
+			const embeddingKey = `${record.mediaId}:${record.model}:${record.embeddingVersion}`;
+			const existingEmbedding = embeddingsByKey.get(embeddingKey);
+			if (
+				!existingEmbedding ||
+				record.extractedAt.getTime() > existingEmbedding.extractedAt.getTime()
+			) {
+				embeddingsByKey.set(embeddingKey, record);
+			}
+		}
+		const now = new Date();
+		await this.database.transaction(async (transaction) => {
+			const regions = await transaction
 				.insert(mediaRegions)
-				.values({
-					mediaId: record.mediaId,
-					kind: FULL_REGION_KIND,
-					sourceModifiedAt: record.mediaModifiedAt,
-					updatedAt: new Date(),
-				})
+				.values(
+					[...regionsByMediaId.values()].map((record) => ({
+						mediaId: record.mediaId,
+						kind: "full" as const,
+						sourceModifiedAt: record.mediaModifiedAt,
+						updatedAt: now,
+					})),
+				)
 				.onConflictDoUpdate({
 					target: mediaRegions.mediaId,
 					targetWhere: sql`${mediaRegions.kind} = 'full'`,
 					set: {
-						sourceModifiedAt: record.mediaModifiedAt,
-						updatedAt: new Date(),
+						sourceModifiedAt: sql`excluded.source_modified_at`,
+						updatedAt: now,
 					},
 				})
 				.returning();
-			if (!region) {
-				throw new Error(
-					`Unable to create full region for media ${record.mediaId}`,
-				);
-			}
-			await this.database
-				.insert(ccipEmbeddings)
-				.values({
-					regionId: region.id,
+			const regionIdByMediaId = new Map(
+				regions.map((region) => [region.mediaId, region.id]),
+			);
+			const embeddings = [...embeddingsByKey.values()].map((record) => {
+				const regionId = regionIdByMediaId.get(record.mediaId);
+				if (!regionId) {
+					throw new Error(
+						`Unable to create full region for media ${record.mediaId}`,
+					);
+				}
+				return {
+					regionId,
 					embedding: record.vector,
 					model: record.model,
 					embeddingVersion: record.embeddingVersion,
 					mediaModifiedAt: record.mediaModifiedAt,
 					extractedAt: record.extractedAt,
-					updatedAt: new Date(),
-				})
+					updatedAt: now,
+				};
+			});
+			await transaction
+				.insert(ccipEmbeddings)
+				.values(embeddings)
 				.onConflictDoUpdate({
 					target: [
 						ccipEmbeddings.regionId,
@@ -211,13 +245,13 @@ export class PostgresCcipVectorStore implements ICcipVectorStore {
 						ccipEmbeddings.embeddingVersion,
 					],
 					set: {
-						embedding: record.vector,
-						mediaModifiedAt: record.mediaModifiedAt,
-						extractedAt: record.extractedAt,
-						updatedAt: new Date(),
+						embedding: sql`excluded.embedding`,
+						mediaModifiedAt: sql`excluded.media_modified_at`,
+						extractedAt: sql`excluded.extracted_at`,
+						updatedAt: now,
 					},
 				});
-		}
+		});
 	}
 
 	async delete(mediaId: string): Promise<void> {
@@ -264,7 +298,7 @@ export class PostgresCcipVectorStore implements ICcipVectorStore {
 	async search(
 		vector: number[],
 		limit: number,
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<CcipVectorCandidate[]> {
 		if (!Number.isSafeInteger(limit) || limit < 1) {
 			throw new Error("limit must be a positive integer");

--- a/apps/server/src/infrastructure/ai/postgres-ccip-vector-store.ts
+++ b/apps/server/src/infrastructure/ai/postgres-ccip-vector-store.ts
@@ -210,8 +210,20 @@ export class PostgresCcipVectorStore implements ICcipVectorStore {
 					target: mediaRegions.mediaId,
 					targetWhere: sql`${mediaRegions.kind} = 'full'`,
 					set: {
-						sourceModifiedAt: sql`excluded.source_modified_at`,
-						updatedAt: now,
+						sourceModifiedAt: sql`
+							CASE
+								WHEN excluded.source_modified_at > ${mediaRegions.sourceModifiedAt}
+								THEN excluded.source_modified_at
+								ELSE ${mediaRegions.sourceModifiedAt}
+							END
+						`,
+						updatedAt: sql`
+							CASE
+								WHEN excluded.source_modified_at > ${mediaRegions.sourceModifiedAt}
+								THEN excluded.updated_at
+								ELSE ${mediaRegions.updatedAt}
+							END
+						`,
 					},
 				})
 				.returning();
@@ -245,10 +257,34 @@ export class PostgresCcipVectorStore implements ICcipVectorStore {
 						ccipEmbeddings.embeddingVersion,
 					],
 					set: {
-						embedding: sql`excluded.embedding`,
-						mediaModifiedAt: sql`excluded.media_modified_at`,
-						extractedAt: sql`excluded.extracted_at`,
-						updatedAt: now,
+						embedding: sql`
+							CASE
+								WHEN excluded.extracted_at > ${ccipEmbeddings.extractedAt}
+								THEN excluded.embedding
+								ELSE ${ccipEmbeddings.embedding}
+							END
+						`,
+						mediaModifiedAt: sql`
+							CASE
+								WHEN excluded.extracted_at > ${ccipEmbeddings.extractedAt}
+								THEN excluded.media_modified_at
+								ELSE ${ccipEmbeddings.mediaModifiedAt}
+							END
+						`,
+						extractedAt: sql`
+							CASE
+								WHEN excluded.extracted_at > ${ccipEmbeddings.extractedAt}
+								THEN excluded.extracted_at
+								ELSE ${ccipEmbeddings.extractedAt}
+							END
+						`,
+						updatedAt: sql`
+							CASE
+								WHEN excluded.extracted_at > ${ccipEmbeddings.extractedAt}
+								THEN excluded.updated_at
+								ELSE ${ccipEmbeddings.updatedAt}
+							END
+						`,
 					},
 				});
 		});

--- a/apps/server/src/infrastructure/ai/postgres-ccip-vector-store.ts
+++ b/apps/server/src/infrastructure/ai/postgres-ccip-vector-store.ts
@@ -1,0 +1,302 @@
+import type {
+	CcipVectorCandidate,
+	CcipVectorMetadata,
+	CcipVectorQuery,
+	CcipVectorRecord,
+	ICcipVectorStore,
+} from "@solid-imager/application/ports/ccip-vector-store";
+import {
+	CCIP_VECTOR_DIMENSIONS,
+	ccipEmbeddings,
+	mediaRegions,
+	medias,
+} from "@solid-imager/db/schema";
+import type { DrizzleExecutor } from "@solid-imager/db/types";
+import { and, eq, inArray, type SQL, sql } from "drizzle-orm";
+import { z } from "zod";
+
+const FULL_REGION_KIND = "full";
+
+const recordRowSchema = z.object({
+	mediaId: z.string().uuid(),
+	mediaSourceId: z.string().uuid(),
+	vector: z.array(z.number().finite()).length(CCIP_VECTOR_DIMENSIONS),
+	model: z.string(),
+	embeddingVersion: z.number().int(),
+	mediaModifiedAt: z.coerce.date(),
+	extractedAt: z.coerce.date(),
+});
+
+const metadataRowSchema = recordRowSchema.omit({ vector: true });
+
+const rawCandidateRowSchema = recordRowSchema.extend({
+	vector: z
+		.union([z.string(), z.array(z.number().finite())])
+		.transform(parseVector),
+	cosineDistance: z.coerce.number().finite(),
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractRows(value: unknown): unknown[] {
+	if (Array.isArray(value)) {
+		return value;
+	}
+	if (isRecord(value) && Array.isArray(value.rows)) {
+		return value.rows;
+	}
+	return [];
+}
+
+function parseVector(value: string | number[]): number[] {
+	const parsed = typeof value === "string" ? JSON.parse(value) : value;
+	if (
+		!Array.isArray(parsed) ||
+		parsed.length !== CCIP_VECTOR_DIMENSIONS ||
+		!parsed.every((item) => typeof item === "number" && Number.isFinite(item))
+	) {
+		throw new Error(
+			`Expected a finite ${CCIP_VECTOR_DIMENSIONS}-dimension vector`,
+		);
+	}
+	return parsed;
+}
+
+function vectorLiteral(vector: number[]): string {
+	const parsed = parseVector(vector);
+	const squaredNorm = parsed.reduce((total, value) => total + value * value, 0);
+	if (squaredNorm === 0) {
+		throw new Error("CCIP vector must not have zero norm");
+	}
+	return `[${parsed.join(",")}]`;
+}
+
+function mapRecord(value: unknown): CcipVectorRecord {
+	return recordRowSchema.parse(value);
+}
+
+function mapMetadata(value: unknown): CcipVectorMetadata {
+	return metadataRowSchema.parse(value);
+}
+
+function recordFilters(query?: CcipVectorQuery): SQL | undefined {
+	return and(
+		eq(mediaRegions.kind, FULL_REGION_KIND),
+		query?.mediaSourceId
+			? eq(medias.mediaSourceId, query.mediaSourceId)
+			: undefined,
+		query?.model ? eq(ccipEmbeddings.model, query.model) : undefined,
+		query?.embeddingVersion !== undefined
+			? eq(ccipEmbeddings.embeddingVersion, query.embeddingVersion)
+			: undefined,
+	);
+}
+
+const recordColumns = {
+	mediaId: medias.id,
+	mediaSourceId: medias.mediaSourceId,
+	vector: ccipEmbeddings.embedding,
+	model: ccipEmbeddings.model,
+	embeddingVersion: ccipEmbeddings.embeddingVersion,
+	mediaModifiedAt: ccipEmbeddings.mediaModifiedAt,
+	extractedAt: ccipEmbeddings.extractedAt,
+};
+
+/** pgvector-backed CCIP store used by the application at runtime. */
+export class PostgresCcipVectorStore implements ICcipVectorStore {
+	constructor(private readonly database: DrizzleExecutor) {}
+
+	async get(
+		mediaId: string,
+		query?: CcipVectorQuery,
+	): Promise<CcipVectorRecord | null> {
+		return (await this.getMany([mediaId], query)).get(mediaId) ?? null;
+	}
+
+	async getMany(
+		mediaIds: string[],
+		query?: CcipVectorQuery,
+	): Promise<Map<string, CcipVectorRecord>> {
+		if (mediaIds.length === 0) {
+			return new Map();
+		}
+		const rows = await this.database
+			.select(recordColumns)
+			.from(ccipEmbeddings)
+			.innerJoin(mediaRegions, eq(ccipEmbeddings.regionId, mediaRegions.id))
+			.innerJoin(medias, eq(mediaRegions.mediaId, medias.id))
+			.where(and(inArray(medias.id, mediaIds), recordFilters(query)));
+		return new Map(
+			rows.map((row) => {
+				const record = mapRecord(row);
+				return [record.mediaId, record];
+			}),
+		);
+	}
+
+	async getMetadataMany(
+		mediaIds: string[],
+		query?: CcipVectorQuery,
+	): Promise<Map<string, CcipVectorMetadata>> {
+		if (mediaIds.length === 0) {
+			return new Map();
+		}
+		const rows = await this.database
+			.select({
+				mediaId: medias.id,
+				mediaSourceId: medias.mediaSourceId,
+				model: ccipEmbeddings.model,
+				embeddingVersion: ccipEmbeddings.embeddingVersion,
+				mediaModifiedAt: ccipEmbeddings.mediaModifiedAt,
+				extractedAt: ccipEmbeddings.extractedAt,
+			})
+			.from(ccipEmbeddings)
+			.innerJoin(mediaRegions, eq(ccipEmbeddings.regionId, mediaRegions.id))
+			.innerJoin(medias, eq(mediaRegions.mediaId, medias.id))
+			.where(and(inArray(medias.id, mediaIds), recordFilters(query)));
+		return new Map(
+			rows.map((row) => {
+				const metadata = mapMetadata(row);
+				return [metadata.mediaId, metadata];
+			}),
+		);
+	}
+
+	async upsert(record: CcipVectorRecord): Promise<void> {
+		await this.upsertMany([record]);
+	}
+
+	async upsertMany(records: CcipVectorRecord[]): Promise<void> {
+		for (const record of records) {
+			vectorLiteral(record.vector);
+			const [region] = await this.database
+				.insert(mediaRegions)
+				.values({
+					mediaId: record.mediaId,
+					kind: FULL_REGION_KIND,
+					sourceModifiedAt: record.mediaModifiedAt,
+					updatedAt: new Date(),
+				})
+				.onConflictDoUpdate({
+					target: mediaRegions.mediaId,
+					targetWhere: sql`${mediaRegions.kind} = 'full'`,
+					set: {
+						sourceModifiedAt: record.mediaModifiedAt,
+						updatedAt: new Date(),
+					},
+				})
+				.returning();
+			if (!region) {
+				throw new Error(
+					`Unable to create full region for media ${record.mediaId}`,
+				);
+			}
+			await this.database
+				.insert(ccipEmbeddings)
+				.values({
+					regionId: region.id,
+					embedding: record.vector,
+					model: record.model,
+					embeddingVersion: record.embeddingVersion,
+					mediaModifiedAt: record.mediaModifiedAt,
+					extractedAt: record.extractedAt,
+					updatedAt: new Date(),
+				})
+				.onConflictDoUpdate({
+					target: [
+						ccipEmbeddings.regionId,
+						ccipEmbeddings.model,
+						ccipEmbeddings.embeddingVersion,
+					],
+					set: {
+						embedding: record.vector,
+						mediaModifiedAt: record.mediaModifiedAt,
+						extractedAt: record.extractedAt,
+						updatedAt: new Date(),
+					},
+				});
+		}
+	}
+
+	async delete(mediaId: string): Promise<void> {
+		const regionIds = this.database
+			.select({ id: mediaRegions.id })
+			.from(mediaRegions)
+			.where(eq(mediaRegions.mediaId, mediaId));
+		await this.database
+			.delete(ccipEmbeddings)
+			.where(inArray(ccipEmbeddings.regionId, regionIds));
+	}
+
+	async deleteBySource(mediaSourceId: string): Promise<void> {
+		const regionIds = this.database
+			.select({ id: mediaRegions.id })
+			.from(mediaRegions)
+			.innerJoin(medias, eq(mediaRegions.mediaId, medias.id))
+			.where(eq(medias.mediaSourceId, mediaSourceId));
+		await this.database
+			.delete(ccipEmbeddings)
+			.where(inArray(ccipEmbeddings.regionId, regionIds));
+	}
+
+	async listMediaIds(query?: CcipVectorQuery): Promise<string[]> {
+		const rows = await this.database
+			.selectDistinct({ mediaId: medias.id })
+			.from(ccipEmbeddings)
+			.innerJoin(mediaRegions, eq(ccipEmbeddings.regionId, mediaRegions.id))
+			.innerJoin(medias, eq(mediaRegions.mediaId, medias.id))
+			.where(recordFilters(query));
+		return rows.map((row) => row.mediaId);
+	}
+
+	async list(query?: CcipVectorQuery): Promise<CcipVectorRecord[]> {
+		const rows = await this.database
+			.select(recordColumns)
+			.from(ccipEmbeddings)
+			.innerJoin(mediaRegions, eq(ccipEmbeddings.regionId, mediaRegions.id))
+			.innerJoin(medias, eq(mediaRegions.mediaId, medias.id))
+			.where(recordFilters(query));
+		return rows.map(mapRecord);
+	}
+
+	async search(
+		vector: number[],
+		limit: number,
+		query?: CcipVectorQuery,
+	): Promise<CcipVectorCandidate[]> {
+		if (!Number.isSafeInteger(limit) || limit < 1) {
+			throw new Error("limit must be a positive integer");
+		}
+		const literal = vectorLiteral(vector);
+		const filters = [
+			sql`${mediaRegions.kind} = ${FULL_REGION_KIND}`,
+			query?.mediaSourceId
+				? sql`${medias.mediaSourceId} = ${query.mediaSourceId}`
+				: undefined,
+			query?.model ? sql`${ccipEmbeddings.model} = ${query.model}` : undefined,
+			query?.embeddingVersion !== undefined
+				? sql`${ccipEmbeddings.embeddingVersion} = ${query.embeddingVersion}`
+				: undefined,
+		].filter((value): value is SQL => value !== undefined);
+		const raw = await this.database.execute(sql`
+			SELECT
+				${medias.id} AS "mediaId",
+				${medias.mediaSourceId} AS "mediaSourceId",
+				${ccipEmbeddings.embedding}::text AS "vector",
+				${ccipEmbeddings.model} AS "model",
+				${ccipEmbeddings.embeddingVersion} AS "embeddingVersion",
+				${ccipEmbeddings.mediaModifiedAt} AS "mediaModifiedAt",
+				${ccipEmbeddings.extractedAt} AS "extractedAt",
+				(${ccipEmbeddings.embedding} <=> ${literal}::vector) AS "cosineDistance"
+			FROM ${ccipEmbeddings}
+			INNER JOIN ${mediaRegions} ON ${ccipEmbeddings.regionId} = ${mediaRegions.id}
+			INNER JOIN ${medias} ON ${mediaRegions.mediaId} = ${medias.id}
+			WHERE ${sql.join(filters, sql` AND `)}
+			ORDER BY ${ccipEmbeddings.embedding} <=> ${literal}::vector
+			LIMIT ${limit}
+		`);
+		return extractRows(raw).map((row) => rawCandidateRowSchema.parse(row));
+	}
+}

--- a/apps/server/src/infrastructure/db/connection.ts
+++ b/apps/server/src/infrastructure/db/connection.ts
@@ -1,6 +1,7 @@
 import { PGlite } from "@electric-sql/pglite";
 import { Pool, type PoolClient } from "pg";
 import type { DatabaseConfig } from "~/config/database";
+import { createPglite } from "./pglite";
 
 export type DbConnection = PGlite | Pool | PoolClient;
 
@@ -8,7 +9,7 @@ export async function createConnection(
 	config: DatabaseConfig,
 ): Promise<DbConnection> {
 	if (config.databaseType === "pglite") {
-		const pglite = new PGlite(config.pglite.path);
+		const pglite = createPglite(config.pglite.path);
 		await pglite.waitReady;
 		return pglite;
 	}

--- a/apps/server/src/infrastructure/db/index.ts
+++ b/apps/server/src/infrastructure/db/index.ts
@@ -1,9 +1,10 @@
 import path from "node:path";
-import { PGlite } from "@electric-sql/pglite";
+import type { PGlite } from "@electric-sql/pglite";
 import { drizzle as drizzleNodePg } from "drizzle-orm/node-postgres";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 import { Pool } from "pg";
 import { logger } from "~/infrastructure/logger";
+import { createPglite } from "./pglite";
 import * as schema from "./schema";
 
 export type NodePgDb = ReturnType<typeof drizzleNodePg<typeof schema>>;
@@ -49,7 +50,7 @@ function initializeDb() {
 			{ path: pglitePath, absolutePath: path.resolve(pglitePath) },
 			"[DB] Using persistent PGlite database",
 		);
-		const client = new PGlite(pglitePath);
+		const client = createPglite(pglitePath);
 		_queryClient = client;
 		_db = drizzlePglite(client, { schema });
 		return _db;

--- a/apps/server/src/infrastructure/db/pglite.ts
+++ b/apps/server/src/infrastructure/db/pglite.ts
@@ -1,0 +1,12 @@
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite-pgvector";
+
+/**
+ * Creates a PGlite client with the same pgvector extension that PostgreSQL
+ * uses in production. Migrations still run `CREATE EXTENSION vector`; passing
+ * the extension here makes that SQL available in every local/test runtime.
+ */
+export function createPglite(dataDir?: string): PGlite {
+	const options = { extensions: { vector } };
+	return dataDir ? new PGlite(dataDir, options) : new PGlite(options);
+}

--- a/apps/server/src/tests/integration/ai/lancedb-ccip-vector-store.test.ts
+++ b/apps/server/src/tests/integration/ai/lancedb-ccip-vector-store.test.ts
@@ -147,15 +147,15 @@ describe("LanceDbCcipVectorStore integration", () => {
 				[NEAR_MEDIA_ID, near],
 			]),
 		);
-		expect(await reopenedStore.listMediaIds(SOURCE_A_ID)).toEqual(
+		expect(
+			await reopenedStore.listMediaIds({ mediaSourceId: SOURCE_A_ID }),
+		).toEqual(
 			expect.arrayContaining([ANCHOR_MEDIA_ID, NEAR_MEDIA_ID, FAR_MEDIA_ID]),
 		);
 
-		const sourceScoped = await reopenedStore.search(
-			anchor.vector,
-			10,
-			SOURCE_A_ID,
-		);
+		const sourceScoped = await reopenedStore.search(anchor.vector, 10, {
+			mediaSourceId: SOURCE_A_ID,
+		});
 		expect(sourceScoped.map((candidate) => candidate.mediaId)).toEqual(
 			expect.arrayContaining([ANCHOR_MEDIA_ID, NEAR_MEDIA_ID, FAR_MEDIA_ID]),
 		);

--- a/apps/server/src/tests/integration/ai/lancedb-ccip-vector-store.test.ts
+++ b/apps/server/src/tests/integration/ai/lancedb-ccip-vector-store.test.ts
@@ -26,6 +26,10 @@ const OTHER_SOURCE_MEDIA_ID = "66666666-6666-4666-8666-666666666666";
 
 const MODIFIED_AT = new Date("2026-07-01T00:00:00.000Z");
 const EXTRACTED_AT = new Date("2026-07-02T00:00:00.000Z");
+const READ_QUERY = {
+	model: CCIP_MODEL,
+	embeddingVersion: CCIP_EMBEDDING_VERSION,
+};
 
 function vector(first: number, second = 0): number[] {
 	return Array.from({ length: 768 }, (_, index) => {
@@ -126,9 +130,9 @@ describe("LanceDbCcipVectorStore integration", () => {
 
 		await store.upsertMany([anchor, near, far, otherSource]);
 
-		const loaded = await store.get(ANCHOR_MEDIA_ID);
+		const loaded = await store.get(ANCHOR_MEDIA_ID, READ_QUERY);
 		expect(loaded).toEqual(anchor);
-		const metadata = await store.getMetadataMany([ANCHOR_MEDIA_ID]);
+		const metadata = await store.getMetadataMany([ANCHOR_MEDIA_ID], READ_QUERY);
 		expect(metadata.get(ANCHOR_MEDIA_ID)).toEqual({
 			mediaId: anchor.mediaId,
 			mediaSourceId: anchor.mediaSourceId,
@@ -140,7 +144,7 @@ describe("LanceDbCcipVectorStore integration", () => {
 
 		const reopenedStore = new LanceDbCcipVectorStore(directory);
 		expect(
-			await reopenedStore.getMany([ANCHOR_MEDIA_ID, NEAR_MEDIA_ID]),
+			await reopenedStore.getMany([ANCHOR_MEDIA_ID, NEAR_MEDIA_ID], READ_QUERY),
 		).toEqual(
 			new Map([
 				[ANCHOR_MEDIA_ID, anchor],
@@ -152,9 +156,20 @@ describe("LanceDbCcipVectorStore integration", () => {
 		).toEqual(
 			expect.arrayContaining([ANCHOR_MEDIA_ID, NEAR_MEDIA_ID, FAR_MEDIA_ID]),
 		);
+		const batches: CcipVectorRecord[][] = [];
+		for await (const batch of reopenedStore.listBatches(2, {
+			mediaSourceId: SOURCE_A_ID,
+		})) {
+			batches.push(batch);
+		}
+		expect(batches.every((batch) => batch.length <= 2)).toBe(true);
+		expect(batches.flat().map((record) => record.mediaId)).toEqual(
+			expect.arrayContaining([ANCHOR_MEDIA_ID, NEAR_MEDIA_ID, FAR_MEDIA_ID]),
+		);
 
 		const sourceScoped = await reopenedStore.search(anchor.vector, 10, {
 			mediaSourceId: SOURCE_A_ID,
+			...READ_QUERY,
 		});
 		expect(sourceScoped.map((candidate) => candidate.mediaId)).toEqual(
 			expect.arrayContaining([ANCHOR_MEDIA_ID, NEAR_MEDIA_ID, FAR_MEDIA_ID]),
@@ -174,14 +189,14 @@ describe("LanceDbCcipVectorStore integration", () => {
 		const near = createRecord(NEAR_MEDIA_ID, SOURCE_A_ID, vector(0.875, 0.125));
 
 		await writer.upsert(anchor);
-		expect(await reader.get(ANCHOR_MEDIA_ID)).toEqual(anchor);
+		expect(await reader.get(ANCHOR_MEDIA_ID, READ_QUERY)).toEqual(anchor);
 
 		// The reader's Table handle is already open at the previous version.
 		// This mirrors Vite HMR, where an older API module and the active job
 		// worker can hold separate LanceDB connections to the same directory.
 		await writer.upsert(near);
 
-		expect(await reader.get(NEAR_MEDIA_ID)).toEqual(near);
+		expect(await reader.get(NEAR_MEDIA_ID, READ_QUERY)).toEqual(near);
 	});
 
 	it("reports ready and stale status and searches candidates through the real store", async () => {

--- a/apps/server/src/tests/integration/ai/postgres-ccip-vector-store.test.ts
+++ b/apps/server/src/tests/integration/ai/postgres-ccip-vector-store.test.ts
@@ -6,9 +6,11 @@ import {
 } from "@solid-imager/application/services/ccip-vector-service";
 import {
 	CCIP_VECTOR_DIMENSIONS,
+	mediaRegions,
 	mediaSources,
 	medias,
 } from "@solid-imager/db/schema";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { migrate } from "drizzle-orm/pglite/migrator";
 import { afterEach, describe, expect, it } from "vite-plus/test";
@@ -25,6 +27,8 @@ const OTHER_SOURCE_MEDIA_ID = "66666666-6666-4666-8666-666666666666";
 
 const MODIFIED_AT = new Date("2026-07-01T00:00:00.000Z");
 const EXTRACTED_AT = new Date("2026-07-02T00:00:00.000Z");
+const NEWER_MODIFIED_AT = new Date("2026-07-03T00:00:00.000Z");
+const NEWER_EXTRACTED_AT = new Date("2026-07-04T00:00:00.000Z");
 
 function vector(first: number, second = 0): number[] {
 	return Array.from({ length: CCIP_VECTOR_DIMENSIONS }, (_, index) => {
@@ -152,5 +156,25 @@ describe("PostgresCcipVectorStore", () => {
 		expect(candidates.map((candidate) => candidate.mediaId)).not.toContain(
 			OTHER_SOURCE_MEDIA_ID,
 		);
+
+		const newerAnchor = {
+			...anchor,
+			vector: vector(0.5, 0.5),
+			mediaModifiedAt: NEWER_MODIFIED_AT,
+			extractedAt: NEWER_EXTRACTED_AT,
+		};
+		await store.upsert(newerAnchor);
+		await store.upsert(anchor);
+		expect(
+			await store.get(ANCHOR_MEDIA_ID, {
+				model: CCIP_MODEL,
+				embeddingVersion: CCIP_EMBEDDING_VERSION,
+			}),
+		).toEqual(newerAnchor);
+		const [region] = await database
+			.select({ sourceModifiedAt: mediaRegions.sourceModifiedAt })
+			.from(mediaRegions)
+			.where(eq(mediaRegions.mediaId, ANCHOR_MEDIA_ID));
+		expect(region?.sourceModifiedAt).toEqual(NEWER_MODIFIED_AT);
 	});
 });

--- a/apps/server/src/tests/integration/ai/postgres-ccip-vector-store.test.ts
+++ b/apps/server/src/tests/integration/ai/postgres-ccip-vector-store.test.ts
@@ -1,0 +1,151 @@
+import path from "node:path";
+import type { CcipVectorRecord } from "@solid-imager/application/ports/ccip-vector-store";
+import {
+	CCIP_EMBEDDING_VERSION,
+	CCIP_MODEL,
+} from "@solid-imager/application/services/ccip-vector-service";
+import {
+	CCIP_VECTOR_DIMENSIONS,
+	mediaSources,
+	medias,
+} from "@solid-imager/db/schema";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { PostgresCcipVectorStore } from "~/infrastructure/ai/postgres-ccip-vector-store";
+import { createPglite } from "~/infrastructure/db/pglite";
+import * as schema from "~/infrastructure/db/schema";
+
+const SOURCE_A_ID = "11111111-1111-4111-8111-111111111111";
+const SOURCE_B_ID = "22222222-2222-4222-8222-222222222222";
+const ANCHOR_MEDIA_ID = "33333333-3333-4333-8333-333333333333";
+const NEAR_MEDIA_ID = "44444444-4444-4444-8444-444444444444";
+const FAR_MEDIA_ID = "55555555-5555-4555-8555-555555555555";
+const OTHER_SOURCE_MEDIA_ID = "66666666-6666-4666-8666-666666666666";
+
+const MODIFIED_AT = new Date("2026-07-01T00:00:00.000Z");
+const EXTRACTED_AT = new Date("2026-07-02T00:00:00.000Z");
+
+function vector(first: number, second = 0): number[] {
+	return Array.from({ length: CCIP_VECTOR_DIMENSIONS }, (_, index) => {
+		if (index === 0) return first;
+		if (index === 1) return second;
+		return 0;
+	});
+}
+
+function record(
+	mediaId: string,
+	mediaSourceId: string,
+	feature: number[],
+): CcipVectorRecord {
+	return {
+		mediaId,
+		mediaSourceId,
+		vector: feature,
+		model: CCIP_MODEL,
+		embeddingVersion: CCIP_EMBEDDING_VERSION,
+		mediaModifiedAt: MODIFIED_AT,
+		extractedAt: EXTRACTED_AT,
+	};
+}
+
+describe("PostgresCcipVectorStore", () => {
+	let client: ReturnType<typeof createPglite> | undefined;
+
+	afterEach(async () => {
+		await client?.close();
+		client = undefined;
+	});
+
+	it("persists and searches CCIP vectors with pgvector without LanceDB", async () => {
+		client = createPglite();
+		const database = drizzle(client, { schema });
+		const migrationsFolder = process.cwd().endsWith("apps/server")
+			? path.resolve(process.cwd(), "drizzle")
+			: path.resolve(process.cwd(), "apps/server/drizzle");
+		await migrate(database, { migrationsFolder });
+
+		await database.insert(mediaSources).values([
+			{
+				id: SOURCE_A_ID,
+				name: "Source A",
+				description: null,
+				type: "local",
+				connectionInfo: { path: "/tmp/source-a" },
+			},
+			{
+				id: SOURCE_B_ID,
+				name: "Source B",
+				description: null,
+				type: "local",
+				connectionInfo: { path: "/tmp/source-b" },
+			},
+		]);
+		await database.insert(medias).values(
+			[ANCHOR_MEDIA_ID, NEAR_MEDIA_ID, FAR_MEDIA_ID, OTHER_SOURCE_MEDIA_ID].map(
+				(id) => ({
+					id,
+					mediaSourceId:
+						id === OTHER_SOURCE_MEDIA_ID ? SOURCE_B_ID : SOURCE_A_ID,
+					filePath: `${id}.png`,
+					fileName: `${id}.png`,
+					mediaType: "image" as const,
+					width: 256,
+					height: 256,
+					modifiedAt: MODIFIED_AT,
+				}),
+			),
+		);
+
+		const store = new PostgresCcipVectorStore(database);
+		const anchor = record(ANCHOR_MEDIA_ID, SOURCE_A_ID, vector(1));
+		await store.upsertMany([
+			anchor,
+			record(NEAR_MEDIA_ID, SOURCE_A_ID, vector(0.875, 0.125)),
+			record(FAR_MEDIA_ID, SOURCE_A_ID, vector(0, 1)),
+			record(OTHER_SOURCE_MEDIA_ID, SOURCE_B_ID, vector(0.75, 0.25)),
+		]);
+
+		expect(
+			await store.get(ANCHOR_MEDIA_ID, {
+				model: CCIP_MODEL,
+				embeddingVersion: CCIP_EMBEDDING_VERSION,
+			}),
+		).toEqual(anchor);
+		expect(
+			await store.getMetadataMany([ANCHOR_MEDIA_ID], {
+				model: CCIP_MODEL,
+				embeddingVersion: CCIP_EMBEDDING_VERSION,
+			}),
+		).toEqual(
+			new Map([
+				[
+					ANCHOR_MEDIA_ID,
+					{
+						mediaId: ANCHOR_MEDIA_ID,
+						mediaSourceId: SOURCE_A_ID,
+						model: CCIP_MODEL,
+						embeddingVersion: CCIP_EMBEDDING_VERSION,
+						mediaModifiedAt: MODIFIED_AT,
+						extractedAt: EXTRACTED_AT,
+					},
+				],
+			]),
+		);
+
+		const candidates = await store.search(anchor.vector, 10, {
+			mediaSourceId: SOURCE_A_ID,
+			model: CCIP_MODEL,
+			embeddingVersion: CCIP_EMBEDDING_VERSION,
+		});
+		expect(candidates.map((candidate) => candidate.mediaId)).toEqual([
+			ANCHOR_MEDIA_ID,
+			NEAR_MEDIA_ID,
+			FAR_MEDIA_ID,
+		]);
+		expect(candidates.map((candidate) => candidate.mediaId)).not.toContain(
+			OTHER_SOURCE_MEDIA_ID,
+		);
+	});
+});

--- a/apps/server/src/tests/integration/ai/postgres-ccip-vector-store.test.ts
+++ b/apps/server/src/tests/integration/ai/postgres-ccip-vector-store.test.ts
@@ -102,6 +102,11 @@ describe("PostgresCcipVectorStore", () => {
 		const anchor = record(ANCHOR_MEDIA_ID, SOURCE_A_ID, vector(1));
 		await store.upsertMany([
 			anchor,
+			{
+				...record(ANCHOR_MEDIA_ID, SOURCE_A_ID, vector(0, 1)),
+				model: "ccip-legacy-model",
+				embeddingVersion: 2,
+			},
 			record(NEAR_MEDIA_ID, SOURCE_A_ID, vector(0.875, 0.125)),
 			record(FAR_MEDIA_ID, SOURCE_A_ID, vector(0, 1)),
 			record(OTHER_SOURCE_MEDIA_ID, SOURCE_B_ID, vector(0.75, 0.25)),

--- a/apps/server/src/tests/integration/media/get-media-details-integration.test.ts
+++ b/apps/server/src/tests/integration/media/get-media-details-integration.test.ts
@@ -24,15 +24,15 @@ import { TagRepository } from "~/infrastructure/repositories/tag-repository";
 import { ServerMediaStorage } from "~/infrastructure/storage/server-media-storage";
 
 // We need to dynamically import these to work around Vitest's hoisting
-let _PGlite: any, drizzle: any, migrate: any, schema: any, _eq: any;
+let drizzle: any, migrate: any, schema: any, _eq: any;
 let testDb: any, db: any;
 
 vi.mock("~/infrastructure/db/index", async () => {
-	const { PGlite: PgLiteClass } = await import("@electric-sql/pglite");
+	const { createPglite } = await import("~/infrastructure/db/pglite");
 	const { drizzle: drizzleFunc } = await import("drizzle-orm/pglite");
 	const schemaModule = await import("~/infrastructure/db/schema");
 
-	const pg = new PgLiteClass();
+	const pg = createPglite();
 	const dbInstance = drizzleFunc(pg, { schema: schemaModule });
 
 	// Expose the testDb instance to the global scope for the test file
@@ -60,8 +60,6 @@ describe("getMediaDetails", () => {
 		services.registerAiClient(new RustAiClient());
 
 		// Dynamically import dependencies
-		const pgliteModule = await import("@electric-sql/pglite");
-		_PGlite = pgliteModule.PGlite;
 		const drizzleOrmModule = await import("drizzle-orm/pglite");
 		drizzle = drizzleOrmModule.drizzle;
 		const drizzleOrm = await import("drizzle-orm");

--- a/apps/server/src/tests/setup-integration.ts
+++ b/apps/server/src/tests/setup-integration.ts
@@ -152,13 +152,13 @@ const { mockDbFactory } = vi.hoisted(() => {
 				return dbInstance;
 			}
 
-			const { PGlite } = await import("@electric-sql/pglite");
+			const { createPglite } = await import("~/infrastructure/db/pglite");
 			const { drizzle } = await import("drizzle-orm/pglite");
 			const { migrate } = await import("drizzle-orm/pglite/migrator");
 			const schema = await import("~/infrastructure/db/schema");
 			const nodePath = await import("node:path");
 
-			const client = new PGlite();
+			const client = createPglite();
 			const testDb = drizzle(client, { schema });
 			const migrationsFolder = process.cwd().endsWith("apps/server")
 				? nodePath.resolve(process.cwd(), "drizzle")

--- a/apps/server/src/tests/setup.ts
+++ b/apps/server/src/tests/setup.ts
@@ -147,13 +147,13 @@ const { mockDbInstance } = vi.hoisted(() => {
 
 				// 統合テストの場合は新しいPGLiteインスタンスを使用
 				// schemaを動的にインポートしてホイスティングの問題を回避
-				const { PGlite } = await import("@electric-sql/pglite");
+				const { createPglite } = await import("~/infrastructure/db/pglite");
 				const { drizzle } = await import("drizzle-orm/pglite");
 				const { migrate } = await import("drizzle-orm/pglite/migrator");
 				const schema = await import("~/infrastructure/db/schema");
 				const nodePath = await import("node:path");
 
-				const client = new PGlite();
+				const client = createPglite();
 				const testDb = drizzle(client, { schema });
 				// Use absolute path to ensure it works from any CWD (monorepo root or app root)
 				const migrationsFolder = process.cwd().endsWith("apps/server")

--- a/apps/server/src/tests/unit/db/connection.test.ts
+++ b/apps/server/src/tests/unit/db/connection.test.ts
@@ -59,7 +59,9 @@ describe("createConnection", () => {
 		expect(connection.constructor.name).toBe("PgLite");
 		// Ensure PgLite constructor was called
 		const { PGlite } = await import("@electric-sql/pglite");
-		expect(PGlite).toHaveBeenCalledWith(config.pglite.path);
+		expect(PGlite).toHaveBeenCalledWith(config.pglite.path, {
+			extensions: { vector: expect.anything() },
+		});
 	});
 
 	it("should create a postgres connection when databaseType is docker-compose-postgres", async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,8 @@
       "name": "@solid-imager/server",
       "version": "0.0.0",
       "dependencies": {
-        "@electric-sql/pglite": "^0.5.2",
+        "@electric-sql/pglite": "0.5.3",
+        "@electric-sql/pglite-pgvector": "0.0.4",
         "@lancedb/lancedb": "^0.30.0",
         "@orpc/client": "^1.14.4",
         "@orpc/contract": "^1.14.4",
@@ -343,6 +344,8 @@
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.5.3", "", {}, "sha512-iTTYbA5Uesrl+N7zss0J5LopT7KE4j9aymYo+EZZh+rZbARQCUQOs+n2pay64JRUpc3fCkpfrniTNJnvYzOE+g=="],
+
+    "@electric-sql/pglite-pgvector": ["@electric-sql/pglite-pgvector@0.0.4", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.3" } }, "sha512-oHOQlYMzgxmoFWRbKhhoV0UNfoNUdbTHUD/z/nujr8LrUe4HdiSAUY2+Mv+Z033hZO9UWqOuj3Be2KztwK79ow=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17
+    image: pgvector/pgvector:pg17
     restart: always
     environment:
       POSTGRES_USER: ${DB_USER}

--- a/packages/application/src/ports/ccip-vector-store.ts
+++ b/packages/application/src/ports/ccip-vector-store.ts
@@ -14,6 +14,13 @@ export type CcipVectorQuery = {
 	embeddingVersion?: number;
 };
 
+/** Query used by reads that must not mix embedding spaces. */
+export type CcipVectorReadQuery = {
+	mediaSourceId?: string;
+	model: string;
+	embeddingVersion: number;
+};
+
 export type CcipVectorMetadata = Omit<CcipVectorRecord, "vector">;
 
 export type CcipVectorCandidate = CcipVectorRecord & {
@@ -23,15 +30,15 @@ export type CcipVectorCandidate = CcipVectorRecord & {
 export interface ICcipVectorStore {
 	get(
 		mediaId: string,
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<CcipVectorRecord | null>;
 	getMany(
 		mediaIds: string[],
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<Map<string, CcipVectorRecord>>;
 	getMetadataMany(
 		mediaIds: string[],
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<Map<string, CcipVectorMetadata>>;
 	upsert(record: CcipVectorRecord): Promise<void>;
 	upsertMany(records: CcipVectorRecord[]): Promise<void>;
@@ -42,6 +49,6 @@ export interface ICcipVectorStore {
 	search(
 		vector: number[],
 		limit: number,
-		query?: CcipVectorQuery,
+		query: CcipVectorReadQuery,
 	): Promise<CcipVectorCandidate[]>;
 }

--- a/packages/application/src/ports/ccip-vector-store.ts
+++ b/packages/application/src/ports/ccip-vector-store.ts
@@ -8,6 +8,12 @@ export type CcipVectorRecord = {
 	extractedAt: Date;
 };
 
+export type CcipVectorQuery = {
+	mediaSourceId?: string;
+	model?: string;
+	embeddingVersion?: number;
+};
+
 export type CcipVectorMetadata = Omit<CcipVectorRecord, "vector">;
 
 export type CcipVectorCandidate = CcipVectorRecord & {
@@ -15,18 +21,27 @@ export type CcipVectorCandidate = CcipVectorRecord & {
 };
 
 export interface ICcipVectorStore {
-	get(mediaId: string): Promise<CcipVectorRecord | null>;
-	getMany(mediaIds: string[]): Promise<Map<string, CcipVectorRecord>>;
-	getMetadataMany(mediaIds: string[]): Promise<Map<string, CcipVectorMetadata>>;
+	get(
+		mediaId: string,
+		query?: CcipVectorQuery,
+	): Promise<CcipVectorRecord | null>;
+	getMany(
+		mediaIds: string[],
+		query?: CcipVectorQuery,
+	): Promise<Map<string, CcipVectorRecord>>;
+	getMetadataMany(
+		mediaIds: string[],
+		query?: CcipVectorQuery,
+	): Promise<Map<string, CcipVectorMetadata>>;
 	upsert(record: CcipVectorRecord): Promise<void>;
 	upsertMany(records: CcipVectorRecord[]): Promise<void>;
 	delete(mediaId: string): Promise<void>;
 	deleteBySource(mediaSourceId: string): Promise<void>;
-	listMediaIds(mediaSourceId?: string): Promise<string[]>;
-	list(mediaSourceId?: string): Promise<CcipVectorRecord[]>;
+	listMediaIds(query?: CcipVectorQuery): Promise<string[]>;
+	list(query?: CcipVectorQuery): Promise<CcipVectorRecord[]>;
 	search(
 		vector: number[],
 		limit: number,
-		mediaSourceId?: string,
+		query?: CcipVectorQuery,
 	): Promise<CcipVectorCandidate[]>;
 }

--- a/packages/application/src/services/ccip-vector-service.ts
+++ b/packages/application/src/services/ccip-vector-service.ts
@@ -33,7 +33,9 @@ export class CcipVectorService {
 		mediaId: string,
 		force = false,
 	): Promise<{ record: CcipVectorRecord; skipped: boolean }> {
-		const existing = force ? null : await this.deps.vectorStore.get(mediaId);
+		const existing = force
+			? null
+			: await this.deps.vectorStore.get(mediaId, this.currentVectorQuery());
 		const result = await this.prepareExtraction(
 			mediaSourceId,
 			mediaId,
@@ -62,7 +64,10 @@ export class CcipVectorService {
 		}
 		const existingById = force
 			? new Map<string, CcipVectorRecord>()
-			: await this.deps.vectorStore.getMany(mediaIds);
+			: await this.deps.vectorStore.getMany(
+					mediaIds,
+					this.currentVectorQuery(),
+				);
 		const results = await asyncPool(mediaIds, concurrency, async (mediaId) => ({
 			mediaId,
 			...(await this.prepareExtraction(
@@ -115,7 +120,10 @@ export class CcipVectorService {
 		extractedAt?: Date;
 	}> {
 		const media = await this.requireImage(mediaSourceId, mediaId);
-		const record = await this.deps.vectorStore.get(mediaId);
+		const record = await this.deps.vectorStore.get(
+			mediaId,
+			this.currentVectorQuery(),
+		);
 		if (!record) return { status: "missing" };
 		return {
 			status: this.isCurrent(record, media, mediaSourceId) ? "ready" : "stale",
@@ -133,21 +141,33 @@ export class CcipVectorService {
 	}
 
 	async getMany(mediaIds: string[]): Promise<Map<string, CcipVectorRecord>> {
-		return await this.deps.vectorStore.getMany(mediaIds);
+		return await this.deps.vectorStore.getMany(
+			mediaIds,
+			this.currentVectorQuery(),
+		);
 	}
 
 	async getMetadataMany(
 		mediaIds: string[],
 	): Promise<Map<string, CcipVectorMetadata>> {
-		return await this.deps.vectorStore.getMetadataMany(mediaIds);
+		return await this.deps.vectorStore.getMetadataMany(
+			mediaIds,
+			this.currentVectorQuery(),
+		);
 	}
 
 	async listExtractedMediaIds(mediaSourceId?: string): Promise<string[]> {
-		return await this.deps.vectorStore.listMediaIds(mediaSourceId);
+		return await this.deps.vectorStore.listMediaIds({
+			...this.currentVectorQuery(),
+			mediaSourceId,
+		});
 	}
 
 	async listRecords(mediaSourceId?: string): Promise<CcipVectorRecord[]> {
-		return await this.deps.vectorStore.list(mediaSourceId);
+		return await this.deps.vectorStore.list({
+			...this.currentVectorQuery(),
+			mediaSourceId,
+		});
 	}
 
 	async searchSimilar(
@@ -157,7 +177,10 @@ export class CcipVectorService {
 	): Promise<SimilarMediaSearchResponse> {
 		const anchorMedia = await this.deps.mediaRepository.findById(anchorMediaId);
 		if (!anchorMedia) throw new Error(`Media not found: ${anchorMediaId}`);
-		const anchor = await this.deps.vectorStore.get(anchorMediaId);
+		const anchor = await this.deps.vectorStore.get(
+			anchorMediaId,
+			this.currentVectorQuery(),
+		);
 		if (
 			!anchor ||
 			!this.isCurrent(anchor, anchorMedia, anchorMedia.mediaSourceId)
@@ -170,11 +193,10 @@ export class CcipVectorService {
 			MAX_CANDIDATES,
 		);
 		const candidates = (
-			await this.deps.vectorStore.search(
-				anchor.vector,
-				candidateLimit + 1,
+			await this.deps.vectorStore.search(anchor.vector, candidateLimit + 1, {
+				...this.currentVectorQuery(),
 				mediaSourceId,
-			)
+			})
 		).filter((candidate) => candidate.mediaId !== anchorMediaId);
 		if (candidates.length === 0) {
 			return { media: [], total: 0, scores: [] };
@@ -234,6 +256,13 @@ export class CcipVectorService {
 			// the current file, regardless of LanceDB timestamp serialization.
 			record.extractedAt.getTime() >= media.modifiedAt.getTime()
 		);
+	}
+
+	private currentVectorQuery() {
+		return {
+			model: CCIP_MODEL,
+			embeddingVersion: CCIP_EMBEDDING_VERSION,
+		};
 	}
 
 	private async requireImage(

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -4,6 +4,8 @@ import {
 	type AnyPgColumn,
 	bigint,
 	boolean,
+	check,
+	customType,
 	index,
 	integer,
 	jsonb,
@@ -19,6 +21,43 @@ import {
 	uniqueIndex,
 	uuid,
 } from "drizzle-orm/pg-core";
+
+export const CCIP_VECTOR_DIMENSIONS = 768;
+
+function isCcipVector(value: unknown): value is number[] {
+	return (
+		Array.isArray(value) &&
+		value.length === CCIP_VECTOR_DIMENSIONS &&
+		value.every((item) => typeof item === "number" && Number.isFinite(item))
+	);
+}
+
+function parseCcipVector(value: string | number[]): number[] {
+	const parsed = typeof value === "string" ? JSON.parse(value) : value;
+	if (!isCcipVector(parsed)) {
+		throw new Error(
+			`Expected a finite ${CCIP_VECTOR_DIMENSIONS}-dimension vector`,
+		);
+	}
+	return parsed;
+}
+
+/** PostgreSQL pgvector column mapped to a finite 768-dimensional JavaScript array. */
+export const ccipVector = customType<{
+	data: number[];
+	driverData: string | number[];
+}>({
+	dataType: () => `vector(${CCIP_VECTOR_DIMENSIONS})`,
+	toDriver: (value) => {
+		if (!isCcipVector(value)) {
+			throw new Error(
+				`Expected a finite ${CCIP_VECTOR_DIMENSIONS}-dimension vector`,
+			);
+		}
+		return `[${value.join(",")}]`;
+	},
+	fromDriver: parseCcipVector,
+});
 
 // 列挙型
 /**
@@ -53,6 +92,12 @@ export const mediaSyncStatusEnum = pgEnum("media_sync_status", [
  * Defines the primary content type of a media file.
  */
 export const mediaTypeEnum = pgEnum("media_type", ["image", "video", "audio"]);
+/** Region types used for full-image and cropped CCIP embeddings. */
+export const mediaRegionKindEnum = pgEnum("media_region_kind", [
+	"full",
+	"person",
+	"manual",
+]);
 /**
  * Enum for job status.
  * Defines the current state of a background job.
@@ -154,6 +199,79 @@ export const medias = pgTable(
 		fileNameIndex: index("idx_media_file_name").on(table.fileName),
 		createdAtIndex: index("idx_media_created_at").on(table.createdAt),
 		descriptionIndex: index("idx_media_description").on(table.description),
+	}),
+);
+
+/**
+ * Stable, coordinate-based regions of a media item. The initial CCIP rollout
+ * creates only one `full` region per media; crop regions are reserved for the
+ * later crop workflow.
+ */
+export const mediaRegions = pgTable(
+	"media_regions",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		mediaId: uuid("media_id")
+			.notNull()
+			.references(() => medias.id, { onDelete: "cascade" }),
+		kind: mediaRegionKindEnum("kind").notNull(),
+		x: real("x"),
+		y: real("y"),
+		width: real("width"),
+		height: real("height"),
+		sourceModifiedAt: timestamp("source_modified_at").notNull(),
+		detector: text("detector"),
+		detectorVersion: text("detector_version"),
+		score: real("score"),
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		mediaIdIndex: index("idx_media_regions_media_id").on(table.mediaId),
+		oneFullRegionPerMedia: uniqueIndex("uq_media_regions_full_media_id")
+			.on(table.mediaId)
+			.where(sql`${table.kind} = 'full'`),
+		bboxByKind: check(
+			"media_regions_bbox_by_kind",
+			sql`(
+				(${table.kind} = 'full' AND ${table.x} IS NULL AND ${table.y} IS NULL AND ${table.width} IS NULL AND ${table.height} IS NULL)
+				OR
+				(${table.kind} <> 'full' AND ${table.x} IS NOT NULL AND ${table.y} IS NOT NULL AND ${table.width} IS NOT NULL AND ${table.height} IS NOT NULL
+					AND ${table.x} >= 0 AND ${table.y} >= 0 AND ${table.width} > 0 AND ${table.height} > 0
+					AND ${table.x} + ${table.width} <= 1 AND ${table.y} + ${table.height} <= 1)
+			)`,
+		),
+		scoreRange: check(
+			"media_regions_score_range",
+			sql`${table.score} IS NULL OR (${table.score} >= 0 AND ${table.score} <= 1)`,
+		),
+	}),
+);
+
+/**
+ * Versioned CCIP embeddings stored in pgvector. Embeddings are tied to a
+ * region so full-image and future crop vectors share one data model.
+ */
+export const ccipEmbeddings = pgTable(
+	"ccip_embeddings",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		regionId: uuid("region_id")
+			.notNull()
+			.references(() => mediaRegions.id, { onDelete: "cascade" }),
+		embedding: ccipVector("embedding").notNull(),
+		model: text("model").notNull(),
+		embeddingVersion: integer("embedding_version").notNull(),
+		mediaModifiedAt: timestamp("media_modified_at").notNull(),
+		extractedAt: timestamp("extracted_at").notNull(),
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		regionModelVersionUnique: unique(
+			"uq_ccip_embeddings_region_model_version",
+		).on(table.regionId, table.model, table.embeddingVersion),
+		regionIdIndex: index("idx_ccip_embeddings_region_id").on(table.regionId),
 	}),
 );
 
@@ -1641,3 +1759,21 @@ export type MediaUrl = InferSelectModel<typeof mediaUrls>;
  * Type definition for inserting a new media url into the database.
  */
 export type NewMediaUrl = InferInsertModel<typeof mediaUrls>;
+
+/**
+ * Type definition for selecting a media region from the database.
+ */
+export type MediaRegion = InferSelectModel<typeof mediaRegions>;
+/**
+ * Type definition for inserting a media region into the database.
+ */
+export type NewMediaRegion = InferInsertModel<typeof mediaRegions>;
+
+/**
+ * Type definition for selecting a CCIP embedding from the database.
+ */
+export type CcipEmbedding = InferSelectModel<typeof ccipEmbeddings>;
+/**
+ * Type definition for inserting a CCIP embedding into the database.
+ */
+export type NewCcipEmbedding = InferInsertModel<typeof ccipEmbeddings>;


### PR DESCRIPTION
## 概要
CCIP 類似検索のベクトルストアを LanceDB から PostgreSQL の pgvector へ移行します。既存の LanceDB データを安全に取り込む移行スクリプトも追加します。

## 変更内容
- pgvector 拡張、media_regions、ccip_embeddings の DB migration を追加
- アプリケーション実行時の CCIP 類似検索を PostgreSQL 実装へ切替
- LanceDB からの CCIP ベクトル移行コマンドを追加
- PGlite テスト・実行環境に pgvector 拡張を登録
- PostgreSQL ベクトルストアの統合テストを追加

## 検証
- apps/server typecheck
- unit test: connection.test.ts
- integration test: 21 files / 68 tests
- production build

## 移行手順
1. bun --cwd apps/server run db:migrate
2. bun --cwd apps/server run ccip:migrate-from-lancedb -- --dry-run
3. bun --cwd apps/server run ccip:migrate-from-lancedb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CCIP埋め込みをPostgreSQLで保存・検索（768次元、メディア領域対応）できるようにしました。
  * モデル/埋め込みバージョン付きの絞り込み検索と、LanceDB→PostgreSQL移行コマンドを追加しました。
* **改善**
  * 重複防止・整合性チェック・検索用インデックスにより、候補の精度と安定性を強化しました。
* **テスト**
  * PostgreSQL上の永続化/取得/検索を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->