### PR TITLE
fix(web): recover bulk imports after SSR failures

### DIFF
--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -34,6 +34,24 @@ http {
         add_header X-Frame-Options DENY;
         add_header X-Content-Type-Options nosniff;
 
+        # oRPC event streams must not be buffered, otherwise small SSE events
+        # remain inside nginx until the upstream closes the long-lived response.
+        location ~ ^/api/rpc/(sources|imports|jobs)/events$ {
+            proxy_pass http://app:3000;
+            proxy_http_version 1.1;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 1h;
+            proxy_send_timeout 1h;
+            proxy_set_header Connection "";
+        }
+
         location / {
             # アプリコンテナ（app）へ転送
             proxy_pass http://app:3000;


### PR DESCRIPTION
## 概要

巨大なSSR Query復元データでソース画面のSSRが途中で失敗し、hydration前にXtracter bulk importのイベントが失われる問題を修正します。

## 変更内容

- source、import、jobのイベントRPCに専用Nginx locationを追加し、proxy bufferingを無効化
- ソース一覧とソース詳細をCSR routeへ戻し、巨大なSSR Query payloadを排除
- Inboxのhydration時に保留import jobを再取得し、購読開始前のbulkAddを回復

## 検証

- git diff --check
- Biome check（変更3ファイル）
- UI typecheck
- server typecheckは未変更のAPI route型エラーで失敗