### PR TITLE
refactor: remove vite-plus, switch to plain Vite 8 + Vitest 4

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,34 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Run biome check on all staged files
+npx lint-staged
+
+# Run tests and typecheck only for changed packages
+CHANGED_SERVER=$(git diff --cached --name-only -- apps/server/ | head -1)
+CHANGED_CORE=$(git diff --cached --name-only -- packages/core/ | head -1)
+CHANGED_UI=$(git diff --cached --name-only -- packages/ui/ | head -1)
+CHANGED_XTRACTER=$(git diff --cached --name-only -- apps/xtracter/ | head -1)
+
+if [ -n "$CHANGED_SERVER" ]; then
+  echo "→ apps/server changed, running tests + typecheck..."
+  bun run --cwd apps/server test:unit
+  bun run --cwd apps/server typecheck
+fi
+
+if [ -n "$CHANGED_CORE" ]; then
+  echo "→ packages/core changed, running tests + typecheck..."
+  bun run --cwd packages/core test
+  bun run --cwd packages/core typecheck
+fi
+
+if [ -n "$CHANGED_UI" ]; then
+  echo "→ packages/ui changed, running tests + typecheck..."
+  bun run --cwd packages/ui test
+  bun run --cwd packages/ui typecheck
+fi
+
+if [ -n "$CHANGED_XTRACTER" ]; then
+  echo "→ apps/xtracter changed, running typecheck..."
+  bun run --cwd apps/xtracter typecheck
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 . "$(dirname "$0")/_/husky.sh"
 
 # Run biome check on all staged files


### PR DESCRIPTION
## 概要
vite-plus を通常の Vite 8 + Vitest 4 に置き換えます。

## 変更内容

- vite-plus を vite@^8.0.0 + vitest@^4.1.8 に置き換え
- vp dev/build/preview/test コマンドを vite/vitest に変更
- vp run lint/check/format を bun run --filter に変更
- vite.config.ts の import を vite-plus から vite に変更
- vitest.config.ts の import を vitest/config に変更
- 全テストファイルの import を vite-plus/test から vitest に変更
- Vite 8 ネイティブの resolve.tsconfigPaths を使用（vite-tsconfig-paths プラグイン削除）
- vite-plus の staged ブロックを削除し、husky + lint-staged に置き換え
- AGENTS.md から vite-plus セクションを削除

## 技術詳細

- Vite 8 は Rolldown ベースで、vite-plus と同じ Vite バージョンを使用
- vitest@4.1.10 は vite-plus がバンドルしていた version と同じ系统
- pre-commit hook は biome check + 変更パッケージの tests/typecheck を実行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - コミット前の自動チェックを導入しました。
  - 変更された領域に応じて、コード品質の確認、ユニットテスト、型チェックを自動実行します。
  - 問題のある変更を早期に検出し、リリース品質の安定化につなげます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->