### PR TITLE
fix(ui): improve responsive media navigation and layouts

### DIFF
--- a/apps/server/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/$mediaId/index.tsx
@@ -1,6 +1,10 @@
 import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { MediaDetailScreen } from "@solid-imager/ui/screens/media-detail-screen";
-import { ClientOnly, createFileRoute } from "@tanstack/solid-router";
+import {
+	ClientOnly,
+	createFileRoute,
+	useRouterState,
+} from "@tanstack/solid-router";
 import { type Accessor, createSignal, onMount, Show } from "solid-js";
 import { MediaSidebar } from "~/components/media/media-sidebar";
 import { MediaViewer } from "~/components/media/media-viewer";
@@ -21,6 +25,10 @@ interface MediaRouteParams {
 
 export const Route = createFileRoute("/sources/$mediaSourceId/$mediaId/")({
 	ssr: true,
+	remountDeps: ({ params }: { params: MediaRouteParams }) => [
+		params.mediaSourceId,
+		params.mediaId,
+	],
 	loader: async ({ context, params }: RouteLoaderContext<MediaRouteParams>) => {
 		await Promise.all([
 			context.queryClient.prefetchQuery(
@@ -70,7 +78,13 @@ function MediaRouteFallback() {
 
 function MediaRouteContent() {
 	const routeData = Route.useLoaderData();
-	const currentParams = Route.useParams();
+	const currentParams = useRouterState({
+		select: (state) =>
+			state.matches.find(
+				(match: { routeId: string; params: MediaRouteParams }) =>
+					match.routeId === Route.id,
+			)?.params,
+	});
 	const mediaSourceId = () =>
 		currentParams()?.mediaSourceId ?? routeData().mediaSourceId;
 	const mediaId = () => currentParams()?.mediaId ?? routeData().mediaId;

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -3,7 +3,7 @@ import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { sourceMediaQueryKeys } from "@solid-imager/ui/query-options";
 import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { SourceMediaPage as SourceMediaPageComponent } from "@solid-imager/ui/source-media-page";
-import { useQueryClient } from "@tanstack/solid-query";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { useParams } from "@tanstack/solid-router";
 import { createSignal, onMount, Show } from "solid-js";
 import { BulkActionDialog } from "~/components/media/bulk-action-dialog";
@@ -25,6 +25,7 @@ import {
 	allCharactersQueryOptions,
 	allIpsQueryOptions,
 	allProjectsQueryOptions,
+	mediaSourcesQueryOptions,
 	tagsQueryOptions,
 } from "~/infrastructure/api-clients/queries";
 import { searchMedia } from "~/infrastructure/api-clients/search-api";
@@ -47,6 +48,9 @@ export function SourceMediaPage() {
 	const mediaSourceId = () => params().mediaSourceId;
 	const queryClient = useQueryClient();
 	const [isMounted, setIsMounted] = createSignal(false);
+	const mediaSources = createQuery(mediaSourcesQueryOptions);
+	const mediaSourceName = () =>
+		mediaSources.data?.find((source) => source.id === mediaSourceId())?.name;
 
 	const transport = createServerTransport(mediaSourceId);
 
@@ -98,6 +102,7 @@ export function SourceMediaPage() {
 			<SourceMediaPageComponent
 				enableVirtualization
 				mediaSourceId={mediaSourceId}
+				mediaSourceName={mediaSourceName}
 				transport={transport}
 				presetClient={PresetClient}
 				actions={{

--- a/apps/server/src/routes/sources/$mediaSourceId/index.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/index.tsx
@@ -6,6 +6,7 @@ import {
 	allCharactersQueryOptions,
 	allIpsQueryOptions,
 	allProjectsQueryOptions,
+	mediaSourcesQueryOptions,
 	tagsQueryOptions,
 } from "~/infrastructure/api-clients/queries";
 import type { RouteLoaderContext } from "~/infrastructure/router/route-types";
@@ -13,6 +14,9 @@ import { SourceMediaPage } from "./components/source-media-page";
 
 export const Route = createFileRoute("/sources/$mediaSourceId/")({
 	ssr: true,
+	remountDeps: ({ params }: { params: { mediaSourceId: string } }) => [
+		params.mediaSourceId,
+	],
 	loader: async ({ context }: RouteLoaderContext) => {
 		await Promise.all([
 			context.queryClient.prefetchQuery(tagsQueryOptions()),
@@ -20,6 +24,7 @@ export const Route = createFileRoute("/sources/$mediaSourceId/")({
 			context.queryClient.prefetchQuery(allIpsQueryOptions()),
 			context.queryClient.prefetchQuery(allCharactersQueryOptions()),
 			context.queryClient.prefetchQuery(allAuthorsQueryOptions()),
+			context.queryClient.prefetchQuery(mediaSourcesQueryOptions()),
 		]);
 	},
 	pendingComponent: SourceMediaRouteFallback,

--- a/apps/server/src/tests/e2e/app-nav.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/app-nav.responsive.spec.ts
@@ -10,6 +10,55 @@ async function expectNoHorizontalOverflow(page: Page): Promise<void> {
 	expect(overflow).toBeLessThanOrEqual(1);
 }
 
+async function expectTextContrast(
+	page: Page,
+	selector: string,
+	backgroundSelector: string,
+): Promise<void> {
+	const contrast = await page.evaluate(
+		({ selector, backgroundSelector }) => {
+			const element = document.querySelector(selector);
+			const background = document.querySelector(backgroundSelector);
+			if (
+				!(element instanceof HTMLElement) ||
+				!(background instanceof HTMLElement)
+			) {
+				throw new Error("Navigation link or drawer was not found");
+			}
+
+			const parseRgb = (color: string): number[] =>
+				color
+					.match(/\d+(?:\.\d+)?/g)
+					?.slice(0, 3)
+					.map(Number) ?? [];
+			const relativeLuminance = ([red, green, blue]: number[]): number => {
+				const [linearRed, linearGreen, linearBlue] = [red, green, blue].map(
+					(channel) => {
+						const normalized = channel / 255;
+						return normalized <= 0.04045
+							? normalized / 12.92
+							: ((normalized + 0.055) / 1.055) ** 2.4;
+					},
+				);
+				return 0.2126 * linearRed + 0.7152 * linearGreen + 0.0722 * linearBlue;
+			};
+
+			const foreground = relativeLuminance(
+				parseRgb(window.getComputedStyle(element).color),
+			);
+			const drawerBackground = relativeLuminance(
+				parseRgb(window.getComputedStyle(background).backgroundColor),
+			);
+			return (
+				(Math.max(foreground, drawerBackground) + 0.05) /
+				(Math.min(foreground, drawerBackground) + 0.05)
+			);
+		},
+		{ selector, backgroundSelector },
+	);
+	expect(contrast).toBeGreaterThanOrEqual(4.5);
+}
+
 test("app navigation is responsive and accessible", async ({
 	page,
 }, testInfo) => {
@@ -36,6 +85,11 @@ test("app navigation is responsive and accessible", async ({
 	await expect(
 		dialog.getByRole("link", { name: "About", exact: true }),
 	).toHaveAttribute("aria-current", "page");
+	await expectTextContrast(
+		page,
+		'[role="dialog"] a[href="/search"]',
+		'[role="dialog"]',
+	);
 
 	await page.keyboard.press("Escape");
 	await expect(dialog).toBeHidden();

--- a/apps/server/src/tests/e2e/loading-recovery.spec.ts
+++ b/apps/server/src/tests/e2e/loading-recovery.spec.ts
@@ -1,5 +1,7 @@
+import type { Page } from "@playwright/test";
 import {
 	E2E_PRIMARY_FILE_NAME,
+	E2E_SOURCE_NAME,
 	mediaPath,
 	sourcePath,
 } from "./support/fixture";
@@ -29,6 +31,29 @@ const networkFailures = [
 		consoleMessage: "net::ERR_CONNECTION_RESET",
 	},
 ] as const;
+
+async function getGridColumnCount(
+	page: Page,
+	selector: string,
+): Promise<number> {
+	return await page
+		.locator(selector)
+		.evaluate(
+			(element) =>
+				window.getComputedStyle(element).gridTemplateColumns.split(" ").length,
+		);
+}
+
+async function getVisibleSkeletonItemCount(page: Page): Promise<number> {
+	return await page
+		.locator('[data-skeleton="media-grid"] > div > [aria-hidden="true"]')
+		.evaluateAll(
+			(elements) =>
+				elements.filter(
+					(element) => window.getComputedStyle(element).display !== "none",
+				).length,
+		);
+}
 
 test.describe("loading and recovery", () => {
 	test("keeps the app shell visible while the initial search response is delayed", async ({
@@ -63,6 +88,13 @@ test.describe("loading and recovery", () => {
 				.locator('[data-skeleton="media-grid"] [aria-hidden="true"]')
 				.first(),
 		).toHaveCSS("animation-name", "none");
+		const skeletonColumnCount = await getGridColumnCount(
+			page,
+			'[data-skeleton="media-grid"] > div',
+		);
+		expect(await getVisibleSkeletonItemCount(page)).toBe(
+			skeletonColumnCount * 2,
+		);
 		await expect(
 			page.getByText("APIの応答を待っています...", { exact: true }),
 		).toBeVisible();
@@ -72,6 +104,9 @@ test.describe("loading and recovery", () => {
 		await expect(
 			page.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) }),
 		).toBeVisible();
+		expect(await getGridColumnCount(page, "[data-media-grid]")).toBe(
+			skeletonColumnCount,
+		);
 		await expect(screenSkeleton).toHaveCount(0);
 	});
 
@@ -148,7 +183,7 @@ test.describe("loading and recovery", () => {
 		await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
 		await expect(
 			page.getByRole("heading", {
-				name: /Media in Source:/,
+				name: E2E_SOURCE_NAME,
 			}),
 		).toBeVisible();
 

--- a/apps/server/src/tests/e2e/media-detail-manager-config.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/media-detail-manager-config.responsive.spec.ts
@@ -109,6 +109,9 @@ test("media detail follows the second search result after returning to search", 
 test("media detail, manager, and settings remain usable on narrow screens", async ({
 	page,
 }, testInfo) => {
+	if (testInfo.project.name === "responsive-768") {
+		await page.setViewportSize({ width: 940, height: 1036 });
+	}
 	await page.goto(mediaPath());
 	await expect(
 		page.getByRole("heading", { name: E2E_PRIMARY_FILE_NAME, exact: true }),
@@ -117,6 +120,37 @@ test("media detail, manager, and settings remain usable on narrow screens", asyn
 	await expect(
 		page.getByRole("img", { name: E2E_PRIMARY_FILE_NAME, exact: true }),
 	).toBeVisible();
+	if (testInfo.project.name === "responsive-desktop") {
+		const verticalOverflow = await page.evaluate(
+			() => document.documentElement.scrollHeight - window.innerHeight,
+		);
+		expect(verticalOverflow).toBeLessThanOrEqual(1);
+		const viewer = page.locator("[data-media-viewer]");
+		const image = page.getByRole("img", {
+			name: E2E_PRIMARY_FILE_NAME,
+			exact: true,
+		});
+		const viewerState = await Promise.all([
+			viewer.evaluate((element) => getComputedStyle(element).backgroundColor),
+			viewer.evaluate((element) => element.clientHeight),
+			image.evaluate((element) => element.clientHeight),
+		]);
+		expect(viewerState[0]).toBe("rgba(0, 0, 0, 0)");
+		expect(viewerState[2]).toBe(viewerState[1]);
+	}
+	if (testInfo.project.name === "responsive-768") {
+		const viewer = page.locator("[data-media-viewer]");
+		const image = page.getByRole("img", {
+			name: E2E_PRIMARY_FILE_NAME,
+			exact: true,
+		});
+		const viewerBox = await viewer.boundingBox();
+		const imageBox = await image.boundingBox();
+		expect(viewerBox).not.toBeNull();
+		expect(imageBox).not.toBeNull();
+		expect(viewerBox?.width ?? 0).toBeGreaterThanOrEqual(900);
+		expect(imageBox?.width ?? 0).toBeGreaterThanOrEqual(900);
+	}
 	const detailsHeading = page.getByRole("heading", {
 		name: "Details",
 		exact: true,

--- a/apps/server/src/tests/e2e/route-reload.spec.ts
+++ b/apps/server/src/tests/e2e/route-reload.spec.ts
@@ -1,7 +1,6 @@
 import type { Page } from "@playwright/test";
 import {
 	E2E_PRIMARY_FILE_NAME,
-	E2E_SOURCE_ID,
 	E2E_SOURCE_NAME,
 	mediaPath,
 	sourcePath,
@@ -140,7 +139,7 @@ const routeCases: readonly RouteCase[] = [
 	{
 		name: "seeded source",
 		path: sourcePath(),
-		heading: `Media in Source: ${E2E_SOURCE_ID}`,
+		heading: E2E_SOURCE_NAME,
 		ssrText: "メディア一覧を準備しています...",
 		hydratedEndpoints: sourceMediaFilterEndpoints,
 		clientEndpoints: ["/api/rpc/media/search"],
@@ -413,7 +412,7 @@ test("SPA intent prefetch and cache revisit do not duplicate route queries", asy
 	await expect(page).toHaveURL(new RegExp(`${sourcePath()}/?$`));
 	await expect(
 		page.getByRole("heading", {
-			name: `Media in Source: ${E2E_SOURCE_ID}`,
+			name: E2E_SOURCE_NAME,
 			exact: true,
 		}),
 	).toBeVisible();

--- a/apps/server/src/tests/e2e/search-pro-dialog.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/search-pro-dialog.responsive.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "./support/test";
+
+test("pro search dialog keeps the value input focused while typing", async ({
+	page,
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== "responsive-desktop",
+		"The pro-search editor is shown in the desktop filter panel.",
+	);
+
+	await page.goto("/search");
+	await page.getByRole("button", { name: "詳細", exact: true }).click();
+	await page.getByRole("button", { name: "詳細条件を編集" }).click();
+
+	const dialog = page.getByRole("dialog");
+	await dialog.getByRole("button", { name: "+ 条件" }).click();
+
+	const valueInput = dialog.getByPlaceholder("値...");
+	await valueInput.pressSequentially("focus");
+	await expect(valueInput).toHaveValue("focus");
+	await expect(valueInput).toBeFocused();
+});

--- a/apps/server/src/tests/e2e/search.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/search.responsive.spec.ts
@@ -91,6 +91,45 @@ test("search keeps controls usable without horizontal overflow", async ({
 			page.getByRole("heading", { name: "検索フィルター", exact: true }),
 		).toBeVisible();
 		await expect(page.getByPlaceholder("ファイル名を入力...")).toBeVisible();
+
+		if (testInfo.project.name === "responsive-768") {
+			await page.setViewportSize({ width: 768, height: 480 });
+			const filterCard = page
+				.getByRole("heading", { name: "検索フィルター", exact: true })
+				.locator("..")
+				.locator("..");
+			const scrollState = await filterCard.evaluate((element) => {
+				element.scrollTop = element.scrollHeight;
+				const bounds = element.getBoundingClientRect();
+				return {
+					clientHeight: element.clientHeight,
+					scrollHeight: element.scrollHeight,
+					scrollTop: element.scrollTop,
+					isWithinViewport:
+						bounds.top >= 0 && bounds.bottom <= window.innerHeight,
+				};
+			});
+			expect(scrollState.scrollHeight).toBeGreaterThan(
+				scrollState.clientHeight,
+			);
+			expect(scrollState.scrollTop).toBeGreaterThan(0);
+			expect(scrollState.isWithinViewport).toBe(true);
+
+			const lastFilter = filterCard.getByPlaceholder("プロジェクトを検索...");
+			await expect(lastFilter).toBeVisible();
+			expect(
+				await lastFilter.evaluate((element) => {
+					const card = element.closest(".sticky");
+					if (!(card instanceof HTMLElement)) return false;
+					const inputBounds = element.getBoundingClientRect();
+					const cardBounds = card.getBoundingClientRect();
+					return (
+						inputBounds.top >= cardBounds.top &&
+						inputBounds.bottom <= cardBounds.bottom
+					);
+				}),
+			).toBe(true);
+		}
 	}
 
 	await expectNoHorizontalOverflow(page);

--- a/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
@@ -1,7 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import {
 	E2E_PRIMARY_FILE_NAME,
-	E2E_SOURCE_ID,
 	E2E_SOURCE_NAME,
 	getFixtureMediaPath,
 	sourcePath,
@@ -117,11 +116,25 @@ test("source media exposes mobile filters and touch selection", async ({
 	await page.goto(sourcePath());
 	await expect(
 		page.getByRole("heading", {
-			name: `Media in Source: ${E2E_SOURCE_ID}`,
+			name: E2E_SOURCE_NAME,
 			exact: true,
 		}),
 	).toBeVisible();
-	await expect(page.locator("[data-media-id]").first()).toBeVisible();
+	const resultCount = page.getByText(/^2 件の結果$/);
+	await expect(resultCount).toHaveCount(1);
+	await expect(resultCount).toBeVisible();
+	const firstMedia = page.locator("[data-media-id]").first();
+	await expect(firstMedia).toBeVisible();
+	const filterCard = page
+		.getByRole("heading", { name: "検索フィルター", exact: true })
+		.locator("..")
+		.locator("..");
+	const [filterTop, mediaTop] = await Promise.all(
+		[filterCard, firstMedia].map((locator) =>
+			locator.evaluate((element) => element.getBoundingClientRect().top),
+		),
+	);
+	expect(Math.abs(filterTop - mediaTop)).toBeLessThanOrEqual(1);
 	await waitForAppHydration(page);
 	await expect(page.getByTestId("media-load-more-sentinel")).toBeVisible();
 	await expectNoHorizontalOverflow(page);

--- a/packages/ui/src/async-state.tsx
+++ b/packages/ui/src/async-state.tsx
@@ -214,51 +214,63 @@ export type QueryStatusProps = {
 	fetchState: QueryUiFetchState;
 	hasData: boolean;
 	hasError?: boolean;
+	/** Omit the empty status region instead of reserving vertical space. */
+	hideWhenIdle?: boolean;
 	offlineLabel: string;
 	updatingLabel: string;
 };
 
 export function QueryStatus(props: QueryStatusProps) {
+	const hasStatus = () =>
+		props.fetchState === "background-fetching" ||
+		(props.fetchState === "paused" && props.hasData) ||
+		Boolean(props.hasError && props.hasData);
+
 	return (
-		<div class={cn("min-h-6", props.class)} data-state-ui-slot="query-status">
-			<Switch>
-				<Match when={props.fetchState === "background-fetching"}>
-					<p
-						class="flex items-center gap-2 text-muted-foreground text-sm"
-						data-state-ui="background-fetching"
-						role="status"
-					>
-						<span
-							aria-hidden="true"
-							class="size-2 animate-pulse rounded-full bg-current motion-reduce:animate-none"
-						/>
-						{props.updatingLabel}
-					</p>
-				</Match>
-				<Match when={props.fetchState === "paused" && props.hasData}>
-					<p
-						class="flex items-center gap-2 text-muted-foreground text-sm"
-						data-state-ui="cached-offline"
-						role="status"
-					>
-						<span
-							aria-hidden="true"
-							class="size-2 rounded-full bg-warning-foreground"
-						/>
-						{props.offlineLabel}
-					</p>
-				</Match>
-				<Match when={props.hasError && props.hasData}>
-					<p
-						class="flex items-center gap-2 text-warning-foreground text-sm"
-						data-state-ui="cached-sync-error"
-						role="status"
-					>
-						<span aria-hidden="true" class="size-2 rounded-full bg-current" />
-						{props.errorLabel ?? "最新のデータを取得できませんでした"}
-					</p>
-				</Match>
-			</Switch>
-		</div>
+		<Show when={!props.hideWhenIdle || hasStatus()}>
+			<div
+				class={cn(!props.hideWhenIdle && "min-h-6", props.class)}
+				data-state-ui-slot="query-status"
+			>
+				<Switch>
+					<Match when={props.fetchState === "background-fetching"}>
+						<p
+							class="flex items-center gap-2 text-muted-foreground text-sm"
+							data-state-ui="background-fetching"
+							role="status"
+						>
+							<span
+								aria-hidden="true"
+								class="size-2 animate-pulse rounded-full bg-current motion-reduce:animate-none"
+							/>
+							{props.updatingLabel}
+						</p>
+					</Match>
+					<Match when={props.fetchState === "paused" && props.hasData}>
+						<p
+							class="flex items-center gap-2 text-muted-foreground text-sm"
+							data-state-ui="cached-offline"
+							role="status"
+						>
+							<span
+								aria-hidden="true"
+								class="size-2 rounded-full bg-warning-foreground"
+							/>
+							{props.offlineLabel}
+						</p>
+					</Match>
+					<Match when={props.hasError && props.hasData}>
+						<p
+							class="flex items-center gap-2 text-warning-foreground text-sm"
+							data-state-ui="cached-sync-error"
+							role="status"
+						>
+							<span aria-hidden="true" class="size-2 rounded-full bg-current" />
+							{props.errorLabel ?? "最新のデータを取得できませんでした"}
+						</p>
+					</Match>
+				</Switch>
+			</div>
+		</Show>
 	);
 }

--- a/packages/ui/src/layouts/app-nav.tsx
+++ b/packages/ui/src/layouts/app-nav.tsx
@@ -30,11 +30,17 @@ export function AppNav(props: AppNavProps) {
 	const [isMenuOpen, setIsMenuOpen] = createSignal(false);
 	const [isClient, setIsClient] = createSignal(false);
 	const isActive = (path: string) => path === location().pathname;
-	const linkClass = (path: string) =>
+	const desktopLinkClass = (path: string) =>
 		`rounded-md px-3 py-2 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-sky-800 ${
 			isActive(path)
 				? "bg-sky-700 text-white"
 				: "text-sky-50 hover:bg-sky-700 hover:text-white"
+		}`;
+	const mobileLinkClass = (path: string) =>
+		`rounded-md px-3 py-2 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+			isActive(path)
+				? "bg-accent text-accent-foreground"
+				: "text-foreground hover:bg-accent hover:text-accent-foreground"
 		}`;
 
 	const [isVisible, setIsVisible] = createSignal(true);
@@ -104,7 +110,7 @@ export function AppNav(props: AppNavProps) {
 							<li>
 								<Link
 									aria-current={isActive(item.to) ? "page" : undefined}
-									class={linkClass(item.to)}
+									class={desktopLinkClass(item.to)}
 									to={item.to}
 								>
 									{item.label}
@@ -113,7 +119,7 @@ export function AppNav(props: AppNavProps) {
 						))}
 						<li>
 							<a
-								class={linkClass("/docs")}
+								class={desktopLinkClass("/docs")}
 								href="/docs/index.html"
 								rel="noopener noreferrer"
 								target="_blank"
@@ -179,7 +185,7 @@ export function AppNav(props: AppNavProps) {
 															aria-current={
 																isActive(item.to) ? "page" : undefined
 															}
-															class={`block min-h-11 ${linkClass(item.to)}`}
+															class={`block min-h-11 ${mobileLinkClass(item.to)}`}
 															onClick={() => setIsMenuOpen(false)}
 															to={item.to}
 														>
@@ -189,7 +195,7 @@ export function AppNav(props: AppNavProps) {
 												))}
 												<li>
 													<a
-														class={`block min-h-11 ${linkClass("/docs")}`}
+														class={`block min-h-11 ${mobileLinkClass("/docs")}`}
 														href="/docs/index.html"
 														rel="noopener noreferrer"
 														target="_blank"

--- a/packages/ui/src/media-viewer.tsx
+++ b/packages/ui/src/media-viewer.tsx
@@ -54,7 +54,11 @@ export function MediaViewer(props: MediaViewerProps) {
 	});
 
 	return (
-		<div class="flex h-full min-h-0 min-w-0 w-full items-center justify-center overflow-hidden rounded-lg bg-black/5 p-2 sm:p-4">
+		<div
+			class="flex aspect-[var(--media-aspect)] min-h-0 min-w-0 w-full items-center justify-center overflow-hidden rounded-lg lg:aspect-auto lg:h-full"
+			data-media-viewer
+			style={`--media-aspect: ${props.width && props.height ? `${props.width} / ${props.height}` : "4 / 3"}`}
+		>
 			<Switch>
 				<Match when={props.source.type === "video"}>
 					<Show
@@ -66,11 +70,7 @@ export function MediaViewer(props: MediaViewerProps) {
 						when={mediaUrl()}
 					>
 						{(url) => (
-							<video
-								class="max-h-full max-w-full rounded-md"
-								controls
-								src={url()}
-							>
+							<video class="h-full max-w-full rounded-md" controls src={url()}>
 								<track kind="captions" />
 							</video>
 						)}
@@ -112,7 +112,7 @@ export function MediaViewer(props: MediaViewerProps) {
 						{(url) => (
 							<img
 								alt={props.fileName}
-								class="max-h-full max-w-full rounded-md object-contain"
+								class="h-full w-full rounded-md object-contain"
 								height={props.height}
 								src={url()}
 								width={props.width}

--- a/packages/ui/src/pro-search-builder.tsx
+++ b/packages/ui/src/pro-search-builder.tsx
@@ -7,7 +7,7 @@ import type {
 } from "@solid-imager/core/domain/media/schemas";
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
-import { createMemo, For, Match, Show, Switch } from "solid-js";
+import { createMemo, Index, Match, Show, Switch } from "solid-js";
 import { Button } from "./button";
 import { Card, CardContent } from "./card";
 import {
@@ -145,6 +145,22 @@ function getValidOperators(target: string) {
 	return Object.keys(OPERATOR_LABELS);
 }
 
+function getSearchGroup(child: SearchCriterion | SearchGroup): SearchGroup {
+	if (child.type === "group") {
+		return child;
+	}
+	throw new Error("Expected a search group");
+}
+
+function getSearchCriterion(
+	child: SearchCriterion | SearchGroup,
+): SearchCriterion {
+	if (child.type === "criterion") {
+		return child;
+	}
+	throw new Error("Expected a search criterion");
+}
+
 function GroupBuilder(props: {
 	group: SearchGroup;
 	onChange: (value: SearchGroup) => void;
@@ -258,17 +274,17 @@ function GroupBuilder(props: {
 				</div>
 
 				<div class="space-y-2 border-border border-l pl-2 sm:pl-4">
-					<For each={props.group.children}>
+					<Index each={props.group.children}>
 						{(child, index) =>
-							child.type === "group" ? (
+							child().type === "group" ? (
 								<GroupBuilder
 									authors={props.authors}
 									characters={props.characters}
 									depth={props.depth + 1}
-									group={child}
+									group={getSearchGroup(child())}
 									ips={props.ips}
-									onChange={(value) => updateChild(index(), value)}
-									onRemove={() => removeChild(index())}
+									onChange={(value) => updateChild(index, value)}
+									onRemove={() => removeChild(index)}
 									projects={props.projects}
 									tags={props.tags}
 								/>
@@ -276,16 +292,16 @@ function GroupBuilder(props: {
 								<CriterionBuilder
 									authors={props.authors}
 									characters={props.characters}
-									criterion={child}
+									criterion={getSearchCriterion(child())}
 									ips={props.ips}
-									onChange={(value) => updateChild(index(), value)}
-									onRemove={() => removeChild(index())}
+									onChange={(value) => updateChild(index, value)}
+									onRemove={() => removeChild(index)}
 									projects={props.projects}
 									tags={props.tags}
 								/>
 							)
 						}
-					</For>
+					</Index>
 					<Show when={props.group.children.length === 0}>
 						<div class="p-2 text-muted-foreground text-sm italic">
 							条件がありません。「+ 条件」ボタンで追加してください。

--- a/packages/ui/src/screens/media-detail-screen.tsx
+++ b/packages/ui/src/screens/media-detail-screen.tsx
@@ -86,7 +86,7 @@ export function MediaDetailScreen(props: MediaDetailScreenProps) {
 	});
 
 	return (
-		<div class="container mx-auto px-3 py-4 sm:p-4">
+		<div class="mx-auto w-full px-3 py-4 sm:px-4 lg:container lg:p-4">
 			<QueryStatus
 				fetchState={state().fetchState}
 				hasData={state().data !== undefined}
@@ -97,8 +97,8 @@ export function MediaDetailScreen(props: MediaDetailScreenProps) {
 				<Match when={state().phase === "data"}>
 					<Show keyed when={state().data}>
 						{(details) => (
-							<div class="flex flex-col gap-4 lg:h-[calc(100dvh-5rem)] lg:flex-row">
-								<div class="aspect-[4/3] min-h-64 min-w-0 overflow-hidden rounded-lg lg:aspect-auto lg:min-h-0 lg:flex-1">
+							<div class="flex flex-col gap-4 lg:h-[calc(100dvh-7.5rem)] lg:flex-row">
+								<div class="min-h-64 min-w-0 overflow-hidden rounded-lg lg:min-h-0 lg:flex-1">
 									{props.renderMediaViewer(details, props.sourceRootPath)}
 								</div>
 								<div class="min-w-0 shrink-0 lg:w-96 lg:max-w-[40%]">

--- a/packages/ui/src/screens/search-screen.tsx
+++ b/packages/ui/src/screens/search-screen.tsx
@@ -94,7 +94,7 @@ export function SearchScreen(props: SearchScreenProps) {
 			</div>
 
 			<div class="grid min-w-0 gap-6 md:grid-cols-[minmax(0,300px)_minmax(0,1fr)]">
-				<Card class="sticky top-20 hidden h-fit max-h-[calc(100vh-6rem)] overflow-y-auto md:block">
+				<Card class="sticky top-20 hidden h-[calc(100dvh-13rem)] self-start overflow-y-auto overscroll-contain md:block">
 					<CardHeader>
 						<CardTitle>検索フィルター</CardTitle>
 					</CardHeader>

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -24,6 +24,7 @@ import { SourceMediaGrid } from "../source-media-grid";
 
 export type SourceMediaScreenProps = {
 	page: UseSourceMediaPageResult;
+	mediaSourceName?: () => string | undefined;
 	/** Render navigation actions without giving them ownership of filter draft state. */
 	renderActions: (props: { onOpenMobileFilters: () => void }) => JSX.Element;
 	/** Render a single media grid item. */
@@ -109,9 +110,16 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 			</Show>
 
 			<div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-				<h1 class="min-w-0 break-all font-bold text-xl sm:text-2xl">
-					Media in Source: {page().mediaSourceId()}
-				</h1>
+				<div class="flex min-w-0 flex-wrap items-baseline gap-x-3 gap-y-1">
+					<h1 class="min-w-0 break-words font-bold text-xl sm:text-2xl">
+						{props.mediaSourceName?.() ?? "メディア一覧"}
+					</h1>
+					<Show when={page().mediaQuery.data?.pages[0]?.total !== undefined}>
+						<p class="shrink-0 text-gray-600 text-sm">
+							{page().mediaQuery.data?.pages[0]?.total} 件の結果
+						</p>
+					</Show>
+				</div>
 				<div class="grid w-full grid-cols-1 gap-2 sm:flex sm:w-auto sm:flex-wrap">
 					<Show when={props.onEnterBulkSelectMode}>
 						<Button
@@ -147,7 +155,7 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 			</Show>
 
 			<div class="grid min-w-0 gap-6 md:grid-cols-[minmax(0,300px)_minmax(0,1fr)]">
-				<Card class="sticky top-20 hidden h-fit max-h-[calc(100vh-6rem)] overflow-y-auto md:block">
+				<Card class="sticky top-20 hidden h-[calc(100dvh-10rem)] self-start overflow-y-auto overscroll-contain md:block">
 					<CardHeader>
 						<CardTitle>検索フィルター</CardTitle>
 					</CardHeader>
@@ -168,6 +176,7 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 						class="mb-2"
 						fetchState={page().contentState().fetchState}
 						hasData={page().contentState().data !== undefined}
+						hideWhenIdle
 						offlineLabel="オフラインのため保存済みデータを表示しています"
 						updatingLabel="メディア一覧を更新中..."
 					/>
@@ -203,6 +212,7 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 							setContextMenuMediaId={page().setContextMenuMediaId}
 							setLoadMoreRef={page().setLoadMoreRef}
 							showOpenInNewTab={props.showOpenInNewTab}
+							showResultCount={false}
 							state={page().contentState}
 							totalCount={page().mediaQuery.data?.pages[0]?.total}
 						/>

--- a/packages/ui/src/skeleton.tsx
+++ b/packages/ui/src/skeleton.tsx
@@ -3,6 +3,19 @@ import { For, splitProps } from "solid-js";
 import { Card, CardContent, CardHeader } from "./card";
 import { cn } from "./utils/cn";
 
+export const mediaGridClassName =
+	"grid grid-cols-2 gap-3 @[30rem]:grid-cols-3 @[40rem]:grid-cols-4 @[50rem]:grid-cols-5 @[60rem]:grid-cols-6 @[65rem]:grid-cols-7 @[70rem]:grid-cols-8";
+
+export function getMediaGridColumnCount(width: number): number {
+	if (width >= 1120) return 8;
+	if (width >= 1040) return 7;
+	if (width >= 960) return 6;
+	if (width >= 800) return 5;
+	if (width >= 640) return 4;
+	if (width >= 480) return 3;
+	return 2;
+}
+
 export type SkeletonProps = Omit<ComponentProps<"div">, "aria-hidden">;
 
 /** Decorative placeholder. Announce loading once on the containing region. */
@@ -111,15 +124,16 @@ export function MediaGridSkeleton(props: MediaGridSkeletonProps) {
 	return (
 		<div
 			aria-hidden="true"
-			class={cn(
-				"grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5",
-				props.class,
-			)}
+			class="@container w-full"
 			data-skeleton="media-grid"
 		>
-			<For each={Array.from({ length: props.count ?? 10 })}>
-				{() => <Skeleton class="aspect-[3/4] w-full rounded-lg" />}
-			</For>
+			<div class={cn(mediaGridClassName, props.class)}>
+				<For each={Array.from({ length: props.count ?? 16 })}>
+					{() => (
+						<Skeleton class="media-grid-skeleton-item aspect-[3/4] w-full rounded-lg" />
+					)}
+				</For>
+			</div>
 		</div>
 	);
 }
@@ -133,7 +147,7 @@ export function MediaDetailSkeleton(props: MediaDetailSkeletonProps) {
 		<div
 			aria-hidden="true"
 			class={cn(
-				"flex min-h-[calc(100dvh-5rem)] flex-col gap-4 lg:flex-row",
+				"flex min-h-[calc(100dvh-7.5rem)] flex-col gap-4 lg:flex-row",
 				props.class,
 			)}
 			data-skeleton="media-detail"

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -21,7 +21,12 @@ import {
 	ContextMenuTrigger,
 } from "./context-menu";
 import type { QueryUiState } from "./query-state";
-import { LoadingRegion, MediaGridSkeleton } from "./skeleton";
+import {
+	getMediaGridColumnCount,
+	LoadingRegion,
+	MediaGridSkeleton,
+	mediaGridClassName,
+} from "./skeleton";
 
 const VIRTUALIZATION_THRESHOLD = 100;
 const GRID_GAP_PX = 12;
@@ -94,9 +99,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 
 	const columnCount = createMemo(() => {
 		const width = mediaGridWidth() || windowWidth();
-		if (width >= 1100) return 5;
-		if (width >= 640) return 3;
-		return 2;
+		return getMediaGridColumnCount(width);
 	});
 
 	const mediaItemWidth = createMemo(() => {
@@ -202,7 +205,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 
 	const gridContent = (
 		<div
-			class="relative min-w-0 w-full"
+			class="@container relative min-w-0 w-full"
 			ref={(element) => {
 				mediaGridRef = element;
 				requestAnimationFrame(() => {
@@ -217,12 +220,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 		>
 			<Show
 				fallback={
-					<div
-						class="grid gap-3"
-						style={{
-							"grid-template-columns": `repeat(${columnCount()}, minmax(0, 1fr))`,
-						}}
-					>
+					<div class={mediaGridClassName} data-media-grid>
 						<For each={props.mediaResults()}>
 							{(media) =>
 								props.renderItem(media, {
@@ -245,7 +243,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 						const rowMedia = () => mediaRows()[virtualRow.index] || [];
 						return (
 							<div
-								class="absolute top-0 left-0 grid gap-3"
+								class={`absolute top-0 left-0 ${mediaGridClassName}`}
 								style={{
 									"grid-template-columns": `repeat(${columnCount()}, minmax(0, 1fr))`,
 									height: `${virtualRow.size}px`,

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -35,6 +35,7 @@ function clientOnlyQueryOptions<TData>(factory: QueryOptionFactory<TData>) {
 
 export type SourceMediaPageProps = {
 	mediaSourceId: Accessor<string>;
+	mediaSourceName?: Accessor<string | undefined>;
 	transport: MediaSourceEventTransport;
 	presetClient: SourceMediaPagePresetClient;
 	actions: SourceMediaPageActions;
@@ -131,6 +132,7 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 	return (
 		<SourceMediaScreen
 			enableVirtualization={props.enableVirtualization}
+			mediaSourceName={props.mediaSourceName}
 			onRetryFilters={async () => {
 				await Promise.all([
 					tags.refetch(),

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -79,6 +79,61 @@
 }
 
 @layer utilities {
+	.media-grid-skeleton-item:nth-child(n + 5) {
+		display: none;
+	}
+
+	@container (min-width: 30rem) {
+		.media-grid-skeleton-item:nth-child(n + 5) {
+			display: block;
+		}
+		.media-grid-skeleton-item:nth-child(n + 7) {
+			display: none;
+		}
+	}
+
+	@container (min-width: 40rem) {
+		.media-grid-skeleton-item:nth-child(n + 7) {
+			display: block;
+		}
+		.media-grid-skeleton-item:nth-child(n + 9) {
+			display: none;
+		}
+	}
+
+	@container (min-width: 50rem) {
+		.media-grid-skeleton-item:nth-child(n + 9) {
+			display: block;
+		}
+		.media-grid-skeleton-item:nth-child(n + 11) {
+			display: none;
+		}
+	}
+
+	@container (min-width: 60rem) {
+		.media-grid-skeleton-item:nth-child(n + 11) {
+			display: block;
+		}
+		.media-grid-skeleton-item:nth-child(n + 13) {
+			display: none;
+		}
+	}
+
+	@container (min-width: 65rem) {
+		.media-grid-skeleton-item:nth-child(n + 13) {
+			display: block;
+		}
+		.media-grid-skeleton-item:nth-child(n + 15) {
+			display: none;
+		}
+	}
+
+	@container (min-width: 70rem) {
+		.media-grid-skeleton-item:nth-child(n + 15) {
+			display: block;
+		}
+	}
+
 	.step {
 		counter-increment: step;
 	}


### PR DESCRIPTION
## 概要
検索・メディア一覧・詳細表示で発生していたレスポンシブ表示とSPA遷移の不整合を修正します。

## 変更内容
- 詳細検索入力のフォーカス維持とフィルターパネルのスクロールを修正
- メディア一覧のグリッド、ローディング枠、ソース名・件数表示を統一
- 詳細画面のSPA遷移で古いメディアが残る問題を修正
- 縦積み詳細画面で元画像の比率を保ちつつ横幅を有効活用
- モバイルナビゲーションの文字コントラストを改善

## 検証
- bun run --cwd apps/server check
- bun run --cwd apps/server typecheck
- 関連Playwright E2E（詳細遷移、940px縦積み、ローディング）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * メディアソース画面にソース名と検索結果件数を表示するようになりました。
  * メディアグリッドが画面幅に応じて最適な列数で表示されます。
  * 検索フィルターのスクロール操作と入力フォーカスが改善されました。

* **改善**
  * メディアビューアーの表示比率とレスポンシブレイアウトを調整しました。
  * ページ切り替え時のデータ表示がより安定しました。
  * ナビゲーションのフォーカス表示とモバイルメニューのコントラストを改善しました。

* **品質向上**
  * 各種画面サイズ、読み込み復旧、ルート移動に関する検証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->