### PR TITLE
fix: preserve active thumbnail jobs during migration

### DIFF
--- a/apps/server/drizzle/0022_sleepy_turbo.sql
+++ b/apps/server/drizzle/0022_sleepy_turbo.sql
@@ -3,13 +3,16 @@ BEGIN
 	DELETE FROM "jobs" AS duplicate
 	USING "jobs" AS retained
 	WHERE duplicate."type" = 'generate_thumbnail'
-		AND duplicate."status" IN ('pending', 'in_progress')
+		AND duplicate."status" = 'pending'
 		AND retained."type" = duplicate."type"
 		AND retained."status" IN ('pending', 'in_progress')
 		AND retained."source_id" = duplicate."source_id"
 		AND retained."payload"->>'mediaId' = duplicate."payload"->>'mediaId'
 		AND retained."payload"->>'size' = duplicate."payload"->>'size'
-		AND (retained."created_at", retained."id") < (duplicate."created_at", duplicate."id");
+		AND (
+			retained."status" = 'in_progress'
+			OR (retained."created_at", retained."id") < (duplicate."created_at", duplicate."id")
+		);
 
 	CREATE UNIQUE INDEX "uq_jobs_active_thumbnail" ON "jobs" USING btree ("source_id",("payload"->>'mediaId'),("payload"->>'size')) WHERE "jobs"."type" = 'generate_thumbnail'
 					AND "jobs"."status" IN ('pending', 'in_progress')


### PR DESCRIPTION
## Summary
- keep in_progress thumbnail jobs intact during migration
- remove only duplicate pending jobs
- retain the active job when choosing the row to keep

## Validation
- bun run --cwd apps/server test:integration
- server unit tests and typecheck via commit hooks

This is a follow-up to #655 and addresses review comment #22.