### PR TITLE
perf(imports): optimize pending import count tracking

### DIFF
--- a/apps/server/drizzle/0020_blue_nuke.sql
+++ b/apps/server/drizzle/0020_blue_nuke.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "idx_jobs_pending_import_request" ON "jobs" USING btree ("id") WHERE "jobs"."status" = 'pending' AND "jobs"."type" = 'import_request';

--- a/apps/server/drizzle/meta/0020_snapshot.json
+++ b/apps/server/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,3313 @@
+{
+  "id": "19ee548d-c82e-4887-a8a8-06f7f3f58cf5",
+  "prevId": "4df58052-f274-418d-a9ab-54e66bb81847",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.author_accounts": {
+      "name": "author_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "author_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_author_accounts_author_id": {
+          "name": "idx_author_accounts_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_author_accounts_platform_account_unique": {
+          "name": "idx_author_accounts_platform_account_unique",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "author_accounts_author_id_authors_id_fk": {
+          "name": "author_accounts_author_id_authors_id_fk",
+          "tableFrom": "author_accounts",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_authors_account_id": {
+          "name": "idx_authors_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authors_name": {
+          "name": "idx_authors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#808080'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ccip_embeddings": {
+      "name": "ccip_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_version": {
+          "name": "embedding_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_modified_at": {
+          "name": "media_modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_at": {
+          "name": "extracted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ccip_embeddings_region_id": {
+          "name": "idx_ccip_embeddings_region_id",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ccip_embeddings_embedding_cosine": {
+          "name": "idx_ccip_embeddings_embedding_cosine",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 16,
+            "ef_construction": 64
+          }
+        }
+      },
+      "foreignKeys": {
+        "ccip_embeddings_region_id_media_regions_id_fk": {
+          "name": "ccip_embeddings_region_id_media_regions_id_fk",
+          "tableFrom": "ccip_embeddings",
+          "tableTo": "media_regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_ccip_embeddings_region_model_version": {
+          "name": "uq_ccip_embeddings_region_model_version",
+          "nullsNotDistinct": false,
+          "columns": [
+            "region_id",
+            "model",
+            "embedding_version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_ips": {
+      "name": "character_ips",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_id": {
+          "name": "ip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_character_ips_ip_id_character_id": {
+          "name": "idx_character_ips_ip_id_character_id",
+          "columns": [
+            {
+              "expression": "ip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_ips_character_id_characters_id_fk": {
+          "name": "character_ips_character_id_characters_id_fk",
+          "tableFrom": "character_ips",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_ips_ip_id_ips_id_fk": {
+          "name": "character_ips_ip_id_ips_id_fk",
+          "tableFrom": "character_ips",
+          "tableTo": "ips",
+          "columnsFrom": [
+            "ip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "character_ips_character_id_ip_id_pk": {
+          "name": "character_ips_character_id_ip_id_pk",
+          "columns": [
+            "character_id",
+            "ip_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "characters_name_unique": {
+          "name": "characters_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ips": {
+      "name": "ips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ips_name_unique": {
+          "name": "ips_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_pending_import_request": {
+          "name": "idx_jobs_pending_import_request",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending' AND \"jobs\".\"type\" = 'import_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_pending_created": {
+          "name": "idx_jobs_pending_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending' AND \"jobs\".\"type\" <> 'import_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_pending_type_created": {
+          "name": "idx_jobs_pending_type_created",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending' AND \"jobs\".\"type\" <> 'import_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_pending_lancedb_source": {
+          "name": "idx_jobs_pending_lancedb_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending'\n\t\t\t\t\tAND \"jobs\".\"type\" IN ('sync_lancedb', 'sync_lancedb_full', 'sync_lancedb_delta')\n\t\t\t\t\tAND \"jobs\".\"source_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_active_lancedb_source": {
+          "name": "idx_jobs_active_lancedb_source",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'in_progress'\n\t\t\t\t\tAND \"jobs\".\"type\" IN ('sync_lancedb', 'sync_lancedb_full', 'sync_lancedb_delta')\n\t\t\t\t\tAND \"jobs\".\"source_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_source_id_media_sources_id_fk": {
+          "name": "jobs_source_id_media_sources_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "jobs_parent_id_jobs_id_fk": {
+          "name": "jobs_parent_id_jobs_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lancedb_sync_dirty": {
+      "name": "lancedb_sync_dirty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upsert'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_lancedb_sync_dirty_source_updated": {
+          "name": "idx_lancedb_sync_dirty_source_updated",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lancedb_sync_dirty_source_id_media_sources_id_fk": {
+          "name": "lancedb_sync_dirty_source_id_media_sources_id_fk",
+          "tableFrom": "lancedb_sync_dirty",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lancedb_sync_dirty_source_media_unique": {
+          "name": "lancedb_sync_dirty_source_media_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "media_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_authors": {
+      "name": "media_authors",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_authors_author_id_media_id": {
+          "name": "idx_media_authors_author_id_media_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_authors_media_id_media_id_fk": {
+          "name": "media_authors_media_id_media_id_fk",
+          "tableFrom": "media_authors",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_authors_author_id_authors_id_fk": {
+          "name": "media_authors_author_id_authors_id_fk",
+          "tableFrom": "media_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_authors_media_id_author_id_pk": {
+          "name": "media_authors_media_id_author_id_pk",
+          "columns": [
+            "media_id",
+            "author_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_categories": {
+      "name": "media_categories",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_categories_category_id_media_id": {
+          "name": "idx_media_categories_category_id_media_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_categories_media_id_media_id_fk": {
+          "name": "media_categories_media_id_media_id_fk",
+          "tableFrom": "media_categories",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_categories_category_id_categories_id_fk": {
+          "name": "media_categories_category_id_categories_id_fk",
+          "tableFrom": "media_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_categories_media_id_category_id_pk": {
+          "name": "media_categories_media_id_category_id_pk",
+          "columns": [
+            "media_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_characters": {
+      "name": "media_characters",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_characters_character_id_media_id": {
+          "name": "idx_media_characters_character_id_media_id",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_characters_media_id_media_id_fk": {
+          "name": "media_characters_media_id_media_id_fk",
+          "tableFrom": "media_characters",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_characters_character_id_characters_id_fk": {
+          "name": "media_characters_character_id_characters_id_fk",
+          "tableFrom": "media_characters",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_characters_media_id_character_id_pk": {
+          "name": "media_characters_media_id_character_id_pk",
+          "columns": [
+            "media_id",
+            "character_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_collections": {
+      "name": "media_collections",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_collections_media_id": {
+          "name": "idx_media_collections_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_collections_collection_id_collections_id_fk": {
+          "name": "media_collections_collection_id_collections_id_fk",
+          "tableFrom": "media_collections",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_collections_media_id_media_id_fk": {
+          "name": "media_collections_media_id_media_id_fk",
+          "tableFrom": "media_collections",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_collections_collection_id_media_id_pk": {
+          "name": "media_collections_collection_id_media_id_pk",
+          "columns": [
+            "collection_id",
+            "media_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_details": {
+      "name": "media_details",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1970-01-01 00:00:00'"
+        }
+      },
+      "indexes": {
+        "idx_media_details_rating": {
+          "name": "idx_media_details_rating",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_details_favorite": {
+          "name": "idx_media_details_favorite",
+          "columns": [
+            {
+              "expression": "favorite",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_details_view_count": {
+          "name": "idx_media_details_view_count",
+          "columns": [
+            {
+              "expression": "view_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_details_media_id_media_id_fk": {
+          "name": "media_details_media_id_media_id_fk",
+          "tableFrom": "media_details",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_generation_info": {
+      "name": "media_generation_info",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negative_prompt": {
+          "name": "negative_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loras": {
+          "name": "loras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vae": {
+          "name": "vae",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hypernetworks": {
+          "name": "hypernetworks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddings": {
+          "name": "embeddings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated": {
+          "name": "ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "seed": {
+          "name": "seed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": -1
+        },
+        "cfg_scale": {
+          "name": "cfg_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_media_generation_info_metadata": {
+          "name": "idx_media_generation_info_metadata",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_generation_info_ai_generated": {
+          "name": "idx_media_generation_info_ai_generated",
+          "columns": [
+            {
+              "expression": "ai_generated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_generation_info_model_name": {
+          "name": "idx_media_generation_info_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_generation_info_media_id_media_id_fk": {
+          "name": "media_generation_info_media_id_media_id_fk",
+          "tableFrom": "media_generation_info",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_ips": {
+      "name": "media_ips",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_id": {
+          "name": "ip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_ips_ip_id_media_id": {
+          "name": "idx_media_ips_ip_id_media_id",
+          "columns": [
+            {
+              "expression": "ip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_ips_media_id_media_id_fk": {
+          "name": "media_ips_media_id_media_id_fk",
+          "tableFrom": "media_ips",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_ips_ip_id_ips_id_fk": {
+          "name": "media_ips_ip_id_ips_id_fk",
+          "tableFrom": "media_ips",
+          "tableTo": "ips",
+          "columnsFrom": [
+            "ip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_ips_media_id_ip_id_pk": {
+          "name": "media_ips_media_id_ip_id_pk",
+          "columns": [
+            "media_id",
+            "ip_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_projects": {
+      "name": "media_projects",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_media_projects_project_id_media_id": {
+          "name": "idx_media_projects_project_id_media_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_projects_media_id_media_id_fk": {
+          "name": "media_projects_media_id_media_id_fk",
+          "tableFrom": "media_projects",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_projects_project_id_projects_id_fk": {
+          "name": "media_projects_project_id_projects_id_fk",
+          "tableFrom": "media_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_projects_media_id_project_id_pk": {
+          "name": "media_projects_media_id_project_id_pk",
+          "columns": [
+            "media_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_regions": {
+      "name": "media_regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "media_region_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detector": {
+          "name": "detector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detector_version": {
+          "name": "detector_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_regions_media_id": {
+          "name": "idx_media_regions_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_media_regions_full_media_id": {
+          "name": "uq_media_regions_full_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"media_regions\".\"kind\" = 'full'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_regions_media_id_media_id_fk": {
+          "name": "media_regions_media_id_media_id_fk",
+          "tableFrom": "media_regions",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "media_regions_bbox_by_kind": {
+          "name": "media_regions_bbox_by_kind",
+          "value": "(\n\t\t\t\t(\"media_regions\".\"kind\" = 'full' AND \"media_regions\".\"x\" IS NULL AND \"media_regions\".\"y\" IS NULL AND \"media_regions\".\"width\" IS NULL AND \"media_regions\".\"height\" IS NULL)\n\t\t\t\tOR\n\t\t\t\t(\"media_regions\".\"kind\" <> 'full' AND \"media_regions\".\"x\" IS NOT NULL AND \"media_regions\".\"y\" IS NOT NULL AND \"media_regions\".\"width\" IS NOT NULL AND \"media_regions\".\"height\" IS NOT NULL\n\t\t\t\t\tAND \"media_regions\".\"x\" >= 0 AND \"media_regions\".\"y\" >= 0 AND \"media_regions\".\"width\" > 0 AND \"media_regions\".\"height\" > 0\n\t\t\t\t\tAND \"media_regions\".\"x\" + \"media_regions\".\"width\" <= 1 AND \"media_regions\".\"y\" + \"media_regions\".\"height\" <= 1)\n\t\t\t)"
+        },
+        "media_regions_score_range": {
+          "name": "media_regions_score_range",
+          "value": "\"media_regions\".\"score\" IS NULL OR (\"media_regions\".\"score\" >= 0 AND \"media_regions\".\"score\" <= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media_relations": {
+      "name": "media_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_media_id": {
+          "name": "parent_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_media_id": {
+          "name": "child_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "media_relation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_relations_child": {
+          "name": "idx_media_relations_child",
+          "columns": [
+            {
+              "expression": "child_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_relations_type": {
+          "name": "idx_media_relations_type",
+          "columns": [
+            {
+              "expression": "relation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_relations_parent_media_id_media_id_fk": {
+          "name": "media_relations_parent_media_id_media_id_fk",
+          "tableFrom": "media_relations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "parent_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_relations_child_media_id_media_id_fk": {
+          "name": "media_relations_child_media_id_media_id_fk",
+          "tableFrom": "media_relations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "child_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_child_type_unique": {
+          "name": "parent_child_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "parent_media_id",
+            "child_media_id",
+            "relation_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_sources": {
+      "name": "media_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "media_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_info": {
+          "name": "connection_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_sync": {
+      "name": "media_sync",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "media_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'synced'"
+        },
+        "backup_urls": {
+          "name": "backup_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_attempts": {
+          "name": "sync_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_sync_media_id_media_id_fk": {
+          "name": "media_sync_media_id_media_id_fk",
+          "tableFrom": "media_sync",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_tags": {
+      "name": "media_tags",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_type": {
+          "name": "tag_type",
+          "type": "tag_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'positive'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_media_tags_tag_id_tag_type_media_id": {
+          "name": "idx_media_tags_tag_id_tag_type_media_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_tags_media_id_media_id_fk": {
+          "name": "media_tags_media_id_media_id_fk",
+          "tableFrom": "media_tags",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_tags_tag_id_tags_id_fk": {
+          "name": "media_tags_tag_id_tags_id_fk",
+          "tableFrom": "media_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_tags_media_id_tag_id_tag_type_pk": {
+          "name": "media_tags_media_id_tag_id_tag_type_pk",
+          "columns": [
+            "media_id",
+            "tag_id",
+            "tag_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_technical_info": {
+      "name": "media_technical_info",
+      "schema": "",
+      "columns": {
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color_profile": {
+          "name": "color_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "exif_data": {
+          "name": "exif_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "hash_md5": {
+          "name": "hash_md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hash_perceptual": {
+          "name": "hash_perceptual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frame_rate": {
+          "name": "frame_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitrate_kbps": {
+          "name": "bitrate_kbps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_codec": {
+          "name": "video_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_media_technical_info_hash_md5": {
+          "name": "idx_media_technical_info_hash_md5",
+          "columns": [
+            {
+              "expression": "hash_md5",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_technical_info_media_id_media_id_fk": {
+          "name": "media_technical_info_media_id_media_id_fk",
+          "tableFrom": "media_technical_info",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_urls": {
+      "name": "media_urls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_media_urls_media_id": {
+          "name": "idx_media_urls_media_id",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_urls_url": {
+          "name": "idx_media_urls_url",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_urls_media_id_url_unique": {
+          "name": "idx_media_urls_media_id_url_unique",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_urls_media_id_media_id_fk": {
+          "name": "media_urls_media_id_media_id_fk",
+          "tableFrom": "media_urls",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "media_organization_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "idx_media_source_id": {
+          "name": "idx_media_source_id",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_file_size": {
+          "name": "idx_media_file_size",
+          "columns": [
+            {
+              "expression": "file_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_file_name": {
+          "name": "idx_media_file_name",
+          "columns": [
+            {
+              "expression": "file_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_created_at": {
+          "name": "idx_media_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_media_description": {
+          "name": "idx_media_description",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_source_id_media_sources_id_fk": {
+          "name": "media_source_id_media_sources_id_fk",
+          "tableFrom": "media",
+          "tableTo": "media_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_id_file_path_unique": {
+          "name": "source_id_file_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "file_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.presets": {
+      "name": "presets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort": {
+          "name": "sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "presets_name_unique": {
+          "name": "presets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_projects_name": {
+          "name": "idx_projects_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.similar_media": {
+      "name": "similar_media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media1_id": {
+          "name": "media1_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media2_id": {
+          "name": "media2_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "similarity_score": {
+          "name": "similarity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'perceptual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_similar_media_score": {
+          "name": "idx_similar_media_score",
+          "columns": [
+            {
+              "expression": "similarity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "similar_media_media1_id_media_id_fk": {
+          "name": "similar_media_media1_id_media_id_fk",
+          "tableFrom": "similar_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "similar_media_media2_id_media_id_fk": {
+          "name": "similar_media_media2_id_media_id_fk",
+          "tableFrom": "similar_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media1Id_media2Id_algorithm_unique": {
+          "name": "media1Id_media2Id_algorithm_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "media1_id",
+            "media2_id",
+            "algorithm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute": {
+          "name": "attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tags_author_id": {
+          "name": "idx_tags_author_id",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_author_id_authors_id_fk": {
+          "name": "tags_author_id_authors_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.view_history": {
+      "name": "view_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "view_history_media_id_media_id_fk": {
+          "name": "view_history_media_id_media_id_fk",
+          "tableFrom": "view_history",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.author_platform": {
+      "name": "author_platform",
+      "schema": "public",
+      "values": [
+        "twitter",
+        "pixiv-fanbox",
+        "danbooru"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.media_organization_status": {
+      "name": "media_organization_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived",
+        "deleted"
+      ]
+    },
+    "public.media_region_kind": {
+      "name": "media_region_kind",
+      "schema": "public",
+      "values": [
+        "full",
+        "person",
+        "manual"
+      ]
+    },
+    "public.media_relation_type": {
+      "name": "media_relation_type",
+      "schema": "public",
+      "values": [
+        "variant",
+        "version",
+        "page",
+        "derivative",
+        "edit",
+        "source"
+      ]
+    },
+    "public.media_source_type": {
+      "name": "media_source_type",
+      "schema": "public",
+      "values": [
+        "local",
+        "sftp",
+        "s3"
+      ]
+    },
+    "public.media_sync_status": {
+      "name": "media_sync_status",
+      "schema": "public",
+      "values": [
+        "synced",
+        "pending",
+        "failed"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "video",
+        "audio"
+      ]
+    },
+    "public.tag_type": {
+      "name": "tag_type",
+      "schema": "public",
+      "values": [
+        "positive",
+        "negative"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1784389747874,
       "tag": "0019_purple_devos",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1785607909433,
+      "tag": "0020_blue_nuke",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/public/openapi.json
+++ b/apps/server/public/openapi.json
@@ -67,7 +67,9 @@
         "operationId": "sources.list",
         "summary": "メディアソース一覧取得",
         "description": "登録されているすべてのメディアソース（ローカル、SFTP、S3等）を取得します。",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -92,7 +94,9 @@
         "operationId": "sources.get",
         "summary": "メディアソース詳細取得",
         "description": "UUIDを指定して特定のメディアソースの情報を取得します。",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -117,7 +121,9 @@
         "operationId": "sources.create",
         "summary": "メディアソース作成",
         "description": "新しいメディアソースを登録します。",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -142,7 +148,9 @@
         "operationId": "sources.update",
         "summary": "メディアソース更新",
         "description": "既存のメディアソースの設定を更新します。",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -167,7 +175,9 @@
         "operationId": "sources.delete",
         "summary": "メディアソース削除",
         "description": "メディアソースを削除し、監視を停止します。",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -191,7 +201,9 @@
       "post": {
         "operationId": "sources.sync",
         "summary": "sync",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -215,7 +227,9 @@
       "post": {
         "operationId": "sources.dump",
         "summary": "dump",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -239,7 +253,9 @@
       "post": {
         "operationId": "sources.restore",
         "summary": "restore",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -263,7 +279,9 @@
       "post": {
         "operationId": "sources.importZip",
         "summary": "importZip",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -287,7 +305,9 @@
       "post": {
         "operationId": "sources.importNdjson",
         "summary": "importNdjson",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -311,7 +331,9 @@
       "post": {
         "operationId": "sources.importLanceDB",
         "summary": "importLanceDB",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -336,7 +358,9 @@
         "operationId": "sources.status",
         "summary": "メディアソースの状態取得",
         "description": "スキャン進捗やファイル数などの統計情報を取得します。",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -360,7 +384,9 @@
       "post": {
         "operationId": "sources.events",
         "summary": "events",
-        "tags": ["Media Sources"],
+        "tags": [
+          "Media Sources"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -382,7 +408,9 @@
                           "type": "number"
                         }
                       },
-                      "required": ["event"]
+                      "required": [
+                        "event"
+                      ]
                     },
                     {
                       "type": "object",
@@ -398,7 +426,9 @@
                           "type": "number"
                         }
                       },
-                      "required": ["event"]
+                      "required": [
+                        "event"
+                      ]
                     },
                     {
                       "type": "object",
@@ -414,7 +444,9 @@
                           "type": "number"
                         }
                       },
-                      "required": ["event"]
+                      "required": [
+                        "event"
+                      ]
                     }
                   ]
                 }
@@ -428,7 +460,9 @@
       "post": {
         "operationId": "tags.list",
         "summary": "list",
-        "tags": ["Tags"],
+        "tags": [
+          "Tags"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -452,7 +486,9 @@
       "post": {
         "operationId": "tags.get",
         "summary": "get",
-        "tags": ["Tags"],
+        "tags": [
+          "Tags"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -476,7 +512,9 @@
       "post": {
         "operationId": "tags.create",
         "summary": "create",
-        "tags": ["Tags"],
+        "tags": [
+          "Tags"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -500,7 +538,9 @@
       "post": {
         "operationId": "tags.update",
         "summary": "update",
-        "tags": ["Tags"],
+        "tags": [
+          "Tags"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -524,7 +564,9 @@
       "post": {
         "operationId": "tags.delete",
         "summary": "delete",
-        "tags": ["Tags"],
+        "tags": [
+          "Tags"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -549,7 +591,9 @@
         "operationId": "media.search",
         "summary": "メディア検索",
         "description": "タグ、プロジェクト、キャラクターなどの条件でメディアを検索します。",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -573,7 +617,9 @@
       "post": {
         "operationId": "media.searchSimilar",
         "summary": "searchSimilar",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -597,7 +643,9 @@
       "post": {
         "operationId": "media.get",
         "summary": "get",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -621,7 +669,9 @@
       "post": {
         "operationId": "media.getDetails",
         "summary": "getDetails",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -645,7 +695,9 @@
       "post": {
         "operationId": "media.findDuplicates",
         "summary": "findDuplicates",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -669,7 +721,9 @@
       "post": {
         "operationId": "media.getContent",
         "summary": "getContent",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -693,7 +747,9 @@
       "post": {
         "operationId": "media.getTags",
         "summary": "getTags",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -717,7 +773,9 @@
       "post": {
         "operationId": "media.update",
         "summary": "update",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -741,7 +799,9 @@
       "post": {
         "operationId": "media.sync",
         "summary": "sync",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -765,7 +825,9 @@
       "post": {
         "operationId": "media.delete",
         "summary": "delete",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -789,7 +851,9 @@
       "post": {
         "operationId": "media.copy",
         "summary": "copy",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -813,7 +877,9 @@
       "post": {
         "operationId": "media.move",
         "summary": "move",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -837,7 +903,9 @@
       "post": {
         "operationId": "media.upload",
         "summary": "upload",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -861,7 +929,9 @@
       "post": {
         "operationId": "media.bulkEdit",
         "summary": "bulkEdit",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -885,7 +955,9 @@
       "post": {
         "operationId": "media.bulkDelete",
         "summary": "bulkDelete",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -909,7 +981,9 @@
       "post": {
         "operationId": "media.bulkMove",
         "summary": "bulkMove",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -933,7 +1007,9 @@
       "post": {
         "operationId": "media.bulkTag",
         "summary": "bulkTag",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -957,7 +1033,9 @@
       "post": {
         "operationId": "media.bulkCopyToSource",
         "summary": "bulkCopyToSource",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -981,7 +1059,9 @@
       "post": {
         "operationId": "media.bulkMoveToSource",
         "summary": "bulkMoveToSource",
-        "tags": ["Media"],
+        "tags": [
+          "Media"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1005,7 +1085,9 @@
       "post": {
         "operationId": "categories.list",
         "summary": "list",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1029,7 +1111,9 @@
       "post": {
         "operationId": "categories.get",
         "summary": "get",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1053,7 +1137,9 @@
       "post": {
         "operationId": "categories.create",
         "summary": "create",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1077,7 +1163,9 @@
       "post": {
         "operationId": "categories.update",
         "summary": "update",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1101,7 +1189,9 @@
       "post": {
         "operationId": "categories.delete",
         "summary": "delete",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1125,7 +1215,9 @@
       "post": {
         "operationId": "projects.list",
         "summary": "list",
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1149,7 +1241,9 @@
       "post": {
         "operationId": "projects.get",
         "summary": "get",
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1173,7 +1267,9 @@
       "post": {
         "operationId": "projects.create",
         "summary": "create",
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1197,7 +1293,9 @@
       "post": {
         "operationId": "projects.update",
         "summary": "update",
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1221,7 +1319,9 @@
       "post": {
         "operationId": "projects.delete",
         "summary": "delete",
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1245,7 +1345,9 @@
       "post": {
         "operationId": "projects.listForMedia",
         "summary": "listForMedia",
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1269,7 +1371,9 @@
       "post": {
         "operationId": "projects.addToMedia",
         "summary": "addToMedia",
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1293,7 +1397,9 @@
       "post": {
         "operationId": "projects.removeFromMedia",
         "summary": "removeFromMedia",
-        "tags": ["Projects"],
+        "tags": [
+          "Projects"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1317,7 +1423,9 @@
       "post": {
         "operationId": "characters.list",
         "summary": "list",
-        "tags": ["Characters"],
+        "tags": [
+          "Characters"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1341,7 +1449,9 @@
       "post": {
         "operationId": "characters.get",
         "summary": "get",
-        "tags": ["Characters"],
+        "tags": [
+          "Characters"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1365,7 +1475,9 @@
       "post": {
         "operationId": "characters.create",
         "summary": "create",
-        "tags": ["Characters"],
+        "tags": [
+          "Characters"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1389,7 +1501,9 @@
       "post": {
         "operationId": "characters.update",
         "summary": "update",
-        "tags": ["Characters"],
+        "tags": [
+          "Characters"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1413,7 +1527,9 @@
       "post": {
         "operationId": "characters.delete",
         "summary": "delete",
-        "tags": ["Characters"],
+        "tags": [
+          "Characters"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1437,7 +1553,9 @@
       "post": {
         "operationId": "characters.listForMedia",
         "summary": "listForMedia",
-        "tags": ["Characters"],
+        "tags": [
+          "Characters"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1461,7 +1579,9 @@
       "post": {
         "operationId": "characters.addToMedia",
         "summary": "addToMedia",
-        "tags": ["Characters"],
+        "tags": [
+          "Characters"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1485,7 +1605,9 @@
       "post": {
         "operationId": "characters.removeFromMedia",
         "summary": "removeFromMedia",
-        "tags": ["Characters"],
+        "tags": [
+          "Characters"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1509,7 +1631,9 @@
       "post": {
         "operationId": "ips.list",
         "summary": "list",
-        "tags": ["IPs"],
+        "tags": [
+          "IPs"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1533,7 +1657,9 @@
       "post": {
         "operationId": "ips.get",
         "summary": "get",
-        "tags": ["IPs"],
+        "tags": [
+          "IPs"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1557,7 +1683,9 @@
       "post": {
         "operationId": "ips.create",
         "summary": "create",
-        "tags": ["IPs"],
+        "tags": [
+          "IPs"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1581,7 +1709,9 @@
       "post": {
         "operationId": "ips.update",
         "summary": "update",
-        "tags": ["IPs"],
+        "tags": [
+          "IPs"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1605,7 +1735,9 @@
       "post": {
         "operationId": "ips.delete",
         "summary": "delete",
-        "tags": ["IPs"],
+        "tags": [
+          "IPs"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1629,7 +1761,9 @@
       "post": {
         "operationId": "ips.listForMedia",
         "summary": "listForMedia",
-        "tags": ["IPs"],
+        "tags": [
+          "IPs"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1653,7 +1787,9 @@
       "post": {
         "operationId": "ips.addToMedia",
         "summary": "addToMedia",
-        "tags": ["IPs"],
+        "tags": [
+          "IPs"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1677,7 +1813,9 @@
       "post": {
         "operationId": "ips.removeFromMedia",
         "summary": "removeFromMedia",
-        "tags": ["IPs"],
+        "tags": [
+          "IPs"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1701,7 +1839,9 @@
       "post": {
         "operationId": "thumbnails.generate",
         "summary": "generate",
-        "tags": ["Thumbnails"],
+        "tags": [
+          "Thumbnails"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1725,7 +1865,9 @@
       "post": {
         "operationId": "thumbnails.clear",
         "summary": "clear",
-        "tags": ["Thumbnails"],
+        "tags": [
+          "Thumbnails"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1749,7 +1891,9 @@
       "post": {
         "operationId": "downloads.start",
         "summary": "start",
-        "tags": ["Downloads"],
+        "tags": [
+          "Downloads"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1773,7 +1917,9 @@
       "post": {
         "operationId": "directories.list",
         "summary": "list",
-        "tags": ["Directories"],
+        "tags": [
+          "Directories"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1797,7 +1943,9 @@
       "post": {
         "operationId": "directories.create",
         "summary": "create",
-        "tags": ["Directories"],
+        "tags": [
+          "Directories"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1821,7 +1969,9 @@
       "post": {
         "operationId": "directories.delete",
         "summary": "delete",
-        "tags": ["Directories"],
+        "tags": [
+          "Directories"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1845,7 +1995,9 @@
       "post": {
         "operationId": "directories.rename",
         "summary": "rename",
-        "tags": ["Directories"],
+        "tags": [
+          "Directories"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1870,7 +2022,35 @@
         "operationId": "ai.tag",
         "summary": "AI自動タグ付け",
         "description": "画像を解析して、関連するタグ（DeepDanbooru等）を自動生成します。",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ai/tagOppaiOracle": {
+      "post": {
+        "operationId": "ai.tagOppaiOracle",
+        "summary": "tagOppaiOracle",
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1894,7 +2074,9 @@
       "post": {
         "operationId": "ai.ccipFeature",
         "summary": "ccipFeature",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1918,7 +2100,9 @@
       "post": {
         "operationId": "ai.ccipDifference",
         "summary": "ccipDifference",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1942,7 +2126,9 @@
       "post": {
         "operationId": "ai.ccipDistances",
         "summary": "ccipDistances",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1966,7 +2152,9 @@
       "post": {
         "operationId": "ai.scanBatchTaggingTargets",
         "summary": "scanBatchTaggingTargets",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1990,7 +2178,9 @@
       "post": {
         "operationId": "ai.startBatchTagging",
         "summary": "startBatchTagging",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2014,7 +2204,9 @@
       "post": {
         "operationId": "ai.ccipVectorStatus",
         "summary": "ccipVectorStatus",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2038,7 +2230,9 @@
       "post": {
         "operationId": "ai.startCcipExtraction",
         "summary": "startCcipExtraction",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2062,7 +2256,9 @@
       "post": {
         "operationId": "ai.scanBatchCcipTargets",
         "summary": "scanBatchCcipTargets",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2086,7 +2282,9 @@
       "post": {
         "operationId": "ai.startBatchCcipExtraction",
         "summary": "startBatchCcipExtraction",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2110,7 +2308,9 @@
       "post": {
         "operationId": "ai.detectAndCropCharacters",
         "summary": "detectAndCropCharacters",
-        "tags": ["AI"],
+        "tags": [
+          "AI"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2157,7 +2357,9 @@
       "post": {
         "operationId": "utils.fetchUrl",
         "summary": "fetchUrl",
-        "tags": ["Utilities"],
+        "tags": [
+          "Utilities"
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2204,6 +2406,29 @@
       "post": {
         "operationId": "imports.listPending",
         "summary": "listPending",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/imports/countPending": {
+      "post": {
+        "operationId": "imports.countPending",
+        "summary": "countPending",
         "responses": {
           "200": {
             "description": "OK",
@@ -2294,7 +2519,9 @@
                           "type": "number"
                         }
                       },
-                      "required": ["event"]
+                      "required": [
+                        "event"
+                      ]
                     },
                     {
                       "type": "object",
@@ -2310,7 +2537,9 @@
                           "type": "number"
                         }
                       },
-                      "required": ["event"]
+                      "required": [
+                        "event"
+                      ]
                     },
                     {
                       "type": "object",
@@ -2326,7 +2555,9 @@
                           "type": "number"
                         }
                       },
-                      "required": ["event"]
+                      "required": [
+                        "event"
+                      ]
                     }
                   ]
                 }
@@ -2361,7 +2592,9 @@
                           "type": "number"
                         }
                       },
-                      "required": ["event"]
+                      "required": [
+                        "event"
+                      ]
                     },
                     {
                       "type": "object",
@@ -2377,7 +2610,9 @@
                           "type": "number"
                         }
                       },
-                      "required": ["event"]
+                      "required": [
+                        "event"
+                      ]
                     },
                     {
                       "type": "object",
@@ -2393,7 +2628,9 @@
                           "type": "number"
                         }
                       },
-                      "required": ["event"]
+                      "required": [
+                        "event"
+                      ]
                     }
                   ]
                 }

--- a/apps/server/public/openapi.json
+++ b/apps/server/public/openapi.json
@@ -97,6 +97,25 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -124,6 +143,123 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": {
+                    "enum": [
+                      "local",
+                      "sftp",
+                      "s3"
+                    ],
+                    "type": "string"
+                  },
+                  "connectionInfo": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991,
+                            "exclusiveMinimum": 0
+                          },
+                          "username": {
+                            "type": "string"
+                          },
+                          "password": {
+                            "type": "string"
+                          },
+                          "privateKey": {
+                            "type": "string"
+                          },
+                          "remotePath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "host",
+                          "port",
+                          "username",
+                          "remotePath"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "region": {
+                            "type": "string"
+                          },
+                          "bucket": {
+                            "type": "string"
+                          },
+                          "accessKeyId": {
+                            "type": "string"
+                          },
+                          "secretAccessKey": {
+                            "type": "string"
+                          },
+                          "prefix": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "region",
+                          "bucket",
+                          "accessKeyId",
+                          "secretAccessKey"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "description",
+                  "type",
+                  "connectionInfo"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -151,6 +287,130 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": {
+                        "enum": [
+                          "local",
+                          "sftp",
+                          "s3"
+                        ],
+                        "type": "string"
+                      },
+                      "connectionInfo": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "path": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991,
+                                "exclusiveMinimum": 0
+                              },
+                              "username": {
+                                "type": "string"
+                              },
+                              "password": {
+                                "type": "string"
+                              },
+                              "privateKey": {
+                                "type": "string"
+                              },
+                              "remotePath": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "host",
+                              "port",
+                              "username",
+                              "remotePath"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "region": {
+                                "type": "string"
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "accessKeyId": {
+                                "type": "string"
+                              },
+                              "secretAccessKey": {
+                                "type": "string"
+                              },
+                              "prefix": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "region",
+                              "bucket",
+                              "accessKeyId",
+                              "secretAccessKey"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -178,6 +438,25 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -204,6 +483,28 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "required": [
+                  "ids"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -230,6 +531,38 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mode": {
+                    "enum": [
+                      "json",
+                      "zip",
+                      "lancedb"
+                    ],
+                    "type": "string",
+                    "default": "json"
+                  },
+                  "includeImages": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -256,6 +589,30 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {}
+                  }
+                },
+                "required": [
+                  "id",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -282,6 +639,29 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "file": {
+                    "not": {}
+                  }
+                },
+                "required": [
+                  "id",
+                  "file"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -308,6 +688,29 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "file": {
+                    "not": {}
+                  }
+                },
+                "required": [
+                  "id",
+                  "file"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -334,6 +737,29 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "file": {
+                    "not": {}
+                  }
+                },
+                "required": [
+                  "id",
+                  "file"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -361,17 +787,57 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "mediaSourceId": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "status": {
+                      "enum": [
+                        "active",
+                        "error"
+                      ],
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "lastChecked": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
                     }
+                  },
+                  "required": [
+                    "mediaSourceId",
+                    "status",
+                    "lastChecked"
                   ]
                 }
               }
@@ -387,6 +853,32 @@
         "tags": [
           "Media Sources"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      {
+                        "const": "*"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -400,7 +892,308 @@
                         "event": {
                           "const": "message"
                         },
-                        "data": {},
+                        "data": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "media-added"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "mediaSourceId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "filePath": {
+                                      "type": "string"
+                                    },
+                                    "mediaId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "timestamp": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "filePath"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "media-deleted"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "mediaSourceId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "filePath": {
+                                      "type": "string"
+                                    },
+                                    "mediaId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "timestamp": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "filePath",
+                                    "mediaId"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "media-changed"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "mediaSourceId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "filePath": {
+                                      "type": "string"
+                                    },
+                                    "mediaId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "timestamp": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "filePath"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "media-copied"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "sourceId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "targetId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "sourceMediaId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "mediaId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "media": {},
+                                    "timestamp": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "media-moved"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "enum": [
+                                        "source",
+                                        "target"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "sourceId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "targetId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "mediaId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "media": {},
+                                    "timestamp": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "thumbnail-generated"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "mediaSourceId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "mediaId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "filePath": {
+                                      "type": "string"
+                                    },
+                                    "timestamp": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "mediaId"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "all-jobs-completed"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "mediaSourceId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "processed": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "processed"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "watcher-error"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "mediaSourceId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "error": {
+                                      "type": "string"
+                                    },
+                                    "timestamp": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "download-error"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "error": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "url",
+                                    "error"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            }
+                          ]
+                        },
                         "id": {
                           "type": "string"
                         },
@@ -409,7 +1202,8 @@
                         }
                       },
                       "required": [
-                        "event"
+                        "event",
+                        "data"
                       ]
                     },
                     {
@@ -489,6 +1283,25 @@
         "tags": [
           "Tags"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -515,6 +1328,37 @@
         "tags": [
           "Tags"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "attribute": {
+                    "type": "string"
+                  },
+                  "color": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -541,6 +1385,46 @@
         "tags": [
           "Tags"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "attribute": {
+                        "type": "string"
+                      },
+                      "color": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -567,6 +1451,25 @@
         "tags": [
           "Tags"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -594,6 +1497,308 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "params": {
+                    "type": "object",
+                    "properties": {
+                      "condition": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "const": "group"
+                          },
+                          "operator": {
+                            "enum": [
+                              "and",
+                              "or"
+                            ],
+                            "type": "string"
+                          },
+                          "children": {
+                            "type": "array",
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "const": "group"
+                                    },
+                                    "operator": {
+                                      "enum": [
+                                        "and",
+                                        "or"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "children": {
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {},
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "const": "criterion"
+                                              },
+                                              "target": {
+                                                "enum": [
+                                                  "keyword",
+                                                  "fileName",
+                                                  "filePath",
+                                                  "description",
+                                                  "mediaType",
+                                                  "width",
+                                                  "height",
+                                                  "fileSize",
+                                                  "createdAt",
+                                                  "rating",
+                                                  "favorite",
+                                                  "viewCount",
+                                                  "aiGenerated",
+                                                  "tag",
+                                                  "author",
+                                                  "project",
+                                                  "ip",
+                                                  "character",
+                                                  "folder"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "enum": [
+                                                  "equals",
+                                                  "contains",
+                                                  "startsWith",
+                                                  "endsWith",
+                                                  "gt",
+                                                  "gte",
+                                                  "lt",
+                                                  "lte",
+                                                  "in",
+                                                  "notIn",
+                                                  "isEmpty",
+                                                  "isNotEmpty"
+                                                ],
+                                                "type": "string",
+                                                "default": "equals"
+                                              },
+                                              "value": {
+                                                "anyOf": [
+                                                  {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      },
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "type": "array",
+                                                        "items": {}
+                                                      },
+                                                      {
+                                                        "type": "array",
+                                                        "items": {}
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "negate": {
+                                                "type": "boolean",
+                                                "default": false
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "target",
+                                              "value"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "negate": {
+                                      "type": "boolean",
+                                      "default": false
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "operator",
+                                    "children"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "const": "criterion"
+                                    },
+                                    "target": {
+                                      "enum": [
+                                        "keyword",
+                                        "fileName",
+                                        "filePath",
+                                        "description",
+                                        "mediaType",
+                                        "width",
+                                        "height",
+                                        "fileSize",
+                                        "createdAt",
+                                        "rating",
+                                        "favorite",
+                                        "viewCount",
+                                        "aiGenerated",
+                                        "tag",
+                                        "author",
+                                        "project",
+                                        "ip",
+                                        "character",
+                                        "folder"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "enum": [
+                                        "equals",
+                                        "contains",
+                                        "startsWith",
+                                        "endsWith",
+                                        "gt",
+                                        "gte",
+                                        "lt",
+                                        "lte",
+                                        "in",
+                                        "notIn",
+                                        "isEmpty",
+                                        "isNotEmpty"
+                                      ],
+                                      "type": "string",
+                                      "default": "equals"
+                                    },
+                                    "value": {
+                                      "anyOf": [
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "number"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "negate": {
+                                      "type": "boolean",
+                                      "default": false
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "target",
+                                    "value"
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "negate": {
+                            "type": "boolean",
+                            "default": false
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "operator",
+                          "children"
+                        ]
+                      },
+                      "sort": {
+                        "enum": [
+                          "date",
+                          "name",
+                          "size",
+                          "rating",
+                          "viewCount"
+                        ],
+                        "type": "string"
+                      },
+                      "order": {
+                        "enum": [
+                          "asc",
+                          "desc"
+                        ],
+                        "type": "string",
+                        "default": "desc"
+                      },
+                      "limit": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "exclusiveMinimum": 0
+                      },
+                      "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991,
+                        "default": 0
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "params"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -620,17 +1825,168 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "anchorMediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "topK": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 50
+                  }
+                },
+                "required": [
+                  "anchorMediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "media": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "mediaSourceId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "filePath": {
+                            "type": "string"
+                          },
+                          "fileName": {
+                            "type": "string"
+                          },
+                          "mediaType": {
+                            "enum": [
+                              "image",
+                              "video",
+                              "audio"
+                            ],
+                            "type": "string"
+                          },
+                          "width": {
+                            "type": "number"
+                          },
+                          "height": {
+                            "type": "number"
+                          },
+                          "fileSize": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "x-native-type": "date"
+                          },
+                          "modifiedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "x-native-type": "date"
+                          },
+                          "indexedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "x-native-type": "date"
+                          },
+                          "status": {
+                            "enum": [
+                              "active",
+                              "archived",
+                              "deleted"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "mediaSourceId",
+                          "filePath",
+                          "fileName",
+                          "mediaType",
+                          "width",
+                          "height",
+                          "fileSize",
+                          "description",
+                          "createdAt",
+                          "modifiedAt",
+                          "indexedAt",
+                          "status"
+                        ]
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "scores": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "mediaId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "cosineDistance": {
+                            "type": "number"
+                          },
+                          "ccipDistance": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "mediaId",
+                          "cosineDistance",
+                          "ccipDistance"
+                        ]
+                      }
                     }
+                  },
+                  "required": [
+                    "media",
+                    "total",
+                    "scores"
                   ]
                 }
               }
@@ -646,6 +2002,30 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "mediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -672,6 +2052,30 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "mediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -698,6 +2102,22 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -724,6 +2144,30 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "mediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -750,6 +2194,30 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "mediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -776,6 +2244,182 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "filePath": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "fileName": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "fileSize": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "exclusiveMinimum": 0
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "x-native-type": "date"
+                      },
+                      "modifiedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "x-native-type": "date"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "x-native-type": "date"
+                      },
+                      "mediaType": {
+                        "enum": [
+                          "image",
+                          "video",
+                          "audio"
+                        ],
+                        "type": "string"
+                      },
+                      "width": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "exclusiveMinimum": 0
+                      },
+                      "height": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "exclusiveMinimum": 0
+                      },
+                      "description": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "sourceUrls": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      },
+                      "authors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "accountId": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "platform": {
+                              "enum": [
+                                "twitter",
+                                "pixiv-fanbox",
+                                "danbooru"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        }
+                      },
+                      "characters": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "confidence": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        }
+                      },
+                      "ips": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "confidence": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "mediaId",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -802,6 +2446,33 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "mediaIds"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -828,6 +2499,30 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "mediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -854,6 +2549,30 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "targetSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId",
+                  "targetSourceId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -880,6 +2599,30 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "targetSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId",
+                  "targetSourceId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -906,6 +2649,44 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "file": {
+                    "not": {}
+                  },
+                  "filename": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "sourceUrl": {
+                    "type": "string"
+                  },
+                  "overwrite": {
+                    "type": "string"
+                  },
+                  "autoIncrement": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "file"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -932,6 +2713,186 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "updates": {
+                    "type": "object",
+                    "properties": {
+                      "filePath": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "fileName": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "fileSize": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "exclusiveMinimum": 0
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "x-native-type": "date"
+                      },
+                      "modifiedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "x-native-type": "date"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "x-native-type": "date"
+                      },
+                      "mediaType": {
+                        "enum": [
+                          "image",
+                          "video",
+                          "audio"
+                        ],
+                        "type": "string"
+                      },
+                      "width": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "exclusiveMinimum": 0
+                      },
+                      "height": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "exclusiveMinimum": 0
+                      },
+                      "description": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "sourceUrls": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      },
+                      "authors": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "accountId": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "platform": {
+                              "enum": [
+                                "twitter",
+                                "pixiv-fanbox",
+                                "danbooru"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        }
+                      },
+                      "characters": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "confidence": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        }
+                      },
+                      "ips": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "confidence": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "mediaSourceId",
+                  "mediaIds",
+                  "updates"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -958,6 +2919,34 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "required": [
+                  "mediaSourceId",
+                  "mediaIds"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -984,6 +2973,39 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "destinationPath": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "mediaSourceId",
+                  "mediaIds",
+                  "destinationPath"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1010,6 +3032,50 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "tagsToAdd": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "tagsToRemove": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "required": [
+                  "mediaSourceId",
+                  "mediaIds",
+                  "tagsToAdd",
+                  "tagsToRemove"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1036,6 +3102,39 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "targetSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaSourceId",
+                  "mediaIds",
+                  "targetSourceId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1062,6 +3161,39 @@
         "tags": [
           "Media"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "targetSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaSourceId",
+                  "mediaIds",
+                  "targetSourceId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1114,6 +3246,25 @@
         "tags": [
           "Categories"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1140,6 +3291,35 @@
         "tags": [
           "Categories"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "color": {
+                    "type": "string"
+                  },
+                  "parentId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1166,6 +3346,45 @@
         "tags": [
           "Categories"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "color": {
+                        "type": "string"
+                      },
+                      "parentId": {
+                        "type": "string",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1192,6 +3411,25 @@
         "tags": [
           "Categories"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1244,6 +3482,25 @@
         "tags": [
           "Projects"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1270,6 +3527,28 @@
         "tags": [
           "Projects"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1296,6 +3575,50 @@
         "tags": [
           "Projects"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "archivedAt": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "date-time",
+                            "x-native-type": "date"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1322,6 +3645,25 @@
         "tags": [
           "Projects"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1348,6 +3690,25 @@
         "tags": [
           "Projects"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1374,6 +3735,30 @@
         "tags": [
           "Projects"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "projectId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId",
+                  "projectId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1400,6 +3785,30 @@
         "tags": [
           "Projects"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "projectId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId",
+                  "projectId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1452,6 +3861,25 @@
         "tags": [
           "Characters"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1478,6 +3906,38 @@
         "tags": [
           "Characters"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "ipIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1504,6 +3964,48 @@
         "tags": [
           "Characters"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "ipIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "format": "uuid"
+                        }
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1530,6 +4032,25 @@
         "tags": [
           "Characters"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1556,6 +4077,25 @@
         "tags": [
           "Characters"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1582,6 +4122,30 @@
         "tags": [
           "Characters"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "characterId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId",
+                  "characterId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1608,6 +4172,30 @@
         "tags": [
           "Characters"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "characterId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId",
+                  "characterId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1660,6 +4248,25 @@
         "tags": [
           "IPs"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1686,6 +4293,27 @@
         "tags": [
           "IPs"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1712,6 +4340,37 @@
         "tags": [
           "IPs"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1738,6 +4397,25 @@
         "tags": [
           "IPs"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1764,6 +4442,25 @@
         "tags": [
           "IPs"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1790,6 +4487,30 @@
         "tags": [
           "IPs"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ipId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId",
+                  "ipId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1816,6 +4537,30 @@
         "tags": [
           "IPs"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ipId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaId",
+                  "ipId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1842,6 +4587,25 @@
         "tags": [
           "Thumbnails"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "sourceId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1868,6 +4632,25 @@
         "tags": [
           "Thumbnails"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "sourceId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1894,6 +4677,314 @@
         "tags": [
           "Downloads"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "items": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "createdAt": {
+                          "anyOf": [
+                            {
+                              "const": ""
+                            },
+                            {
+                              "type": "string",
+                              "format": "date-time",
+                              "x-native-type": "date"
+                            }
+                          ]
+                        },
+                        "sourceUrls": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "accountId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "platform": {
+                                "enum": [
+                                  "twitter",
+                                  "pixiv-fanbox",
+                                  "danbooru"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "enum": [
+                                  "positive",
+                                  "negative"
+                                ],
+                                "type": "string"
+                              },
+                              "confidence": {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "source": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "characters": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "confidence": {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "linkedIps": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "source": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "ips": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "confidence": {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "source": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "projects": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "generationInfo": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "prompt": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "negativePrompt": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "modelName": {
+                                  "type": "string"
+                                },
+                                "seed": {
+                                  "type": "number"
+                                },
+                                "steps": {
+                                  "type": "number"
+                                },
+                                "cfgScale": {
+                                  "type": "number"
+                                },
+                                "aiGenerated": {
+                                  "type": "boolean"
+                                },
+                                "workflow": {
+                                  "anyOf": [
+                                    {},
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "metadata": {
+                                  "anyOf": [
+                                    {},
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "targetUrl": {
+                          "type": "string",
+                          "format": "uri"
+                        },
+                        "filePath": {
+                          "type": "string"
+                        },
+                        "fileName": {
+                          "type": "string"
+                        },
+                        "cookies": {
+                          "type": "array",
+                          "items": {}
+                        },
+                        "userAgent": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "mediaSourceId",
+                  "items"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1920,6 +5011,29 @@
         "tags": [
           "Directories"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "path": {
+                    "type": "string",
+                    "default": ""
+                  }
+                },
+                "required": [
+                  "sourceId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1946,6 +5060,33 @@
         "tags": [
           "Directories"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "path",
+                  "name"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1972,6 +5113,32 @@
         "tags": [
           "Directories"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "force": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "path"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1998,6 +5165,33 @@
         "tags": [
           "Directories"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "oldPath": {
+                    "type": "string"
+                  },
+                  "newPath": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sourceId",
+                  "oldPath",
+                  "newPath"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2025,6 +5219,39 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "file": {
+                        "not": {}
+                      }
+                    },
+                    "required": [
+                      "file"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "mediaSourceId": {
+                        "type": "string"
+                      },
+                      "mediaId": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2051,6 +5278,39 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "file": {
+                        "not": {}
+                      }
+                    },
+                    "required": [
+                      "file"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "mediaSourceId": {
+                        "type": "string"
+                      },
+                      "mediaId": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2077,6 +5337,39 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "file": {
+                        "not": {}
+                      }
+                    },
+                    "required": [
+                      "file"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "mediaSourceId": {
+                        "type": "string"
+                      },
+                      "mediaId": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2103,6 +5396,34 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "feature1": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "feature2": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "required": [
+                  "feature1",
+                  "feature2"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2129,17 +5450,58 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "feature": {
+                    "type": "array",
+                    "minItems": 768,
+                    "maxItems": 768,
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "candidates": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 768,
+                      "maxItems": 768,
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "feature",
+                  "candidates"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "distances": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
                     }
+                  },
+                  "required": [
+                    "distances"
                   ]
                 }
               }
@@ -2155,17 +5517,43 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "type": "boolean"
+                  },
+                  "batchSize": {
+                    "type": "number"
+                  },
+                  "mediaSourceId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
                     }
+                  },
+                  "required": [
+                    "count"
                   ]
                 }
               }
@@ -2181,17 +5569,50 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "type": "boolean"
+                  },
+                  "batchSize": {
+                    "type": "number"
+                  },
+                  "mediaSourceId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "jobId": {
+                      "type": "string",
+                      "format": "uuid"
                     }
+                  },
+                  "required": [
+                    "success",
+                    "message",
+                    "jobId"
                   ]
                 }
               }
@@ -2207,17 +5628,66 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "mediaSourceId",
+                  "mediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "enum": [
+                        "missing",
+                        "processing",
+                        "ready",
+                        "stale",
+                        "failed"
+                      ],
+                      "type": "string"
+                    },
+                    "jobId": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "model": {
+                      "type": "string"
+                    },
+                    "extractedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "error": {
+                      "type": "string"
                     }
+                  },
+                  "required": [
+                    "status"
                   ]
                 }
               }
@@ -2233,17 +5703,57 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "mediaId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "force": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "required": [
+                  "mediaSourceId",
+                  "mediaId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "jobId": {
+                      "type": "string",
+                      "format": "uuid"
                     }
+                  },
+                  "required": [
+                    "success",
+                    "message",
+                    "jobId"
                   ]
                 }
               }
@@ -2259,17 +5769,42 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
                     }
+                  },
+                  "required": [
+                    "count"
                   ]
                 }
               }
@@ -2285,17 +5820,49 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "mediaSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "jobId": {
+                      "type": "string",
+                      "format": "uuid"
                     }
+                  },
+                  "required": [
+                    "success",
+                    "message",
+                    "jobId"
                   ]
                 }
               }
@@ -2311,6 +5878,48 @@
         "tags": [
           "AI"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "mediaId": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "transparent": {
+                        "type": "boolean",
+                        "default": false
+                      }
+                    },
+                    "required": [
+                      "mediaId"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "file": {
+                        "not": {}
+                      },
+                      "transparent": {
+                        "type": "boolean",
+                        "default": false
+                      }
+                    },
+                    "required": [
+                      "file"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2360,6 +5969,25 @@
         "tags": [
           "Utilities"
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": [
+                  "url"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2383,6 +6011,308 @@
       "post": {
         "operationId": "imports.bulkAdd",
         "summary": "bulkAdd",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "createdAt": {
+                          "anyOf": [
+                            {
+                              "const": ""
+                            },
+                            {
+                              "type": "string",
+                              "format": "date-time",
+                              "x-native-type": "date"
+                            }
+                          ]
+                        },
+                        "sourceUrls": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "accountId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "platform": {
+                                "enum": [
+                                  "twitter",
+                                  "pixiv-fanbox",
+                                  "danbooru"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "enum": [
+                                  "positive",
+                                  "negative"
+                                ],
+                                "type": "string"
+                              },
+                              "confidence": {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "source": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "characters": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "confidence": {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "linkedIps": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "source": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "ips": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "confidence": {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "source": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "projects": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          }
+                        },
+                        "generationInfo": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "prompt": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "negativePrompt": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "modelName": {
+                                  "type": "string"
+                                },
+                                "seed": {
+                                  "type": "number"
+                                },
+                                "steps": {
+                                  "type": "number"
+                                },
+                                "cfgScale": {
+                                  "type": "number"
+                                },
+                                "aiGenerated": {
+                                  "type": "boolean"
+                                },
+                                "workflow": {
+                                  "anyOf": [
+                                    {},
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "metadata": {
+                                  "anyOf": [
+                                    {},
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "targetUrl": {
+                          "type": "string",
+                          "format": "uri"
+                        },
+                        "filePath": {
+                          "type": "string"
+                        },
+                        "fileName": {
+                          "type": "string"
+                        },
+                        "cookies": {
+                          "type": "array",
+                          "items": {}
+                        },
+                        "userAgent": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "items"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2435,11 +6365,16 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
                     }
+                  },
+                  "required": [
+                    "count"
                   ]
                 }
               }
@@ -2452,6 +6387,33 @@
       "post": {
         "operationId": "imports.process",
         "summary": "process",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "jobIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "targetSourceId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "jobIds",
+                  "targetSourceId"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2475,6 +6437,28 @@
       "post": {
         "operationId": "imports.cancel",
         "summary": "cancel",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "jobIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "required": [
+                  "jobIds"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2511,7 +6495,83 @@
                         "event": {
                           "const": "message"
                         },
-                        "data": {},
+                        "data": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "import-request:created"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "count": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "count"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "import-request:processed"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "processedCount": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "processedCount"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "import-request:deleted"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "jobIds": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "format": "uuid"
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "jobIds"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            }
+                          ]
+                        },
                         "id": {
                           "type": "string"
                         },
@@ -2520,7 +6580,8 @@
                         }
                       },
                       "required": [
-                        "event"
+                        "event",
+                        "data"
                       ]
                     },
                     {
@@ -2584,7 +6645,86 @@
                         "event": {
                           "const": "message"
                         },
-                        "data": {},
+                        "data": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "job-progress"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "jobId": {
+                                      "type": "string"
+                                    },
+                                    "processed": {
+                                      "type": "number"
+                                    },
+                                    "total": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "processed",
+                                    "total"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "job-completed"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "jobId": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "job-failed"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "jobId": {
+                                      "type": "string"
+                                    },
+                                    "error": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            }
+                          ]
+                        },
                         "id": {
                           "type": "string"
                         },
@@ -2593,7 +6733,8 @@
                         }
                       },
                       "required": [
-                        "event"
+                        "event",
+                        "data"
                       ]
                     },
                     {
@@ -2650,12 +6791,310 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string",
+                      "default": "1.0.0"
+                    },
+                    "jobs": {
+                      "type": "object",
+                      "properties": {
+                        "concurrency": {
+                          "type": "number",
+                          "minimum": 1,
+                          "default": 3
+                        },
+                        "aiConcurrency": {
+                          "type": "number",
+                          "minimum": 1,
+                          "default": 1
+                        },
+                        "pollIntervalMs": {
+                          "type": "number",
+                          "minimum": 100,
+                          "default": 1000
+                        },
+                        "enableAutoTagging": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "enableAutoCcipExtraction": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      },
+                      "default": {
+                        "concurrency": 3,
+                        "aiConcurrency": 1,
+                        "pollIntervalMs": 1000,
+                        "enableAutoTagging": false,
+                        "enableAutoCcipExtraction": false
+                      }
+                    },
+                    "ai": {
+                      "type": "object",
+                      "properties": {
+                        "baseUrl": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "timeoutMs": {
+                          "type": "number",
+                          "minimum": 1000,
+                          "default": 120000
+                        }
+                      },
+                      "default": {
+                        "baseUrl": "",
+                        "timeoutMs": 120000
+                      }
+                    },
+                    "downloads": {
+                      "type": "object",
+                      "properties": {
+                        "rateLimitEnabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "requestIntervalMs": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 60000,
+                          "default": 1000
+                        }
+                      },
+                      "default": {
+                        "rateLimitEnabled": true,
+                        "requestIntervalMs": 1000
+                      }
+                    },
+                    "storage": {
+                      "type": "object",
+                      "properties": {
+                        "thumbnailDir": {
+                          "type": "string",
+                          "default": ".cache/thumbnails"
+                        },
+                        "thumbnailSize": {
+                          "type": "number",
+                          "minimum": 64,
+                          "maximum": 4096,
+                          "default": 512
+                        },
+                        "thumbnailQuality": {
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 100,
+                          "default": 80
+                        }
+                      },
+                      "default": {
+                        "thumbnailDir": ".cache/thumbnails",
+                        "thumbnailSize": 512,
+                        "thumbnailQuality": 80
+                      }
+                    },
+                    "media": {
+                      "type": "object",
+                      "properties": {
+                        "supportedExtensions": {
+                          "type": "object",
+                          "properties": {
+                            "image": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "default": [
+                                ".jpg",
+                                ".jpeg",
+                                ".png",
+                                ".webp"
+                              ]
+                            },
+                            "video": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "default": [
+                                ".mp4",
+                                ".webm",
+                                ".mov"
+                              ]
+                            },
+                            "audio": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "default": [
+                                ".mp3",
+                                ".wav"
+                              ]
+                            }
+                          },
+                          "default": {
+                            "image": [
+                              ".jpg",
+                              ".jpeg",
+                              ".png",
+                              ".webp"
+                            ],
+                            "video": [
+                              ".mp4",
+                              ".webm",
+                              ".mov"
+                            ],
+                            "audio": [
+                              ".mp3",
+                              ".wav"
+                            ]
+                          }
+                        },
+                        "tagExtraction": {
+                          "type": "object",
+                          "properties": {
+                            "comfyui": {
+                              "type": "object",
+                              "properties": {
+                                "positiveNodeTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "default": [
+                                    "CLIPTextEncode",
+                                    "CR Combine Prompt"
+                                  ]
+                                },
+                                "negativeKeywords": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "default": [
+                                    "negative"
+                                  ]
+                                },
+                                "negativeTags": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "default": [
+                                    "lowres"
+                                  ]
+                                }
+                              },
+                              "default": {
+                                "positiveNodeTypes": [
+                                  "CLIPTextEncode",
+                                  "CR Combine Prompt"
+                                ],
+                                "negativeKeywords": [
+                                  "negative"
+                                ],
+                                "negativeTags": [
+                                  "lowres"
+                                ]
+                              }
+                            }
+                          },
+                          "default": {
+                            "comfyui": {
+                              "positiveNodeTypes": [
+                                "CLIPTextEncode",
+                                "CR Combine Prompt"
+                              ],
+                              "negativeKeywords": [
+                                "negative"
+                              ],
+                              "negativeTags": [
+                                "lowres"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "default": {
+                        "supportedExtensions": {
+                          "image": [
+                            ".jpg",
+                            ".jpeg",
+                            ".png",
+                            ".webp"
+                          ],
+                          "video": [
+                            ".mp4",
+                            ".webm",
+                            ".mov"
+                          ],
+                          "audio": [
+                            ".mp3",
+                            ".wav"
+                          ]
+                        },
+                        "tagExtraction": {
+                          "comfyui": {
+                            "positiveNodeTypes": [
+                              "CLIPTextEncode",
+                              "CR Combine Prompt"
+                            ],
+                            "negativeKeywords": [
+                              "negative"
+                            ],
+                            "negativeTags": [
+                              "lowres"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "logging": {
+                      "type": "object",
+                      "properties": {
+                        "level": {
+                          "enum": [
+                            "trace",
+                            "debug",
+                            "info",
+                            "warn",
+                            "error",
+                            "fatal"
+                          ],
+                          "type": "string",
+                          "default": "info"
+                        }
+                      },
+                      "default": {
+                        "level": "info"
+                      }
+                    },
+                    "lancedb": {
+                      "type": "object",
+                      "properties": {
+                        "autoFullSync": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "cacheDir": {
+                          "type": "string",
+                          "default": ".cache/lancedb-cache"
+                        },
+                        "ccipVectorDir": {
+                          "type": "string",
+                          "default": ".cache/lancedb-ccip"
+                        }
+                      },
+                      "default": {
+                        "autoFullSync": true,
+                        "cacheDir": ".cache/lancedb-cache",
+                        "ccipVectorDir": ".cache/lancedb-ccip"
+                      }
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -2667,18 +7106,629 @@
       "post": {
         "operationId": "config.update",
         "summary": "update",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "version": {
+                    "type": "string",
+                    "default": "1.0.0"
+                  },
+                  "jobs": {
+                    "type": "object",
+                    "properties": {
+                      "concurrency": {
+                        "type": "number",
+                        "minimum": 1,
+                        "default": 3
+                      },
+                      "aiConcurrency": {
+                        "type": "number",
+                        "minimum": 1,
+                        "default": 1
+                      },
+                      "pollIntervalMs": {
+                        "type": "number",
+                        "minimum": 100,
+                        "default": 1000
+                      },
+                      "enableAutoTagging": {
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "enableAutoCcipExtraction": {
+                        "type": "boolean",
+                        "default": false
+                      }
+                    },
+                    "default": {
+                      "concurrency": 3,
+                      "aiConcurrency": 1,
+                      "pollIntervalMs": 1000,
+                      "enableAutoTagging": false,
+                      "enableAutoCcipExtraction": false
+                    }
+                  },
+                  "ai": {
+                    "type": "object",
+                    "properties": {
+                      "baseUrl": {
+                        "type": "string",
+                        "default": ""
+                      },
+                      "timeoutMs": {
+                        "type": "number",
+                        "minimum": 1000,
+                        "default": 120000
+                      }
+                    },
+                    "default": {
+                      "baseUrl": "",
+                      "timeoutMs": 120000
+                    }
+                  },
+                  "downloads": {
+                    "type": "object",
+                    "properties": {
+                      "rateLimitEnabled": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "requestIntervalMs": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 60000,
+                        "default": 1000
+                      }
+                    },
+                    "default": {
+                      "rateLimitEnabled": true,
+                      "requestIntervalMs": 1000
+                    }
+                  },
+                  "storage": {
+                    "type": "object",
+                    "properties": {
+                      "thumbnailDir": {
+                        "type": "string",
+                        "default": ".cache/thumbnails"
+                      },
+                      "thumbnailSize": {
+                        "type": "number",
+                        "minimum": 64,
+                        "maximum": 4096,
+                        "default": 512
+                      },
+                      "thumbnailQuality": {
+                        "type": "number",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 80
+                      }
+                    },
+                    "default": {
+                      "thumbnailDir": ".cache/thumbnails",
+                      "thumbnailSize": 512,
+                      "thumbnailQuality": 80
+                    }
+                  },
+                  "media": {
+                    "type": "object",
+                    "properties": {
+                      "supportedExtensions": {
+                        "type": "object",
+                        "properties": {
+                          "image": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "default": [
+                              ".jpg",
+                              ".jpeg",
+                              ".png",
+                              ".webp"
+                            ]
+                          },
+                          "video": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "default": [
+                              ".mp4",
+                              ".webm",
+                              ".mov"
+                            ]
+                          },
+                          "audio": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "default": [
+                              ".mp3",
+                              ".wav"
+                            ]
+                          }
+                        },
+                        "default": {
+                          "image": [
+                            ".jpg",
+                            ".jpeg",
+                            ".png",
+                            ".webp"
+                          ],
+                          "video": [
+                            ".mp4",
+                            ".webm",
+                            ".mov"
+                          ],
+                          "audio": [
+                            ".mp3",
+                            ".wav"
+                          ]
+                        }
+                      },
+                      "tagExtraction": {
+                        "type": "object",
+                        "properties": {
+                          "comfyui": {
+                            "type": "object",
+                            "properties": {
+                              "positiveNodeTypes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "default": [
+                                  "CLIPTextEncode",
+                                  "CR Combine Prompt"
+                                ]
+                              },
+                              "negativeKeywords": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "default": [
+                                  "negative"
+                                ]
+                              },
+                              "negativeTags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "default": [
+                                  "lowres"
+                                ]
+                              }
+                            },
+                            "default": {
+                              "positiveNodeTypes": [
+                                "CLIPTextEncode",
+                                "CR Combine Prompt"
+                              ],
+                              "negativeKeywords": [
+                                "negative"
+                              ],
+                              "negativeTags": [
+                                "lowres"
+                              ]
+                            }
+                          }
+                        },
+                        "default": {
+                          "comfyui": {
+                            "positiveNodeTypes": [
+                              "CLIPTextEncode",
+                              "CR Combine Prompt"
+                            ],
+                            "negativeKeywords": [
+                              "negative"
+                            ],
+                            "negativeTags": [
+                              "lowres"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "default": {
+                      "supportedExtensions": {
+                        "image": [
+                          ".jpg",
+                          ".jpeg",
+                          ".png",
+                          ".webp"
+                        ],
+                        "video": [
+                          ".mp4",
+                          ".webm",
+                          ".mov"
+                        ],
+                        "audio": [
+                          ".mp3",
+                          ".wav"
+                        ]
+                      },
+                      "tagExtraction": {
+                        "comfyui": {
+                          "positiveNodeTypes": [
+                            "CLIPTextEncode",
+                            "CR Combine Prompt"
+                          ],
+                          "negativeKeywords": [
+                            "negative"
+                          ],
+                          "negativeTags": [
+                            "lowres"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "logging": {
+                    "type": "object",
+                    "properties": {
+                      "level": {
+                        "enum": [
+                          "trace",
+                          "debug",
+                          "info",
+                          "warn",
+                          "error",
+                          "fatal"
+                        ],
+                        "type": "string",
+                        "default": "info"
+                      }
+                    },
+                    "default": {
+                      "level": "info"
+                    }
+                  },
+                  "lancedb": {
+                    "type": "object",
+                    "properties": {
+                      "autoFullSync": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "cacheDir": {
+                        "type": "string",
+                        "default": ".cache/lancedb-cache"
+                      },
+                      "ccipVectorDir": {
+                        "type": "string",
+                        "default": ".cache/lancedb-ccip"
+                      }
+                    },
+                    "default": {
+                      "autoFullSync": true,
+                      "cacheDir": ".cache/lancedb-cache",
+                      "ccipVectorDir": ".cache/lancedb-ccip"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string",
+                      "default": "1.0.0"
+                    },
+                    "jobs": {
+                      "type": "object",
+                      "properties": {
+                        "concurrency": {
+                          "type": "number",
+                          "minimum": 1,
+                          "default": 3
+                        },
+                        "aiConcurrency": {
+                          "type": "number",
+                          "minimum": 1,
+                          "default": 1
+                        },
+                        "pollIntervalMs": {
+                          "type": "number",
+                          "minimum": 100,
+                          "default": 1000
+                        },
+                        "enableAutoTagging": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "enableAutoCcipExtraction": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      },
+                      "default": {
+                        "concurrency": 3,
+                        "aiConcurrency": 1,
+                        "pollIntervalMs": 1000,
+                        "enableAutoTagging": false,
+                        "enableAutoCcipExtraction": false
+                      }
+                    },
+                    "ai": {
+                      "type": "object",
+                      "properties": {
+                        "baseUrl": {
+                          "type": "string",
+                          "default": ""
+                        },
+                        "timeoutMs": {
+                          "type": "number",
+                          "minimum": 1000,
+                          "default": 120000
+                        }
+                      },
+                      "default": {
+                        "baseUrl": "",
+                        "timeoutMs": 120000
+                      }
+                    },
+                    "downloads": {
+                      "type": "object",
+                      "properties": {
+                        "rateLimitEnabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "requestIntervalMs": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 60000,
+                          "default": 1000
+                        }
+                      },
+                      "default": {
+                        "rateLimitEnabled": true,
+                        "requestIntervalMs": 1000
+                      }
+                    },
+                    "storage": {
+                      "type": "object",
+                      "properties": {
+                        "thumbnailDir": {
+                          "type": "string",
+                          "default": ".cache/thumbnails"
+                        },
+                        "thumbnailSize": {
+                          "type": "number",
+                          "minimum": 64,
+                          "maximum": 4096,
+                          "default": 512
+                        },
+                        "thumbnailQuality": {
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 100,
+                          "default": 80
+                        }
+                      },
+                      "default": {
+                        "thumbnailDir": ".cache/thumbnails",
+                        "thumbnailSize": 512,
+                        "thumbnailQuality": 80
+                      }
+                    },
+                    "media": {
+                      "type": "object",
+                      "properties": {
+                        "supportedExtensions": {
+                          "type": "object",
+                          "properties": {
+                            "image": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "default": [
+                                ".jpg",
+                                ".jpeg",
+                                ".png",
+                                ".webp"
+                              ]
+                            },
+                            "video": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "default": [
+                                ".mp4",
+                                ".webm",
+                                ".mov"
+                              ]
+                            },
+                            "audio": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "default": [
+                                ".mp3",
+                                ".wav"
+                              ]
+                            }
+                          },
+                          "default": {
+                            "image": [
+                              ".jpg",
+                              ".jpeg",
+                              ".png",
+                              ".webp"
+                            ],
+                            "video": [
+                              ".mp4",
+                              ".webm",
+                              ".mov"
+                            ],
+                            "audio": [
+                              ".mp3",
+                              ".wav"
+                            ]
+                          }
+                        },
+                        "tagExtraction": {
+                          "type": "object",
+                          "properties": {
+                            "comfyui": {
+                              "type": "object",
+                              "properties": {
+                                "positiveNodeTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "default": [
+                                    "CLIPTextEncode",
+                                    "CR Combine Prompt"
+                                  ]
+                                },
+                                "negativeKeywords": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "default": [
+                                    "negative"
+                                  ]
+                                },
+                                "negativeTags": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "default": [
+                                    "lowres"
+                                  ]
+                                }
+                              },
+                              "default": {
+                                "positiveNodeTypes": [
+                                  "CLIPTextEncode",
+                                  "CR Combine Prompt"
+                                ],
+                                "negativeKeywords": [
+                                  "negative"
+                                ],
+                                "negativeTags": [
+                                  "lowres"
+                                ]
+                              }
+                            }
+                          },
+                          "default": {
+                            "comfyui": {
+                              "positiveNodeTypes": [
+                                "CLIPTextEncode",
+                                "CR Combine Prompt"
+                              ],
+                              "negativeKeywords": [
+                                "negative"
+                              ],
+                              "negativeTags": [
+                                "lowres"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "default": {
+                        "supportedExtensions": {
+                          "image": [
+                            ".jpg",
+                            ".jpeg",
+                            ".png",
+                            ".webp"
+                          ],
+                          "video": [
+                            ".mp4",
+                            ".webm",
+                            ".mov"
+                          ],
+                          "audio": [
+                            ".mp3",
+                            ".wav"
+                          ]
+                        },
+                        "tagExtraction": {
+                          "comfyui": {
+                            "positiveNodeTypes": [
+                              "CLIPTextEncode",
+                              "CR Combine Prompt"
+                            ],
+                            "negativeKeywords": [
+                              "negative"
+                            ],
+                            "negativeTags": [
+                              "lowres"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "logging": {
+                      "type": "object",
+                      "properties": {
+                        "level": {
+                          "enum": [
+                            "trace",
+                            "debug",
+                            "info",
+                            "warn",
+                            "error",
+                            "fatal"
+                          ],
+                          "type": "string",
+                          "default": "info"
+                        }
+                      },
+                      "default": {
+                        "level": "info"
+                      }
+                    },
+                    "lancedb": {
+                      "type": "object",
+                      "properties": {
+                        "autoFullSync": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "cacheDir": {
+                          "type": "string",
+                          "default": ".cache/lancedb-cache"
+                        },
+                        "ccipVectorDir": {
+                          "type": "string",
+                          "default": ".cache/lancedb-ccip"
+                        }
+                      },
+                      "default": {
+                        "autoFullSync": true,
+                        "cacheDir": ".cache/lancedb-cache",
+                        "ccipVectorDir": ".cache/lancedb-ccip"
+                      }
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -2713,6 +7763,26 @@
       "post": {
         "operationId": "presets.get",
         "summary": "get",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2736,6 +7806,24 @@
       "post": {
         "operationId": "presets.getByName",
         "summary": "getByName",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2759,6 +7847,295 @@
       "post": {
         "operationId": "presets.create",
         "summary": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "value": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "const": "group"
+                      },
+                      "operator": {
+                        "enum": [
+                          "and",
+                          "or"
+                        ],
+                        "type": "string"
+                      },
+                      "children": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "const": "group"
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "and",
+                                    "or"
+                                  ],
+                                  "type": "string"
+                                },
+                                "children": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {},
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "const": "criterion"
+                                          },
+                                          "target": {
+                                            "enum": [
+                                              "keyword",
+                                              "fileName",
+                                              "filePath",
+                                              "description",
+                                              "mediaType",
+                                              "width",
+                                              "height",
+                                              "fileSize",
+                                              "createdAt",
+                                              "rating",
+                                              "favorite",
+                                              "viewCount",
+                                              "aiGenerated",
+                                              "tag",
+                                              "author",
+                                              "project",
+                                              "ip",
+                                              "character",
+                                              "folder"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "contains",
+                                              "startsWith",
+                                              "endsWith",
+                                              "gt",
+                                              "gte",
+                                              "lt",
+                                              "lte",
+                                              "in",
+                                              "notIn",
+                                              "isEmpty",
+                                              "isNotEmpty"
+                                            ],
+                                            "type": "string",
+                                            "default": "equals"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "number"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "negate": {
+                                            "type": "boolean",
+                                            "default": false
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "target",
+                                          "value"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "negate": {
+                                  "type": "boolean",
+                                  "default": false
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "operator",
+                                "children"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "const": "criterion"
+                                },
+                                "target": {
+                                  "enum": [
+                                    "keyword",
+                                    "fileName",
+                                    "filePath",
+                                    "description",
+                                    "mediaType",
+                                    "width",
+                                    "height",
+                                    "fileSize",
+                                    "createdAt",
+                                    "rating",
+                                    "favorite",
+                                    "viewCount",
+                                    "aiGenerated",
+                                    "tag",
+                                    "author",
+                                    "project",
+                                    "ip",
+                                    "character",
+                                    "folder"
+                                  ],
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "enum": [
+                                    "equals",
+                                    "contains",
+                                    "startsWith",
+                                    "endsWith",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "in",
+                                    "notIn",
+                                    "isEmpty",
+                                    "isNotEmpty"
+                                  ],
+                                  "type": "string",
+                                  "default": "equals"
+                                },
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "number"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "negate": {
+                                  "type": "boolean",
+                                  "default": false
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "target",
+                                "value"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "negate": {
+                        "type": "boolean",
+                        "default": false
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "operator",
+                      "children"
+                    ]
+                  },
+                  "sort": {
+                    "enum": [
+                      "date",
+                      "name",
+                      "size",
+                      "rating",
+                      "viewCount"
+                    ],
+                    "type": "string"
+                  },
+                  "order": {
+                    "enum": [
+                      "asc",
+                      "desc"
+                    ],
+                    "type": "string"
+                  },
+                  "mode": {
+                    "enum": [
+                      "simple",
+                      "pro"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2782,6 +8159,301 @@
       "post": {
         "operationId": "presets.update",
         "summary": "update",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "value": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "const": "group"
+                          },
+                          "operator": {
+                            "enum": [
+                              "and",
+                              "or"
+                            ],
+                            "type": "string"
+                          },
+                          "children": {
+                            "type": "array",
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "const": "group"
+                                    },
+                                    "operator": {
+                                      "enum": [
+                                        "and",
+                                        "or"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "children": {
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {},
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "const": "criterion"
+                                              },
+                                              "target": {
+                                                "enum": [
+                                                  "keyword",
+                                                  "fileName",
+                                                  "filePath",
+                                                  "description",
+                                                  "mediaType",
+                                                  "width",
+                                                  "height",
+                                                  "fileSize",
+                                                  "createdAt",
+                                                  "rating",
+                                                  "favorite",
+                                                  "viewCount",
+                                                  "aiGenerated",
+                                                  "tag",
+                                                  "author",
+                                                  "project",
+                                                  "ip",
+                                                  "character",
+                                                  "folder"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "enum": [
+                                                  "equals",
+                                                  "contains",
+                                                  "startsWith",
+                                                  "endsWith",
+                                                  "gt",
+                                                  "gte",
+                                                  "lt",
+                                                  "lte",
+                                                  "in",
+                                                  "notIn",
+                                                  "isEmpty",
+                                                  "isNotEmpty"
+                                                ],
+                                                "type": "string",
+                                                "default": "equals"
+                                              },
+                                              "value": {
+                                                "anyOf": [
+                                                  {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      },
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "type": "array",
+                                                        "items": {}
+                                                      },
+                                                      {
+                                                        "type": "array",
+                                                        "items": {}
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "negate": {
+                                                "type": "boolean",
+                                                "default": false
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "target",
+                                              "value"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "negate": {
+                                      "type": "boolean",
+                                      "default": false
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "operator",
+                                    "children"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "const": "criterion"
+                                    },
+                                    "target": {
+                                      "enum": [
+                                        "keyword",
+                                        "fileName",
+                                        "filePath",
+                                        "description",
+                                        "mediaType",
+                                        "width",
+                                        "height",
+                                        "fileSize",
+                                        "createdAt",
+                                        "rating",
+                                        "favorite",
+                                        "viewCount",
+                                        "aiGenerated",
+                                        "tag",
+                                        "author",
+                                        "project",
+                                        "ip",
+                                        "character",
+                                        "folder"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "enum": [
+                                        "equals",
+                                        "contains",
+                                        "startsWith",
+                                        "endsWith",
+                                        "gt",
+                                        "gte",
+                                        "lt",
+                                        "lte",
+                                        "in",
+                                        "notIn",
+                                        "isEmpty",
+                                        "isNotEmpty"
+                                      ],
+                                      "type": "string",
+                                      "default": "equals"
+                                    },
+                                    "value": {
+                                      "anyOf": [
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "number"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "negate": {
+                                      "type": "boolean",
+                                      "default": false
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "target",
+                                    "value"
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "negate": {
+                            "type": "boolean",
+                            "default": false
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "operator",
+                          "children"
+                        ]
+                      },
+                      "sort": {
+                        "enum": [
+                          "date",
+                          "name",
+                          "size",
+                          "rating",
+                          "viewCount"
+                        ],
+                        "type": "string"
+                      },
+                      "order": {
+                        "enum": [
+                          "asc",
+                          "desc"
+                        ],
+                        "type": "string"
+                      },
+                      "mode": {
+                        "enum": [
+                          "simple",
+                          "pro"
+                        ],
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -2805,6 +8477,26 @@
       "post": {
         "operationId": "presets.delete",
         "summary": "delete",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",

--- a/apps/server/scripts/generate-swagger-spec.ts
+++ b/apps/server/scripts/generate-swagger-spec.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { OpenAPIGenerator } from "@orpc/openapi";
+import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import type { OpenAPI } from "@orpc/contract";
 import { appRouter } from "../src/domain/shared/api-contract";
 import { openApiTags } from "../src/infrastructure/api/openapi-tags";
@@ -61,7 +62,9 @@ async function generateOpenAPISpec() {
   try {
     console.log("Generating OpenAPI specification with detailed descriptions...");
 
-    const generator = new OpenAPIGenerator();
+    const generator = new OpenAPIGenerator({
+      schemaConverters: [new ZodToJsonSchemaConverter()],
+    });
     const spec = await generator.generate(appRouter, {
       info: {
         title: "Solid Imager oRPC API",

--- a/apps/server/src/components/imports/pending-downloads-indicator.tsx
+++ b/apps/server/src/components/imports/pending-downloads-indicator.tsx
@@ -8,6 +8,10 @@ import { fetchMediaSources } from "~/infrastructure/api-clients/sources-api";
 
 export function PendingDownloadsIndicator() {
 	const props: PendingDownloadsIndicatorProps = {
+		countPending: async () => {
+			const result = await orpc.imports.countPending();
+			return result.count;
+		},
 		listPending: async () => {
 			const jobs = await orpc.imports.listPending();
 			return jobs;

--- a/apps/server/src/components/imports/pending-downloads-indicator.tsx
+++ b/apps/server/src/components/imports/pending-downloads-indicator.tsx
@@ -34,10 +34,12 @@ export function PendingDownloadsIndicator() {
 			const result = await orpc.imports.cancel({ jobIds });
 			return { success: result.success };
 		},
-		subscribeImportEvents: (handler) => {
+		subscribeImportEvents: (handler, onConnected) => {
 			return subscribeToEventStream(
 				(signal) => orpc.imports.events(undefined, { signal }),
 				handler,
+				undefined,
+				onConnected,
 			);
 		},
 	};

--- a/apps/server/src/infrastructure/api/routers/imports-router.ts
+++ b/apps/server/src/infrastructure/api/routers/imports-router.ts
@@ -1,5 +1,8 @@
 import { eventIterator, os } from "@orpc/server";
-import { downloadItemSchema } from "@solid-imager/core/domain/media/schemas";
+import {
+	downloadItemSchema,
+	pendingImportCountSchema,
+} from "@solid-imager/core/domain/media/schemas";
 import {
 	type ImportEvent,
 	importEventSchema,
@@ -151,7 +154,7 @@ export const importsRouter = {
 	/**
 	 * Count pending import requests without loading their payloads.
 	 */
-	countPending: os.handler(async () => {
+	countPending: os.output(pendingImportCountSchema).handler(async () => {
 		const [result] = await db
 			.select({ count: count() })
 			.from(jobs)

--- a/apps/server/src/infrastructure/api/routers/imports-router.ts
+++ b/apps/server/src/infrastructure/api/routers/imports-router.ts
@@ -4,7 +4,7 @@ import {
 	type ImportEvent,
 	importEventSchema,
 } from "@solid-imager/core/domain/sources/events";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, count, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import type { BackupService } from "~/application/services/backup-service";
 import { db } from "~/infrastructure/db";
@@ -146,6 +146,18 @@ export const importsRouter = {
 			item: job.payload as z.infer<typeof downloadItemSchema>,
 			createdAt: job.createdAt,
 		}));
+	}),
+
+	/**
+	 * Count pending import requests without loading their payloads.
+	 */
+	countPending: os.handler(async () => {
+		const [result] = await db
+			.select({ count: count() })
+			.from(jobs)
+			.where(and(eq(jobs.type, "import_request"), eq(jobs.status, "pending")));
+
+		return { count: result?.count ?? 0 };
 	}),
 
 	/**

--- a/apps/tauri/src/components/imports/pending-downloads-indicator.tsx
+++ b/apps/tauri/src/components/imports/pending-downloads-indicator.tsx
@@ -21,10 +21,12 @@ export function PendingDownloadsIndicator() {
 			processPending={(jobIds, targetSourceId) =>
 				processPendingImports(jobIds, targetSourceId)
 			}
-			subscribeImportEvents={(handler) => {
+			subscribeImportEvents={(handler, onConnected) => {
 				return subscribeToEventStream(
 					(signal) => orpc.imports.events(undefined, { signal }),
 					handler,
+					undefined,
+					onConnected,
 				);
 			}}
 		/>

--- a/apps/tauri/src/components/imports/pending-downloads-indicator.tsx
+++ b/apps/tauri/src/components/imports/pending-downloads-indicator.tsx
@@ -12,6 +12,10 @@ export function PendingDownloadsIndicator() {
 	return (
 		<SharedPendingDownloadsIndicator
 			cancelPending={cancelPendingImports}
+			countPending={async () => {
+				const result = await orpc.imports.countPending();
+				return result.count;
+			}}
 			listPending={listPendingImports}
 			listSources={fetchMediaSources}
 			processPending={(jobIds, targetSourceId) =>

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,7 @@
 services:
   db:
     image: pgvector/pgvector:pg17
+    shm_size: 256mb
     restart: always
     environment:
       POSTGRES_USER: ${DB_USER}

--- a/packages/core/src/domain/contract/imports.contract.ts
+++ b/packages/core/src/domain/contract/imports.contract.ts
@@ -1,6 +1,10 @@
 import { eventIterator, oc } from "@orpc/contract";
 import { z } from "zod";
-import { downloadItemSchema, pendingImportJobSchema } from "../media/schemas";
+import {
+	downloadItemSchema,
+	pendingImportCountSchema,
+	pendingImportJobSchema,
+} from "../media/schemas";
 import { importEventSchema } from "../sources/events";
 
 export const importsContract = {
@@ -8,7 +12,7 @@ export const importsContract = {
 
 	listPending: oc.output(z.array(pendingImportJobSchema)),
 
-	countPending: oc.output(z.object({ count: z.number().int().nonnegative() })),
+	countPending: oc.output(pendingImportCountSchema),
 
 	process: oc
 		.input(

--- a/packages/core/src/domain/contract/imports.contract.ts
+++ b/packages/core/src/domain/contract/imports.contract.ts
@@ -8,6 +8,8 @@ export const importsContract = {
 
 	listPending: oc.output(z.array(pendingImportJobSchema)),
 
+	countPending: oc.output(z.object({ count: z.number().int().nonnegative() })),
+
 	process: oc
 		.input(
 			z.object({

--- a/packages/core/src/domain/media/schemas.ts
+++ b/packages/core/src/domain/media/schemas.ts
@@ -536,6 +536,12 @@ export const pendingImportJobSchema = z.object({
 
 export type PendingImportJob = z.infer<typeof pendingImportJobSchema>;
 
+export const pendingImportCountSchema = z.object({
+	count: z.number().int().nonnegative(),
+});
+
+export type PendingImportCount = z.infer<typeof pendingImportCountSchema>;
+
 export const bulkDownloadRequestSchema = z.object({
 	mediaSourceId: z.uuid({ version: "v4", message: "Invalid media source ID" }),
 	items: z.array(downloadItemSchema).min(1, "At least one item is required"),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1044,6 +1044,11 @@ export const jobs = pgTable(
 		}),
 	},
 	(table) => ({
+		pendingImportRequestIndex: index("idx_jobs_pending_import_request")
+			.on(table.id)
+			.where(
+				sql`${table.status} = 'pending' AND ${table.type} = 'import_request'`,
+			),
 		pendingCreatedIndex: index("idx_jobs_pending_created")
 			.on(table.createdAt, table.id)
 			.where(

--- a/packages/ui/src/event-stream.test.ts
+++ b/packages/ui/src/event-stream.test.ts
@@ -59,4 +59,28 @@ describe("subscribeToEventStream", () => {
 		unsubscribe();
 		expect(streamSignal?.aborted).toBe(true);
 	});
+
+	it("notifies after the stream connection is ready", async () => {
+		let resolveConnected!: () => void;
+		const connected = new Promise<void>((resolve) => {
+			resolveConnected = resolve;
+		});
+		const onConnected = vi.fn(resolveConnected);
+		const openStream = vi.fn(async () => ({
+			async *[Symbol.asyncIterator]() {
+				yield* [];
+			},
+		}));
+
+		const unsubscribe = subscribeToEventStream(
+			openStream,
+			vi.fn(),
+			undefined,
+			onConnected,
+		);
+		await connected;
+
+		expect(onConnected).toHaveBeenCalledOnce();
+		unsubscribe();
+	});
 });

--- a/packages/ui/src/event-stream.ts
+++ b/packages/ui/src/event-stream.ts
@@ -8,6 +8,8 @@ export type EventStreamErrorHandler = (
 	delay: number,
 ) => void;
 
+export type EventStreamConnectedHandler = () => void | Promise<void>;
+
 const MAX_RETRY_DELAY = 30_000;
 const INITIAL_RETRY_DELAY = 1_000;
 
@@ -32,6 +34,7 @@ export function subscribeToEventStream<TEvent>(
 	openStream: EventStreamFactory<TEvent>,
 	onEvent: (event: TEvent) => void | Promise<void>,
 	onError?: EventStreamErrorHandler,
+	onConnected?: EventStreamConnectedHandler,
 ): () => void {
 	const abortController = new AbortController();
 	const canObservePageLifecycle = typeof window !== "undefined";
@@ -51,6 +54,7 @@ export function subscribeToEventStream<TEvent>(
 		while (!abortController.signal.aborted) {
 			try {
 				const events = await openStream(abortController.signal);
+				await onConnected?.();
 
 				for await (const event of events) {
 					if (abortController.signal.aborted) {

--- a/packages/ui/src/import-review-modal.tsx
+++ b/packages/ui/src/import-review-modal.tsx
@@ -75,15 +75,10 @@ export function ImportReviewModal(props: ImportReviewModalProps) {
 	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = createSignal(false);
 
 	const [pendingJobs, { refetch: refetchJobs }] = createResource(
+		() => props.isOpen || undefined,
 		props.listPending,
 	);
 	const [sources] = createResource(props.listSources);
-
-	createEffect(() => {
-		if (props.isOpen) {
-			void refetchJobs();
-		}
-	});
 
 	createEffect(() => {
 		const jobs = pendingJobs();

--- a/packages/ui/src/pending-downloads-indicator.tsx
+++ b/packages/ui/src/pending-downloads-indicator.tsx
@@ -2,7 +2,6 @@ import type { ImportEvent } from "@solid-imager/core/domain/sources/events";
 import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
 import { getErrorMessage } from "@solid-imager/core/utils";
 import {
-	createResource,
 	createSignal,
 	ErrorBoundary,
 	onCleanup,
@@ -16,6 +15,7 @@ import {
 import { toast } from "./toast";
 
 export type ImportEventHandler = (event: ImportEvent) => void | Promise<void>;
+export type ImportEventConnectedHandler = () => void | Promise<void>;
 
 export type PendingDownloadsIndicatorProps = {
 	countPending: () => Promise<number>;
@@ -28,6 +28,7 @@ export type PendingDownloadsIndicatorProps = {
 	cancelPending: (jobIds: string[]) => Promise<{ success: boolean }>;
 	subscribeImportEvents: (
 		handler: ImportEventHandler,
+		onConnected?: ImportEventConnectedHandler,
 	) => Promise<(() => void) | undefined> | (() => void) | undefined;
 };
 
@@ -35,16 +36,39 @@ export function PendingDownloadsIndicator(
 	props: PendingDownloadsIndicatorProps,
 ) {
 	const [isModalOpen, setIsModalOpen] = createSignal(false);
-	const [pendingCount, { mutate: setPendingCount, refetch }] = createResource(
-		async () => {
-			try {
-				return await props.countPending();
-			} catch (error) {
-				toast.error(`Failed to check inbox: ${getErrorMessage(error)}`);
-				return 0;
+	const [pendingCount, setPendingCount] = createSignal<number>();
+	let eventVersion = 0;
+	let refreshRequested = false;
+	let refreshInFlight: Promise<void> | undefined;
+
+	const refreshPendingCount = () => {
+		refreshRequested = true;
+		if (refreshInFlight) {
+			return refreshInFlight;
+		}
+
+		refreshInFlight = (async () => {
+			while (refreshRequested) {
+				refreshRequested = false;
+				const requestEventVersion = eventVersion;
+				try {
+					const count = await props.countPending();
+					if (requestEventVersion === eventVersion) {
+						setPendingCount(count);
+					} else {
+						refreshRequested = true;
+					}
+				} catch (error) {
+					toast.error(`Failed to check inbox: ${getErrorMessage(error)}`);
+				}
 			}
-		},
-	);
+		})().finally(() => {
+			refreshInFlight = undefined;
+		});
+
+		return refreshInFlight;
+	};
+
 	const hasPendingImports = () => (pendingCount() ?? 0) > 0;
 
 	onMount(() => {
@@ -52,23 +76,35 @@ export function PendingDownloadsIndicator(
 		let cleanup: (() => void) | undefined;
 
 		void Promise.resolve(
-			props.subscribeImportEvents((event) => {
-				setPendingCount((currentCount) => {
-					const count = currentCount ?? 0;
-					switch (event.event) {
-						case "import-request:created":
-							return count + event.data.count;
-						case "import-request:processed":
-							return Math.max(0, count - event.data.processedCount);
-						case "import-request:deleted":
-							return Math.max(0, count - event.data.jobIds.length);
-						default: {
-							const exhaustiveCheck: never = event;
-							return exhaustiveCheck;
+			props.subscribeImportEvents(
+				(event) => {
+					eventVersion += 1;
+					const currentCount = pendingCount();
+					if (currentCount !== undefined) {
+						switch (event.event) {
+							case "import-request:created":
+								setPendingCount(currentCount + event.data.count);
+								break;
+							case "import-request:processed":
+								setPendingCount(
+									Math.max(0, currentCount - event.data.processedCount),
+								);
+								break;
+							case "import-request:deleted":
+								setPendingCount(
+									Math.max(0, currentCount - event.data.jobIds.length),
+								);
+								break;
+							default: {
+								const exhaustiveCheck: never = event;
+								return exhaustiveCheck;
+							}
 						}
 					}
-				});
-			}),
+					void refreshPendingCount();
+				},
+				() => refreshPendingCount(),
+			),
 		)
 			.then((unsub) => {
 				if (disposed) {
@@ -129,7 +165,7 @@ export function PendingDownloadsIndicator(
 				listSources={props.listSources}
 				onClose={() => setIsModalOpen(false)}
 				onImportCompleted={() => {
-					void refetch();
+					void refreshPendingCount();
 				}}
 				processPending={props.processPending}
 			/>

--- a/packages/ui/src/pending-downloads-indicator.tsx
+++ b/packages/ui/src/pending-downloads-indicator.tsx
@@ -18,6 +18,7 @@ import { toast } from "./toast";
 export type ImportEventHandler = (event: ImportEvent) => void | Promise<void>;
 
 export type PendingDownloadsIndicatorProps = {
+	countPending: () => Promise<number>;
 	listPending: () => Promise<PendingImportJob[]>;
 	listSources: () => Promise<SafeMediaSource[]>;
 	processPending: (
@@ -34,22 +35,39 @@ export function PendingDownloadsIndicator(
 	props: PendingDownloadsIndicatorProps,
 ) {
 	const [isModalOpen, setIsModalOpen] = createSignal(false);
-	const [pendingCount, { refetch }] = createResource(async () => {
-		try {
-			return (await props.listPending()).length;
-		} catch (error) {
-			toast.error(`Failed to check inbox: ${getErrorMessage(error)}`);
-			return 0;
-		}
-	});
+	const [pendingCount, { mutate: setPendingCount, refetch }] = createResource(
+		async () => {
+			try {
+				return await props.countPending();
+			} catch (error) {
+				toast.error(`Failed to check inbox: ${getErrorMessage(error)}`);
+				return 0;
+			}
+		},
+	);
+	const hasPendingImports = () => (pendingCount() ?? 0) > 0;
 
 	onMount(() => {
 		let disposed = false;
 		let cleanup: (() => void) | undefined;
 
 		void Promise.resolve(
-			props.subscribeImportEvents(() => {
-				void refetch();
+			props.subscribeImportEvents((event) => {
+				setPendingCount((currentCount) => {
+					const count = currentCount ?? 0;
+					switch (event.event) {
+						case "import-request:created":
+							return count + event.data.count;
+						case "import-request:processed":
+							return Math.max(0, count - event.data.processedCount);
+						case "import-request:deleted":
+							return Math.max(0, count - event.data.jobIds.length);
+						default: {
+							const exhaustiveCheck: never = event;
+							return exhaustiveCheck;
+						}
+					}
+				});
 			}),
 		)
 			.then((unsub) => {
@@ -84,13 +102,17 @@ export function PendingDownloadsIndicator(
 			)}
 		>
 			<button
+				aria-disabled={!hasPendingImports()}
 				class={`flex items-center gap-1 rounded px-3 py-1.5 font-bold text-xs transition-colors ${
-					(pendingCount() ?? 0) > 0
+					hasPendingImports()
 						? "bg-sky-600 text-white hover:bg-sky-500"
 						: "cursor-default bg-gray-700 text-gray-400"
 				}`}
-				disabled={(pendingCount() ?? 0) === 0}
-				onClick={() => setIsModalOpen(true)}
+				onClick={() => {
+					if (hasPendingImports()) {
+						setIsModalOpen(true);
+					}
+				}}
 				type="button"
 			>
 				<span>Inbox</span>


### PR DESCRIPTION
## 概要

pending import受信箱の件数表示を、一覧全件取得から件数専用APIとリアルタイムイベント更新に変更します。

## 変更内容

- imports.countPending APIを追加
- Web/Tauriの受信箱インジケータをイベントベースの件数更新に変更
- レビュー一覧はモーダルを開いた時だけ取得
- OpenAPI仕様を更新
- PostgreSQLコンテナの共有メモリを256MBに設定

## 検証

- bun run typecheck: 成功
- git diff --check: 成功
- bun run check / Biome: db-backupディレクトリの権限エラーで完走せず
- テストスイート: 未実行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 保留中のダウンロード件数を専用に取得し、より効率的に表示できるようになりました。
  * ダウンロードの追加・処理・削除に応じて、保留件数がリアルタイムに更新されます。
  * 保留中の項目がある場合のみ、件数表示から確認画面を開けるようになりました。

* **改善**
  * インポート確認画面を開いたときのみ、必要な情報を取得するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->