### PR TITLE
fix(web): recover bulk imports after SSR failures

### DIFF
--- a/apps/server/src/routes/sources/$mediaSourceId/index.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/index.tsx
@@ -1,40 +1,15 @@
-import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { createFileRoute } from "@tanstack/solid-router";
 import { createSignal, onMount, Show } from "solid-js";
-import {
-	allAuthorsQueryOptions,
-	allCharactersQueryOptions,
-	allIpsQueryOptions,
-	allProjectsQueryOptions,
-	tagsQueryOptions,
-} from "~/infrastructure/api-clients/queries";
 import { SourceMediaPage } from "./components/source-media-page";
 
 export const Route = createFileRoute("/sources/$mediaSourceId/")({
-	ssr: true,
-	loader: async ({ context }) => {
-		await Promise.all([
-			context.queryClient.prefetchQuery(tagsQueryOptions()),
-			context.queryClient.prefetchQuery(allProjectsQueryOptions()),
-			context.queryClient.prefetchQuery(allIpsQueryOptions()),
-			context.queryClient.prefetchQuery(allCharactersQueryOptions()),
-			context.queryClient.prefetchQuery(allAuthorsQueryOptions()),
-		]);
-	},
-	pendingComponent: SourceMediaRouteFallback,
-	pendingMinMs: 0,
+	ssr: false,
+	pendingComponent: () => null,
 	component: SourceMediaRoute,
 });
 
 function SourceMediaRouteFallback() {
-	return (
-		<RouteDataPendingScreen
-			description="メディア一覧を準備しています..."
-			layout="media-grid"
-			showAction
-			title="メディア一覧"
-		/>
-	);
+	return null;
 }
 
 function SourceMediaRoute() {

--- a/apps/server/src/routes/sources/index.tsx
+++ b/apps/server/src/routes/sources/index.tsx
@@ -3,7 +3,6 @@ import { subscribeToEventStream } from "@solid-imager/ui/event-stream";
 import type { RawEventHandler } from "@solid-imager/ui/hooks/use-sources-events";
 import { useSourcesPage } from "@solid-imager/ui/hooks/use-sources-page";
 import { toQueryUiState } from "@solid-imager/ui/query-state";
-import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { SourcesScreen } from "@solid-imager/ui/screens/sources-screen";
 import { SourceCard } from "@solid-imager/ui/source-card";
 import { SourceDeleteModal } from "@solid-imager/ui/source-delete-modal";
@@ -20,23 +19,8 @@ import {
 } from "~/infrastructure/api-clients/sources-api";
 
 export const Route = createFileRoute("/sources/")({
-	ssr: true,
-	loader: async ({ context }) => {
-		const mediaSources = await context.queryClient.fetchQuery(
-			mediaSourcesQueryOptions(),
-		);
-		return { mediaSources };
-	},
-	pendingComponent: () => (
-		<RouteDataPendingScreen
-			class="p-6"
-			description="ソース一覧を準備しています..."
-			layout="cards"
-			showAction
-			title="Media Sources"
-		/>
-	),
-	pendingMinMs: 0,
+	ssr: false,
+	pendingComponent: () => null,
 	component: SourcesRouteContent,
 });
 
@@ -49,9 +33,8 @@ function registerSourceEvents(handler: RawEventHandler): () => void {
 
 function SourcesRouteContent() {
 	const queryClient = useQueryClient();
-	const loaderData = Route.useLoaderData();
 	const mediaSources = createQuery(mediaSourcesQueryOptions);
-	const sourceData = () => mediaSources.data ?? loaderData().mediaSources;
+	const sourceData = () => mediaSources.data;
 
 	const page = useSourcesPage({
 		actions: {

--- a/packages/ui/src/pending-downloads-indicator.tsx
+++ b/packages/ui/src/pending-downloads-indicator.tsx
@@ -46,6 +46,9 @@ export function PendingDownloadsIndicator(
 	onMount(() => {
 		let disposed = false;
 		let cleanup: (() => void) | undefined;
+		// Events emitted before hydration cannot be replayed by the live stream.
+		// Reconcile with the durable job list when the client becomes active.
+		void refetch();
 
 		void Promise.resolve(
 			props.subscribeImportEvents(() => {


### PR DESCRIPTION
## 概要

ソース画面の巨大なSSR Query payloadによるSSR失敗と、hydration前に発行されたXtracter bulk importイベントの取りこぼしを修正します。

## 変更内容

- ソース一覧とソース詳細をCSR routeへ戻し、SSR Queryの巨大な復元payloadを排除
- Inboxのhydration時に保留import jobを再取得し、購読開始前のbulkAddを回復

## 検証

- git diff --check
- Biome check（変更3ファイル）
- UI typecheck
- server typecheckは未変更のAPI route型エラーで失敗