### PR TITLE
chore: disable LanceDB delta and startup sync

### DIFF
--- a/apps/server/drizzle/0021_clear_lancedb_delta_jobs.sql
+++ b/apps/server/drizzle/0021_clear_lancedb_delta_jobs.sql
@@ -1,0 +1,2 @@
+DELETE FROM "jobs" WHERE "type" = 'sync_lancedb_delta';--> statement-breakpoint
+DELETE FROM "lancedb_sync_dirty";

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1785607909433,
       "tag": "0020_blue_nuke",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1785608829741,
+      "tag": "0021_clear_lancedb_delta_jobs",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/application/services/maintenance-service.ts
+++ b/apps/server/src/application/services/maintenance-service.ts
@@ -100,80 +100,12 @@ export class MaintenanceService {
 			let queuedCount = 0;
 
 			for (const source of sources) {
-				const hasCache = await this.hasLanceDbCache(source.id);
-				let jobType: "sync_lancedb_full" | "sync_lancedb_delta" =
-					"sync_lancedb_full";
-
-				if (hasCache) {
-					try {
-						const cacheDir = await this.getLanceDbCacheDir(source.id);
-						const { readMediaIds } = await import(
-							"~/application/services/lancedb-dump-service"
-						);
-						const lanceDbIds = await readMediaIds(cacheDir);
-						const postgresMedias = await this.mediaRepo.findAllPathsBySourceId(
-							source.id,
-						);
-
-						const postgresIdsSet = new Set(postgresMedias.map((m) => m.id));
-						const lanceDbIdsSet = new Set(lanceDbIds);
-
-						// PostgreSQL にあって LanceDB にない -> 追加 (upsert)
-						const toUpsert = postgresMedias
-							.filter((m) => !lanceDbIdsSet.has(m.id))
-							.map((m) => m.id);
-
-						// LanceDB にあって PostgreSQL にない -> 削除 (delete)
-						const toDelete = lanceDbIds.filter((id) => !postgresIdsSet.has(id));
-
-						if (toUpsert.length > 0 || toDelete.length > 0) {
-							logger.info(
-								{
-									sourceId: source.id,
-									toUpsertCount: toUpsert.length,
-									toDeleteCount: toDelete.length,
-								},
-								"Found discrepancies between PostgreSQL and LanceDB on startup. Queueing delta sync.",
-							);
-
-							const { BackupService } = await import(
-								"~/application/services/backup-service"
-							);
-
-							if (toUpsert.length > 0) {
-								await BackupService.queueSourceLanceDBDelta(
-									source.id,
-									toUpsert,
-									"upsert",
-									{
-										enqueueJob: false,
-									},
-								);
-							}
-							if (toDelete.length > 0) {
-								await BackupService.queueSourceLanceDBDelta(
-									source.id,
-									toDelete,
-									"delete",
-									{
-										enqueueJob: false,
-									},
-								);
-							}
-						}
-
-						jobType = "sync_lancedb_delta";
-					} catch (compareError) {
-						logger.error(
-							{ err: compareError, sourceId: source.id },
-							"Failed to compare PostgreSQL and LanceDB on startup. Falling back to full sync.",
-						);
-						jobType = "sync_lancedb_full";
-					}
+				if (await this.hasLanceDbCache(source.id)) {
+					continue;
 				}
 
 				const created = await this.jobRepo.createIfUnique({
-					type: jobType,
+					type: "sync_lancedb_full",
 					mediaSourceId: source.id,
 					payload: { reason: "startup" },
 				});

--- a/apps/server/src/application/services/maintenance-service.ts
+++ b/apps/server/src/application/services/maintenance-service.ts
@@ -29,7 +29,6 @@ export class MaintenanceService {
 		try {
 			await this.queueMissingMetadata();
 			await this.queueMissingThumbnails();
-			await this.queueLanceDbCacheSync();
 			logger.info("Startup checks completed.");
 		} catch (err) {
 			logger.error({ err }, "Startup checks failed");
@@ -91,59 +90,6 @@ export class MaintenanceService {
 			}
 		} catch (error) {
 			logger.error({ err: error }, "Failed to queue missing thumbnail jobs");
-		}
-	}
-
-	private async queueLanceDbCacheSync() {
-		try {
-			const sources = await this.sourceRepo.findAll();
-			let queuedCount = 0;
-
-			for (const source of sources) {
-				if (await this.hasLanceDbCache(source.id)) {
-					continue;
-				}
-
-				const created = await this.jobRepo.createIfUnique({
-					type: "sync_lancedb_full",
-					mediaSourceId: source.id,
-					payload: { reason: "startup" },
-				});
-				if (created) {
-					queuedCount++;
-				}
-			}
-
-			if (queuedCount > 0) {
-				logger.info(
-					{ count: queuedCount },
-					"Queued LanceDB cache sync jobs for startup",
-				);
-			}
-		} catch (error) {
-			logger.error({ err: error }, "Failed to queue LanceDB cache sync jobs");
-		}
-	}
-
-	private async getLanceDbCacheDir(sourceId: string): Promise<string> {
-		const { services } = await import("~/application/registry");
-		const config = services.getConfigService().getConfig();
-		const baseCacheDir = config.lancedb?.cacheDir ?? ".cache/lancedb-cache";
-		return path.resolve(process.cwd(), baseCacheDir, `source-${sourceId}`);
-	}
-
-	private async hasLanceDbCache(sourceId: string): Promise<boolean> {
-		const cacheDir = await this.getLanceDbCacheDir(sourceId);
-		const manifestPath = path.join(cacheDir, "manifest.json");
-		try {
-			const content = await fs.readFile(manifestPath, "utf-8");
-			const manifest = JSON.parse(content) as { version?: unknown };
-			const { LANCEDB_DUMP_VERSION } = await import(
-				"~/application/services/lancedb-dump-service"
-			);
-			return manifest.version === LANCEDB_DUMP_VERSION;
-		} catch {
-			return false;
 		}
 	}
 

--- a/apps/server/src/infrastructure/jobs/tagging-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/tagging-jobs.ts
@@ -77,12 +77,6 @@ export async function processAutoTaggingJob(job: Job): Promise<void> {
 			},
 			"Auto tagging completed",
 		);
-		await services.getJobRepository().createIfUnique({
-			type: "sync_lancedb_delta",
-			mediaSourceId,
-			payload: { reason: "auto_tagging", mediaIds: [mediaId] },
-		});
-
 		if (parentId) {
 			const jobRepo = services.getJobRepository();
 			const progress = await jobRepo.incrementProgress(parentId, job.id);

--- a/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
@@ -38,30 +38,6 @@ vi.mock("~/application/registry", () => ({
 	},
 }));
 
-// Mock lancedb-dump-service
-const mockReadMediaIds = vi.fn();
-vi.mock(
-	"~/application/services/lancedb-dump-service",
-	async (importOriginal) => {
-		const actual =
-			await importOriginal<
-				typeof import("~/application/services/lancedb-dump-service")
-			>();
-		return {
-			...actual,
-			readMediaIds: mockReadMediaIds,
-		};
-	},
-);
-
-// Mock backup-service
-const mockQueueSourceLanceDBDelta = vi.fn();
-vi.mock("~/application/services/backup-service", () => ({
-	BackupService: {
-		queueSourceLanceDBDelta: mockQueueSourceLanceDBDelta,
-	},
-}));
-
 // Silence logger output during tests
 vi.mock("~/infrastructure/logger", () => ({
 	logger: {
@@ -122,8 +98,6 @@ describe("MaintenanceService", () => {
 
 	afterEach(() => {
 		vi.clearAllMocks();
-		mockReadMediaIds.mockReset();
-		mockQueueSourceLanceDBDelta.mockReset();
 	});
 
 	// --------------------------------------------------------------------------
@@ -389,7 +363,7 @@ describe("MaintenanceService", () => {
 			);
 		});
 
-		it("should queue delta sync job without queueing delta details if PostgreSQL and LanceDB are in sync", async () => {
+		it("should not queue delta sync when a valid LanceDB cache exists", async () => {
 			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
 			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
 			mockSourceRepo.findAll.mockResolvedValue([
@@ -401,25 +375,13 @@ describe("MaintenanceService", () => {
 			(fs.readFile as unknown as Mock).mockResolvedValue(
 				JSON.stringify({ version: 4 }),
 			);
-
-			// Both LanceDB and Postgres have media-1
-			mockReadMediaIds.mockResolvedValue(["media-1"]);
-			mockMediaRepo.findAllPathsBySourceId.mockResolvedValue([
-				{ id: "media-1", filePath: "/media/media-1.png" },
-			]);
 
 			await service.performStartupChecks();
 
-			expect(mockQueueSourceLanceDBDelta).not.toHaveBeenCalled();
-			expect(mockJobRepo.createIfUnique).toHaveBeenCalledWith(
-				expect.objectContaining({
-					type: "sync_lancedb_delta",
-					mediaSourceId: "source-1",
-				}),
-			);
+			expect(mockJobRepo.createIfUnique).not.toHaveBeenCalled();
 		});
 
-		it("should queue discrepancies to delta table and trigger delta sync job if discrepancies are found", async () => {
+		it("should skip existing-cache comparison instead of creating delta work", async () => {
 			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
 			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
 			mockSourceRepo.findAll.mockResolvedValue([
@@ -432,10 +394,7 @@ describe("MaintenanceService", () => {
 				JSON.stringify({ version: 4 }),
 			);
 
-			// Postgres: media-1, media-2
-			// LanceDB: media-2, media-3
-			// Discrepancies: upsert [media-1], delete [media-3]
-			mockReadMediaIds.mockResolvedValue(["media-2", "media-3"]);
+			// The cache may be stale, but the old delta comparison must not run.
 			mockMediaRepo.findAllPathsBySourceId.mockResolvedValue([
 				{ id: "media-1", filePath: "/media/media-1.png" },
 				{ id: "media-2", filePath: "/media/media-2.png" },
@@ -443,55 +402,8 @@ describe("MaintenanceService", () => {
 
 			await service.performStartupChecks();
 
-			expect(mockQueueSourceLanceDBDelta).toHaveBeenCalledTimes(2);
-			expect(mockQueueSourceLanceDBDelta).toHaveBeenNthCalledWith(
-				1,
-				"source-1",
-				["media-1"],
-				"upsert",
-				{ enqueueJob: false },
-			);
-			expect(mockQueueSourceLanceDBDelta).toHaveBeenNthCalledWith(
-				2,
-				"source-1",
-				["media-3"],
-				"delete",
-				{ enqueueJob: false },
-			);
-
-			expect(mockJobRepo.createIfUnique).toHaveBeenCalledWith(
-				expect.objectContaining({
-					type: "sync_lancedb_delta",
-					mediaSourceId: "source-1",
-				}),
-			);
-		});
-
-		it("should fall back to full sync if comparison throws an error", async () => {
-			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
-			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
-			mockSourceRepo.findAll.mockResolvedValue([
-				makeLocalSource("source-1", "/path-1"),
-			]);
-			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
-
-			// Simulate a current manifest.json.
-			(fs.readFile as unknown as Mock).mockResolvedValue(
-				JSON.stringify({ version: 4 }),
-			);
-
-			// readMediaIds throws error
-			mockReadMediaIds.mockRejectedValue(new Error("LanceDB read error"));
-
-			await service.performStartupChecks();
-
-			expect(mockQueueSourceLanceDBDelta).not.toHaveBeenCalled();
-			expect(mockJobRepo.createIfUnique).toHaveBeenCalledWith(
-				expect.objectContaining({
-					type: "sync_lancedb_full",
-					mediaSourceId: "source-1",
-				}),
-			);
+			expect(mockMediaRepo.findAllPathsBySourceId).not.toHaveBeenCalled();
+			expect(mockJobRepo.createIfUnique).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/maintenance-service.test.ts
@@ -12,30 +12,16 @@ import { MaintenanceService } from "~/application/services/maintenance-service";
 
 // ---- Module mocks ----
 
-// Mock node:fs/promises to control thumbnail directory reads and lanceDb manifest reads
+// Mock node:fs/promises to control thumbnail directory reads
 vi.mock("node:fs/promises", () => ({
 	default: {
 		readdir: vi.fn(),
-		readFile: vi.fn(),
 	},
 }));
 
 // Mock getSourceCacheDir to return a predictable path
 vi.mock("~/infrastructure/jobs/thumbnails", () => ({
 	getSourceCacheDir: vi.fn((sourceId: string) => `/cache/${sourceId}`),
-}));
-
-// Mock registry for configuration loading
-vi.mock("~/application/registry", () => ({
-	services: {
-		getConfigService: () => ({
-			getConfig: () => ({
-				lancedb: {
-					cacheDir: ".cache/lancedb-cache",
-				},
-			}),
-		}),
-	},
 }));
 
 // Silence logger output during tests
@@ -53,7 +39,6 @@ vi.mock("~/infrastructure/logger", () => ({
 const mockMediaRepo = {
 	findIdsWithMissingGenerationInfo: vi.fn(),
 	findAllMediaIndices: vi.fn(),
-	findAllPathsBySourceId: vi.fn(),
 };
 
 const mockJobRepo = {
@@ -93,7 +78,6 @@ describe("MaintenanceService", () => {
 			mockSourceRepo as any,
 		);
 		mockSourceRepo.findAll.mockResolvedValue([]);
-		mockMediaRepo.findAllPathsBySourceId.mockResolvedValue([]);
 	});
 
 	afterEach(() => {
@@ -116,6 +100,7 @@ describe("MaintenanceService", () => {
 				mockMediaRepo.findIdsWithMissingGenerationInfo,
 			).toHaveBeenCalledOnce();
 			expect(mockMediaRepo.findAllMediaIndices).toHaveBeenCalledOnce();
+			expect(mockSourceRepo.findAll).not.toHaveBeenCalled();
 		});
 	});
 
@@ -332,78 +317,4 @@ describe("MaintenanceService", () => {
 		});
 	});
 
-	describe("LanceDB startup behavior", () => {
-		it("should queue one full LanceDB sync job per source without a cache during startup checks", async () => {
-			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
-			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
-			mockSourceRepo.findAll.mockResolvedValue([
-				makeLocalSource("source-1", "/path-1"),
-				makeLocalSource("source-2", "/path-2"),
-			]);
-			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
-
-			// Simulate manifest.json doesn't exist (ENOENT)
-			const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-			(fs.readFile as unknown as Mock).mockRejectedValue(err);
-
-			await service.performStartupChecks();
-
-			expect(mockSourceRepo.findAll).toHaveBeenCalledOnce();
-			expect(mockJobRepo.createIfUnique).toHaveBeenCalledWith(
-				expect.objectContaining({
-					type: "sync_lancedb_full",
-					mediaSourceId: "source-1",
-				}),
-			);
-			expect(mockJobRepo.createIfUnique).toHaveBeenCalledWith(
-				expect.objectContaining({
-					type: "sync_lancedb_full",
-					mediaSourceId: "source-2",
-				}),
-			);
-		});
-
-		it("should not queue delta sync when a valid LanceDB cache exists", async () => {
-			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
-			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
-			mockSourceRepo.findAll.mockResolvedValue([
-				makeLocalSource("source-1", "/path-1"),
-			]);
-			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
-
-			// Simulate a current manifest.json.
-			(fs.readFile as unknown as Mock).mockResolvedValue(
-				JSON.stringify({ version: 4 }),
-			);
-
-			await service.performStartupChecks();
-
-			expect(mockJobRepo.createIfUnique).not.toHaveBeenCalled();
-		});
-
-		it("should skip existing-cache comparison instead of creating delta work", async () => {
-			mockMediaRepo.findIdsWithMissingGenerationInfo.mockResolvedValue([]);
-			mockMediaRepo.findAllMediaIndices.mockResolvedValue([]);
-			mockSourceRepo.findAll.mockResolvedValue([
-				makeLocalSource("source-1", "/path-1"),
-			]);
-			mockJobRepo.createIfUnique.mockResolvedValue({ id: "job-new" });
-
-			// Simulate a current manifest.json.
-			(fs.readFile as unknown as Mock).mockResolvedValue(
-				JSON.stringify({ version: 4 }),
-			);
-
-			// The cache may be stale, but the old delta comparison must not run.
-			mockMediaRepo.findAllPathsBySourceId.mockResolvedValue([
-				{ id: "media-1", filePath: "/media/media-1.png" },
-				{ id: "media-2", filePath: "/media/media-2.png" },
-			]);
-
-			await service.performStartupChecks();
-
-			expect(mockMediaRepo.findAllPathsBySourceId).not.toHaveBeenCalled();
-			expect(mockJobRepo.createIfUnique).not.toHaveBeenCalled();
-		});
-	});
 });

--- a/apps/server/src/tests/unit/application/services/media-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/media-service.test.ts
@@ -339,6 +339,7 @@ describe("MediaService Unit Tests", () => {
 				}),
 			);
 			expect(mockMediaRepository.upsert).toHaveBeenCalled();
+			expect(mockJobRepository.createIfUnique).not.toHaveBeenCalled();
 		});
 	});
 

--- a/apps/server/src/tests/unit/infrastructure/jobs/tagging-jobs.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/tagging-jobs.test.ts
@@ -98,6 +98,7 @@ describe("processAutoTaggingJob", () => {
 			"00000000-0000-4000-8000-000000000020",
 		);
 		expect(findById).not.toHaveBeenCalled();
+		expect(createIfUnique).not.toHaveBeenCalled();
 		expect(publishJob).not.toHaveBeenCalled();
 	});
 
@@ -143,6 +144,7 @@ describe("processAutoTaggingJob", () => {
 			jobId: "00000000-0000-4000-8000-000000000010",
 			message: "Batch tagging completed",
 		});
+		expect(createIfUnique).not.toHaveBeenCalled();
 	});
 
 	it("increments failed count and marks parent failed when all children are done", async () => {

--- a/packages/application/src/services/media-processing-service.ts
+++ b/packages/application/src/services/media-processing-service.ts
@@ -161,11 +161,6 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 				type: "processMedia",
 			},
 		});
-		await this.jobRepo.createIfUnique({
-			type: "sync_lancedb_delta",
-			mediaSourceId,
-			payload: { reason: "media_added", mediaIds: [media.id] },
-		});
 
 		// Notify clients
 		this.publishSourceEvent(mediaSourceId, "media-added", {
@@ -286,11 +281,6 @@ export class MediaProcessingServiceImpl implements IMediaProcessingService {
 			}
 		}
 
-		await this.jobRepo.createIfUnique({
-			type: "sync_lancedb_delta",
-			mediaSourceId,
-			payload: { reason: "media_processed", mediaIds: [media.id] },
-		});
 	}
 
 	private async registerContextMetadata(

--- a/packages/application/src/services/media-transfer-service.ts
+++ b/packages/application/src/services/media-transfer-service.ts
@@ -87,11 +87,6 @@ export class MediaTransferService {
 			return await execute(tx);
 		}
 		const updatedMedia = await this.transactionManager.transaction(execute);
-		await this.jobRepo.createIfUnique({
-			type: "sync_lancedb_delta",
-			mediaSourceId: validatedSourceId,
-			payload: { reason: "media_updated", mediaIds: [validatedMediaId] },
-		});
 		return updatedMedia;
 	}
 
@@ -195,16 +190,11 @@ export class MediaTransferService {
 				type: "processMedia",
 			},
 		};
-		const deferredSyncJob = {
-			type: "sync_lancedb_delta" as const,
-			payload: { reason: "media_added", mediaIds: [newMediaEntry.id] },
-		};
-
 		const deferredActions: DeferredActions = {
 			jobs: [
 				{
 					mediaSourceId: validatedTargetSourceId,
-					jobs: [deferredJob, deferredSyncJob],
+					jobs: [deferredJob],
 				},
 			],
 			sourceEvents: [],
@@ -237,11 +227,6 @@ export class MediaTransferService {
 				sourcePath,
 				type: "processMedia",
 			},
-		});
-		await this.jobRepo.createIfUnique({
-			type: "sync_lancedb_delta",
-			mediaSourceId: validatedTargetSourceId,
-			payload: { reason: "media_added", mediaIds: [newMediaEntry.id] },
 		});
 
 		this.eventPublisher.notifyMediaCopied(
@@ -426,36 +411,12 @@ export class MediaTransferService {
 
 		if (tx) {
 			return {
-				jobs: [
-					{
-						mediaSourceId: validatedSourceId,
-						jobs: [
-							{
-								type: "sync_lancedb_delta",
-								payload: {
-									reason: "media_deleted",
-									operation: "delete",
-									mediaIds: [validatedMediaId],
-								},
-							},
-						],
-					},
-				],
+				jobs: [],
 				sourceEvents: [sourceEvent],
 				filesToDelete,
 				thumbnailsToDelete,
 			};
 		}
-
-		await this.jobRepo.createIfUnique({
-			type: "sync_lancedb_delta",
-			mediaSourceId: validatedSourceId,
-			payload: {
-				reason: "media_deleted",
-				operation: "delete",
-				mediaIds: [validatedMediaId],
-			},
-		});
 
 		if (thumbnailsToDelete) {
 			for (const thumb of thumbnailsToDelete) {

--- a/packages/application/src/services/media-upload-service.ts
+++ b/packages/application/src/services/media-upload-service.ts
@@ -142,11 +142,6 @@ export class MediaUploadService {
 				type: "processMedia",
 			},
 		});
-		await this.jobRepo.createIfUnique({
-			type: "sync_lancedb_delta",
-			mediaSourceId: validatedSourceId,
-			payload: { reason: "media_added", mediaIds: [insertedMedia.id] },
-		});
 
 		return {
 			success: true,
@@ -211,14 +206,6 @@ export class MediaUploadService {
 					},
 				});
 			}
-			await this.jobRepo.createIfUnique({
-				type: "sync_lancedb_delta",
-				mediaSourceId: validatedSourceId,
-				payload: {
-					reason: "media_added",
-					mediaIds: newMediaItems.map((item) => item.id),
-				},
-			});
 		}
 	}
 }


### PR DESCRIPTION
## 概要
LanceDB delta jobによるディスク・CPU負荷を停止し、起動時のLanceDB自動同期も無効化します。

## 変更内容
- メディアの追加・更新・削除・処理・自動タグ付けからdelta job投入を停止
- 起動時のLanceDB full/delta同期投入を停止
- 既存のdelta jobとdirty markerを削除する一回限りのmigrationを追加
- dispatcher、worker、手動LanceDB dump/import経路は維持

## 検証
- Server unit tests: 39 files / 165 tests passed
- bun run typecheck passed
- lintは既存のdb-backup権限エラーで実行不能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * メディアの追加・更新・削除や自動タグ付け後に、不要な検索キャッシュ同期処理が自動実行されなくなりました。
  * 起動時の検索キャッシュ同期チェックを廃止しました。
  * 保留中の検索キャッシュ同期ジョブと変更情報をクリーンアップしました。

* **改善**
  * メディア処理やタグ付け、メタデータ・サムネイル復旧など、関連しない処理は従来どおり維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->