### PR TITLE
fix: preserve search scroll and recover blank virtual grid

### DIFF
--- a/apps/server/nitro.config.ts
+++ b/apps/server/nitro.config.ts
@@ -28,21 +28,38 @@ export default defineNitroConfig({
         fs.existsSync(pgliteLocalPath) ? pgliteLocalPath : pgliteRootPath,
       );
       const pgliteDistPath = path.join(pglitePkgPath, "dist");
+      const pgvectorLocalPath = path.resolve(
+        __dirname,
+        "node_modules/@electric-sql/pglite-pgvector/package.json",
+      );
+      const pgvectorRootPath = path.resolve(
+        __dirname,
+        "../../node_modules/@electric-sql/pglite-pgvector/package.json",
+      );
+      const pgvectorPkgPath = path.dirname(
+        fs.existsSync(pgvectorLocalPath) ? pgvectorLocalPath : pgvectorRootPath,
+      );
 
-      const assetsToCopy = ["pglite.data", "pglite.wasm"];
+      const assetsToCopy = [
+        { name: "pglite.data", source: path.join(pgliteDistPath, "pglite.data") },
+        { name: "pglite.wasm", source: path.join(pgliteDistPath, "pglite.wasm") },
+        {
+          name: "vector.tar.gz",
+          source: path.join(pgvectorPkgPath, "dist/vector.tar.gz"),
+        },
+      ];
 
       for (const asset of assetsToCopy) {
-        const source = path.join(pgliteDistPath, asset);
-        const destination = path.join(libsDir, asset);
+        const destination = path.join(libsDir, asset.name);
 
-        if (fs.existsSync(source)) {
+        if (fs.existsSync(asset.source)) {
           if (!fs.existsSync(libsDir)) {
             fs.mkdirSync(libsDir, { recursive: true });
           }
-          fs.copyFileSync(source, destination);
-          console.log(`[Nitro] Successfully copied ${asset} to ${destination}`);
+          fs.copyFileSync(asset.source, destination);
+          console.log(`[Nitro] Successfully copied ${asset.name} to ${destination}`);
         } else {
-          console.warn(`[Nitro] Warning: ${asset} not found at ${source}`);
+          console.warn(`[Nitro] Warning: ${asset.name} not found at ${asset.source}`);
         }
       }
 

--- a/apps/server/scripts/isolated-runtime.ts
+++ b/apps/server/scripts/isolated-runtime.ts
@@ -1,4 +1,5 @@
-import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { copyFile, mkdir, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { defaultAppConfig } from "@solid-imager/core/domain/config/config-schema";
 import { mediaGenerationInfo, medias, mediaSources } from "@solid-imager/db/schema";
@@ -16,6 +17,7 @@ import {
 } from "../src/tests/e2e/support/fixture";
 
 const appRoot = path.resolve(import.meta.dir, "..");
+const E2E_PAGINATED_MEDIA_COUNT = 600;
 
 export type IsolatedRuntime = {
   routeTreePath: string;
@@ -42,8 +44,10 @@ function createImageSvg(accentColor: string, backgroundColor: string): Buffer {
 async function seedMediaFixtures(runtimeDir: string): Promise<void> {
   const mediaDir = path.join(runtimeDir, "media");
   const thumbnailDir = path.join(runtimeDir, "thumbnails", E2E_SOURCE_ID);
+  const smallThumbnailDir = path.join(thumbnailDir, "256");
   await mkdir(mediaDir, { recursive: true });
   await mkdir(thumbnailDir, { recursive: true });
+  await mkdir(smallThumbnailDir, { recursive: true });
 
   const primaryPath = path.join(mediaDir, E2E_PRIMARY_FILE_NAME);
   const similarPath = path.join(mediaDir, E2E_SIMILAR_FILE_NAME);
@@ -64,6 +68,39 @@ async function seedMediaFixtures(runtimeDir: string): Promise<void> {
   ]);
 
   const [primaryStats, similarStats] = await Promise.all([stat(primaryPath), stat(similarPath)]);
+  const paginatedMedia = Array.from({ length: E2E_PAGINATED_MEDIA_COUNT }, (_, index) => ({
+    id: randomUUID(),
+    fileName: `e2e-scroll-${String(index + 1).padStart(4, "0")}.png`,
+  }));
+  const primaryThumbnailPath = path.join(
+    thumbnailDir,
+    `${E2E_PRIMARY_MEDIA_ID}.webp`,
+  );
+  const similarThumbnailPath = path.join(
+    thumbnailDir,
+    `${E2E_SIMILAR_MEDIA_ID}.webp`,
+  );
+  await Promise.all(
+    [
+      copyFile(
+        primaryThumbnailPath,
+        path.join(smallThumbnailDir, `${E2E_PRIMARY_MEDIA_ID}.webp`),
+      ),
+      copyFile(
+        similarThumbnailPath,
+        path.join(smallThumbnailDir, `${E2E_SIMILAR_MEDIA_ID}.webp`),
+      ),
+      ...paginatedMedia.flatMap(({ id, fileName }) => [
+        copyFile(primaryPath, path.join(mediaDir, fileName)),
+        copyFile(primaryThumbnailPath, path.join(thumbnailDir, `${id}.webp`)),
+        copyFile(
+          primaryThumbnailPath,
+          path.join(smallThumbnailDir, `${id}.webp`),
+        ),
+      ]),
+    ],
+  );
+
   const pgliteDir = path.join(runtimeDir, "pglite");
   const client = createPglite(pgliteDir);
   const db = drizzle(client);
@@ -111,6 +148,24 @@ async function seedMediaFixtures(runtimeDir: string): Promise<void> {
         indexedAt: seededAt,
         status: "active",
       },
+      ...paginatedMedia.map(({ id, fileName }, index) => {
+        const createdAt = new Date(seededAt.getTime() - (index + 2) * 1000);
+        return {
+          id,
+          mediaSourceId: E2E_SOURCE_ID,
+          filePath: fileName,
+          fileName,
+          mediaType: "image" as const,
+          width: 256,
+          height: 256,
+          fileSize: primaryStats.size,
+          description: "Paginated browser scroll fixture media",
+          createdAt,
+          modifiedAt: createdAt,
+          indexedAt: seededAt,
+          status: "active" as const,
+        };
+      }),
     ]);
     await db.insert(mediaGenerationInfo).values([
       {
@@ -121,6 +176,10 @@ async function seedMediaFixtures(runtimeDir: string): Promise<void> {
         mediaId: E2E_SIMILAR_MEDIA_ID,
         metadata: { fixture: "e2e-similar" },
       },
+      ...paginatedMedia.map(({ id }) => ({
+        mediaId: id,
+        metadata: { fixture: "e2e-scroll" },
+      })),
     ]);
   } finally {
     await client.close();

--- a/apps/server/src/components/imports/pending-downloads-indicator.tsx
+++ b/apps/server/src/components/imports/pending-downloads-indicator.tsx
@@ -1,10 +1,53 @@
 import { subscribeToEventStream } from "@solid-imager/ui/event-stream";
 import {
+	type ImportEventConnectedHandler,
+	type ImportEventHandler,
 	type PendingDownloadsIndicatorProps,
 	PendingDownloadsIndicator as SharedPendingDownloadsIndicator,
 } from "@solid-imager/ui/pending-downloads-indicator";
 import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import { fetchMediaSources } from "~/infrastructure/api-clients/sources-api";
+
+type ImportSubscriber = {
+	handler: ImportEventHandler;
+	onConnected?: ImportEventConnectedHandler;
+};
+
+const importSubscribers = new Set<ImportSubscriber>();
+let cleanupImportStream: (() => void) | undefined;
+
+function subscribeSharedImportEvents(
+	handler: ImportEventHandler,
+	onConnected?: ImportEventConnectedHandler,
+): () => void {
+	const subscriber = { handler, onConnected };
+	importSubscribers.add(subscriber);
+
+	if (!cleanupImportStream) {
+		cleanupImportStream = subscribeToEventStream(
+			(signal) => orpc.imports.events(undefined, { signal }),
+			(event) => {
+				for (const current of importSubscribers) {
+					void current.handler(event);
+				}
+			},
+			undefined,
+			async () => {
+				for (const current of importSubscribers) {
+					await current.onConnected?.();
+				}
+			},
+		);
+	}
+
+	return () => {
+		importSubscribers.delete(subscriber);
+		if (importSubscribers.size === 0) {
+			cleanupImportStream?.();
+			cleanupImportStream = undefined;
+		}
+	};
+}
 
 export function PendingDownloadsIndicator(
 	displayProps: { compact?: boolean; variant?: "default" | "v2" } = {},
@@ -37,12 +80,7 @@ export function PendingDownloadsIndicator(
 			return { success: result.success };
 		},
 		subscribeImportEvents: (handler, onConnected) => {
-			return subscribeToEventStream(
-				(signal) => orpc.imports.events(undefined, { signal }),
-				handler,
-				undefined,
-				onConnected,
-			);
+			return subscribeSharedImportEvents(handler, onConnected);
 		},
 	};
 

--- a/apps/server/src/components/v2/v2-app-shell.tsx
+++ b/apps/server/src/components/v2/v2-app-shell.tsx
@@ -16,7 +16,6 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@solid-imager/ui/dialog";
-import { subscribeToEventStream } from "@solid-imager/ui/event-stream";
 import type { RawEventHandler } from "@solid-imager/ui/hooks/use-sources-events";
 import { useSourcesPage } from "@solid-imager/ui/hooks/use-sources-page";
 import {
@@ -49,7 +48,7 @@ import { Link, useLocation } from "@tanstack/solid-router";
 import type { JSX, ParentProps } from "solid-js";
 import { createSignal, For, Show } from "solid-js";
 import { PendingDownloadsIndicator } from "~/components/imports/pending-downloads-indicator";
-import { orpc } from "~/infrastructure/api-clients/orpc-client";
+import { createServerTransport } from "~/hooks/use-media-source-events";
 import { mediaSourcesQueryOptions } from "~/infrastructure/api-clients/queries";
 import {
 	createMediaSource,
@@ -79,13 +78,6 @@ const V2_NAVIGATION_ITEMS = [
 	{ icon: Clock3, label: "Jobs", to: "/v2/jobs" },
 	{ icon: Settings, label: "Settings", to: "/v2/config" },
 ] as const;
-
-function registerSourceEvents(handler: RawEventHandler): () => void {
-	return subscribeToEventStream(
-		(signal) => orpc.sources.events({ id: "*" }, { signal }),
-		handler,
-	);
-}
 
 function sourceTypeLabel(source: SafeMediaSource): string {
 	return source.type === "local" ? "Local" : source.type.toUpperCase();
@@ -357,6 +349,9 @@ function V2Sidebar(props: V2SidebarProps) {
 export function V2AppShell(props: V2AppShellProps) {
 	const queryClient = useQueryClient();
 	const mediaSources = createQuery(mediaSourcesQueryOptions);
+	const sourceEventTransport = createServerTransport(() => "*");
+	const registerSourceEvents = (handler: RawEventHandler) =>
+		sourceEventTransport.listen(handler);
 	const [sidebarExpanded, setSidebarExpanded] = createSignal(true);
 	const [mobileMenuOpen, setMobileMenuOpen] = createSignal(false);
 	const sourceData = () => mediaSources.data ?? [];

--- a/apps/server/src/hooks/use-media-source-events.ts
+++ b/apps/server/src/hooks/use-media-source-events.ts
@@ -32,7 +32,7 @@ type SharedSourceTransport = {
 	idleSince: number | null;
 };
 
-const SOURCE_TRANSPORT_IDLE_TIMEOUT_MS = 30_000;
+const SOURCE_TRANSPORT_IDLE_TIMEOUT_MS = 0;
 const MAX_IDLE_SOURCE_TRANSPORTS = 2;
 
 type SourceTransportGlobal = typeof globalThis & {
@@ -79,7 +79,7 @@ export function createServerTransport(
 		if (!id) {
 			return false;
 		}
-		if (pathname === "/search" || pathname === "/v2/search") {
+		if (id === "*" && (pathname === "/search" || pathname.startsWith("/v2/"))) {
 			return true;
 		}
 		if (id === "*") {

--- a/apps/server/src/routes/v2/search.tsx
+++ b/apps/server/src/routes/v2/search.tsx
@@ -69,7 +69,7 @@ function V2SearchRoute() {
 		similarityTopK: () => searchState.similarityTopK,
 		refreshDebounceMs: SEARCH_RESULTS_REFRESH_DEBOUNCE_MS,
 		isSearchStateRestored,
-		scrollContainerSelector: "[data-media-scroll]",
+		scrollContainerSelector: '[data-media-scroll="v2-search"]',
 	});
 
 	useMediaSourceEvents(() => searchState.selectedSource || "*", {

--- a/apps/server/src/routes/v2/sources/$mediaSourceId/$mediaId/index.tsx
+++ b/apps/server/src/routes/v2/sources/$mediaSourceId/$mediaId/index.tsx
@@ -55,7 +55,7 @@ function MediaDetailHeader(props: {
 				returnPath.startsWith("/v2/sources/"))
 		) {
 			sessionStorage.removeItem("v2:media-return");
-			void navigate({ to: returnPath });
+			window.history.back();
 			return;
 		}
 		void navigate({

--- a/apps/server/src/tests/e2e/ui-components.gallery.spec.ts
+++ b/apps/server/src/tests/e2e/ui-components.gallery.spec.ts
@@ -276,6 +276,58 @@ test("virtual media grid stays populated after restoring a deep scroll position"
 	await expectVisibleImagesLoaded(scroller);
 });
 
+test("virtual media grid preserves offset after a route-style remount and page update", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 1_280, height: 720 });
+	await page.goto(`${getGalleryUrl()}/?virtual-grid=1&remount-grid=1`);
+
+	const scroller = page.getByTestId("virtual-grid-scroller");
+	await expect(scroller.locator("[data-media-id]").first()).toBeVisible();
+	await scroller.evaluate(async (element) => {
+		element.scrollTop = 1_500;
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+		);
+	});
+	const beforeRemount = await scroller.evaluate((element) => element.scrollTop);
+	expect(beforeRemount).toBeGreaterThan(500);
+
+	await page.getByTestId("remount-virtual-grid").click();
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollTop))
+		.toBeGreaterThan(beforeRemount - 2);
+	await page.evaluate(() =>
+		window.dispatchEvent(new WheelEvent("wheel", { deltaY: 1 })),
+	);
+	const restoredTop = await scroller.evaluate((element) => element.scrollTop);
+	const heightBeforeAppend = await scroller.evaluate(
+		(element) => element.scrollHeight,
+	);
+	const nextTop = restoredTop + 1_800;
+
+	await page.evaluate((targetTop) => {
+		const element = document.querySelector<HTMLElement>(
+			"[data-testid=virtual-grid-scroller]",
+		);
+		if (!element) throw new Error("Virtual grid scroller was not found");
+		element.scrollTop = 0;
+		document
+			.querySelector<HTMLElement>("[data-testid=append-virtual-grid-page]")
+			?.click();
+		requestAnimationFrame(() => {
+			element.scrollTop = targetTop;
+		});
+	}, nextTop);
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollHeight))
+		.toBeGreaterThan(heightBeforeAppend);
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollTop))
+		.toBeGreaterThan(restoredTop + 100);
+	await expectVisibleImagesLoaded(scroller);
+});
+
 test.describe("high-density virtual media grid", () => {
 	test.use({ deviceScaleFactor: 2 });
 

--- a/apps/server/src/tests/e2e/ui-components.gallery.spec.ts
+++ b/apps/server/src/tests/e2e/ui-components.gallery.spec.ts
@@ -258,6 +258,24 @@ test("virtual media grid stays populated and DOM-bounded during fast scrolling",
 	expect(transferSummary.retransferredUrls).toEqual([]);
 });
 
+test("virtual media grid stays populated after restoring a deep scroll position", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 1_280, height: 720 });
+	await page.goto(`${getGalleryUrl()}/?virtual-grid=1&restore-grid=1`);
+
+	const scroller = page.getByTestId("virtual-grid-scroller");
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollTop))
+		.toBeGreaterThan(1_000);
+	await expectVisibleImagesLoaded(scroller);
+
+	await scroller.evaluate((element) => {
+		element.scrollTop += element.clientHeight * 2;
+	});
+	await expectVisibleImagesLoaded(scroller);
+});
+
 test.describe("high-density virtual media grid", () => {
 	test.use({ deviceScaleFactor: 2 });
 

--- a/apps/server/src/tests/e2e/ui-components.gallery.spec.ts
+++ b/apps/server/src/tests/e2e/ui-components.gallery.spec.ts
@@ -328,6 +328,41 @@ test("virtual media grid preserves offset after a route-style remount and page u
 	await expectVisibleImagesLoaded(scroller);
 });
 
+test("virtual media grid preserves offset while fast scrolling starts a page fetch", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 1_280, height: 720 });
+	await page.goto(`${getGalleryUrl()}/?virtual-grid=1&remount-grid=1`);
+
+	const scroller = page.getByTestId("virtual-grid-scroller");
+	await expect(scroller.locator("[data-media-id]").first()).toBeVisible();
+	await scroller.evaluate(async (element) => {
+		element.scrollTop = 1_500;
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+		);
+	});
+
+	await page.getByTestId("remount-virtual-grid").click();
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollTop))
+		.toBeGreaterThan(1_000);
+	await page.evaluate(() =>
+		window.dispatchEvent(new WheelEvent("wheel", { deltaY: 1 })),
+	);
+
+	const restoredTop = await scroller.evaluate((element) => element.scrollTop);
+	await scroller.evaluate((element) => {
+		element.scrollTop = element.scrollHeight - element.clientHeight - 1;
+	});
+
+	await expect(page.getByText("読み込み中...", { exact: true })).toBeVisible();
+	await expect(page.getByText("読み込み中...", { exact: true })).toHaveCount(0);
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollTop))
+		.toBeGreaterThan(restoredTop + 100);
+});
+
 test.describe("high-density virtual media grid", () => {
 	test.use({ deviceScaleFactor: 2 });
 

--- a/apps/server/src/tests/e2e/ui-components.gallery.spec.ts
+++ b/apps/server/src/tests/e2e/ui-components.gallery.spec.ts
@@ -265,9 +265,16 @@ test("virtual media grid stays populated after restoring a deep scroll position"
 	await page.goto(`${getGalleryUrl()}/?virtual-grid=1&restore-grid=1`);
 
 	const scroller = page.getByTestId("virtual-grid-scroller");
+	await expect(scroller.locator("[data-media-id]").first()).toBeVisible();
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollHeight))
+		.toBeGreaterThan(1_000);
+	const maxScrollTop = await scroller.evaluate(
+		(element) => element.scrollHeight - element.clientHeight,
+	);
 	await expect
 		.poll(() => scroller.evaluate((element) => element.scrollTop))
-		.toBeGreaterThan(1_000);
+		.toBeGreaterThan(maxScrollTop * 0.9);
 	await expectVisibleImagesLoaded(scroller);
 
 	await scroller.evaluate((element) => {
@@ -324,7 +331,7 @@ test("virtual media grid preserves offset after a route-style remount and page u
 		.toBeGreaterThan(heightBeforeAppend);
 	await expect
 		.poll(() => scroller.evaluate((element) => element.scrollTop))
-		.toBeGreaterThan(restoredTop + 100);
+		.toBeGreaterThan(restoredTop + 1_700);
 	await expectVisibleImagesLoaded(scroller);
 });
 
@@ -346,7 +353,7 @@ test("virtual media grid preserves offset while fast scrolling starts a page fet
 	await page.getByTestId("remount-virtual-grid").click();
 	await expect
 		.poll(() => scroller.evaluate((element) => element.scrollTop))
-		.toBeGreaterThan(1_000);
+		.toBeGreaterThan(1_400);
 	await page.evaluate(() =>
 		window.dispatchEvent(new WheelEvent("wheel", { deltaY: 1 })),
 	);
@@ -360,7 +367,7 @@ test("virtual media grid preserves offset while fast scrolling starts a page fet
 	await expect(page.getByText("読み込み中...", { exact: true })).toHaveCount(0);
 	await expect
 		.poll(() => scroller.evaluate((element) => element.scrollTop))
-		.toBeGreaterThan(restoredTop + 100);
+		.toBeGreaterThan(restoredTop + 1_000);
 });
 
 test.describe("high-density virtual media grid", () => {

--- a/apps/server/src/tests/e2e/ui-gallery/src.tsx
+++ b/apps/server/src/tests/e2e/ui-gallery/src.tsx
@@ -62,6 +62,7 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@solid-imager/ui/dialog";
+import { useScrollRestoration } from "@solid-imager/ui/hooks/scroll-container";
 import { Input } from "@solid-imager/ui/input";
 import {
 	Popover,
@@ -132,6 +133,38 @@ const VIRTUAL_GRID_MEDIA = Array.from(
 );
 
 function VirtualGridGallery() {
+	const restoreGrid = new URLSearchParams(window.location.search).has(
+		"restore-grid",
+	);
+	const [loadedCount, setLoadedCount] = createSignal(
+		restoreGrid ? 200 : VIRTUAL_GRID_ITEM_COUNT,
+	);
+	const [isFetchingNextPage, setIsFetchingNextPage] = createSignal(false);
+	const mediaResults = () => VIRTUAL_GRID_MEDIA.slice(0, loadedCount());
+	const fetchNextPage = async () => {
+		if (
+			!restoreGrid ||
+			isFetchingNextPage() ||
+			loadedCount() >= VIRTUAL_GRID_ITEM_COUNT
+		) {
+			return;
+		}
+		setIsFetchingNextPage(true);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		setLoadedCount((count) => Math.min(count + 200, VIRTUAL_GRID_ITEM_COUNT));
+		setIsFetchingNextPage(false);
+	};
+	useScrollRestoration({
+		restoreKey: () => "virtual-grid",
+		getPosition: () => (restoreGrid ? 20_000 : 0),
+		setPosition: () => undefined,
+		isReady: () => mediaResults().length > 0,
+		hasNextPage: () => loadedCount() < VIRTUAL_GRID_ITEM_COUNT,
+		isFetchingNextPage,
+		fetchNextPage,
+		scrollContainerSelector: "[data-media-scroll]",
+	});
+
 	return (
 		<main class="h-dvh bg-background p-4 text-foreground">
 			<h1 class="sr-only">Virtual media grid performance fixture</h1>
@@ -143,10 +176,12 @@ function VirtualGridGallery() {
 				<SourceMediaGrid
 					disableContextMenu
 					enableVirtualization
-					isFetchingNextPage={false}
+					isFetchingNextPage={isFetchingNextPage()}
 					itemAspectRatio={4 / 3}
-					mediaResults={() => VIRTUAL_GRID_MEDIA}
-					mediaSourceId={() => VIRTUAL_GRID_MEDIA[0]?.mediaSourceId}
+					hasNextPage={loadedCount() < VIRTUAL_GRID_ITEM_COUNT}
+					mediaResults={mediaResults}
+					mediaSourceId={() => mediaResults()[0]?.mediaSourceId}
+					onLoadMore={fetchNextPage}
 					renderItem={(media, options) => (
 						// The immutable, uniquely-addressed URLs exercise the browser's real
 						// memory cache when a virtual row is unmounted and revisited.
@@ -177,7 +212,7 @@ function VirtualGridGallery() {
 					setLoadMoreRef={() => undefined}
 					showResultCount={false}
 					state={() => ({
-						data: VIRTUAL_GRID_MEDIA,
+						data: mediaResults(),
 						error: undefined,
 						fetchState: "idle",
 						phase: "data",

--- a/apps/server/src/tests/e2e/ui-gallery/src.tsx
+++ b/apps/server/src/tests/e2e/ui-gallery/src.tsx
@@ -101,7 +101,7 @@ import {
 } from "@solid-imager/ui/text-field";
 import { ThumbnailImage } from "@solid-imager/ui/thumbnail-image";
 import { Toaster, toast } from "@solid-imager/ui/toast";
-import { createSignal } from "solid-js";
+import { createSignal, Show } from "solid-js";
 import { render } from "solid-js/web";
 import "../../../app.css";
 
@@ -133,17 +133,20 @@ const VIRTUAL_GRID_MEDIA = Array.from(
 );
 
 function VirtualGridGallery() {
-	const restoreGrid = new URLSearchParams(window.location.search).has(
-		"restore-grid",
-	);
+	const params = new URLSearchParams(window.location.search);
+	const restoreGrid = params.has("restore-grid");
+	const remountGrid = params.has("remount-grid");
+	const pagedGrid = restoreGrid || remountGrid;
 	const [loadedCount, setLoadedCount] = createSignal(
-		restoreGrid ? 200 : VIRTUAL_GRID_ITEM_COUNT,
+		pagedGrid ? 200 : VIRTUAL_GRID_ITEM_COUNT,
 	);
 	const [isFetchingNextPage, setIsFetchingNextPage] = createSignal(false);
+	const [savedScrollTop, setSavedScrollTop] = createSignal(0);
+	const [showGrid, setShowGrid] = createSignal(true);
 	const mediaResults = () => VIRTUAL_GRID_MEDIA.slice(0, loadedCount());
 	const fetchNextPage = async () => {
 		if (
-			!restoreGrid ||
+			!pagedGrid ||
 			isFetchingNextPage() ||
 			loadedCount() >= VIRTUAL_GRID_ITEM_COUNT
 		) {
@@ -154,71 +157,112 @@ function VirtualGridGallery() {
 		setLoadedCount((count) => Math.min(count + 200, VIRTUAL_GRID_ITEM_COUNT));
 		setIsFetchingNextPage(false);
 	};
-	useScrollRestoration({
-		restoreKey: () => "virtual-grid",
-		getPosition: () => (restoreGrid ? 20_000 : 0),
-		setPosition: () => undefined,
-		isReady: () => mediaResults().length > 0,
-		hasNextPage: () => loadedCount() < VIRTUAL_GRID_ITEM_COUNT,
-		isFetchingNextPage,
-		fetchNextPage,
-		scrollContainerSelector: "[data-media-scroll]",
-	});
+	const saveScrollPosition = () => {
+		const scroller = document.querySelector<HTMLElement>(
+			"[data-testid=virtual-grid-scroller]",
+		);
+		if (scroller) setSavedScrollTop(scroller.scrollTop);
+	};
+	const remount = () => {
+		saveScrollPosition();
+		setShowGrid(false);
+		setTimeout(() => setShowGrid(true), 25);
+	};
+	const VirtualGridContent = () => {
+		useScrollRestoration({
+			restoreKey: () => "virtual-grid",
+			getPosition: () => savedScrollTop() || (restoreGrid ? 20_000 : 0),
+			setPosition: (_key, position) => setSavedScrollTop(position),
+			isReady: () => mediaResults().length > 0,
+			hasNextPage: () => loadedCount() < VIRTUAL_GRID_ITEM_COUNT,
+			isFetchingNextPage,
+			fetchNextPage,
+			scrollContainerSelector: "[data-media-scroll]",
+		});
+
+		return (
+			<SourceMediaGrid
+				disableContextMenu
+				enableVirtualization
+				isFetchingNextPage={isFetchingNextPage()}
+				itemAspectRatio={4 / 3}
+				hasNextPage={loadedCount() < VIRTUAL_GRID_ITEM_COUNT}
+				mediaResults={mediaResults}
+				mediaSourceId={() => mediaResults()[0]?.mediaSourceId}
+				onLoadMore={fetchNextPage}
+				renderItem={(media, options) => (
+					// The immutable, uniquely-addressed URLs exercise the browser's real
+					// memory cache when a virtual row is unmounted and revisited.
+					<a
+						class="block aspect-[4/3] overflow-hidden rounded-md bg-muted"
+						data-media-id={media.id}
+						href={`#${media.id}`}
+						onContextMenu={options.onContextMenu}
+					>
+						<ThumbnailImage
+							alt={media.fileName}
+							class="h-full w-full object-cover"
+							enabled={options.imageLoadPolicy?.enabled}
+							fetchpriority={options.imageLoadPolicy?.fetchpriority}
+							height={384}
+							loading={options.imageLoadPolicy?.loading}
+							sizes="160px"
+							source={{
+								getSrcSet: () =>
+									`/virtual-thumbnail/${media.id}-256.webp 256w, /virtual-thumbnail/${media.id}-512.webp 512w`,
+								getUrl: () => `/virtual-thumbnail/${media.id}-512.webp`,
+							}}
+							width={512}
+						/>
+					</a>
+				)}
+				scrollMode="element"
+				setLoadMoreRef={() => undefined}
+				showResultCount={false}
+				state={() => ({
+					data: mediaResults(),
+					error: undefined,
+					fetchState: "idle",
+					phase: "data",
+				})}
+				totalCount={VIRTUAL_GRID_ITEM_COUNT}
+			/>
+		);
+	};
 
 	return (
 		<main class="h-dvh bg-background p-4 text-foreground">
 			<h1 class="sr-only">Virtual media grid performance fixture</h1>
+			<Show when={remountGrid}>
+				<div class="fixed top-2 left-2 z-10 flex gap-2">
+					<button
+						data-testid="remount-virtual-grid"
+						onClick={remount}
+						type="button"
+					>
+						Remount virtual grid
+					</button>
+					<button
+						data-testid="append-virtual-grid-page"
+						onClick={() =>
+							setLoadedCount((count) =>
+								Math.min(count + 200, VIRTUAL_GRID_ITEM_COUNT),
+							)
+						}
+						type="button"
+					>
+						Append virtual grid page
+					</button>
+				</div>
+			</Show>
 			<div
 				class="h-full min-h-0 overflow-y-auto overscroll-contain"
 				data-media-scroll
 				data-testid="virtual-grid-scroller"
 			>
-				<SourceMediaGrid
-					disableContextMenu
-					enableVirtualization
-					isFetchingNextPage={isFetchingNextPage()}
-					itemAspectRatio={4 / 3}
-					hasNextPage={loadedCount() < VIRTUAL_GRID_ITEM_COUNT}
-					mediaResults={mediaResults}
-					mediaSourceId={() => mediaResults()[0]?.mediaSourceId}
-					onLoadMore={fetchNextPage}
-					renderItem={(media, options) => (
-						// The immutable, uniquely-addressed URLs exercise the browser's real
-						// memory cache when a virtual row is unmounted and revisited.
-						<a
-							class="block aspect-[4/3] overflow-hidden rounded-md bg-muted"
-							data-media-id={media.id}
-							href={`#${media.id}`}
-							onContextMenu={options.onContextMenu}
-						>
-							<ThumbnailImage
-								alt={media.fileName}
-								class="h-full w-full object-cover"
-								enabled={options.imageLoadPolicy?.enabled}
-								fetchpriority={options.imageLoadPolicy?.fetchpriority}
-								height={384}
-								loading={options.imageLoadPolicy?.loading}
-								sizes="160px"
-								source={{
-									getSrcSet: () =>
-										`/virtual-thumbnail/${media.id}-256.webp 256w, /virtual-thumbnail/${media.id}-512.webp 512w`,
-									getUrl: () => `/virtual-thumbnail/${media.id}-512.webp`,
-								}}
-								width={512}
-							/>
-						</a>
-					)}
-					scrollMode="element"
-					setLoadMoreRef={() => undefined}
-					showResultCount={false}
-					state={() => ({
-						data: mediaResults(),
-						error: undefined,
-						fetchState: "idle",
-						phase: "data",
-					})}
-					totalCount={VIRTUAL_GRID_ITEM_COUNT}
-				/>
+				<Show when={showGrid()}>
+					<VirtualGridContent />
+				</Show>
 			</div>
 		</main>
 	);

--- a/apps/server/src/tests/e2e/ui-gallery/src.tsx
+++ b/apps/server/src/tests/e2e/ui-gallery/src.tsx
@@ -10,6 +10,7 @@ import {
 	AlertDialogTitle,
 	AlertDialogTrigger,
 } from "@solid-imager/ui/alert-dialog";
+import { QueryStatus } from "@solid-imager/ui/async-state";
 import { Badge } from "@solid-imager/ui/badge";
 import { Button, buttonVariants } from "@solid-imager/ui/button";
 import {
@@ -101,7 +102,7 @@ import {
 } from "@solid-imager/ui/text-field";
 import { ThumbnailImage } from "@solid-imager/ui/thumbnail-image";
 import { Toaster, toast } from "@solid-imager/ui/toast";
-import { createSignal, Show } from "solid-js";
+import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 import { render } from "solid-js/web";
 import "../../../app.css";
 
@@ -137,12 +138,14 @@ function VirtualGridGallery() {
 	const restoreGrid = params.has("restore-grid");
 	const remountGrid = params.has("remount-grid");
 	const pagedGrid = restoreGrid || remountGrid;
+	const fetchDelayMs = remountGrid ? 100 : 10;
 	const [loadedCount, setLoadedCount] = createSignal(
 		pagedGrid ? 200 : VIRTUAL_GRID_ITEM_COUNT,
 	);
 	const [isFetchingNextPage, setIsFetchingNextPage] = createSignal(false);
 	const [savedScrollTop, setSavedScrollTop] = createSignal(0);
 	const [showGrid, setShowGrid] = createSignal(true);
+	const [loadMoreRef, setLoadMoreRef] = createSignal<HTMLDivElement>();
 	const mediaResults = () => VIRTUAL_GRID_MEDIA.slice(0, loadedCount());
 	const fetchNextPage = async () => {
 		if (
@@ -153,10 +156,23 @@ function VirtualGridGallery() {
 			return;
 		}
 		setIsFetchingNextPage(true);
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await new Promise((resolve) => setTimeout(resolve, fetchDelayMs));
 		setLoadedCount((count) => Math.min(count + 200, VIRTUAL_GRID_ITEM_COUNT));
 		setIsFetchingNextPage(false);
 	};
+	createEffect(() => {
+		const element = loadMoreRef();
+		const hasNextPage = loadedCount() < VIRTUAL_GRID_ITEM_COUNT;
+		if (!element || !hasNextPage) return;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting) void fetchNextPage();
+			},
+			{ threshold: 0.5, rootMargin: "2400px" },
+		);
+		observer.observe(element);
+		onCleanup(() => observer.disconnect());
+	});
 	const saveScrollPosition = () => {
 		const scroller = document.querySelector<HTMLElement>(
 			"[data-testid=virtual-grid-scroller]",
@@ -217,7 +233,7 @@ function VirtualGridGallery() {
 					</a>
 				)}
 				scrollMode="element"
-				setLoadMoreRef={() => undefined}
+				setLoadMoreRef={setLoadMoreRef}
 				showResultCount={false}
 				state={() => ({
 					data: mediaResults(),
@@ -231,7 +247,7 @@ function VirtualGridGallery() {
 	};
 
 	return (
-		<main class="h-dvh bg-background p-4 text-foreground">
+		<main class="flex h-dvh min-h-0 min-w-0 flex-col bg-background p-4 text-foreground">
 			<h1 class="sr-only">Virtual media grid performance fixture</h1>
 			<Show when={remountGrid}>
 				<div class="fixed top-2 left-2 z-10 flex gap-2">
@@ -255,14 +271,28 @@ function VirtualGridGallery() {
 					</button>
 				</div>
 			</Show>
+			<div class="shrink-0 h-24" />
+			<div class="shrink-0 h-8">
+				<QueryStatus
+					fetchState={isFetchingNextPage() ? "background-fetching" : "idle"}
+					hasData
+					hideWhenIdle
+					offlineLabel="オフライン"
+					updatingLabel="検索結果を更新中..."
+				/>
+			</div>
 			<div
-				class="h-full min-h-0 overflow-y-auto overscroll-contain"
+				class="min-h-0 flex-1 overflow-y-auto overscroll-contain"
 				data-media-scroll
 				data-testid="virtual-grid-scroller"
 			>
-				<Show when={showGrid()}>
-					<VirtualGridContent />
-				</Show>
+				<div class="2xl:grid 2xl:grid-cols-[minmax(0,1fr)_clamp(20rem,26vw,26rem)] 2xl:items-start 2xl:gap-4">
+					<div class="min-w-0">
+						<Show when={showGrid()}>
+							<VirtualGridContent />
+						</Show>
+					</div>
+				</div>
 			</div>
 		</main>
 	);

--- a/apps/server/src/tests/e2e/v2-scroll-restoration.spec.ts
+++ b/apps/server/src/tests/e2e/v2-scroll-restoration.spec.ts
@@ -1,0 +1,237 @@
+import type { Page } from "@playwright/test";
+import { E2E_SOURCE_ID, E2E_SOURCE_NAME } from "./support/fixture";
+import { expect, test, waitForAppHydration } from "./support/test";
+
+const searchEndpoint = "**/api/rpc/media/search**";
+
+async function verifyRestoredScrollerDuringFastPageFetch(
+	page: Page,
+	entryPath: string,
+	heading: string,
+	scrollerSelector: string,
+	returnMethod: "browser" | "ui",
+): Promise<void> {
+	await page.setViewportSize({ width: 1280, height: 633 });
+
+	let delaySearchRequests = false;
+	let delayedNextPageRequestCount = 0;
+	await page.addInitScript(() => {
+		sessionStorage.removeItem("current-all");
+		sessionStorage.removeItem("solid-imager-scroll-positions");
+		sessionStorage.removeItem("v2:media-return");
+	});
+	await page.route(searchEndpoint, async (route) => {
+		if (delaySearchRequests && route.request().method() === "POST") {
+			if ((route.request().postData() ?? "").includes('"offset":200')) {
+				delayedNextPageRequestCount += 1;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+		}
+		await route.continue();
+	});
+
+	await page.goto(entryPath);
+	await waitForAppHydration(page);
+	await expect(page.getByText(heading, { exact: true }).last()).toBeVisible();
+
+	const scroller = page.locator(scrollerSelector);
+	await expect(scroller.locator("[data-media-id]").first()).toBeVisible();
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollHeight))
+		.toBeGreaterThan(2000);
+	await scroller.hover();
+	await page.mouse.wheel(0, 1500);
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollTop))
+		.toBeGreaterThan(1000);
+	await page.waitForTimeout(300);
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollTop))
+		.toBeGreaterThan(1000);
+
+	const mediaId = await scroller.evaluate((element) => {
+		const bounds = element.getBoundingClientRect();
+		return [...element.querySelectorAll<HTMLElement>("[data-media-id]")].find(
+			(item) => {
+				const itemBounds = item.getBoundingClientRect();
+				return itemBounds.bottom > bounds.top && itemBounds.top < bounds.bottom;
+			},
+		)?.dataset.mediaId;
+	});
+	expect(mediaId).toBeDefined();
+	if (!mediaId) throw new Error("A visible media item was not found");
+	const mediaFileName = await page
+		.locator(`[data-media-id="${mediaId}"] img`)
+		.getAttribute("alt");
+	expect(mediaFileName).toBeTruthy();
+	if (!mediaFileName)
+		throw new Error("The visible media item has no file name");
+
+	await page.locator(`[data-media-id="${mediaId}"]`).click();
+	await expect(page).toHaveURL(/\/v2\/sources\/[^/]+\/[^/]+$/);
+	await expect(
+		page.getByRole("heading", { name: mediaFileName, exact: true }),
+	).toBeVisible();
+
+	if (returnMethod === "browser") {
+		await page.goBack();
+	} else {
+		await page.getByRole("button", { name: "一覧に戻る", exact: true }).click();
+	}
+	await expect.poll(() => new URL(page.url()).pathname).toBe(entryPath);
+	await waitForAppHydration(page);
+	await expect(scroller.locator("[data-media-id]").first()).toBeVisible();
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollTop))
+		.toBeGreaterThan(1000);
+	await page.evaluate(
+		() =>
+			new Promise<void>((resolve) => {
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+			}),
+	);
+
+	await page.evaluate((selector) => {
+		const main = document.querySelector("#v2-main-content");
+		const initialScroller = document.querySelector<HTMLElement>(selector);
+		if (!main || !initialScroller) {
+			throw new Error("v2 media scroll containers were not found");
+		}
+
+		const probe = {
+			initialMain: main,
+			initialScroller,
+			removedSections: 0,
+			scrollTops: [] as number[],
+		};
+		const observer = new MutationObserver((records) => {
+			for (const record of records) {
+				if (record.target !== main) continue;
+				probe.removedSections += [...record.removedNodes].filter(
+					(node) => node instanceof HTMLElement && node.tagName === "SECTION",
+				).length;
+			}
+		});
+		observer.observe(main, { childList: true });
+		window.addEventListener(
+			"scroll",
+			(event) => {
+				if (event.target instanceof HTMLElement) {
+					probe.scrollTops.push(event.target.scrollTop);
+				}
+			},
+			true,
+		);
+		Object.assign(window, { __v2ScrollProbe: probe });
+	}, scrollerSelector);
+
+	const heightBeforeFetch = await scroller.evaluate(
+		(element) => element.scrollHeight,
+	);
+	const nextPageResponsePromise = page.waitForResponse(
+		(response) =>
+			response.url().includes("/api/rpc/media/search") &&
+			(response.request().postData() ?? "").includes('"offset":200'),
+		{ timeout: 10_000 },
+	);
+	delaySearchRequests = true;
+	await scroller.hover();
+	await page.mouse.wheel(0, 1800);
+	await expect.poll(() => delayedNextPageRequestCount).toBeGreaterThan(0);
+	await page.waitForTimeout(100);
+
+	const probeDuringFetch = await page.evaluate((selector) => {
+		const probe = (
+			window as Window & {
+				__v2ScrollProbe?: {
+					initialMain: Element;
+					initialScroller: Element;
+					removedSections: number;
+					scrollTops: number[];
+				};
+			}
+		).__v2ScrollProbe;
+		const currentScroller = document.querySelector(selector);
+		return {
+			scrollEventCount: probe?.scrollTops.length ?? 0,
+			removedSections: probe?.removedSections ?? -1,
+			mainWasReplaced:
+				probe?.initialMain !== document.querySelector("#v2-main-content"),
+			scrollerWasReplaced: probe?.initialScroller !== currentScroller,
+			minObservedScrollTop: probe?.scrollTops.length
+				? Math.min(...probe.scrollTops)
+				: -1,
+			finalScrollTop:
+				currentScroller instanceof HTMLElement ? currentScroller.scrollTop : -1,
+		};
+	}, scrollerSelector);
+
+	expect(probeDuringFetch.removedSections).toBe(0);
+	expect(probeDuringFetch.scrollEventCount).toBeGreaterThan(0);
+	expect(probeDuringFetch.mainWasReplaced).toBe(false);
+	expect(probeDuringFetch.scrollerWasReplaced).toBe(false);
+	expect(probeDuringFetch.minObservedScrollTop).toBeGreaterThan(0);
+	expect(probeDuringFetch.finalScrollTop).toBeGreaterThan(1000);
+
+	const nextPageResponse = await nextPageResponsePromise;
+	expect(nextPageResponse.status()).toBe(200);
+	await expect
+		.poll(() => scroller.evaluate((element) => element.scrollHeight), {
+			timeout: 10_000,
+		})
+		.toBeGreaterThan(heightBeforeFetch);
+	const probeAfterFetch = await page.evaluate((selector) => {
+		const probe = (
+			window as Window & {
+				__v2ScrollProbe?: {
+					initialMain: Element;
+					initialScroller: Element;
+					removedSections: number;
+				};
+			}
+		).__v2ScrollProbe;
+		const currentScroller = document.querySelector(selector);
+		return {
+			removedSections: probe?.removedSections ?? -1,
+			mainWasReplaced:
+				probe?.initialMain !== document.querySelector("#v2-main-content"),
+			scrollerWasReplaced: probe?.initialScroller !== currentScroller,
+			finalScrollTop:
+				currentScroller instanceof HTMLElement ? currentScroller.scrollTop : -1,
+		};
+	}, scrollerSelector);
+	expect(probeAfterFetch.removedSections).toBe(0);
+	expect(probeAfterFetch.mainWasReplaced).toBe(false);
+	expect(probeAfterFetch.scrollerWasReplaced).toBe(false);
+	expect(probeAfterFetch.finalScrollTop).toBeGreaterThan(1000);
+}
+
+const restorationCases = [
+	{
+		name: "v2 search",
+		entryPath: "/v2/search",
+		heading: "すべてのメディア",
+		scrollerSelector: '[data-media-scroll="v2-search"]',
+	},
+	{
+		name: "v2 source media",
+		entryPath: `/v2/sources/${E2E_SOURCE_ID}`,
+		heading: E2E_SOURCE_NAME,
+		scrollerSelector: `[data-media-scroll="${E2E_SOURCE_ID}"]`,
+	},
+] as const;
+for (const restorationCase of restorationCases) {
+	for (const returnMethod of ["browser", "ui"] as const) {
+		test(`${restorationCase.name} keeps its restored scroller mounted during a fast page fetch via ${returnMethod} back`, async ({
+			page,
+		}) => {
+			await verifyRestoredScrollerDuringFastPageFetch(
+				page,
+				restorationCase.entryPath,
+				restorationCase.heading,
+				restorationCase.scrollerSelector,
+				returnMethod,
+			);
+		});
+	}
+}

--- a/packages/ui/src/hooks/scroll-container.ts
+++ b/packages/ui/src/hooks/scroll-container.ts
@@ -213,7 +213,13 @@ export function useScrollRestoration(
 		}
 
 		const cancelRestore = () => {
-			if (!isRestored()) cancelled = true;
+			if (!isRestored()) {
+				cancelled = true;
+				// User input takes ownership of the scroll position. Mark the
+				// restoration complete so cleanup persists the position they chose
+				// instead of treating it as an unfinished restore.
+				setIsRestored(true);
+			}
 		};
 		window.addEventListener("pointerdown", cancelRestore, { passive: true });
 		window.addEventListener("wheel", cancelRestore, { passive: true });

--- a/packages/ui/src/hooks/scroll-container.ts
+++ b/packages/ui/src/hooks/scroll-container.ts
@@ -90,6 +90,8 @@ export function useScrollRestoration(
 	let frameId: number | undefined;
 	let settleTimer: ReturnType<typeof setTimeout> | undefined;
 	let restoreGeneration = 0;
+	let reconcileFrameId: number | undefined;
+	let secondReconcileFrameId: number | undefined;
 
 	const requestRestore = () => {
 		if (frameId !== undefined || isServer) return;
@@ -212,13 +214,56 @@ export function useScrollRestoration(
 			history.scrollRestoration = "manual";
 		}
 
+		const notifyScrollPosition = () => {
+			if (options.scrollContainerSelector) {
+				resolveScrollContainer(options.scrollContainerSelector)?.dispatchEvent(
+					new Event("scroll"),
+				);
+				return;
+			}
+			window.dispatchEvent(new Event("scroll"));
+		};
+
+		const reconcileVirtualizerPosition = () => {
+			notifyScrollPosition();
+			if (reconcileFrameId !== undefined) {
+				cancelAnimationFrame(reconcileFrameId);
+			}
+			if (secondReconcileFrameId !== undefined) {
+				cancelAnimationFrame(secondReconcileFrameId);
+			}
+			reconcileFrameId = requestAnimationFrame(() => {
+				reconcileFrameId = undefined;
+				notifyScrollPosition();
+				secondReconcileFrameId = requestAnimationFrame(() => {
+					secondReconcileFrameId = undefined;
+					notifyScrollPosition();
+				});
+			});
+		};
+
 		const cancelRestore = () => {
 			if (!isRestored()) {
 				cancelled = true;
+				restoreGeneration += 1;
+				if (frameId !== undefined) {
+					cancelAnimationFrame(frameId);
+					frameId = undefined;
+				}
+				if (settleTimer !== undefined) {
+					clearTimeout(settleTimer);
+					settleTimer = undefined;
+				}
 				// User input takes ownership of the scroll position. Mark the
 				// restoration complete so cleanup persists the position they chose
 				// instead of treating it as an unfinished restore.
 				setIsRestored(true);
+				// The virtualizer listens to native scroll events. A user event can
+				// cancel restoration before the browser changes scrollTop, leaving
+				// its previous (restored) range mounted at the top of the container.
+				// Re-notify it now and for the next two frames so it reconciles with
+				// the actual scroll position after pending layout work settles.
+				reconcileVirtualizerPosition();
 			}
 		};
 		window.addEventListener("pointerdown", cancelRestore, { passive: true });
@@ -238,6 +283,10 @@ export function useScrollRestoration(
 		restoreGeneration += 1;
 		if (frameId !== undefined) cancelAnimationFrame(frameId);
 		if (settleTimer !== undefined) clearTimeout(settleTimer);
+		if (reconcileFrameId !== undefined) cancelAnimationFrame(reconcileFrameId);
+		if (secondReconcileFrameId !== undefined) {
+			cancelAnimationFrame(secondReconcileFrameId);
+		}
 		savePosition();
 	});
 

--- a/packages/ui/src/hooks/use-current-search-persistence.test.ts
+++ b/packages/ui/src/hooks/use-current-search-persistence.test.ts
@@ -185,6 +185,19 @@ describe("useCurrentSearchPersistence", () => {
 		expect(searchState.selectedSource).toBe("saved-source");
 	});
 
+	it("preserves the current scroll position while restoring search state", async () => {
+		setSearchState("scrollY", 1840);
+		sessionStorage.setItem(
+			"current-all",
+			JSON.stringify(createPersistedSimpleState("saved query")),
+		);
+
+		mountPersistence("all");
+		await flushMicrotasks();
+
+		expect(searchState.scrollY).toBe(1840);
+	});
+
 	it("does not inherit a source for legacy vector sessions", async () => {
 		setSearchState("selectedSource", "stale-source");
 		sessionStorage.setItem(

--- a/packages/ui/src/hooks/use-current-search-persistence.test.ts
+++ b/packages/ui/src/hooks/use-current-search-persistence.test.ts
@@ -130,6 +130,13 @@ describe("useCurrentSearchPersistence", () => {
 		expect(searchState.selectedSource).toBe("source-1");
 	});
 
+	it("persists the initial state before the debounce expires", async () => {
+		mountPersistence("all");
+		await flushMicrotasks();
+
+		expect(sessionStorage.getItem("current-all")).toContain('"mode":"simple"');
+	});
+
 	it("restores the latest source when the source accessor changes", async () => {
 		const [sourceId, setSourceId] = createSignal("source-a");
 		sessionStorage.setItem(

--- a/packages/ui/src/hooks/use-current-search-persistence.ts
+++ b/packages/ui/src/hooks/use-current-search-persistence.ts
@@ -47,9 +47,10 @@ function applyPreset(
 	if (!shouldApply()) {
 		return;
 	}
+	const preservedScrollY = searchState.scrollY;
 	resetSearchState();
 	loadPreset(preset);
-	setSearchState("selectedSource", selectedSource);
+	setSearchState({ selectedSource, scrollY: preservedScrollY });
 	if (clearActivePreset) {
 		setSearchState("activePresetId", null);
 	}
@@ -102,6 +103,7 @@ function restoreCurrentSearchState(
 		if (!shouldApply()) {
 			return;
 		}
+		const preservedScrollY = searchState.scrollY;
 		const selectedSource =
 			typeof current.selectedSource === "string" ? current.selectedSource : "";
 		resetSearchState();
@@ -116,6 +118,7 @@ function restoreCurrentSearchState(
 				current.similarityTopK === 20 || current.similarityTopK === 100
 					? current.similarityTopK
 					: 50,
+			scrollY: preservedScrollY,
 		});
 		return;
 	}

--- a/packages/ui/src/hooks/use-current-search-persistence.ts
+++ b/packages/ui/src/hooks/use-current-search-persistence.ts
@@ -152,6 +152,7 @@ export function useCurrentSearchPersistence(
 	const [isRestored, setIsRestored] = createSignal(false);
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 	let restoreVersion = 0;
+	let lastPersistedPresetName: string | null = null;
 
 	const getSourceId = () =>
 		typeof sourceId === "function" ? sourceId() : sourceId;
@@ -209,28 +210,37 @@ export function useCurrentSearchPersistence(
 			return;
 		}
 
-		const condition = getSearchCondition() || {
-			type: "group" as const,
-			operator: "and" as const,
-			children: [],
-		};
-		const presetData = {
-			value: condition,
-			selectedSource: searchState.selectedSource,
-			sort: searchState.sortBy,
-			order: searchState.sortOrder,
-			mode: searchState.mode,
-			similarityAnchorMediaId: searchState.similarityAnchorMediaId,
-			similarityTopK: searchState.similarityTopK,
-		};
-
-		debounceTimer = setTimeout(() => {
+		const persistCurrentState = () => {
+			const condition = getSearchCondition() || {
+				type: "group" as const,
+				operator: "and" as const,
+				children: [],
+			};
+			const presetData = {
+				value: condition,
+				selectedSource: searchState.selectedSource,
+				sort: searchState.sortBy,
+				order: searchState.sortOrder,
+				mode: searchState.mode,
+				similarityAnchorMediaId: searchState.similarityAnchorMediaId,
+				similarityTopK: searchState.similarityTopK,
+			};
 			try {
 				sessionStorage.setItem(presetName, JSON.stringify(presetData));
+				lastPersistedPresetName = presetName;
 			} catch {
 				// Persistence errors must not disrupt the UI.
 			}
-		}, DEBOUNCE_MS);
+		};
+
+		// Persist the initial state synchronously so navigating to a media detail
+		// before the debounce expires cannot reset the list on return.
+		if (lastPersistedPresetName !== presetName) {
+			persistCurrentState();
+			return;
+		}
+
+		debounceTimer = setTimeout(persistCurrentState, DEBOUNCE_MS);
 	});
 
 	onCleanup(() => {

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -9,7 +9,12 @@ import type {
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
-import { createInfiniteQuery, createQuery } from "@tanstack/solid-query";
+import {
+	createInfiniteQuery,
+	createQuery,
+	type InfiniteData,
+	useQueryClient,
+} from "@tanstack/solid-query";
 import {
 	type Accessor,
 	createEffect,
@@ -85,6 +90,8 @@ export interface UseSearchPageResult {
 		typeof createInfiniteQuery<MediaSearchResponse>
 	>;
 	searchResults: () => MediaSearchResponse["media"];
+	hasData: () => boolean;
+	totalCount: () => number | undefined;
 	contentState: () => QueryUiState<MediaSearchResponse["media"]>;
 	filterStates: {
 		tags: () => QueryUiState<TagResponse[]>;
@@ -157,7 +164,7 @@ export function useSearchPage(
 		JSON.stringify(getSearchCondition() ?? null),
 	);
 
-	const searchResultQuery = createInfiniteQuery(() =>
+	const searchResultQueryOptions = createMemo(() =>
 		buildSearchResultsQueryOptions({
 			mode: mode(),
 			sourceId: selectedSource() || undefined,
@@ -174,10 +181,31 @@ export function useSearchPage(
 			gcTime,
 		}),
 	);
+	const searchResultQuery = createInfiniteQuery(searchResultQueryOptions);
+	const queryClient = useQueryClient();
+	const [searchResultData, setSearchResultData] = createSignal<
+		InfiniteData<MediaSearchResponse> | undefined
+	>();
+
+	createEffect(() => {
+		// Solid Query exposes `data` as a resource-backed accessor. During an
+		// infinite-page fetch it can suspend even when previous pages are cached;
+		// keep the rendered result in a regular signal so the collection DOM stays
+		// mounted while the next page is loading.
+		const queryKey = searchResultQueryOptions().queryKey;
+		searchResultQuery.dataUpdatedAt;
+		const cachedData =
+			queryClient.getQueryData<InfiniteData<MediaSearchResponse>>(queryKey);
+		if (cachedData !== undefined) {
+			setSearchResultData(cachedData);
+		} else if (!searchResultQuery.isPlaceholderData) {
+			setSearchResultData(undefined);
+		}
+	});
 
 	const searchResults = createMemo(() => {
 		const seen = new Set<string>();
-		return (searchResultQuery.data?.pages.flatMap((p) => p.media) || []).filter(
+		return (searchResultData()?.pages.flatMap((p) => p.media) || []).filter(
 			(m) => {
 				if (seen.has(m.id)) {
 					return false;
@@ -190,7 +218,7 @@ export function useSearchPage(
 	const contentState = () =>
 		toQueryUiState(
 			{
-				data: searchResultQuery.data ? searchResults() : undefined,
+				data: searchResultData() ? searchResults() : undefined,
 				error: searchResultQuery.error,
 				status: searchResultQuery.status,
 				fetchStatus: searchResultQuery.fetchStatus,
@@ -254,8 +282,7 @@ export function useSearchPage(
 			void key;
 			setScrollY(position);
 		},
-		isReady: () =>
-			Boolean(searchResultQuery.data) && !searchResultQuery.isLoading,
+		isReady: () => Boolean(searchResultData()) && !searchResultQuery.isLoading,
 		hasNextPage: () => searchResultQuery.hasNextPage,
 		isFetchingNextPage: () => searchResultQuery.isFetchingNextPage,
 		fetchNextPage: () => searchResultQuery.fetchNextPage(),
@@ -306,6 +333,8 @@ export function useSearchPage(
 	return {
 		searchResultQuery,
 		searchResults,
+		hasData: () => searchResultData() !== undefined,
+		totalCount: () => searchResultData()?.pages[0]?.total,
 		contentState,
 		filterStates: {
 			tags: () => arrayState(tags),

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -92,6 +92,7 @@ export interface UseSearchPageResult {
 	searchResults: () => MediaSearchResponse["media"];
 	hasData: () => boolean;
 	totalCount: () => number | undefined;
+	fetchNextPage: () => Promise<unknown>;
 	contentState: () => QueryUiState<MediaSearchResponse["media"]>;
 	filterStates: {
 		tags: () => QueryUiState<TagResponse[]>;
@@ -134,6 +135,13 @@ export function useSearchPage(
 		refreshDebounceMs = DEFAULT_REFRESH_DEBOUNCE_MS,
 		isSearchStateRestored = () => true,
 	} = options;
+	const queryClient = useQueryClient();
+	const tagsQueryKey = queries.tags().queryKey;
+	const sourcesQueryKey = queries.sources().queryKey;
+	const projectsQueryKey = queries.projects().queryKey;
+	const ipsQueryKey = queries.ips().queryKey;
+	const charactersQueryKey = queries.characters().queryKey;
+	const authorsQueryKey = queries.authors().queryKey;
 
 	const tags = createQuery<TagResponse[]>(() => ({
 		...queries.tags(),
@@ -159,13 +167,52 @@ export function useSearchPage(
 		...queries.authors(),
 		enabled: !isServer,
 	}));
+	const [tagsData, setTagsData] = createSignal<TagResponse[] | undefined>();
+	const [sourcesData, setSourcesData] = createSignal<
+		SafeMediaSource[] | undefined
+	>();
+	const [projectsData, setProjectsData] = createSignal<Project[] | undefined>();
+	const [ipsData, setIpsData] = createSignal<Ip[] | undefined>();
+	const [charactersData, setCharactersData] = createSignal<
+		Character[] | undefined
+	>();
+	const [authorsData, setAuthorsData] = createSignal<Author[] | undefined>();
+
+	createEffect(() => {
+		tags.dataUpdatedAt;
+		setTagsData(queryClient.getQueryData<TagResponse[]>(tagsQueryKey));
+	});
+	createEffect(() => {
+		sources.dataUpdatedAt;
+		setSourcesData(
+			queryClient.getQueryData<SafeMediaSource[]>(sourcesQueryKey),
+		);
+	});
+	createEffect(() => {
+		allProjects.dataUpdatedAt;
+		setProjectsData(queryClient.getQueryData<Project[]>(projectsQueryKey));
+	});
+	createEffect(() => {
+		allIps.dataUpdatedAt;
+		setIpsData(queryClient.getQueryData<Ip[]>(ipsQueryKey));
+	});
+	createEffect(() => {
+		allCharacters.dataUpdatedAt;
+		setCharactersData(
+			queryClient.getQueryData<Character[]>(charactersQueryKey),
+		);
+	});
+	createEffect(() => {
+		allAuthors.dataUpdatedAt;
+		setAuthorsData(queryClient.getQueryData<Author[]>(authorsQueryKey));
+	});
 
 	const conditionKey = createMemo(() =>
 		JSON.stringify(getSearchCondition() ?? null),
 	);
 
-	const searchResultQueryOptions = createMemo(() =>
-		buildSearchResultsQueryOptions({
+	const searchResultQueryOptions = createMemo(() => {
+		return buildSearchResultsQueryOptions({
 			mode: mode(),
 			sourceId: selectedSource() || undefined,
 			condition: getSearchCondition(),
@@ -179,10 +226,13 @@ export function useSearchPage(
 			searchSimilar: options.searchSimilar,
 			enabled: !isServer && isSearchStateRestored(),
 			gcTime,
-		}),
-	);
+		});
+	});
 	const searchResultQuery = createInfiniteQuery(searchResultQueryOptions);
-	const queryClient = useQueryClient();
+	const fetchNextPage = () =>
+		isSearchStateRestored()
+			? searchResultQuery.fetchNextPage()
+			: Promise.resolve();
 	const [searchResultData, setSearchResultData] = createSignal<
 		InfiniteData<MediaSearchResponse> | undefined
 	>();
@@ -225,12 +275,24 @@ export function useSearchPage(
 			},
 			{ isEmpty: (data) => data.length === 0 },
 		);
-	const arrayState = <T>(query: {
-		data: T[] | undefined;
-		error: unknown;
-		status: "pending" | "error" | "success";
-		fetchStatus: "idle" | "fetching" | "paused";
-	}) => toQueryUiState(query, { isEmpty: (data) => data.length === 0 });
+	const arrayState = <T>(
+		query: {
+			data: T[] | undefined;
+			error: unknown;
+			status: "pending" | "error" | "success";
+			fetchStatus: "idle" | "fetching" | "paused";
+		},
+		data: () => T[] | undefined,
+	) =>
+		toQueryUiState(
+			{
+				data: data(),
+				error: query.error,
+				status: query.status,
+				fetchStatus: query.fetchStatus,
+			},
+			{ isEmpty: (items) => items.length === 0 },
+		);
 	const retryFilters = async () => {
 		await Promise.all([
 			tags.refetch(),
@@ -243,7 +305,7 @@ export function useSearchPage(
 	};
 
 	const getSourceRootPath = (mediaSourceId: string) => {
-		const source = sources.data?.find((item) => item.id === mediaSourceId);
+		const source = sourcesData()?.find((item) => item.id === mediaSourceId);
 		if (source?.type !== "local") {
 			return undefined;
 		}
@@ -282,10 +344,13 @@ export function useSearchPage(
 			void key;
 			setScrollY(position);
 		},
-		isReady: () => Boolean(searchResultData()) && !searchResultQuery.isLoading,
+		isReady: () =>
+			isSearchStateRestored() &&
+			Boolean(searchResultData()) &&
+			!searchResultQuery.isLoading,
 		hasNextPage: () => searchResultQuery.hasNextPage,
 		isFetchingNextPage: () => searchResultQuery.isFetchingNextPage,
-		fetchNextPage: () => searchResultQuery.fetchNextPage(),
+		fetchNextPage,
 		scrollContainerSelector: options.scrollContainerSelector,
 	});
 
@@ -314,14 +379,14 @@ export function useSearchPage(
 		const hasNextPage = searchResultQuery.hasNextPage;
 		const isFetching = searchResultQuery.isFetching;
 
-		if (!hasNextPage || isFetching) {
+		if (!isSearchStateRestored() || !hasNextPage || isFetching) {
 			return;
 		}
 
 		const observer = new IntersectionObserver(
 			(entries) => {
-				if (entries[0].isIntersecting) {
-					searchResultQuery.fetchNextPage();
+				if (entries[0].isIntersecting && isSearchStateRestored()) {
+					fetchNextPage();
 				}
 			},
 			{ threshold: 0.5, rootMargin: "2400px" },
@@ -335,33 +400,34 @@ export function useSearchPage(
 		searchResults,
 		hasData: () => searchResultData() !== undefined,
 		totalCount: () => searchResultData()?.pages[0]?.total,
+		fetchNextPage,
 		contentState,
 		filterStates: {
-			tags: () => arrayState(tags),
-			sources: () => arrayState(sources),
-			projects: () => arrayState(allProjects),
-			ips: () => arrayState(allIps),
-			characters: () => arrayState(allCharacters),
-			authors: () => arrayState(allAuthors),
+			tags: () => arrayState(tags, tagsData),
+			sources: () => arrayState(sources, sourcesData),
+			projects: () => arrayState(allProjects, projectsData),
+			ips: () => arrayState(allIps, ipsData),
+			characters: () => arrayState(allCharacters, charactersData),
+			authors: () => arrayState(allAuthors, authorsData),
 		},
 		filterData: {
 			get tags() {
-				return tags.data;
+				return tagsData();
 			},
 			get projects() {
-				return allProjects.data;
+				return projectsData();
 			},
 			get ips() {
-				return allIps.data;
+				return ipsData();
 			},
 			get characters() {
-				return allCharacters.data;
+				return charactersData();
 			},
 			get authors() {
-				return allAuthors.data;
+				return authorsData();
 			},
 		},
-		sources: () => sources.data,
+		sources: sourcesData,
 		getSourceRootPath,
 		isRestored,
 		handleSearch,

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -177,6 +177,8 @@ export type UseSourceMediaPageResult = {
 	mediaSourceId: () => string | undefined;
 	mediaQuery: ReturnType<typeof createInfiniteQuery<MediaSearchResponse>>;
 	mediaResults: () => MediaSearchResponse["media"];
+	hasData: () => boolean;
+	totalCount: () => number | undefined;
 	contentState: () => QueryUiState<MediaSearchResponse["media"]>;
 	filterData: () => SourceMediaPageFilterData;
 	filterStates: () => SourceMediaPageQueryStates;
@@ -255,7 +257,7 @@ export function useSourceMediaPage(
 		JSON.stringify(getSearchCondition() ?? null),
 	);
 
-	const mediaQuery = createInfiniteQuery(() =>
+	const mediaQueryOptions = createMemo(() =>
 		buildSourceMediaResultsQueryOptions({
 			sourceId: id(),
 			condition: getSearchCondition(),
@@ -267,11 +269,29 @@ export function useSourceMediaPage(
 			enabled: !isServer && isSearchStateRestored() && !!id(),
 		}),
 	);
+	const mediaQuery = createInfiniteQuery(mediaQueryOptions);
+	const [mediaQueryData, setMediaQueryData] = createSignal<
+		InfiniteData<MediaSearchResponse> | undefined
+	>();
+
+	createEffect(() => {
+		// Keep paginated results outside Solid Query's resource-backed `data`
+		// accessor. A page fetch must not suspend and remount the media grid.
+		const queryKey = mediaQueryOptions().queryKey;
+		mediaQuery.dataUpdatedAt;
+		const cachedData =
+			queryClient.getQueryData<InfiniteData<MediaSearchResponse>>(queryKey);
+		if (cachedData !== undefined) {
+			setMediaQueryData(cachedData);
+		} else if (!mediaQuery.isPlaceholderData) {
+			setMediaQueryData(undefined);
+		}
+	});
 
 	// --- Deduplicated results ---
 	const mediaResults = createMemo(() => {
 		const seen = new Set<string>();
-		return (mediaQuery.data?.pages.flatMap((page) => page.media) || []).filter(
+		return (mediaQueryData()?.pages.flatMap((page) => page.media) || []).filter(
 			(media) => {
 				if (seen.has(media.id)) {
 					return false;
@@ -284,7 +304,7 @@ export function useSourceMediaPage(
 	const contentState = () =>
 		toQueryUiState(
 			{
-				data: mediaQuery.data ? mediaResults() : undefined,
+				data: mediaQueryData() ? mediaResults() : undefined,
 				error: mediaQuery.error,
 				status: mediaQuery.status,
 				fetchStatus: mediaQuery.fetchStatus,
@@ -304,7 +324,7 @@ export function useSourceMediaPage(
 		restoreKey: id,
 		getPosition: (sourceId) => getScrollPosition(sourceId),
 		setPosition: (sourceId, position) => setScrollPosition(sourceId, position),
-		isReady: () => Boolean(mediaQuery.data) && !mediaQuery.isLoading,
+		isReady: () => Boolean(mediaQueryData()) && !mediaQuery.isLoading,
 		hasNextPage: () => mediaQuery.hasNextPage,
 		isFetchingNextPage: () => mediaQuery.isFetchingNextPage,
 		fetchNextPage: () => mediaQuery.fetchNextPage(),
@@ -908,7 +928,7 @@ export function useSourceMediaPage(
 	};
 
 	const handleSyncLoadedMedia = async () => {
-		const allPages = mediaQuery.data?.pages;
+		const allPages = mediaQueryData()?.pages;
 		if (!allPages || isSyncingMedia()) {
 			return;
 		}
@@ -946,6 +966,8 @@ export function useSourceMediaPage(
 		mediaSourceId: id,
 		mediaQuery,
 		mediaResults,
+		hasData: () => mediaQueryData() !== undefined,
+		totalCount: () => mediaQueryData()?.pages[0]?.total,
 		contentState,
 		filterData,
 		filterStates: queryStates,

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -278,7 +278,7 @@ export function useSourceMediaPage(
 		// Keep paginated results outside Solid Query's resource-backed `data`
 		// accessor. A page fetch must not suspend and remount the media grid.
 		const queryKey = mediaQueryOptions().queryKey;
-		mediaQuery.dataUpdatedAt;
+		void mediaQuery.dataUpdatedAt;
 		const cachedData =
 			queryClient.getQueryData<InfiniteData<MediaSearchResponse>>(queryKey);
 		if (cachedData !== undefined) {

--- a/packages/ui/src/screens/search-screen.tsx
+++ b/packages/ui/src/screens/search-screen.tsx
@@ -149,7 +149,7 @@ export function SearchScreen(props: SearchScreenProps) {
 							isFetchingNextPage={page().searchResultQuery.isFetchingNextPage}
 							mediaResults={page().searchResults}
 							mediaSourceId={() => undefined}
-							onLoadMore={() => page().searchResultQuery.fetchNextPage()}
+							onLoadMore={page().fetchNextPage}
 							onRetry={async () => {
 								await page().searchResultQuery.refetch();
 							}}

--- a/packages/ui/src/screens/search-screen.tsx
+++ b/packages/ui/src/screens/search-screen.tsx
@@ -161,7 +161,7 @@ export function SearchScreen(props: SearchScreenProps) {
 							showEmptyState
 							showResultCount
 							state={page().contentState}
-							totalCount={page().searchResultQuery.data?.pages[0]?.total}
+							totalCount={page().totalCount()}
 						/>
 					</Show>
 				</div>

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -126,9 +126,9 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 					<h1 class="min-w-0 break-words font-bold text-xl sm:text-2xl">
 						{props.mediaSourceName?.() ?? "メディア一覧"}
 					</h1>
-					<Show when={page().mediaQuery.data?.pages[0]?.total !== undefined}>
+					<Show when={page().totalCount() !== undefined}>
 						<p class="shrink-0 text-gray-600 text-sm">
-							{page().mediaQuery.data?.pages[0]?.total} 件の結果
+							{page().totalCount()} 件の結果
 						</p>
 					</Show>
 				</div>
@@ -144,9 +144,7 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 					</Show>
 					<Button
 						class="w-full sm:w-auto"
-						disabled={
-							page().isSyncingMedia() || !page().mediaQuery.data?.pages.length
-						}
+						disabled={page().isSyncingMedia() || !page().hasData()}
 						onClick={page().handleSyncLoadedMedia}
 						variant="outline"
 					>
@@ -226,7 +224,7 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 							showOpenInNewTab={props.showOpenInNewTab}
 							showResultCount={false}
 							state={page().contentState}
-							totalCount={page().mediaQuery.data?.pages[0]?.total}
+							totalCount={page().totalCount()}
 						/>
 					</Show>
 				</div>

--- a/packages/ui/src/screens/v2-search-screen.tsx
+++ b/packages/ui/src/screens/v2-search-screen.tsx
@@ -37,7 +37,7 @@ export function V2SearchScreen(props: SearchScreenProps) {
 			<V2SearchToolbar
 				context="global"
 				filterData={props.filterData}
-				itemCount={page().searchResultQuery.data?.pages[0]?.total}
+				itemCount={page().totalCount()}
 				onSearch={page().handleSearch}
 				onSelectSource={props.onSelectSource}
 				presetClient={props.presetClient}
@@ -106,7 +106,7 @@ export function V2SearchScreen(props: SearchScreenProps) {
 								showResultCount={false}
 								scrollMode="element"
 								state={page().contentState}
-								totalCount={page().searchResultQuery.data?.pages[0]?.total}
+								totalCount={page().totalCount()}
 							/>
 						</Show>
 					</div>

--- a/packages/ui/src/screens/v2-search-screen.tsx
+++ b/packages/ui/src/screens/v2-search-screen.tsx
@@ -45,32 +45,35 @@ export function V2SearchScreen(props: SearchScreenProps) {
 				sourceName={sourceName()}
 				sources={props.sources}
 			/>
+			<div class="shrink-0 px-3 pt-3 sm:px-4">
+				<Show
+					when={filterStates().some(
+						(state) => state.phase === "error" || state.phase === "offline",
+					)}
+				>
+					<FilterErrorBanner
+						class="mb-2"
+						message="一部の検索フィルターを取得できませんでした。検索結果は引き続き利用できます。"
+						onRetry={page().retryFilters}
+					/>
+				</Show>
+				<div class="h-8">
+					<QueryStatus
+						fetchState={page().contentState().fetchState}
+						hasData={page().contentState().data !== undefined}
+						hideWhenIdle
+						offlineLabel="オフラインのため保存済みの検索結果を表示しています"
+						updatingLabel="検索結果を更新中..."
+					/>
+				</div>
+			</div>
 
 			<div
 				class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-3 sm:px-4 [scrollbar-gutter:stable]"
-				data-media-scroll
+				data-media-scroll="v2-search"
 			>
 				<div class="2xl:grid 2xl:grid-cols-[minmax(0,1fr)_clamp(20rem,26vw,26rem)] 2xl:items-start 2xl:gap-4">
 					<div class="min-w-0">
-						<Show
-							when={filterStates().some(
-								(state) => state.phase === "error" || state.phase === "offline",
-							)}
-						>
-							<FilterErrorBanner
-								class="mb-3"
-								message="一部の検索フィルターを取得できませんでした。検索結果は引き続き利用できます。"
-								onRetry={page().retryFilters}
-							/>
-						</Show>
-						<QueryStatus
-							class="mb-2"
-							fetchState={page().contentState().fetchState}
-							hasData={page().contentState().data !== undefined}
-							hideWhenIdle
-							offlineLabel="オフラインのため保存済みの検索結果を表示しています"
-							updatingLabel="検索結果を更新中..."
-						/>
 						<Show
 							fallback={
 								<LoadingRegion label="検索結果を読み込んでいます...">

--- a/packages/ui/src/screens/v2-search-screen.tsx
+++ b/packages/ui/src/screens/v2-search-screen.tsx
@@ -92,7 +92,7 @@ export function V2SearchScreen(props: SearchScreenProps) {
 								itemAspectRatio={4 / 3}
 								mediaResults={page().searchResults}
 								mediaSourceId={() => undefined}
-								onLoadMore={() => page().searchResultQuery.fetchNextPage()}
+								onLoadMore={page().fetchNextPage}
 								onRetry={async () => {
 									await page().searchResultQuery.refetch();
 								}}

--- a/packages/ui/src/screens/v2-source-media-screen.tsx
+++ b/packages/ui/src/screens/v2-source-media-screen.tsx
@@ -51,9 +51,7 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 						</Show>
 						<Button
 							class="min-h-11 sm:min-h-9"
-							disabled={
-								page().isSyncingMedia() || !page().mediaQuery.data?.pages.length
-							}
+							disabled={page().isSyncingMedia() || !page().hasData()}
 							onClick={page().handleSyncLoadedMedia}
 							size="sm"
 							variant="outline"
@@ -72,7 +70,7 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 				}
 				context="source"
 				filterData={page().filterData()}
-				itemCount={page().mediaQuery.data?.pages[0]?.total}
+				itemCount={page().totalCount()}
 				onSearch={page().handleSearch}
 				presetClient={page().presetClient}
 				sourceName={props.mediaSourceName?.() ?? "メディア一覧"}
@@ -149,7 +147,7 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 								showResultCount={false}
 								scrollMode="element"
 								state={page().contentState}
-								totalCount={page().mediaQuery.data?.pages[0]?.total}
+								totalCount={page().totalCount()}
 							/>
 						</Show>
 					</div>

--- a/packages/ui/src/screens/v2-source-media-screen.tsx
+++ b/packages/ui/src/screens/v2-source-media-screen.tsx
@@ -81,32 +81,35 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 			<Show when={props.renderJobProgress && page().jobProgress()}>
 				{props.renderJobProgress?.({ jobProgress: page().jobProgress })}
 			</Show>
+			<div class="shrink-0 px-3 pt-3 sm:px-4">
+				<Show
+					when={filterStates().some(
+						(state) => state.phase === "error" || state.phase === "offline",
+					)}
+				>
+					<FilterErrorBanner
+						class="mb-2"
+						message="一部の検索フィルターを取得できませんでした。メディア一覧は引き続き利用できます。"
+						onRetry={props.onRetryFilters}
+					/>
+				</Show>
+				<div class="h-8">
+					<QueryStatus
+						fetchState={page().contentState().fetchState}
+						hasData={page().contentState().data !== undefined}
+						hideWhenIdle
+						offlineLabel="オフラインのため保存済みデータを表示しています"
+						updatingLabel="メディア一覧を更新中..."
+					/>
+				</div>
+			</div>
 
 			<div
 				class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-3 sm:px-4 [scrollbar-gutter:stable]"
-				data-media-scroll
+				data-media-scroll={page().mediaSourceId() ?? "v2-source"}
 			>
 				<div class="2xl:grid 2xl:grid-cols-[minmax(0,1fr)_clamp(20rem,26vw,26rem)] 2xl:items-start 2xl:gap-4">
 					<div class="min-w-0">
-						<Show
-							when={filterStates().some(
-								(state) => state.phase === "error" || state.phase === "offline",
-							)}
-						>
-							<FilterErrorBanner
-								class="mb-3"
-								message="一部の検索フィルターを取得できませんでした。メディア一覧は引き続き利用できます。"
-								onRetry={props.onRetryFilters}
-							/>
-						</Show>
-						<QueryStatus
-							class="mb-2"
-							fetchState={page().contentState().fetchState}
-							hasData={page().contentState().data !== undefined}
-							hideWhenIdle
-							offlineLabel="オフラインのため保存済みデータを表示しています"
-							updatingLabel="メディア一覧を更新中..."
-						/>
 						<Show
 							fallback={
 								<LoadingRegion label="メディア一覧を読み込んでいます...">

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -251,7 +251,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 			// A virtualizer can briefly have no measured range while its scroll
 			// container is being restored. Keep mounted rows loadable so a
 			// transient range reset does not blank the entire viewport.
-			return { enabled: true, loading: "lazy" };
+			return { enabled: true, loading: "eager" };
 		}
 
 		const isVisible =
@@ -342,6 +342,12 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 		rowCount();
 		mediaItemHeight();
 		columnCount();
+		// The element virtualizer is created before the grid's mount callback
+		// discovers its nested scroller. Re-measure when that scroller or the
+		// content offset becomes available so the initial range is populated
+		// without requiring a user scroll event.
+		scrollElement();
+		scrollMargin();
 		mediaRowVirtualizer().measure();
 	});
 

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -351,23 +351,12 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 		const virtualizer = mediaRowVirtualizer();
 		virtualizer.measure();
 		const element = scrollElement();
-		if (
-			props.scrollMode === "element" &&
-			element &&
-			virtualizer.scrollOffset !== null &&
-			virtualizer.scrollOffset !== element.scrollTop
-		) {
-			// Query updates can clamp the real scroll position while the
-			// virtualizer still holds the previous offset. Reconcile from the
-			// element before rendering the next range instead of leaving rows
-			// mounted outside the viewport until another user scroll event.
-			virtualizer.scrollToOffset(element.scrollTop);
-		}
 		if (props.scrollMode === "element" && element) {
 			// Element scroll containers do not consistently emit a native scroll
 			// event when their content is replaced or clamped. Window scrolling in
-			// the v1 screen gets that notification from the browser automatically;
-			// keep the v2 virtualizer in the same state after every grid update.
+			// the v1 screen gets that notification from the browser automatically.
+			// Dispatching lets the virtualizer read the element's current offset
+			// without imperatively writing a possibly stale offset back to it.
 			element.dispatchEvent(new Event("scroll"));
 		}
 	});

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -248,7 +248,10 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 	): MediaGridImageLoadPolicy => {
 		const state = elementLoadState();
 		if (!state) {
-			return { enabled: false };
+			// A virtualizer can briefly have no measured range while its scroll
+			// container is being restored. Keep mounted rows loadable so a
+			// transient range reset does not blank the entire viewport.
+			return { enabled: true, loading: "lazy" };
 		}
 
 		const isVisible =

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -363,6 +363,13 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 			// mounted outside the viewport until another user scroll event.
 			virtualizer.scrollToOffset(element.scrollTop);
 		}
+		if (props.scrollMode === "element" && element) {
+			// Element scroll containers do not consistently emit a native scroll
+			// event when their content is replaced or clamped. Window scrolling in
+			// the v1 screen gets that notification from the browser automatically;
+			// keep the v2 virtualizer in the same state after every grid update.
+			element.dispatchEvent(new Event("scroll"));
+		}
 	});
 
 	// Virtual scroll-based load more: trigger when user scrolls near the end

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -297,10 +297,19 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 		},
 	});
 
+	const resolveScrollElement = () =>
+		props.scrollMode === "element"
+			? (mediaGridRef?.closest("[data-media-scroll]") as HTMLElement | null)
+			: null;
+
 	const updateMediaGridMetrics = () => {
 		if (!mediaGridRef) return;
 		setMediaGridWidth(mediaGridRef.getBoundingClientRect().width);
-		const scroller = scrollElement();
+		const resolvedScrollElement = resolveScrollElement();
+		if (resolvedScrollElement !== scrollElement()) {
+			setScrollElement(resolvedScrollElement);
+		}
+		const scroller = resolvedScrollElement;
 		setScrollMargin(
 			props.scrollMode === "element" && scroller
 				? mediaGridRef.getBoundingClientRect().top -
@@ -312,11 +321,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 
 	onMount(() => {
 		setWindowWidth(window.innerWidth);
-		setScrollElement(
-			props.scrollMode === "element"
-				? (mediaGridRef?.closest("[data-media-scroll]") as HTMLElement | null)
-				: null,
-		);
+		setScrollElement(resolveScrollElement());
 		updateMediaGridMetrics();
 
 		const handleResize = () => {

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -267,14 +267,19 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 		const isPrefetch = isForwardPrefetch || isBackwardPrefetch;
 
 		return {
-			enabled: isVisible || isPrefetch,
+			// The element virtualizer already bounds the DOM to the visible range
+			// plus a small directional buffer. Keep every mounted row loadable:
+			// during navigation restoration the virtualizer can report the previous
+			// range for one frame, and disabling those rows leaves the viewport blank
+			// when the user scrolls again.
+			enabled: true,
 			fetchpriority:
 				isVisible && mediaIndex < INITIAL_HIGH_PRIORITY_MEDIA
 					? "high"
 					: isPrefetch
 						? "low"
 						: undefined,
-			loading: isVisible || isPrefetch ? "eager" : "lazy",
+			loading: "eager",
 		};
 	};
 	const createElementImageLoadPolicy = (

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -348,7 +348,21 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 		// without requiring a user scroll event.
 		scrollElement();
 		scrollMargin();
-		mediaRowVirtualizer().measure();
+		const virtualizer = mediaRowVirtualizer();
+		virtualizer.measure();
+		const element = scrollElement();
+		if (
+			props.scrollMode === "element" &&
+			element &&
+			virtualizer.scrollOffset !== null &&
+			virtualizer.scrollOffset !== element.scrollTop
+		) {
+			// Query updates can clamp the real scroll position while the
+			// virtualizer still holds the previous offset. Reconcile from the
+			// element before rendering the next range instead of leaving rows
+			// mounted outside the viewport until another user scroll event.
+			virtualizer.scrollToOffset(element.scrollTop);
+		}
 	});
 
 	// Virtual scroll-based load more: trigger when user scrolls near the end

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -123,7 +123,9 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 		onThumbnailReady: props.onThumbnailReady,
 		isSearchStateRestored,
 		scrollContainerSelector:
-			props.variant === "v2" ? "[data-media-scroll]" : undefined,
+			props.variant === "v2"
+				? `[data-media-scroll="${props.mediaSourceId()}"]`
+				: undefined,
 	});
 
 	const renderActions: SourceMediaScreenProps["renderActions"] = (actions) => (

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -124,7 +124,7 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 		isSearchStateRestored,
 		scrollContainerSelector:
 			props.variant === "v2"
-				? `[data-media-scroll="${props.mediaSourceId()}"]`
+				? `[data-media-scroll="${props.mediaSourceId() ?? "v2-source"}"]`
 				: undefined,
 	});
 

--- a/packages/ui/src/v2/search-toolbar.tsx
+++ b/packages/ui/src/v2/search-toolbar.tsx
@@ -369,7 +369,6 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 				/>
 
 				<Popover
-					forceMount
 					onOpenChange={setFilterOpen}
 					open={filterOpen()}
 					placement="bottom-end"


### PR DESCRIPTION
## 概要
取り込み済みのPR #657後に確認された、検索画面のスクロール未保存とsource一覧の復帰後のグリッド白画面を修正します。

## 変更内容
- 検索条件の復元時に現在のsearchState.scrollYを保持
- vector検索の状態復元でもスクロール位置を保持
- 仮想グリッドの測定範囲が一時的に未確定でも、マウント済み画像のロードを停止しない
- 検索スクロール保持の回帰テストを追加

## 検証
- packages/ui tests: 58 passed
- packages/ui typecheck
- apps/server typecheck
- 仮想グリッドE2E: 4 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 検索状態やプリセット、ベクトル検索モードの復元・適用時に、現在のスクロール位置が維持されるようになりました。
  * スクロール復元を中断した場合も、選択した位置が正しく保存されるようになりました。
  * 仮想スクロール中や深いスクロール位置の復元後も、画像が継続して正常に読み込まれるようになりました。
  * ページ追加や画面の再マウント後も、スクロール位置と画像の読み込み状態が維持されるようになりました。
  * 検索・メディア一覧のエラーや読み込み状態が、スクロールに影響されにくい固定領域に表示されるようになりました。
  * データ取得中も既に表示された検索結果が維持され、総件数が正しく表示されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->