### PR TITLE
feat(v2): add no-migration feature support

### DIFF
--- a/.agents/skills/gh-stack/SKILL.md
+++ b/.agents/skills/gh-stack/SKILL.md
@@ -1,0 +1,891 @@
+---
+description: |
+    Manage stacked branches and pull requests with the gh-stack GitHub CLI extension. Use when the user wants to create, push, rebase, sync, navigate, or view stacks of dependent PRs. Triggers on tasks involving stacked diffs, dependent pull requests, branch chains, or incremental code review workflows.
+metadata:
+    author: github
+    github-path: skills/gh-stack
+    github-ref: refs/tags/v0.1.0
+    github-repo: https://github.com/github/gh-stack
+    github-tree-sha: c95c8b5b4dd850f3fef007b304428f5684f2fb87
+    version: 0.0.9
+name: gh-stack
+---
+# gh-stack
+
+`gh stack` is a [GitHub CLI](https://cli.github.com/) extension for managing **stacked branches and pull requests**. A stack is an ordered list of branches where each branch builds on the one below it, rooted on a trunk branch (typically the repo's default branch). Each branch maps to one PR whose base is the branch below it, so reviewers see only the diff for that layer.
+
+```
+main (trunk)
+ └── auth-layer     → PR #1 (base: main)            - bottom (closest to trunk)
+  └── api-endpoints → PR #2 (base: auth-layer)
+   └── frontend     → PR #3 (base: api-endpoints)   - top (furthest from trunk)
+```
+
+The **bottom** of the stack is the branch closest to the trunk, and the **top** is the branch furthest from the trunk. Each branch inherits from the one below it. Navigation commands (`up`, `down`, `top`, `bottom`) follow this model: `up` moves away from trunk, `down` moves toward it.
+
+## When to use this skill
+
+Use this skill when the user wants to:
+
+- Break a large change into a chain of small, reviewable PRs
+- Create, rebase, push, or sync a stack of dependent branches
+- Navigate between layers of a branch stack
+- View the status of stacked PRs
+- Tear down and rebuild a stack to remove, reorder, or rename branches
+
+## Prerequisites
+
+The GitHub CLI (`gh`) v2.0+ must be installed and authenticated. Install the extension with:
+
+```bash
+gh extension install github/gh-stack
+```
+
+Before using `gh stack`, configure git to prevent interactive prompts:
+
+```bash
+git config rerere.enabled true           # remember conflict resolutions (skips prompt on init)
+git config remote.pushDefault origin     # if multiple remotes exist (skips remote picker)
+```
+
+## Agent rules
+
+**All `gh stack` commands must be run non-interactively.** Every command invocation must include the flags and positional arguments needed to avoid prompts, TUIs, and interactive menus. If a command would prompt for input, it will hang indefinitely.
+
+1. **Always supply branch names as positional arguments** to `init`, `add`, and `checkout`. Running these commands without arguments triggers interactive prompts. Branch names are used exactly as given — a name is never prefixed or transformed, so `gh stack add refactor/foo` creates a branch named `refactor/foo`.
+2. **Always use `--auto` with `gh stack submit`** to auto-generate PR titles. Without `--auto`, `submit` prompts for a title for each new PR.
+3. **Always use `--json` with `gh stack view`.** Without `--json`, the command launches an interactive TUI that cannot be operated by agents. There is no other appropriate flag — always pass `--json`.
+4. **Handle multiple remotes.** If more than one remote is configured, pre-configure `git config remote.pushDefault origin`, or pass `--remote <name>` to the commands that accept it: `push`, `submit`, `sync`, `rebase`, and `link`. `checkout`, `modify`, and `trunk` resolve a remote but have **no `--remote` flag** — they rely on `remote.pushDefault`. With multiple remotes and no configured default, these commands exit with an error in non-interactive mode.
+5. **Avoid branches shared across multiple stacks.** If a branch belongs to multiple stacks, commands exit with code 6. Check out a non-shared branch first.
+6. **Plan your stack layers by dependency order before writing code.** Foundational changes (models, APIs, shared utilities) go in lower branches; dependent changes (UI, consumers) go in higher branches. Think through the dependency chain before running `gh stack init`.
+7. **Use standard `git add` and `git commit` for staging and committing.** This gives you full control over which changes go into each branch. The `-Am` shortcut is available but should not be the default approach—stacked PRs are most effective when each branch contains a deliberate, logical set of changes.
+8. **Navigate down the stack when you need to change a lower layer.** If you're working on a frontend branch and realize you need API changes, don't hack around it at the current layer. Navigate to the appropriate branch (`gh stack down`, `gh stack checkout`, or `gh stack bottom`), make and commit the changes there, run `gh stack rebase --upstack`, then navigate back up to continue.
+9. **Use `gh stack link` for external tool workflows.** When branches are managed by an external tool (jj, Sapling, etc.), use `gh stack link branch-a branch-b`. `link` does not rely on local tracking state and is intended for API-driven PR and stack management. Provide at least two branches/PRs to create or update a stack, or a stack number followed by the new branches/PRs to append them to the top of an existing stack (e.g. `gh stack link 7 branch-c`).
+10. **Use `gh stack merge --yes` to merge stacked PRs.** `gh pr merge` does not work with stacked PRs. In a non-interactive terminal `gh stack merge` runs without prompting and merges the entire stack (bottom to top) atomically; pass `--yes` to be explicit. Scope the merge by passing a pull request number (`gh stack merge 42 --yes` merges everything up to and including PR #42) or a stack number (`gh stack merge 7 --yes`, which needs no local checkout). Choose the method with `--squash`, `--rebase`, `--merge`, or `--merge-method <method>`; without one, the last-used method is used. The merge is all-or-nothing — if any PR can't be merged, none are, and the failure reason is reported. Only basic pull request state is checked before merging (open and not a draft); bypassing merge requirements is not supported for stacks. If the base branch uses a merge queue, the stack is added to the queue instead of merging directly: the queue chooses the merge method (any method you pass is ignored with a warning), and the pull requests are added to the queue together but merge as the queue processes them, so they may land in separate groups rather than all at once.
+
+**Never do any of the following — each triggers an interactive prompt or TUI that will hang:**
+- ❌ `gh stack view` or `gh stack view --short` — always use `gh stack view --json`
+- ❌ `gh stack submit` without `--auto` — always use `gh stack submit --auto`
+- ❌ `gh stack init` without branch arguments — always provide branch names
+- ❌ `gh stack add` without a branch name — always provide a branch name
+- ❌ `gh stack checkout` without an argument — always provide a PR number or branch name
+- ❌ `gh stack checkout <pr-number>` when a different local stack already exists on those branches — this triggers an unbypassable conflict resolution prompt; use `gh stack unstack --local` first to remove the local tracking state (this keeps the stack on GitHub intact), then retry the checkout
+
+## Thinking about stack structure
+
+Each branch in a stack should represent a **discrete, logical unit of work** that can be reviewed independently. The changes within a branch should be cohesive—they belong together and make sense as a single PR.
+
+### Dependency chain
+
+Stacked branches form a dependency chain: each branch builds on the one below it. This means **foundational changes must go in lower (earlier) branches**, and code that depends on them goes in higher (later) branches.
+
+**Plan your layers before writing code.** For example, a full-stack feature might be structured like this (use branch names relevant to your actual task, not these generic ones):
+
+```
+main (trunk)
+ └── data-models    ← shared types, database schema
+  └── api-endpoints ← API routes that use the models
+   └── frontend-ui  ← UI components that call the APIs
+    └── integration ← tests that exercise the full stack
+```
+
+This is illustrative — choose branch names and layer boundaries that reflect the specific work you're doing. The key principle is: if code in one layer depends on code in another, the dependency must be in the same branch or a lower one.
+
+### Branch naming
+
+Choose a clear, descriptive branch name for each layer that reflects the concern it contains (e.g., `auth`, `api-routes`, `frontend`). Branch names are used exactly as you provide them to `init` and `add` — nothing is prepended or transformed. Slashes are allowed and are treated as part of the name (e.g., `gh stack add refactor/foo` creates a branch named `refactor/foo`).
+
+### Staging changes deliberately
+
+The main reason to use `git add` and `git commit` directly is to control **which changes go into which branch**. When you have multiple files in your working tree, you can stage a subset for the current branch, commit them, then create a new branch and stage the rest there:
+
+```bash
+# You're on data-models with several new files in your working tree.
+# Stage only the model files for this branch:
+git add internal/models/user.go internal/models/session.go
+git commit -m "Add user and session models"
+
+git add db/migrations/001_create_users.sql
+git commit -m "Add user table migration"
+
+# Now create a new branch for the API layer and stage the API files there:
+gh stack add api-routes # created & switched to the api-routes branch
+git add internal/api/routes.go internal/api/handlers.go
+git commit -m "Add user API routes"
+```
+
+This keeps each branch focused on one concern. Multiple commits per branch are fine — the key is that all commits in a branch relate to the same logical concern, and changes that belong to a different concern go in a different branch.
+
+### When to create a new branch
+
+Create a new branch (`gh stack add`) when you're starting a **different concern** that depends on what you've built so far. Signs it's time for a new branch:
+
+- You're switching from backend to frontend work
+- You're moving from core logic to tests or documentation
+- The next set of changes has a different reviewer audience
+- The current branch's PR is already large enough to review
+
+### One stack, one story
+
+Think of a stack from the reviewer's perspective: the stack of PRs should **tell a cohesive story** about a feature or project. A reviewer should be able to read the PRs in sequence and understand the progression of changes, with each PR being a small, logical piece of the whole.
+
+**When to use a single stack:** All the branches are part of the same feature, project, or closely related effort. Even if the work spans multiple concerns (models, API, frontend), they're all building toward the same goal.
+
+**When to create a separate stack:** The work is unrelated to your current stack — a different feature, a bug fix in an unrelated area, or an independent refactor. Don't mix unrelated work into a single stack just because you happen to be working on both. Start a new stack with `gh stack init` or switch to an existing stack with `gh stack checkout` for each distinct effort.
+
+Small, incidental fixes (e.g., fixing a typo you noticed) can go in the current stack if they're trivial. But if a change grows into its own project, it deserves its own stack.
+
+## Quick reference
+
+| Task | Command |
+|------|---------|
+| Create a stack | `gh stack init auth` |
+| Create a stack of multiple branches | `gh stack init auth api frontend` |
+| Adopt existing branches | `gh stack init existing-branch-a existing-branch-b` |
+| Set custom trunk | `gh stack init --base develop branch-a` |
+| Add a branch to stack | `gh stack add api-routes` |
+| Add branch + stage all + commit | `gh stack add -Am "message" api-routes` |
+| Push branches to remote | `gh stack push` |
+| Push to specific remote | `gh stack push --remote origin` |
+| Push branches + create draft PRs | `gh stack submit --auto` |
+| Create PRs as ready for review | `gh stack submit --auto --open` |
+| Sync (fetch, rebase, push) | `gh stack sync` |
+| Sync with specific remote | `gh stack sync --remote origin` |
+| Sync and prune merged branches | `gh stack sync --prune` |
+| Rebase entire stack | `gh stack rebase` |
+| Rebase upstack only | `gh stack rebase --upstack` |
+| Rebase without trunk | `gh stack rebase --no-trunk` |
+| Continue after conflict | `gh stack rebase --continue` |
+| Abort rebase | `gh stack rebase --abort` |
+| View stack details (JSON) | `gh stack view --json` |
+| Switch branches up/down in stack | `gh stack up [n]` / `gh stack down [n]` |
+| Switch to top/bottom branch | `gh stack top` / `gh stack bottom` |
+| Check out by stack number | `gh stack checkout 7` |
+| Check out by PR | `gh stack checkout 42` |
+| Check out by branch (local only) | `gh stack checkout feature-auth` |
+| Tear down the current stack to restructure it | `gh stack unstack` |
+| Tear down a specific stack by number | `gh stack unstack 7` |
+| Merge the whole current stack | `gh stack merge --yes` |
+| Merge a stack by number | `gh stack merge 7 --yes` |
+| Merge up to a specific PR | `gh stack merge 42 --yes` |
+| Merge with a specific method | `gh stack merge --yes --squash` |
+
+---
+
+## Workflows
+
+### End-to-end: create a stack from scratch
+
+```bash
+# 1. Initialize a stack with the first branch
+gh stack init auth
+# → creates auth and checks it out
+
+# 2. Write code for the first layer (auth)
+cat > auth.go << 'EOF'
+package auth
+
+func Middleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // verify token
+        next.ServeHTTP(w, r)
+    })
+}
+EOF
+
+# 3. Stage and commit using standard git commands
+git add auth.go
+git commit -m "Add auth middleware"
+
+# You can make multiple commits on the same branch
+cat > auth_test.go << 'EOF'
+package auth
+
+func TestMiddleware(t *testing.T) {
+    // test auth middleware
+}
+EOF
+git add auth_test.go
+git commit -m "Add auth middleware tests"
+
+# 4. When you're ready for a new concern, add the next branch
+gh stack add api-routes
+# → creates api-routes
+
+# 5. Write code for the API layer
+cat > api.go << 'EOF'
+package api
+
+func RegisterRoutes(mux *http.ServeMux) {
+    mux.HandleFunc("/users", handleUsers)
+}
+EOF
+git add api.go
+git commit -m "Add API routes"
+
+# 6. Add a third layer for frontend
+gh stack add frontend
+# → creates frontend
+
+cat > frontend.go << 'EOF'
+package frontend
+
+func RenderDashboard(w http.ResponseWriter) {
+    // calls the API endpoints from the layer below
+}
+EOF
+git add frontend.go
+git commit -m "Add frontend dashboard"
+
+# ── Stack complete: auth → api-routes → frontend ──
+
+# 7. Push everything and create PRs (drafts by default)
+gh stack submit --auto
+
+# 8. Verify the stack
+gh stack view --json
+```
+
+> **Shortcut:** If you prefer a faster flow, `gh stack add -Am "message" branch-name` combines staging, committing, and branch creation into one command. This is useful for single-commit layers but bypasses deliberate staging.
+
+### Making mid-stack changes
+
+This is a critical workflow for agents. When you're working on a higher layer and realize you need to change something in a lower layer (e.g., you're building frontend components but need to add an API endpoint), **navigate down to the correct branch, make the change there, and rebase**.
+
+```bash
+# You're on frontend but need to add an API endpoint
+
+# 1. Navigate to the API branch
+gh stack down
+# or: gh stack checkout api-routes
+
+# 2. Make the change where it belongs
+cat > users_api.go << 'EOF'
+package api
+
+func handleGetUser(w http.ResponseWriter, r *http.Request) {
+    // new endpoint the frontend needs
+}
+EOF
+git add users_api.go
+git commit -m "Add get-user endpoint"
+
+# 3. Rebase everything above to pick up the change
+gh stack rebase --upstack
+
+# 4. Navigate back to where you were working
+gh stack top
+# or: gh stack checkout frontend
+
+# 5. Continue working — the API changes are now available
+```
+
+**Why this matters:** If you make API changes on the frontend branch, those changes will end up in the wrong PR. The API PR won't include them, and the frontend PR will have unrelated API diffs mixed in. Always put changes in the branch where they logically belong.
+
+### Modify a mid-stack branch and sync
+
+When you need to revisit a branch after the initial creation (e.g., responding to review feedback):
+
+```bash
+# 1. Navigate to the branch that needs changes
+gh stack bottom
+# or: gh stack checkout auth
+# or: gh stack checkout 42  (by PR number)
+
+# 2. Make changes and commit
+cat > auth.go << 'EOF'
+package auth
+// updated implementation
+EOF
+git add auth.go
+git commit -m "Fix auth token validation"
+
+# 3. Rebase everything above this branch
+gh stack rebase --upstack
+
+# 4. Push the updated stack
+gh stack push
+```
+
+### Routine sync after merges
+
+```bash
+# Single command: fetch, rebase, push, sync PR and stack state
+gh stack sync
+
+# Sync and automatically clean up local branches for merged PRs
+gh stack sync --prune
+```
+
+> **Note for agents:** In non-interactive environments, the prune prompt is not shown. Use `--prune` explicitly to delete local branches for merged PRs.
+
+> **Note for agents:** `sync` also mirrors the stack on GitHub locally. If PRs were added to the stack on github.com, their branches are pulled down and appended to the local stack automatically. If the local and remote stacks have **diverged** (you changed the local stack while the remote stack changed differently), sync can only prompt to resolve it in an interactive terminal — in non-interactive environments it aborts the sync (nothing is pushed or updated) and exits successfully with `ℹ Sync aborted`. Resolve a divergence by unstacking and recreating the stack.
+
+### Squash-merge recovery
+
+When a PR is squash-merged on GitHub, the original branch's commits no longer exist in the trunk history. `gh stack` detects this automatically and uses `git rebase --onto` to correctly replay remaining commits.
+
+```bash
+# After PR #1 (auth) is squash-merged on GitHub:
+gh stack sync
+# → fetches latest, detects the merge, fast-forwards trunk
+# → rebases api-routes onto updated trunk (skips merged branch)
+# → rebases frontend onto api-routes
+# → pushes updated branches
+# → reports: "Merged: #1"
+
+# Verify the result
+gh stack view --json
+# → auth shows "isMerged": true, "state": "MERGED"
+# → api-routes and frontend show updated heads
+```
+
+If `sync` hits a conflict during this process, it restores all branches to their pre-rebase state and exits with code 3. See [Handle rebase conflicts](#handle-rebase-conflicts-agent-workflow) for the resolution workflow.
+
+### Handle rebase conflicts (agent workflow)
+
+```bash
+# 1. Start the rebase
+gh stack rebase
+
+# 2. If exit code 3 (conflict):
+#    - Parse stderr for conflicted file paths
+#    - Read those files to find <<<<<<< / ======= / >>>>>>> markers
+#    - Edit files to resolve conflicts
+#    - Stage resolved files:
+git add path/to/resolved-file.go
+
+# 3. Continue the rebase
+gh stack rebase --continue
+
+# 4. If another conflict occurs, repeat steps 2-3
+
+# 5. If unable to resolve, abort to restore everything
+gh stack rebase --abort
+```
+
+### Parsing `--json` output
+
+```bash
+# Get stack state as JSON
+output=$(gh stack view --json)
+
+# Check if any branch needs a rebase, and rebase if so
+needs_rebase=$(echo "$output" | jq '[.branches[] | select(.needsRebase == true)] | length')
+if [ "$needs_rebase" -gt 0 ]; then
+  echo "Branches need rebase, rebasing stack..."
+  gh stack rebase
+fi
+
+# Get all open PR URLs
+echo "$output" | jq -r '.branches[] | select(.pr.state == "OPEN") | .pr.url'
+
+# Find merged branches
+echo "$output" | jq -r '.branches[] | select(.isMerged == true) | .name'
+
+# Get the current branch
+echo "$output" | jq -r '.currentBranch'
+
+# Check if the stack is fully merged (all branches merged)
+echo "$output" | jq '[.branches[] | .isMerged] | all'
+```
+
+### Restructure a stack (remove a branch, reorder, or rename)
+
+Use `unstack` to tear down the stack, make structural changes, then re-init:
+
+```bash
+# 1. Remove the local tracking and the GitHub stack grouping (PRs are NOT deleted)
+gh stack unstack
+
+# 2. Make structural changes — e.g. delete a branch, reorder, rename
+git branch -m old-branch-1 new-branch-1
+
+# 3. Re-create the stack with the new structure
+gh stack init --base main new-branch-1 new-branch-2 new-branch-3
+```
+
+---
+
+## Commands
+
+### Initialize a stack — `gh stack init`
+
+Creates a new stack. **Always provide at least one branch name as a positional argument** — running without branch arguments triggers interactive prompts that agents cannot use.
+
+```
+gh stack init [flags] <branches...>
+```
+
+```bash
+# Create a stack with a new branch
+gh stack init auth
+# → creates auth and checks it out
+
+# Create a stack with new branches
+gh stack init branch-a branch-b branch-c
+
+# Use a different trunk branch
+gh stack init --base develop branch-a branch-b
+
+# Adopt existing branches into a stack (handled automatically if the branches exist)
+gh stack init branch-a branch-b branch-c
+```
+
+| Flag | Description |
+|------|-------------|
+| `-b, --base <branch>` | Trunk branch (defaults to the repo's default branch) |
+
+**Behavior:**
+
+- Branch names are created exactly as given (slashes are allowed and kept as-is)
+- Creates any branches that don't already exist (branching from the trunk branch)
+- Existing branches are adopted automatically; missing branches are created from the trunk
+- Checks out the last branch in the list
+- Enables `git rerere` so conflict resolutions are remembered across rebases. On first run in a repo, this may trigger a confirmation prompt — pre-configure with `git config rerere.enabled true` to avoid it
+
+---
+
+### Add a branch — `gh stack add`
+
+Add a new branch on top of the current stack. Must be run while on the topmost branch (or the trunk if the stack has no branches yet). **Always provide a branch name** — running without one triggers an interactive prompt.
+
+```
+gh stack add [flags] <branch>
+```
+
+**Recommended workflow — create the branch, then use standard git:**
+
+```bash
+# Create a new branch and switch to it
+gh stack add api-routes
+
+# Write code, stage deliberately, and commit
+git add internal/api/routes.go internal/api/handlers.go
+git commit -m "Add user API routes"
+
+# Make more commits on the same branch as needed
+git add internal/api/middleware.go
+git commit -m "Add rate limiting middleware"
+```
+
+**Shortcut — stage, commit, and branch in one command:**
+
+```bash
+# Create a new branch, stage all changes, and commit
+gh stack add -Am "Add API routes" api-routes
+
+# Create a new branch, stage tracked files only, and commit
+gh stack add -um "Fix auth bug" auth-fix
+```
+
+| Flag | Description |
+|------|-------------|
+| `-m, --message <string>` | Create a commit with this message |
+| `-A, --all` | Stage all changes including untracked files (requires `-m`) |
+| `-u, --update` | Stage tracked files only (requires `-m`) |
+
+**Behavior notes:**
+
+- `-A` and `-u` are mutually exclusive.
+- When the current branch has no commits (e.g., right after `init`), `add -Am` commits directly on the current branch instead of creating a new one.
+- **Branch names are used verbatim.** `gh stack add refactor/foo` creates a branch named `refactor/foo` — names are never prefixed or transformed. When `-m` is given without a branch name, the name is auto-generated from the commit message in date+slug format (e.g., `03-24-add_api_routes`).
+- If called from a branch that is not the topmost in the stack, exits with code 5: `"can only add branches on top of the stack"`. Use `gh stack top` to switch first.
+- **Uncommitted changes:** When using `gh stack add branch-name` without `-Am`, any uncommitted changes (staged or unstaged) in your working tree carry over to the new branch. This is standard git behavior — the working tree is not touched. Commit or stash changes on the current branch before running `add` if you want a clean starting point on the new branch.
+
+---
+
+### Push branches to remote — `gh stack push`
+
+Push active stack branches to the remote.
+
+```
+gh stack push [flags]
+```
+
+```bash
+# Push all branches
+gh stack push
+
+# Push to specific remote
+gh stack push --remote upstream
+```
+
+| Flag | Description |
+|------|-------------|
+| `--remote <name>` | Remote to push to (use if multiple remotes exist) |
+
+**Behavior:**
+
+- Pushes all active (non-merged, non-queued) branches in one non-atomic multi-ref push with explicit per-branch `--force-with-lease` checks
+- Some branches may update if another is rejected; fix the rejected branch and rerun the command
+- Does **not** create or update pull requests — use `gh stack submit` for that
+
+**Output (stderr):**
+
+- `Pushed N branches` summary
+
+---
+
+### Submit branches and create PRs — `gh stack submit`
+
+Push all stack branches and create PRs on GitHub. **Always pass `--auto`** — without it, `submit` prompts for a PR title for each new branch.
+
+```bash
+# Submit and auto-title new PRs (required for non-interactive use)
+gh stack submit --auto
+
+# Submit and create PRs as ready for review (not drafts)
+gh stack submit --auto --open
+```
+
+| Flag | Description |
+|------|-------------|
+| `--auto` | Auto-generate PR titles without prompting (**required** for non-interactive use) |
+| `--open` | Mark new and existing PRs as ready for review |
+| `--remote <name>` | Remote to push to (use if multiple remotes exist) |
+
+**Behavior:**
+
+- Pushes each active (non-merged, non-queued) branch sequentially with explicit per-branch `--force-with-lease` checks; the overall submit is not atomic
+- If a later branch push is rejected, earlier branch pushes and PR updates remain; fix the rejection and rerun the same command
+- Creates a new PR for each branch that doesn't have one (base set to the first non-merged ancestor branch)
+- After creating PRs, links them together as a **Stack** on GitHub (requires the repository to have stacks enabled)
+- If every PR in the stack has already been merged, the stack is complete and can't be extended. `submit` automatically forks your unmerged branches into a **new** stack rooted at the trunk and creates it on GitHub, leaving the merged stack untouched.
+- If stacks are not available (exit code 9), the repository does not have stacked PRs enabled. In interactive mode, `submit` offers to create regular (unstacked) PRs instead. In non-interactive mode, it exits with code 9.
+- Syncs PR metadata for branches that already have PRs
+
+**PR title auto-generation (`--auto`):**
+
+- Single commit on branch → uses the commit subject as the PR title, commit body as PR body
+- Multiple commits on branch → humanizes the branch name (hyphens/underscores → spaces) as the title
+
+**Output (stderr):**
+
+- `Created PR #N for <branch>` for each newly created PR
+- `PR #N for <branch> is up to date` for existing PRs
+- `Pushed and synced N branches` summary
+
+---
+
+### Link branches as a stack (no local tracking) — `gh stack link`
+
+Link PRs into a stack on GitHub without creating any local tracking state. This is the recommended approach if you are managing stacked branches with other tools (jj, Sapling, git-town) and want to simply create GitHub Stacked PRs via an API.
+
+```
+gh stack link [flags] <stack-number | branch-or-pr> <branch-or-pr> [...]
+```
+
+```bash
+# Link branches into a stack (pushes, creates PRs, creates stack)
+gh stack link branch-a branch-b branch-c
+
+# Use a different base branch and mark PRs as ready for review
+gh stack link --base develop --open branch-a branch-b branch-c
+
+# Link existing PRs by number
+gh stack link 10 20 30
+
+# Add branches to an existing stack of PRs
+gh stack link 42 43 feature-auth feature-ui
+
+# Append to the top of an existing stack by its stack number
+# (7 is a stack number; only the new PRs/branches are listed)
+gh stack link 7 48 feature-auth
+```
+
+When the first argument is a stack number, the remaining arguments are appended to the top of that stack, so you don't have to re-list its current PRs. Arguments already in the stack are skipped; arguments in a different stack are rejected. A numeric first argument is treated as a stack only when it matches an existing stack — otherwise it is a PR or branch.
+
+| Flag | Description |
+|------|---------|
+| `--base <branch>` | Base branch for the bottom of the stack (defaults to the repository's default branch) |
+| `--open` | Mark new and existing PRs as ready for review |
+| `--remote <name>` | Remote to push to (use if multiple remotes exist) |
+
+**Behavior:**
+
+- Arguments are provided in stack order (bottom to top)
+- Each argument can be a branch name or a PR number. Numeric arguments are tried as PR numbers first; if no PR with that number exists, the argument is treated as a branch name
+- Branch arguments are pushed to the remote automatically (non-force, atomic)
+- For branches without open PRs, new PRs are created with auto-generated titles and the correct base branch chaining (first branch uses `--base`, subsequent branches use the previous branch)
+- Existing PRs whose base branch doesn't match the expected chain are corrected automatically
+- If the PRs are not yet in a stack, a new stack is created. If some PRs are already in a stack, the stack is updated (additive only — existing PRs are never removed)
+- Does **not** create or modify any local state
+
+**Output (stderr):**
+
+- `Pushing N branches to <remote>...`
+- `Found PR #N for branch <name>` for branches with existing PRs
+- `Created PR #N for <branch> (base: <base>)` for newly created PRs
+- `Updated base branch for PR #N to <base>` when base branches are corrected
+- `Created stack with N PRs` or `Updated stack to N PRs`
+
+---
+
+### Sync the stack — `gh stack sync`
+
+Fetch, rebase, push, and sync PR state in a single command. This is the recommended command for routine synchronization.
+
+```
+gh stack sync [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--remote <name>` | Remote to fetch from and push to (use if multiple remotes exist) |
+| `--prune` | Delete local branches for merged PRs |
+
+**What it does (in order):**
+
+1. **Fetch** latest changes from the remote
+2. **Reconcile the remote stack** — mirror the GitHub stack locally. If PRs were added to the stack on GitHub, pull their branches down and append them to the local stack. If the local and remote stacks have diverged, aborts the sync in a non-interactive terminal. In an interactive terminal, offers prompts to resolve any divergence (replace local stack with remote version, delete stack on GitHub so it can be recreated, or cancel).
+3. **Fast-forward trunk** to match remote (skips if already up to date, warns if diverged)
+4. **Cascade rebase** all stack branches onto their updated parents (only if trunk moved). Handles merged PRs automatically. If a conflict is detected, **all branches are restored** to their pre-rebase state and the command exits with code 3 — see [Handle rebase conflicts](#handle-rebase-conflicts-agent-workflow) for the resolution workflow
+5. **Push** all active branches atomically
+6. **Sync PR state** from GitHub and report the status of each PR
+7. **Sync the stack object** — link the open PRs into a stack on GitHub. If the PRs are not yet in a stack, a new stack is created; if some PRs are already in a stack, it is updated (additive only). This only happens when two or more PRs exist. Sync **never opens PRs** — use `gh stack submit` for that
+8. **Prune** — in interactive terminals, prompts to delete local branches for merged PRs. Use `--prune` to skip the prompt. In non-interactive environments, pruning only happens when `--prune` is passed explicitly
+
+**Output (stderr):**
+
+- `✓ Fetched latest changes from origin`
+- `Pulling N new branches from the remote stack ...` then `✓ Pulled N new branches into the stack from the remote` (when the remote stack is ahead)
+- `⚠ Your local stack has diverged from the stack on GitHub` (with `Local:` / `Remote:` chains) when the stacks have diverged
+- `ℹ Sync aborted — no changes were made` when a sync is cancelled
+- `✓ Trunk main fast-forwarded to <sha>` or `✓ Trunk main is already up to date`
+- `✓ Rebased <branch> onto <base>` per branch (if base moved)
+- `✓ Pushed N branches`
+- `✓ PR #N (<branch>) — Open` per branch
+- `Merged: #N, #M` for merged branches
+- `✓ Stack created on GitHub with N PRs` / `✓ Stack updated on GitHub with N PRs` / `✓ Linked to the existing stack on GitHub` (when two or more PRs exist)
+- `✓ Pruned <branch> (merged)` per pruned branch (when pruning)
+- `✓ Stack synced` when the stack object on GitHub was created/updated to match local, or `✓ Branches synced` when only the branches were synced (fewer than two PRs or stacked PRs unavailable)
+
+---
+
+### Rebase the stack — `gh stack rebase`
+
+Pull from remote and cascade-rebase stack branches. Use this when `sync` reports a conflict or when you need finer control (e.g., rebase only part of the stack).
+
+```
+gh stack rebase [flags] [branch]
+```
+
+```bash
+# Rebase the entire stack
+gh stack rebase
+
+# Rebase only branches from trunk to current branch
+gh stack rebase --downstack
+
+# Rebase only branches from current branch to top
+gh stack rebase --upstack
+
+# Rebase stack branches without pulling from or rebasing with trunk
+gh stack rebase --no-trunk
+
+# After resolving a conflict: stage files with `git add`, then:
+gh stack rebase --continue
+
+# Abort and restore all branches to pre-rebase state
+gh stack rebase --abort
+```
+
+| Flag | Description |
+|------|-------------|
+| `--downstack` | Only rebase branches from trunk to the current branch |
+| `--upstack` | Only rebase branches from the current branch to the top |
+| `--no-trunk` | Skip trunk — only rebase stack branches onto each other (no fetch, no trunk rebase) |
+| `--continue` | Continue after resolving conflicts |
+| `--abort` | Abort and restore all branches |
+| `--remote <name>` | Remote to fetch from (use if multiple remotes exist) |
+
+| Argument | Description |
+|----------|-------------|
+| `[branch]` | Target branch (defaults to the current branch) |
+
+**Conflict handling:** See [Handle rebase conflicts](#handle-rebase-conflicts-agent-workflow) in the Workflows section for the full resolution workflow.
+
+**Merged PR detection:** If a branch's PR was merged on GitHub, the rebase automatically handles this using `--onto` mode and correctly replays commits on top of the merge target.
+
+**Rerere (conflict memory):** `git rerere` is enabled by `init` so previously resolved conflicts are auto-resolved in future rebases.
+
+**No-trunk mode:** Use `--no-trunk` to skip fetching from the remote and rebasing with the trunk branch. Only inter-branch rebases are performed (branch 2 onto branch 1, branch 3 onto branch 2, etc.). Useful when you only need to align stack branches with each other without pulling upstream changes.
+
+---
+
+### View the stack — `gh stack view`
+
+Display the current stack's branches, PR status, and recent commits. **Always pass `--json`** — without it, this command launches an interactive TUI that agents cannot operate.
+
+```bash
+# Always use --json
+gh stack view --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output stack data as JSON to stdout (**required** for non-interactive use) |
+
+**`--json` output format:**
+
+```json
+{
+  "trunk": "main",
+  "currentBranch": "api-routes",
+  "branches": [
+    {
+      "name": "auth",
+      "head": "abc1234...",
+      "base": "def5678...",
+      "isCurrent": false,
+      "isMerged": true,
+      "isQueued": false,
+      "needsRebase": false,
+      "pr": {
+        "number": 42,
+        "url": "https://github.com/owner/repo/pull/42",
+        "state": "MERGED"
+      }
+    },
+    {
+      "name": "api-routes",
+      "head": "789abcd...",
+      "base": "abc1234...",
+      "isCurrent": true,
+      "isMerged": false,
+      "isQueued": false,
+      "needsRebase": false,
+      "pr": {
+        "number": 43,
+        "url": "https://github.com/owner/repo/pull/43",
+        "state": "OPEN"
+      }
+    }
+  ]
+}
+```
+
+Fields per branch:
+- `name` — branch name
+- `head` — current HEAD SHA
+- `base` — parent branch's HEAD SHA at last sync
+- `isCurrent` — whether this is the checked-out branch
+- `isMerged` — whether the PR has been merged
+- `isQueued` — whether the PR is queued for merge (in a merge queue)
+- `needsRebase` — whether the base branch is not an ancestor (non-linear history)
+- `pr` — PR metadata (omitted if no PR exists). `state` is `"OPEN"`, `"MERGED"`, or `"QUEUED"`.
+
+---
+
+### Navigate the stack
+
+Move between branches without remembering branch names. These commands are fully non-interactive.
+
+```bash
+gh stack up          # Move up one branch (further from trunk)
+gh stack up 3        # Move up three branches
+gh stack down        # Move down one branch (closer to trunk)
+gh stack down 2      # Move down two branches
+gh stack top         # Jump to the top of the stack (furthest from trunk)
+gh stack bottom      # Jump to the bottom (first non-merged branch above trunk)
+gh stack trunk       # Jump to the trunk branch (e.g. main)
+```
+
+Navigation clamps to stack bounds. Merged branches are skipped when navigating from active branches.
+
+---
+
+### Check out a stack — `gh stack checkout`
+
+Check out a stack by stack number, pull request number, PR URL, or branch name. **Always provide an argument** — running `gh stack checkout` without arguments triggers an interactive selection menu.
+
+```
+gh stack checkout <stack-number | pr-number | pr-url | branch>
+```
+
+```bash
+# By stack number (the identifier shown in the GitHub stack UI)
+gh stack checkout 7
+
+# By PR number (pulls from GitHub)
+gh stack checkout 42
+
+# By PR URL
+gh stack checkout https://github.com/owner/repo/pull/42
+
+# By branch name (local only)
+gh stack checkout feature-auth
+```
+
+A bare number is resolved as a **stack number first** (the identifier shown in the GitHub stack UI); if no stack has that number it is tried as a PR number, then a branch name. When a stack or PR number (or PR URL) is provided, the command fetches the stack on GitHub, pulls the branches, and sets up the stack locally. If the stack already exists locally and matches, it switches to the branch.
+
+> **⚠️ Agent warning:** If the local and remote stacks have different branch compositions, this command triggers an interactive conflict-resolution prompt that cannot be bypassed with a flag. To avoid this: run `gh stack unstack --local` first to remove the conflicting local tracking state (this keeps the stack on GitHub intact), then retry `gh stack checkout <pr-number>`.
+
+When a branch name is provided, the command resolves it against locally tracked stacks only. This is always safe for non-interactive use.
+
+---
+
+### Remove a stack — `gh stack unstack`
+
+Tear down a stack so you can restructure it — remove a branch, reorder branches, rename branches, or make other large changes. After unstacking, use `gh stack init` to re-create the stack with the desired structure.
+
+Unstacking only removes the stack grouping (on GitHub and/or locally); it never deletes the underlying pull requests or branches.
+
+With no argument, the command targets the active stack — the one containing the currently checked out branch — unstacking it on GitHub and removing local tracking.
+
+Provide a stack number to unstack a specific stack on GitHub. This works from anywhere in the repository, whether or not the stack is checked out locally — the number is unstacked directly through the GitHub API (like `gh stack link`, no local tracking required). If the stack is also tracked locally, its local tracking is removed as well.
+
+```
+gh stack unstack [<stack-number>] [flags]
+```
+
+```bash
+# Tear down the current stack — removes local tracking and the GitHub grouping (PRs are NOT deleted), then rebuild
+gh stack unstack
+gh stack init --base main branch-2 branch-1 branch-3 # reordered
+
+# Unstack a specific stack by its number, from anywhere in the repo
+gh stack unstack 7
+
+# Only remove local tracking (keep the stack on GitHub)
+gh stack unstack --local
+```
+
+| Flag | Description |
+|------|-------------|
+| `--local` | Only remove the stack locally (keep it on GitHub); never contacts GitHub |
+
+> **Note for agents:** `gh stack unstack <number>` is a remote-first API wrapper — it unstacks on GitHub by number from anywhere in the repo, tracked locally or not, and is safe for non-interactive use. `--local` never contacts GitHub; combining `--local` with a number that isn't tracked locally is an error. An unknown stack number returns a "not found on GitHub" error (exit code 2).
+
+---
+
+## Output conventions
+
+- **Status messages** go to **stderr** with emoji prefixes: `✓` (success), `✗` (error), `⚠` (warning), `ℹ` (info).
+- **Data output** (e.g., `view --json`) goes to **stdout**.
+- When piping output, use `2>/dev/null` to suppress status messages if only data output is needed.
+
+## Exit codes and error recovery
+
+| Code | Meaning | Agent action |
+|------|---------|-------------|
+| 0 | Success | Proceed normally |
+| 1 | Generic error | Read stderr for details; may indicate commit/push failure |
+| 2 | Not in a stack | Run `gh stack init` to create a stack first |
+| 3 | Rebase conflict | Parse stderr for conflicted file paths, resolve conflicts, run `gh stack rebase --continue` |
+| 4 | GitHub API failure | Check `gh auth status`, retry the command |
+| 5 | Invalid arguments | Fix the command invocation (check flags and arguments) |
+| 6 | Disambiguation required | A branch belongs to multiple stacks. Run `gh stack checkout <specific-branch>` to switch to a non-shared branch first |
+| 7 | Rebase already in progress | Run `gh stack rebase --continue` (after resolving conflicts) or `gh stack rebase --abort` to start over |
+| 8 | Stack is locked | Another `gh stack` process is writing the stack file. Wait and retry — the lock times out after 5 seconds |
+| 9 | Stacked PRs unavailable | The repository does not have stacked PRs enabled. Tell the user that stacks must be enabled on the repository first |
+| 10 | Modify recovery required | A `gh stack modify` session was interrupted. This skill does not use `modify`, so agents should not produce this; if the repo is left in this state, run `gh stack modify --abort` to restore the pre-modify state |
+
+## Known limitations
+
+1. **Stacks are strictly linear.** Branching stacks (multiple children on a single parent) are not supported. Each branch has exactly one parent and at most one child. If you need parallel workstreams, use separate stacks.
+2. **Stack disambiguation cannot be bypassed.** If the current branch is the trunk of multiple stacks, commands error with code 6. Check out a non-shared branch first.
+3. **Multiple remotes require `--remote` or config.** If more than one remote is configured, set `remote.pushDefault` in git config, or pass `--remote <name>` to the commands that accept it (`push`, `submit`, `sync`, `rebase`, `link`). `checkout`, `modify`, and `trunk` have no `--remote` flag and rely on `remote.pushDefault`.
+4. **Remote stack checkout requires a stack or PR number.** `checkout` with a branch name only works with locally tracked stacks. Use a stack number or PR number (e.g. `gh stack checkout 7` or `gh stack checkout 123`) to pull a stack from GitHub.
+5. **PR title and body are auto-generated.** There is no flag to set a custom PR title or body during `submit`. The title and body are generated from commit messages plus a footer. Use `gh pr edit` to modify PR title and body after creation.

--- a/.agents/skills/gh-stack/SKILL.md
+++ b/.agents/skills/gh-stack/SKILL.md
@@ -53,7 +53,7 @@ git config remote.pushDefault origin     # if multiple remotes exist (skips remo
 **All `gh stack` commands must be run non-interactively.** Every command invocation must include the flags and positional arguments needed to avoid prompts, TUIs, and interactive menus. If a command would prompt for input, it will hang indefinitely.
 
 1. **Always supply branch names as positional arguments** to `init`, `add`, and `checkout`. Running these commands without arguments triggers interactive prompts. Branch names are used exactly as given — a name is never prefixed or transformed, so `gh stack add refactor/foo` creates a branch named `refactor/foo`.
-2. **Always use `--auto` with `gh stack submit`** to auto-generate PR titles. Without `--auto`, `submit` prompts for a title for each new PR.
+2. **Always use `--auto` with `gh stack submit`** to skip the full-screen editor. Without `--auto`, `submit` opens the editor for each PR's title, body, and draft/ready status.
 3. **Always use `--json` with `gh stack view`.** Without `--json`, the command launches an interactive TUI that cannot be operated by agents. There is no other appropriate flag — always pass `--json`.
 4. **Handle multiple remotes.** If more than one remote is configured, pre-configure `git config remote.pushDefault origin`, or pass `--remote <name>` to the commands that accept it: `push`, `submit`, `sync`, `rebase`, and `link`. `checkout`, `modify`, and `trunk` resolve a remote but have **no `--remote` flag** — they rely on `remote.pushDefault`. With multiple remotes and no configured default, these commands exit with an error in non-interactive mode.
 5. **Avoid branches shared across multiple stacks.** If a branch belongs to multiple stacks, commands exit with code 6. Check out a non-shared branch first.
@@ -319,7 +319,7 @@ gh stack sync --prune
 
 > **Note for agents:** In non-interactive environments, the prune prompt is not shown. Use `--prune` explicitly to delete local branches for merged PRs.
 
-> **Note for agents:** `sync` also mirrors the stack on GitHub locally. If PRs were added to the stack on github.com, their branches are pulled down and appended to the local stack automatically. If the local and remote stacks have **diverged** (you changed the local stack while the remote stack changed differently), sync can only prompt to resolve it in an interactive terminal — in non-interactive environments it aborts the sync (nothing is pushed or updated) and exits successfully with `ℹ Sync aborted`. Resolve a divergence by unstacking and recreating the stack.
+> **Note for agents:** `sync` also mirrors the stack on GitHub locally. If PRs were added to the stack on github.com, their branches are pulled down and appended to the local stack automatically. If the local and remote stacks have **diverged** (you changed the local stack while the remote stack changed differently), sync can only prompt to resolve it in an interactive terminal — in non-interactive environments it aborts the sync (nothing is pushed or updated) and exits successfully with `ℹ Sync aborted`. Automation must inspect stderr for that message and stop instead of treating the exit code as success. For a flow that continues, validate the current stack with `gh stack view --json`; resolve the divergence by unstacking and recreating the stack.
 
 ### Squash-merge recovery
 

--- a/.agents/skills/gh-stack/SKILL.md
+++ b/.agents/skills/gh-stack/SKILL.md
@@ -14,7 +14,7 @@ name: gh-stack
 
 `gh stack` is a [GitHub CLI](https://cli.github.com/) extension for managing **stacked branches and pull requests**. A stack is an ordered list of branches where each branch builds on the one below it, rooted on a trunk branch (typically the repo's default branch). Each branch maps to one PR whose base is the branch below it, so reviewers see only the diff for that layer.
 
-```
+```text
 main (trunk)
  └── auth-layer     → PR #1 (base: main)            - bottom (closest to trunk)
   └── api-endpoints → PR #2 (base: auth-layer)
@@ -81,7 +81,7 @@ Stacked branches form a dependency chain: each branch builds on the one below it
 
 **Plan your layers before writing code.** For example, a full-stack feature might be structured like this (use branch names relevant to your actual task, not these generic ones):
 
-```
+```text
 main (trunk)
  └── data-models    ← shared types, database schema
   └── api-endpoints ← API routes that use the models
@@ -318,8 +318,7 @@ gh stack sync --prune
 ```
 
 > **Note for agents:** In non-interactive environments, the prune prompt is not shown. Use `--prune` explicitly to delete local branches for merged PRs.
-
-> **Note for agents:** `sync` also mirrors the stack on GitHub locally. If PRs were added to the stack on github.com, their branches are pulled down and appended to the local stack automatically. If the local and remote stacks have **diverged** (you changed the local stack while the remote stack changed differently), sync can only prompt to resolve it in an interactive terminal — in non-interactive environments it aborts the sync (nothing is pushed or updated) and exits successfully with `ℹ Sync aborted`. Automation must inspect stderr for that message and stop instead of treating the exit code as success. For a flow that continues, validate the current stack with `gh stack view --json`; resolve the divergence by unstacking and recreating the stack.
+> **Note for agents:** `sync` also mirrors the stack on GitHub locally. If PRs were added to the stack on GitHub, their branches are pulled down and appended to the local stack automatically. If the local and remote stacks have **diverged** (you changed the local stack while the remote stack changed differently), sync can only prompt to resolve it in an interactive terminal — in non-interactive environments it aborts the sync (nothing is pushed or updated) and exits successfully with `ℹ Sync aborted`. Automation must inspect stderr for that message and stop instead of treating the exit code as success. For a flow that continues, validate the current stack with `gh stack view --json`; resolve the divergence by unstacking and recreating the stack. Before running `gh stack init` again, confirm that the GitHub stack has disappeared. If any PR is queued or has auto-merge enabled, `unstack` may leave the GitHub stack and local tracking in place; if all PRs are affected it can return HTTP 422. Remove the PRs from the merge queue or disable auto-merge, rerun `gh stack unstack`, and only then initialize the stack.
 
 ### Squash-merge recovery
 
@@ -413,7 +412,7 @@ gh stack init --base main new-branch-1 new-branch-2 new-branch-3
 
 Creates a new stack. **Always provide at least one branch name as a positional argument** — running without branch arguments triggers interactive prompts that agents cannot use.
 
-```
+```text
 gh stack init [flags] <branches...>
 ```
 
@@ -450,7 +449,7 @@ gh stack init branch-a branch-b branch-c
 
 Add a new branch on top of the current stack. Must be run while on the topmost branch (or the trunk if the stack has no branches yet). **Always provide a branch name** — running without one triggers an interactive prompt.
 
-```
+```text
 gh stack add [flags] <branch>
 ```
 
@@ -499,7 +498,7 @@ gh stack add -um "Fix auth bug" auth-fix
 
 Push active stack branches to the remote.
 
-```
+```text
 gh stack push [flags]
 ```
 
@@ -572,7 +571,7 @@ gh stack submit --auto --open
 
 Link PRs into a stack on GitHub without creating any local tracking state. This is the recommended approach if you are managing stacked branches with other tools (jj, Sapling, git-town) and want to simply create GitHub Stacked PRs via an API.
 
-```
+```text
 gh stack link [flags] <stack-number | branch-or-pr> <branch-or-pr> [...]
 ```
 
@@ -626,7 +625,7 @@ When the first argument is a stack number, the remaining arguments are appended 
 
 Fetch, rebase, push, and sync PR state in a single command. This is the recommended command for routine synchronization.
 
-```
+```text
 gh stack sync [flags]
 ```
 
@@ -667,7 +666,7 @@ gh stack sync [flags]
 
 Pull from remote and cascade-rebase stack branches. Use this when `sync` reports a conflict or when you need finer control (e.g., rebase only part of the stack).
 
-```
+```text
 gh stack rebase [flags] [branch]
 ```
 
@@ -800,7 +799,7 @@ Navigation clamps to stack bounds. Merged branches are skipped when navigating f
 
 Check out a stack by stack number, pull request number, PR URL, or branch name. **Always provide an argument** — running `gh stack checkout` without arguments triggers an interactive selection menu.
 
-```
+```text
 gh stack checkout <stack-number | pr-number | pr-url | branch>
 ```
 
@@ -834,9 +833,9 @@ Unstacking only removes the stack grouping (on GitHub and/or locally); it never 
 
 With no argument, the command targets the active stack — the one containing the currently checked out branch — unstacking it on GitHub and removing local tracking.
 
-Provide a stack number to unstack a specific stack on GitHub. This works from anywhere in the repository, whether or not the stack is checked out locally — the number is unstacked directly through the GitHub API (like `gh stack link`, no local tracking required). If the stack is also tracked locally, its local tracking is removed as well.
+Provide a stack number to unstack a specific stack on GitHub. This works from anywhere in the repository, whether the stack is checked out locally or not — the number is unstacked directly through the GitHub API (like `gh stack link`, no local tracking required). If the stack is also tracked locally, its local tracking is removed as well.
 
-```
+```text
 gh stack unstack [<stack-number>] [flags]
 ```
 
@@ -857,6 +856,7 @@ gh stack unstack --local
 | `--local` | Only remove the stack locally (keep it on GitHub); never contacts GitHub |
 
 > **Note for agents:** `gh stack unstack <number>` is a remote-first API wrapper — it unstacks on GitHub by number from anywhere in the repo, tracked locally or not, and is safe for non-interactive use. `--local` never contacts GitHub; combining `--local` with a number that isn't tracked locally is an error. An unknown stack number returns a "not found on GitHub" error (exit code 2).
+> **Stopping condition:** If any PR in the stack is queued or has auto-merge enabled, `gh stack unstack` may leave the GitHub stack and local tracking in place. If all PRs are affected, the API can return HTTP 422. Do not run `gh stack init` until the GitHub stack has disappeared; remove the PRs from the merge queue or disable auto-merge, then rerun `gh stack unstack`.
 
 ---
 
@@ -870,9 +870,9 @@ gh stack unstack --local
 
 | Code | Meaning | Agent action |
 |------|---------|-------------|
-| 0 | Success | Proceed normally |
+| 0 | Command succeeded; `gh stack sync` may still print `Sync aborted` and make no changes | Inspect stderr for `Sync aborted` before continuing; if present, stop and inspect the stack |
 | 1 | Generic error | Read stderr for details; may indicate commit/push failure |
-| 2 | Not in a stack | Run `gh stack init` to create a stack first |
+| 2 | Command-specific: not in a stack, or the specified stack was not found | For an unknown `gh stack unstack <number>`, report the missing stack and do not run `gh stack init`; otherwise initialize with explicit branch arguments only when local stack membership is required |
 | 3 | Rebase conflict | Parse stderr for conflicted file paths, resolve conflicts, run `gh stack rebase --continue` |
 | 4 | GitHub API failure | Check `gh auth status`, retry the command |
 | 5 | Invalid arguments | Fix the command invocation (check flags and arguments) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@
 | `cli`                | imager-cli コマンド開発                                                            | CLIコマンド追加・変更時                                 |
 | `git-worktree`       | git worktree を用いた並列開発ワークフロー                                          | 複数PRの同時進行時                                      |
 | `git-pr`             | ブランチ作成→コミット→push→PR作成の標準ワークフロー                                | 単一PRの作成時                                          |
+| `gh-stack`           | GitHub CLIのgh stackによる積み上げブランチ・PRの作成、同期、rebase、状態確認          | stacked PR・依存PRの管理時                              |
 | `issue-driven`       | GitHub Issue駆動開発ワークフロー（証跡・進捗管理）                                 | issueをベースに開発作業を始めるとき                     |
 | `tanstack-ssr`       | TanStack Start SSR、Selective SSR、hydration、loaderの診断と回帰防止               | F5・直接アクセス・Hydration Mismatch・SSR/CSR境界変更時 |
 | `tanstack-db`        | TanStack DBクライアントデータレイヤー（永続化、useLiveQuery、includes）            | クライアント側データレイヤー変更時                      |

--- a/REPORT.md
+++ b/REPORT.md
@@ -6,19 +6,19 @@
 
 | 項目 | 現状の原因 | 必要な実装 | V2での扱い |
 | --- | --- | --- | --- |
-| Jobs一覧・履歴・詳細 | jobs contractはイベント購読のみで、一覧取得APIがない | Job DTO、list/detail query | 専用画面の骨格と未対応状態を表示 |
-| JobのRetry / Cancel | 対応するuse caseとmutationがない | retry/cancel command、状態遷移、権限制御 | 操作をdisabled |
-| Sourceの件数・同期中状態 | `SafeMediaSource`にmedia countとsync lifecycleがない | source summary DTO、集計、sync status event | sidebarに「件数未取得」 |
-| Managerの利用件数 | Project / IP / Character一覧にmedia count等がない | 集計queryまたはsummary DTO | 取得可能な実データだけ表示 |
+| Jobs一覧・履歴・詳細 | jobs contractはイベント購読のみで、一覧取得APIがない | Job DTO、list/detail query | 既存jobsテーブルからSafe DTOで一覧・詳細を表示。SSEで更新 |
+| JobのRetry / Cancel | 対応するuse caseとmutationがない | retry/cancel command、状態遷移、権限制御 | 失敗JobのRetryを実装。Cancelは自然な状態遷移・権限制御が必要なため未対応 |
+| Sourceの件数・同期中状態 | `SafeMediaSource`にmedia countとsync lifecycleがない | source summary DTO、集計、sync status event | 既存mediaの集計件数とプロセス内の同期状態を表示。同期イベントで更新 |
+| Managerの利用件数 | Project / IP / Character一覧にmedia count等がない | 集計queryまたはsummary DTO | 既存の中間テーブルからProject / IP / Characterの利用件数を表示 |
 | Export / RestoreのJobs追跡 | 現行はHTTP download/uploadを直接実行する | job type、progress、artifact、失敗履歴 | 転送自体は実行し、Jobs連携は表示しない |
-| AI接続状態・latency | health check contractがない | typed health endpointとtimeout/error定義 | Settingsで「未確認」、確認操作をdisabled |
-| リロード後の前後メディア移動 | 詳細routeだけでは元のfilter/sort/cursorを復元できない | navigation context永続化、またはneighbor query | 前後ボタンをdisabled |
+| AI接続状態・latency | health check contractがない | typed health endpointとtimeout/error定義 | Settingsの確認操作から実際のhealth checkを実行し、状態とlatencyを表示 |
+| リロード後の前後メディア移動 | 詳細routeだけでは元のfilter/sort/cursorを復元できない | navigation context永続化、またはneighbor query | sessionStorageに最大500件の表示コンテキストを保存し、前後移動を提供。コンテキストなしではdisabled |
 
 ## Frontend follow-up
 
 | 項目 | 理由 | V2での扱い |
 | --- | --- | --- |
-| Collectionのlist表示 | 4:3 gridを先行し、listの情報設計とvirtual row実装が未着手 | toggleをdisabled |
-| Tauri route adapter | TauriはWebと別のhash routerを持つ | 今回はWebの`/v2/*`のみ。共有screenを使う薄いroute追加が必要 |
+| Collectionのlist表示 | 4:3 gridを先行し、listの情報設計とvirtual row実装が未着手 | Name / Type / Dimensions / Size / Modifiedを表示するlistへ切り替え可能 |
+| Tauri route adapter | TauriはWebと別のhash routerを持つ | 既存Tauri画面へつなぐ`/v2/*`薄いroute adapterを追加。JobsはWeb側のみ |
 
 バックエンド追加時は、無効状態を消すだけでなく、loading / error / offline / retryとリアルタイム更新まで同じ画面内で接続します。

--- a/apps/server/public/openapi.json
+++ b/apps/server/public/openapi.json
@@ -1179,6 +1179,45 @@
                               "type": "object",
                               "properties": {
                                 "event": {
+                                  "const": "source-sync-status"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "mediaSourceId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "status": {
+                                      "enum": [
+                                        "idle",
+                                        "syncing",
+                                        "error"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    },
+                                    "timestamp": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "mediaSourceId",
+                                    "status"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
                                   "const": "download-error"
                                 },
                                 "data": {
@@ -5253,6 +5292,77 @@
         }
       }
     },
+    "/ai/health": {
+      "post": {
+        "operationId": "ai.health",
+        "summary": "health",
+        "tags": [
+          "AI"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "enum": [
+                        "available",
+                        "unavailable"
+                      ],
+                      "type": "string"
+                    },
+                    "mode": {
+                      "enum": [
+                        "local",
+                        "remote"
+                      ],
+                      "type": "string"
+                    },
+                    "latencyMs": {
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "message": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "mode",
+                    "latencyMs",
+                    "message",
+                    "checkedAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ai/tag": {
       "post": {
         "operationId": "ai.tag",
@@ -6661,6 +6771,146 @@
                       "required": [
                         "event"
                       ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/jobs/list": {
+      "post": {
+        "operationId": "jobs.list",
+        "summary": "list",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "enum": [
+                      "pending",
+                      "in_progress",
+                      "completed",
+                      "failed"
+                    ],
+                    "type": "string"
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 200,
+                    "default": 50
+                  },
+                  "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991,
+                    "default": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/jobs/get": {
+      "post": {
+        "operationId": "jobs.get",
+        "summary": "get",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/jobs/retry": {
+      "post": {
+        "operationId": "jobs.retry",
+        "summary": "retry",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {},
+                    {
+                      "not": {}
                     }
                   ]
                 }

--- a/apps/server/public/openapi.json
+++ b/apps/server/public/openapi.json
@@ -6823,11 +6823,138 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "mediaSourceId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "in_progress",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "x-native-type": "date"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "x-native-type": "date"
+                          },
+                          "parentId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "error": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "targetMediaId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "progress": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "processed": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 9007199254740991
+                                  },
+                                  "failed": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 9007199254740991
+                                  },
+                                  "total": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 9007199254740991
+                                  }
+                                },
+                                "required": [
+                                  "processed",
+                                  "failed",
+                                  "total"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "mediaSourceId",
+                          "status",
+                          "createdAt",
+                          "updatedAt",
+                          "parentId",
+                          "error",
+                          "targetMediaId",
+                          "progress"
+                        ]
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
                     }
+                  },
+                  "required": [
+                    "items",
+                    "total"
                   ]
                 }
               }
@@ -6865,11 +6992,121 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "mediaSourceId": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "in_progress",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "parentId": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "error": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "targetMediaId": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "progress": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "processed": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "failed": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "total": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "processed",
+                            "failed",
+                            "total"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     }
+                  },
+                  "required": [
+                    "id",
+                    "type",
+                    "mediaSourceId",
+                    "status",
+                    "createdAt",
+                    "updatedAt",
+                    "parentId",
+                    "error",
+                    "targetMediaId",
+                    "progress"
                   ]
                 }
               }
@@ -6907,11 +7144,121 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {},
-                    {
-                      "not": {}
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "mediaSourceId": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "in_progress",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "x-native-type": "date"
+                    },
+                    "parentId": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "error": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "targetMediaId": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "progress": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "processed": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "failed": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            "total": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "processed",
+                            "failed",
+                            "total"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     }
+                  },
+                  "required": [
+                    "id",
+                    "type",
+                    "mediaSourceId",
+                    "status",
+                    "createdAt",
+                    "updatedAt",
+                    "parentId",
+                    "error",
+                    "targetMediaId",
+                    "progress"
                   ]
                 }
               }
@@ -6962,6 +7309,29 @@
                                     "processed",
                                     "total"
                                   ]
+                                }
+                              },
+                              "required": [
+                                "event",
+                                "data"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "event": {
+                                  "const": "job-retried"
+                                },
+                                "data": {
+                                  "type": "object",
+                                  "properties": {
+                                    "jobId": {
+                                      "type": "string"
+                                    },
+                                    "message": {
+                                      "type": "string"
+                                    }
+                                  }
                                 }
                               },
                               "required": [

--- a/apps/server/src/application/services/directory-sync-service.ts
+++ b/apps/server/src/application/services/directory-sync-service.ts
@@ -31,6 +31,8 @@ const sourceSyncStates =
 	syncStateGlobal.__SOLID_IMAGER_SOURCE_SYNC_STATES__ ??
 	new Map<string, SourceSyncStatus>();
 syncStateGlobal.__SOLID_IMAGER_SOURCE_SYNC_STATES__ = sourceSyncStates;
+const activeSyncs = new Map<string, Promise<SyncResult>>();
+const PublicDirectorySyncFailureMessage = "Directory sync failed";
 
 function publishSyncStatus(
 	mediaSourceId: string,
@@ -160,116 +162,135 @@ export const DirectorySyncService = {
 	 * Performs a comprehensive sync for a specific local media source.
 	 */
 	async syncMediaSource(mediaSourceId: string): Promise<SyncResult> {
-		const result: SyncResult = {
-			sourceId: mediaSourceId,
-			added: 0,
-			deleted: 0,
-		};
-		publishSyncStatus(mediaSourceId, "syncing");
-		try {
-			const source = await sourceRepo.findById(mediaSourceId);
-			if (source?.type !== "local") {
-				logger.info(
-					{ mediaSourceId },
-					"Skipping sync for non-local or missing source",
-				);
-				publishSyncStatus(
-					mediaSourceId,
-					"idle",
-					source
-						? "Source type does not support directory sync"
-						: "Source not found",
-				);
-				return result;
-			}
+		const activeSync = activeSyncs.get(mediaSourceId);
+		if (activeSync) {
+			return activeSync;
+		}
 
-			const basePath = (source.connectionInfo as { path: string }).path;
-
+		const syncPromise = (async (): Promise<SyncResult> => {
+			const result: SyncResult = {
+				sourceId: mediaSourceId,
+				added: 0,
+				deleted: 0,
+			};
+			publishSyncStatus(mediaSourceId, "syncing");
 			try {
-				await fs.access(basePath);
-			} catch {
-				logger.error(
+				const source = await sourceRepo.findById(mediaSourceId);
+				if (source?.type !== "local") {
+					logger.info(
+						{ mediaSourceId },
+						"Skipping sync for non-local or missing source",
+					);
+					publishSyncStatus(
+						mediaSourceId,
+						"idle",
+						source
+							? "Source type does not support directory sync"
+							: "Source not found",
+					);
+					return result;
+				}
+
+				const basePath = (source.connectionInfo as { path: string }).path;
+
+				try {
+					await fs.access(basePath);
+				} catch {
+					logger.error(
+						{ mediaSourceId, basePath },
+						"Base path does not exist or is not accessible during sync",
+					);
+					publishSyncStatus(
+						mediaSourceId,
+						"error",
+						"Source path is not accessible",
+					);
+					return result;
+				}
+
+				logger.info(
 					{ mediaSourceId, basePath },
-					"Base path does not exist or is not accessible during sync",
+					"Starting directory sync for source",
+				);
+
+				// 1. Get existing paths from DB
+				const existingRecords =
+					await MediaRepository.findAllPathsBySourceId(mediaSourceId);
+				const dbPathMap = new Map<string, string>(); // relativePath -> id
+				for (const record of existingRecords) {
+					// Ensure path uses POSIX separators for uniform comparison
+					const normalizedPath = record.filePath.split(path.sep).join("/");
+					dbPathMap.set(normalizedPath, record.id);
+				}
+
+				// 2. Scan the actual file system with runtime-portable Node APIs.
+				const fsPaths = await scanFiles(basePath);
+
+				const mediaExtensions = services.getConfigService().getConfig()
+					.media.supportedExtensions;
+				const allowedExts = new Set(
+					Object.values(mediaExtensions)
+						.flat()
+						.map((ext) => ext.toLowerCase()),
+				);
+
+				const actualMediaPaths = fsPaths.filter((p) => {
+					const ext = path.extname(p).toLowerCase();
+					return allowedExts.has(ext);
+				});
+				const allFilesPathSet = new Set(fsPaths);
+
+				// 3. Calculate diffs
+				const filesToAdd: string[] = [];
+				for (const p of actualMediaPaths) {
+					if (!dbPathMap.has(p)) {
+						filesToAdd.push(p.split("/").join(path.sep));
+					}
+				}
+
+				const filesToDelete: { id: string; relativePath: string }[] = [];
+				for (const [p, id] of dbPathMap.entries()) {
+					if (!allFilesPathSet.has(p)) {
+						filesToDelete.push({
+							id,
+							relativePath: p.split("/").join(path.sep),
+						});
+					}
+				}
+
+				// 4. Batch process additions
+				await processAdditions(mediaSourceId, filesToAdd, result);
+
+				// 5. Batch process deletions
+				await processDeletions(mediaSourceId, filesToDelete, result);
+
+				logger.info(
+					{ mediaSourceId, syncResult: result },
+					"Directory sync completed successfully",
+				);
+				publishSyncStatus(mediaSourceId, "idle");
+				return result;
+			} catch (error) {
+				logger.error(
+					{ err: error, mediaSourceId },
+					"Error during directory sync",
 				);
 				publishSyncStatus(
 					mediaSourceId,
 					"error",
-					"Source path is not accessible",
+					PublicDirectorySyncFailureMessage,
 				);
 				return result;
 			}
+		})();
 
-			logger.info(
-				{ mediaSourceId, basePath },
-				"Starting directory sync for source",
-			);
-
-			// 1. Get existing paths from DB
-			const existingRecords =
-				await MediaRepository.findAllPathsBySourceId(mediaSourceId);
-			const dbPathMap = new Map<string, string>(); // relativePath -> id
-			for (const record of existingRecords) {
-				// Ensure path uses POSIX separators for uniform comparison
-				const normalizedPath = record.filePath.split(path.sep).join("/");
-				dbPathMap.set(normalizedPath, record.id);
+		activeSyncs.set(mediaSourceId, syncPromise);
+		try {
+			return await syncPromise;
+		} finally {
+			if (activeSyncs.get(mediaSourceId) === syncPromise) {
+				activeSyncs.delete(mediaSourceId);
 			}
-
-			// 2. Scan the actual file system with runtime-portable Node APIs.
-			const fsPaths = await scanFiles(basePath);
-
-			const mediaExtensions = services.getConfigService().getConfig()
-				.media.supportedExtensions;
-			const allowedExts = new Set(
-				Object.values(mediaExtensions)
-					.flat()
-					.map((ext) => ext.toLowerCase()),
-			);
-
-			const actualMediaPaths = fsPaths.filter((p) => {
-				const ext = path.extname(p).toLowerCase();
-				return allowedExts.has(ext);
-			});
-			const allFilesPathSet = new Set(fsPaths);
-
-			// 3. Calculate diffs
-			const filesToAdd: string[] = [];
-			for (const p of actualMediaPaths) {
-				if (!dbPathMap.has(p)) {
-					filesToAdd.push(p.split("/").join(path.sep));
-				}
-			}
-
-			const filesToDelete: { id: string; relativePath: string }[] = [];
-			for (const [p, id] of dbPathMap.entries()) {
-				if (!allFilesPathSet.has(p)) {
-					filesToDelete.push({ id, relativePath: p.split("/").join(path.sep) });
-				}
-			}
-
-			// 4. Batch process additions
-			await processAdditions(mediaSourceId, filesToAdd, result);
-
-			// 5. Batch process deletions
-			await processDeletions(mediaSourceId, filesToDelete, result);
-
-			logger.info(
-				{ mediaSourceId, syncResult: result },
-				"Directory sync completed successfully",
-			);
-			publishSyncStatus(mediaSourceId, "idle");
-			return result;
-		} catch (error) {
-			logger.error(
-				{ err: error, mediaSourceId },
-				"Error during directory sync",
-			);
-			publishSyncStatus(
-				mediaSourceId,
-				"error",
-				error instanceof Error ? error.message : "Directory sync failed",
-			);
-			return result;
 		}
 	},
 

--- a/apps/server/src/application/services/directory-sync-service.ts
+++ b/apps/server/src/application/services/directory-sync-service.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { MediaSourceSyncState } from "@solid-imager/core/domain/sources/schemas";
 import { services } from "~/application/registry";
 import { ccipVectorService } from "~/application/services/ccip-vector-service";
 import { MediaProcessingService } from "~/application/services/media-processing-service";
@@ -16,6 +17,42 @@ type SyncResult = {
 	added: number;
 	deleted: number;
 };
+
+type SourceSyncStatus = {
+	message?: string;
+	status: MediaSourceSyncState;
+	updatedAt: Date;
+};
+
+const syncStateGlobal = globalThis as typeof globalThis & {
+	__SOLID_IMAGER_SOURCE_SYNC_STATES__?: Map<string, SourceSyncStatus>;
+};
+const sourceSyncStates =
+	syncStateGlobal.__SOLID_IMAGER_SOURCE_SYNC_STATES__ ??
+	new Map<string, SourceSyncStatus>();
+syncStateGlobal.__SOLID_IMAGER_SOURCE_SYNC_STATES__ = sourceSyncStates;
+
+function publishSyncStatus(
+	mediaSourceId: string,
+	status: MediaSourceSyncState,
+	message?: string,
+): void {
+	const updatedAt = new Date();
+	const state = { status, message, updatedAt } satisfies SourceSyncStatus;
+	sourceSyncStates.set(mediaSourceId, state);
+	RealtimeEventBus.publishSource(mediaSourceId, "source-sync-status", {
+		mediaSourceId,
+		status,
+		message,
+		timestamp: updatedAt.toISOString(),
+	});
+}
+
+export function getSourceSyncState(
+	mediaSourceId: string,
+): MediaSourceSyncState {
+	return sourceSyncStates.get(mediaSourceId)?.status ?? "idle";
+}
 
 async function scanFiles(basePath: string): Promise<string[]> {
 	const files: string[] = [];
@@ -128,12 +165,20 @@ export const DirectorySyncService = {
 			added: 0,
 			deleted: 0,
 		};
+		publishSyncStatus(mediaSourceId, "syncing");
 		try {
 			const source = await sourceRepo.findById(mediaSourceId);
 			if (source?.type !== "local") {
 				logger.info(
 					{ mediaSourceId },
 					"Skipping sync for non-local or missing source",
+				);
+				publishSyncStatus(
+					mediaSourceId,
+					"idle",
+					source
+						? "Source type does not support directory sync"
+						: "Source not found",
 				);
 				return result;
 			}
@@ -146,6 +191,11 @@ export const DirectorySyncService = {
 				logger.error(
 					{ mediaSourceId, basePath },
 					"Base path does not exist or is not accessible during sync",
+				);
+				publishSyncStatus(
+					mediaSourceId,
+					"error",
+					"Source path is not accessible",
 				);
 				return result;
 			}
@@ -207,11 +257,17 @@ export const DirectorySyncService = {
 				{ mediaSourceId, syncResult: result },
 				"Directory sync completed successfully",
 			);
+			publishSyncStatus(mediaSourceId, "idle");
 			return result;
 		} catch (error) {
 			logger.error(
 				{ err: error, mediaSourceId },
 				"Error during directory sync",
+			);
+			publishSyncStatus(
+				mediaSourceId,
+				"error",
+				error instanceof Error ? error.message : "Directory sync failed",
 			);
 			return result;
 		}

--- a/apps/server/src/components/media/legacy-media-grid-item.tsx
+++ b/apps/server/src/components/media/legacy-media-grid-item.tsx
@@ -18,6 +18,7 @@ export type ServerMediaGridItemProps = {
 	isBulkSelectMode?: boolean;
 	isSelected?: boolean;
 	onToggleSelect?: () => void;
+	onPrepareMediaDetail?: () => void;
 	onPreviewSelect?: () => void;
 };
 

--- a/apps/server/src/components/media/v2-media-grid-item.tsx
+++ b/apps/server/src/components/media/v2-media-grid-item.tsx
@@ -37,6 +37,7 @@ export function V2MediaGridItem(props: V2ServerMediaGridItemProps) {
 					!event.shiftKey &&
 					!event.altKey
 				) {
+					props.onPrepareMediaDetail?.();
 					sessionStorage.setItem("v2:media-return", location().href);
 				}
 			}}

--- a/apps/server/src/components/v2/v2-source-list.tsx
+++ b/apps/server/src/components/v2/v2-source-list.tsx
@@ -35,10 +35,17 @@ function sourceTypeLabel(source: SafeMediaSource): string {
 	return source.type === "local" ? "Local" : source.type.toUpperCase();
 }
 
+function sourceStatusLabel(source: SafeMediaSource): string {
+	if (source.syncStatus === "syncing") return "同期中";
+	if (source.syncStatus === "error") return "同期エラー";
+	return sourceTypeLabel(source);
+}
+
 function V2SourceActions(props: {
 	onDelete: () => void;
 	onEdit: () => void;
 	onSync: () => void;
+	isSyncing: boolean;
 	sourceName: string;
 }) {
 	return (
@@ -52,12 +59,13 @@ function V2SourceActions(props: {
 			<PopoverContent class="w-44 space-y-1 p-1.5">
 				<Button
 					class="h-11 w-full justify-start px-2 md:h-8"
+					disabled={props.isSyncing}
 					onClick={props.onSync}
 					size="sm"
 					variant="ghost"
 				>
 					<RefreshCw aria-hidden="true" size={14} />
-					Sync
+					{props.isSyncing ? "Syncing..." : "Sync"}
 				</Button>
 				<Button
 					class="h-11 w-full justify-start px-2 md:h-8"
@@ -144,13 +152,15 @@ export function V2SourceList(props: V2SourceListProps) {
 												{source.name}
 											</span>
 											<span class="mt-0.5 block text-[10px] text-[var(--v2-text-muted)]">
-												{sourceTypeLabel(source)} · 件数未取得
+												{sourceStatusLabel(source)} ·{" "}
+												{source.mediaCount?.toLocaleString() ?? "—"}件
 											</span>
 										</Link>
 										<V2SourceActions
 											onDelete={() => props.onDeleteSource(source)}
 											onEdit={() => props.onEditSource(source)}
 											onSync={() => props.onSyncSource(source)}
+											isSyncing={source.syncStatus === "syncing"}
 											sourceName={source.name}
 										/>
 									</div>

--- a/apps/server/src/hooks/use-media-source-events.ts
+++ b/apps/server/src/hooks/use-media-source-events.ts
@@ -17,6 +17,7 @@ export type {
 	MediaCopiedEvent,
 	MediaDeletedEvent,
 	MediaMovedEvent,
+	SourceSyncStatusEvent,
 	ThumbnailGeneratedEvent,
 	WatcherErrorEvent,
 } from "@solid-imager/ui/hooks/use-media-source-events";

--- a/apps/server/src/infrastructure/api-clients/queries/index.ts
+++ b/apps/server/src/infrastructure/api-clients/queries/index.ts
@@ -7,11 +7,13 @@ import {
 	defaultCharactersQueryConfig,
 	defaultConfigQueryConfig,
 	defaultIpsQueryConfig,
+	defaultJobsQueryConfig,
 	defaultMediaDetailsQueryConfig,
 	defaultProjectsQueryConfig,
 	defaultSourcesQueryConfig,
 	defaultTagsQueryConfig,
 	ipsQueryKeys,
+	jobsQueryKeys,
 	mediaDetailsQueryKeys,
 	projectsQueryKeys,
 	sourcesQueryKeys,
@@ -45,6 +47,11 @@ export const allIpsQueryOptions = () => ({
 	...utils.ips.list.queryOptions(),
 	queryKey: ipsQueryKeys.all(),
 	...defaultIpsQueryConfig,
+});
+export const jobsQueryOptions = (input = { limit: 200, offset: 0 }) => ({
+	...utils.jobs.list.queryOptions({ input }),
+	queryKey: jobsQueryKeys.list(input),
+	...defaultJobsQueryConfig,
 });
 export const allAuthorsQueryOptions = () => ({
 	...utils.authors.list.queryOptions(),

--- a/apps/server/src/infrastructure/api/routers/ai-router.ts
+++ b/apps/server/src/infrastructure/api/routers/ai-router.ts
@@ -8,6 +8,7 @@ import {
 import { createClient } from "@solid-imager/client";
 
 import {
+	aiHealthResponseSchema,
 	batchCcipExtractionRequestSchema,
 	batchTaggingRequestSchema,
 	batchTargetCountResponseSchema,
@@ -170,6 +171,26 @@ async function cropDetection(
 }
 
 export const aiRouter = {
+	health: os.output(aiHealthResponseSchema).handler(async () => {
+		const config = services.getConfigService().getConfig();
+		const mode = config.ai.baseUrl?.trim() ? "remote" : "local";
+		const startedAt = performance.now();
+		let available = false;
+
+		try {
+			available = await services.getAiClient().healthCheck();
+		} catch {
+			available = false;
+		}
+
+		return {
+			status: available ? "available" : "unavailable",
+			mode,
+			latencyMs: Math.max(0, Math.round(performance.now() - startedAt)),
+			message: available ? null : "AI service is unavailable",
+			checkedAt: new Date(),
+		};
+	}),
 	tag: os
 		.input(
 			z.union([

--- a/apps/server/src/infrastructure/api/routers/characters-router.ts
+++ b/apps/server/src/infrastructure/api/routers/characters-router.ts
@@ -5,12 +5,22 @@ import {
 } from "@solid-imager/core/domain/characters/schemas";
 import { z } from "zod";
 import { CharacterService } from "~/application/services/character-service";
+import { getCharacterMediaCounts } from "./entity-media-counts";
 
 /**
  * Characters Router Implementation
  */
 export const charactersRouter = {
-	list: os.handler(() => CharacterService.getAllCharacters()),
+	list: os.handler(async () => {
+		const characters = await CharacterService.getAllCharacters();
+		const mediaCounts = await getCharacterMediaCounts(
+			characters.map((character) => character.id),
+		);
+		return characters.map((character) => ({
+			...character,
+			mediaCount: mediaCounts.get(character.id) ?? 0,
+		}));
+	}),
 
 	get: os
 		.input(z.object({ id: z.string().uuid() }))

--- a/apps/server/src/infrastructure/api/routers/entity-media-counts.ts
+++ b/apps/server/src/infrastructure/api/routers/entity-media-counts.ts
@@ -1,0 +1,43 @@
+import { count, inArray } from "drizzle-orm";
+import { db } from "~/infrastructure/db";
+import {
+	mediaCharacters,
+	mediaIps,
+	mediaProjects,
+} from "~/infrastructure/db/schema";
+
+export async function getProjectMediaCounts(
+	ids: string[],
+): Promise<Map<string, number>> {
+	if (ids.length === 0) return new Map();
+	const rows = await db
+		.select({ id: mediaProjects.projectId, mediaCount: count() })
+		.from(mediaProjects)
+		.where(inArray(mediaProjects.projectId, ids))
+		.groupBy(mediaProjects.projectId);
+	return new Map(rows.map((row) => [row.id, Number(row.mediaCount)] as const));
+}
+
+export async function getIpMediaCounts(
+	ids: string[],
+): Promise<Map<string, number>> {
+	if (ids.length === 0) return new Map();
+	const rows = await db
+		.select({ id: mediaIps.ipId, mediaCount: count() })
+		.from(mediaIps)
+		.where(inArray(mediaIps.ipId, ids))
+		.groupBy(mediaIps.ipId);
+	return new Map(rows.map((row) => [row.id, Number(row.mediaCount)] as const));
+}
+
+export async function getCharacterMediaCounts(
+	ids: string[],
+): Promise<Map<string, number>> {
+	if (ids.length === 0) return new Map();
+	const rows = await db
+		.select({ id: mediaCharacters.characterId, mediaCount: count() })
+		.from(mediaCharacters)
+		.where(inArray(mediaCharacters.characterId, ids))
+		.groupBy(mediaCharacters.characterId);
+	return new Map(rows.map((row) => [row.id, Number(row.mediaCount)] as const));
+}

--- a/apps/server/src/infrastructure/api/routers/ips-router.ts
+++ b/apps/server/src/infrastructure/api/routers/ips-router.ts
@@ -1,12 +1,20 @@
 import { os } from "@orpc/server";
 import { z } from "zod";
 import { IpService } from "~/application/services/ip-service";
+import { getIpMediaCounts } from "./entity-media-counts";
 
 /**
  * IPs Router Implementation
  */
 export const ipsRouter = {
-	list: os.handler(() => IpService.getAllIps()),
+	list: os.handler(async () => {
+		const ips = await IpService.getAllIps();
+		const mediaCounts = await getIpMediaCounts(ips.map((ip) => ip.id));
+		return ips.map((ip) => ({
+			...ip,
+			mediaCount: mediaCounts.get(ip.id) ?? 0,
+		}));
+	}),
 
 	get: os
 		.input(z.object({ id: z.string().uuid() }))

--- a/apps/server/src/infrastructure/api/routers/jobs-router.ts
+++ b/apps/server/src/infrastructure/api/routers/jobs-router.ts
@@ -1,7 +1,9 @@
 import { eventIterator, ORPCError, os } from "@orpc/server";
 import {
+	jobDtoSchema,
 	jobIdRequestSchema,
 	jobListRequestSchema,
+	jobListResponseSchema,
 	jobStatusSchema,
 } from "@solid-imager/core/domain/jobs/schemas";
 import {
@@ -15,6 +17,7 @@ import { jobs } from "~/infrastructure/db/schema";
 import { RealtimeEventBus } from "~/infrastructure/events/realtime-event-bus";
 
 type JobRow = typeof jobs.$inferSelect;
+const PublicJobFailureMessage = "Job failed";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -59,7 +62,7 @@ function toJobDto(job: JobRow) {
 		createdAt: job.createdAt,
 		updatedAt: job.updatedAt,
 		parentId: job.parentId,
-		error: job.error,
+		error: job.error === null ? null : PublicJobFailureMessage,
 		targetMediaId: readTargetMediaId(job.payload),
 		progress: readProgress(job.payload),
 	};
@@ -70,59 +73,71 @@ function jobWhere(status?: z.infer<typeof jobStatusSchema>) {
 }
 
 export const jobsRouter = {
-	list: os.input(jobListRequestSchema).handler(async ({ input }) => {
-		const where = jobWhere(input.status);
-		const [rows, totalRows] = await Promise.all([
-			db
-				.select()
-				.from(jobs)
-				.where(where)
-				.orderBy(desc(jobs.createdAt), desc(jobs.id))
-				.limit(input.limit)
-				.offset(input.offset),
-			db.select({ total: count() }).from(jobs).where(where),
-		]);
+	list: os
+		.input(jobListRequestSchema)
+		.output(jobListResponseSchema)
+		.handler(async ({ input }) => {
+			const where = jobWhere(input.status);
+			const [rows, totalRows] = await Promise.all([
+				db
+					.select()
+					.from(jobs)
+					.where(where)
+					.orderBy(desc(jobs.createdAt), desc(jobs.id))
+					.limit(input.limit)
+					.offset(input.offset),
+				db.select({ total: count() }).from(jobs).where(where),
+			]);
 
-		return {
-			items: rows.map(toJobDto),
-			total: Number(totalRows[0]?.total ?? 0),
-		};
-	}),
+			return {
+				items: rows.map(toJobDto),
+				total: Number(totalRows[0]?.total ?? 0),
+			};
+		}),
 
-	get: os.input(jobIdRequestSchema).handler(async ({ input }) => {
-		const [job] = await db.select().from(jobs).where(eq(jobs.id, input.id));
-		if (!job) {
-			throw new ORPCError("NOT_FOUND", { message: "Job not found" });
-		}
-		return toJobDto(job);
-	}),
+	get: os
+		.input(jobIdRequestSchema)
+		.output(jobDtoSchema)
+		.handler(async ({ input }) => {
+			const [job] = await db.select().from(jobs).where(eq(jobs.id, input.id));
+			if (!job) {
+				throw new ORPCError("NOT_FOUND", { message: "Job not found" });
+			}
+			return toJobDto(job);
+		}),
 
-	retry: os.input(jobIdRequestSchema).handler(async ({ input }) => {
-		const [job] = await db.select().from(jobs).where(eq(jobs.id, input.id));
-		if (!job) {
-			throw new ORPCError("NOT_FOUND", { message: "Job not found" });
-		}
-		if (job.status !== "failed") {
-			throw new ORPCError("BAD_REQUEST", {
-				message: "Only failed jobs can be retried",
+	retry: os
+		.input(jobIdRequestSchema)
+		.output(jobDtoSchema)
+		.handler(async ({ input }) => {
+			const [requeued] = await db
+				.update(jobs)
+				.set({
+					status: "pending",
+					error: null,
+					result: null,
+					updatedAt: new Date(),
+				})
+				.where(and(eq(jobs.id, input.id), eq(jobs.status, "failed")))
+				.returning();
+			if (!requeued) {
+				const [current] = await db
+					.select({ id: jobs.id })
+					.from(jobs)
+					.where(eq(jobs.id, input.id));
+				if (!current) {
+					throw new ORPCError("NOT_FOUND", { message: "Job not found" });
+				}
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Only failed jobs can be retried",
+				});
+			}
+			RealtimeEventBus.publishJob("job-retried", {
+				jobId: requeued.id,
+				message: "Job queued for retry",
 			});
-		}
-
-		const [requeued] = await db
-			.update(jobs)
-			.set({
-				status: "pending",
-				error: null,
-				result: null,
-				updatedAt: new Date(),
-			})
-			.where(eq(jobs.id, input.id))
-			.returning();
-		if (!requeued) {
-			throw new ORPCError("NOT_FOUND", { message: "Job not found" });
-		}
-		return toJobDto(requeued);
-	}),
+			return toJobDto(requeued);
+		}),
 
 	events: os.output(eventIterator(jobEventSchema)).handler(async function* ({
 		signal,

--- a/apps/server/src/infrastructure/api/routers/jobs-router.ts
+++ b/apps/server/src/infrastructure/api/routers/jobs-router.ts
@@ -1,11 +1,129 @@
-import { eventIterator, os } from "@orpc/server";
+import { eventIterator, ORPCError, os } from "@orpc/server";
+import {
+	jobIdRequestSchema,
+	jobListRequestSchema,
+	jobStatusSchema,
+} from "@solid-imager/core/domain/jobs/schemas";
 import {
 	type JobEvent,
 	jobEventSchema,
 } from "@solid-imager/core/domain/sources/events";
+import { and, count, desc, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "~/infrastructure/db";
+import { jobs } from "~/infrastructure/db/schema";
 import { RealtimeEventBus } from "~/infrastructure/events/realtime-event-bus";
 
+type JobRow = typeof jobs.$inferSelect;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readNonNegativeInteger(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isInteger(value) && value >= 0
+		? value
+		: undefined;
+}
+
+function readTargetMediaId(payload: unknown): string | null {
+	if (!isRecord(payload)) {
+		return null;
+	}
+	const result = z.string().uuid().safeParse(payload.mediaId);
+	return result.success ? result.data : null;
+}
+
+function readProgress(payload: unknown) {
+	if (!isRecord(payload)) {
+		return null;
+	}
+	const processed = readNonNegativeInteger(payload.processed);
+	const total = readNonNegativeInteger(payload.total);
+	if (processed === undefined || total === undefined) {
+		return null;
+	}
+	return {
+		processed,
+		failed: readNonNegativeInteger(payload.failed) ?? 0,
+		total,
+	};
+}
+
+function toJobDto(job: JobRow) {
+	return {
+		id: job.id,
+		type: job.type,
+		mediaSourceId: job.mediaSourceId,
+		status: jobStatusSchema.parse(job.status),
+		createdAt: job.createdAt,
+		updatedAt: job.updatedAt,
+		parentId: job.parentId,
+		error: job.error,
+		targetMediaId: readTargetMediaId(job.payload),
+		progress: readProgress(job.payload),
+	};
+}
+
+function jobWhere(status?: z.infer<typeof jobStatusSchema>) {
+	return status ? and(eq(jobs.status, status)) : undefined;
+}
+
 export const jobsRouter = {
+	list: os.input(jobListRequestSchema).handler(async ({ input }) => {
+		const where = jobWhere(input.status);
+		const [rows, totalRows] = await Promise.all([
+			db
+				.select()
+				.from(jobs)
+				.where(where)
+				.orderBy(desc(jobs.createdAt), desc(jobs.id))
+				.limit(input.limit)
+				.offset(input.offset),
+			db.select({ total: count() }).from(jobs).where(where),
+		]);
+
+		return {
+			items: rows.map(toJobDto),
+			total: Number(totalRows[0]?.total ?? 0),
+		};
+	}),
+
+	get: os.input(jobIdRequestSchema).handler(async ({ input }) => {
+		const [job] = await db.select().from(jobs).where(eq(jobs.id, input.id));
+		if (!job) {
+			throw new ORPCError("NOT_FOUND", { message: "Job not found" });
+		}
+		return toJobDto(job);
+	}),
+
+	retry: os.input(jobIdRequestSchema).handler(async ({ input }) => {
+		const [job] = await db.select().from(jobs).where(eq(jobs.id, input.id));
+		if (!job) {
+			throw new ORPCError("NOT_FOUND", { message: "Job not found" });
+		}
+		if (job.status !== "failed") {
+			throw new ORPCError("BAD_REQUEST", {
+				message: "Only failed jobs can be retried",
+			});
+		}
+
+		const [requeued] = await db
+			.update(jobs)
+			.set({
+				status: "pending",
+				error: null,
+				result: null,
+				updatedAt: new Date(),
+			})
+			.where(eq(jobs.id, input.id))
+			.returning();
+		if (!requeued) {
+			throw new ORPCError("NOT_FOUND", { message: "Job not found" });
+		}
+		return toJobDto(requeued);
+	}),
+
 	events: os.output(eventIterator(jobEventSchema)).handler(async function* ({
 		signal,
 	}) {

--- a/apps/server/src/infrastructure/api/routers/projects-router.ts
+++ b/apps/server/src/infrastructure/api/routers/projects-router.ts
@@ -5,12 +5,22 @@ import {
 } from "@solid-imager/core/domain/projects/schemas";
 import { z } from "zod";
 import { ProjectService } from "~/application/services/project-service";
+import { getProjectMediaCounts } from "./entity-media-counts";
 
 /**
  * Projects Router Implementation
  */
 export const projectsRouter = {
-	list: os.handler(() => ProjectService.getAllProjects()),
+	list: os.handler(async () => {
+		const projects = await ProjectService.getAllProjects();
+		const mediaCounts = await getProjectMediaCounts(
+			projects.map((project) => project.id),
+		);
+		return projects.map((project) => ({
+			...project,
+			mediaCount: mediaCounts.get(project.id) ?? 0,
+		}));
+	}),
 
 	get: os
 		.input(z.object({ id: z.string().uuid() }))

--- a/apps/server/src/infrastructure/api/routers/sources-router.ts
+++ b/apps/server/src/infrastructure/api/routers/sources-router.ts
@@ -14,11 +14,17 @@ import {
 } from "@solid-imager/core/domain/sources/schemas";
 import { asyncPool } from "@solid-imager/core/utils/async-pool";
 import { isRecord } from "@solid-imager/core/utils/type-guards";
+import { count, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { BackupService } from "~/application/services/backup-service";
-import { DirectorySyncService } from "~/application/services/directory-sync-service";
+import {
+	DirectorySyncService,
+	getSourceSyncState,
+} from "~/application/services/directory-sync-service";
 import { MediaService } from "~/application/services/media-service";
 import { MediaSourceService } from "~/application/services/media-source-service";
+import { db } from "~/infrastructure/db";
+import { medias } from "~/infrastructure/db/schema";
 import { RealtimeEventBus } from "~/infrastructure/events/realtime-event-bus";
 import { logger } from "~/infrastructure/logger";
 import {
@@ -70,6 +76,38 @@ function toSafeMediaSource(source: MediaSource): SafeMediaSource {
 	throw new Error(`Unsupported source type: ${source.type}`);
 }
 
+async function getMediaCounts(
+	sourceIds: string[],
+): Promise<Map<string, number>> {
+	if (sourceIds.length === 0) {
+		return new Map();
+	}
+
+	const rows = await db
+		.select({ mediaCount: count(), sourceId: medias.mediaSourceId })
+		.from(medias)
+		.where(inArray(medias.mediaSourceId, sourceIds))
+		.groupBy(medias.mediaSourceId);
+
+	return new Map(
+		rows.map((row) => [row.sourceId, Number(row.mediaCount)] as const),
+	);
+}
+
+function addSourceSummary(
+	source: SafeMediaSource,
+	mediaCounts: Map<string, number>,
+): SafeMediaSource {
+	if (!source.id) {
+		return source;
+	}
+	return {
+		...source,
+		mediaCount: mediaCounts.get(source.id) ?? 0,
+		syncStatus: getSourceSyncState(source.id),
+	};
+}
+
 /**
  * Media Sources Router Implementation
  */
@@ -85,7 +123,12 @@ export const sourcesRouter = {
 		})
 		.handler(async () => {
 			const sources = await MediaSourceService.fetchSources();
-			return sources.map(toSafeMediaSource);
+			const mediaCounts = await getMediaCounts(
+				sources.map((source) => source.id),
+			);
+			return sources.map((source) =>
+				addSourceSummary(toSafeMediaSource(source), mediaCounts),
+			);
 		}),
 
 	get: os
@@ -106,7 +149,8 @@ export const sourcesRouter = {
 			if (!source) {
 				throw new Error(`Source not found: ${input.id}`);
 			}
-			return toSafeMediaSource(source);
+			const mediaCounts = await getMediaCounts([source.id]);
+			return addSourceSummary(toSafeMediaSource(source), mediaCounts);
 		}),
 
 	create: os
@@ -149,7 +193,8 @@ export const sourcesRouter = {
 					});
 			}
 
-			return toSafeMediaSource(createdSource);
+			const mediaCounts = await getMediaCounts([createdSource.id]);
+			return addSourceSummary(toSafeMediaSource(createdSource), mediaCounts);
 		}),
 
 	update: os
@@ -171,7 +216,8 @@ export const sourcesRouter = {
 				input.id,
 				input.data,
 			);
-			return toSafeMediaSource(result[0]);
+			const mediaCounts = await getMediaCounts([result[0].id]);
+			return addSourceSummary(toSafeMediaSource(result[0]), mediaCounts);
 		}),
 
 	/**

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -61,6 +61,7 @@ export type SourceMediaPageControllerProps = {
 	ssrGuard?: boolean;
 	scrollContainerSelector?: Accessor<string>;
 	onOpenMediaDetail?: SourceMediaScreenProps["onOpenMediaDetail"];
+	onPrepareMediaDetail?: SourceMediaScreenProps["onPrepareMediaDetail"];
 	renderMediaPreview?: SourceMediaScreenProps["renderMediaPreview"];
 };
 
@@ -175,6 +176,7 @@ export function SourceMediaPageController(
 					props.renderItem(media, options, () => handleToggleSelect(media.id))
 				}
 				onOpenMediaDetail={props.onOpenMediaDetail}
+				onPrepareMediaDetail={props.onPrepareMediaDetail}
 				renderMediaPreview={props.renderMediaPreview}
 				moveCopyDialogComponent={MoveCopyMediaDialog}
 				uploadModalComponent={props.uploadModalComponent}

--- a/apps/server/src/routes/sources/$mediaSourceId/components/v2-source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/v2-source-media-page.tsx
@@ -4,6 +4,7 @@ import type { Accessor } from "solid-js";
 import { ThumbnailImage } from "~/components/media/thumbnail-image";
 import { V2MediaGridItem } from "~/components/media/v2-media-grid-item";
 import { V2UploadMediaModal } from "~/components/v2-upload-media-modal";
+import { saveV2MediaContext } from "~/routes/v2/media-context";
 import {
 	SourceMediaPageController,
 	type SourceMediaPageControllerProps,
@@ -14,8 +15,9 @@ export function V2SourceMediaPage(props: { mediaSourceId?: Accessor<string> }) {
 	const navigate = useNavigate();
 
 	const onOpenMediaDetail: SourceMediaPageControllerProps["onOpenMediaDetail"] =
-		(media) => {
+		(media, context) => {
 			sessionStorage.setItem("v2:media-return", location().href);
+			saveV2MediaContext(location().href, context ?? [media]);
 			void navigate({
 				params: {
 					mediaId: media.id,
@@ -24,11 +26,17 @@ export function V2SourceMediaPage(props: { mediaSourceId?: Accessor<string> }) {
 				to: "/v2/sources/$mediaSourceId/$mediaId",
 			});
 		};
+	const onPrepareMediaDetail: SourceMediaPageControllerProps["onPrepareMediaDetail"] =
+		(media, context) => {
+			sessionStorage.setItem("v2:media-return", location().href);
+			saveV2MediaContext(location().href, context ?? [media]);
+		};
 
 	return (
 		<SourceMediaPageController
 			mediaSourceId={props.mediaSourceId}
 			onOpenMediaDetail={onOpenMediaDetail}
+			onPrepareMediaDetail={onPrepareMediaDetail}
 			persistenceSurface="v2"
 			bulkActionsClass="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] left-1/2 z-50 flex w-[calc(100%-2rem)] max-w-md -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface)] px-3 py-3 sm:bottom-[calc(1.5rem+env(safe-area-inset-bottom))] sm:w-auto sm:max-w-none sm:flex-nowrap sm:gap-3 sm:px-4"
 			renderItem={(media, options, onToggleSelect) => (
@@ -38,6 +46,7 @@ export function V2SourceMediaPage(props: { mediaSourceId?: Accessor<string> }) {
 					isSelected={options.isSelected || options.isPreviewSelected}
 					media={media}
 					onContextMenu={options.onContextMenu}
+					onPrepareMediaDetail={options.onPrepareMediaDetail}
 					onPreviewSelect={options.onPreviewSelect}
 					onToggleSelect={onToggleSelect}
 					priority={options.priority}

--- a/apps/server/src/routes/v2/config.tsx
+++ b/apps/server/src/routes/v2/config.tsx
@@ -16,6 +16,7 @@ function V2ConfigPage() {
 
 	return (
 		<V2ConfigStateScreen
+			checkAiHealth={() => orpc.ai.health()}
 			data={configQuery.data}
 			onRetry={async () => {
 				await configQuery.refetch();

--- a/apps/server/src/routes/v2/jobs.tsx
+++ b/apps/server/src/routes/v2/jobs.tsx
@@ -19,7 +19,10 @@ function V2JobsRoute() {
 
 	useJobEvents(
 		(signal) => orpc.jobs.events(undefined, { signal }),
-		() => {
+		(event) => {
+			if (event.event === "job-progress") {
+				return;
+			}
 			void queryClient.invalidateQueries({ queryKey: jobsQueryKeys.all() });
 		},
 	);

--- a/apps/server/src/routes/v2/jobs.tsx
+++ b/apps/server/src/routes/v2/jobs.tsx
@@ -1,10 +1,51 @@
+import type { JobListResponse } from "@solid-imager/core/domain/jobs/schemas";
+import { useJobEvents } from "@solid-imager/ui/hooks/use-job-events";
+import { jobsQueryKeys } from "@solid-imager/ui/query-options";
+import { toQueryUiState } from "@solid-imager/ui/query-state";
 import { V2JobsScreen } from "@solid-imager/ui/screens/v2-jobs-screen";
+import { toast } from "@solid-imager/ui/toast";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { createFileRoute } from "@tanstack/solid-router";
+import { orpc } from "~/infrastructure/api-clients/orpc-client";
+import { jobsQueryOptions } from "~/infrastructure/api-clients/queries";
 
 export const Route = createFileRoute("/v2/jobs")({
 	component: V2JobsRoute,
 });
 
 function V2JobsRoute() {
-	return <V2JobsScreen />;
+	const jobsQuery = createQuery<JobListResponse>(() => jobsQueryOptions());
+	const queryClient = useQueryClient();
+
+	useJobEvents(
+		(signal) => orpc.jobs.events(undefined, { signal }),
+		() => {
+			void queryClient.invalidateQueries({ queryKey: jobsQueryKeys.all() });
+		},
+	);
+
+	return (
+		<V2JobsScreen
+			isRefreshing={() => jobsQuery.isFetching}
+			jobs={() => jobsQuery.data?.items ?? []}
+			onRefresh={async () => {
+				await jobsQuery.refetch();
+			}}
+			onRetry={async (jobId) => {
+				try {
+					await orpc.jobs.retry({ id: jobId });
+					await queryClient.invalidateQueries({
+						queryKey: jobsQueryKeys.all(),
+					});
+					toast.success("Job queued for retry");
+				} catch (error) {
+					toast.error(
+						error instanceof Error ? error.message : "Failed to retry job",
+					);
+					throw error;
+				}
+			}}
+			state={() => toQueryUiState(jobsQuery)}
+		/>
+	);
 }

--- a/apps/server/src/routes/v2/media-context.ts
+++ b/apps/server/src/routes/v2/media-context.ts
@@ -1,0 +1,107 @@
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import {
+	mediaIdSchema,
+	mediaSourceIdSchema,
+} from "@solid-imager/core/domain/media/schemas";
+
+const STORAGE_KEY = "v2:media-context";
+const MAX_CONTEXT_ITEMS = 500;
+
+export type V2MediaContextItem = Pick<Media, "id" | "mediaSourceId">;
+
+type StoredMediaContext = {
+	items: V2MediaContextItem[];
+	returnPath: string;
+	updatedAt: number;
+};
+
+function getStorage(): Storage | null {
+	try {
+		return typeof sessionStorage === "undefined" ? null : sessionStorage;
+	} catch {
+		return null;
+	}
+}
+
+export function saveV2MediaContext(
+	returnPath: string,
+	items: readonly V2MediaContextItem[],
+): void {
+	const storage = getStorage();
+	if (!storage) return;
+
+	const uniqueItems = new Map<string, V2MediaContextItem>();
+	for (const item of items) {
+		if (
+			mediaIdSchema.safeParse(item.id).success &&
+			mediaSourceIdSchema.safeParse(item.mediaSourceId).success
+		) {
+			uniqueItems.set(item.id, {
+				id: item.id,
+				mediaSourceId: item.mediaSourceId,
+			});
+		}
+		if (uniqueItems.size >= MAX_CONTEXT_ITEMS) break;
+	}
+
+	try {
+		storage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({
+				items: [...uniqueItems.values()],
+				returnPath,
+				updatedAt: Date.now(),
+			} satisfies StoredMediaContext),
+		);
+	} catch {
+		// Session storage is an enhancement; navigation remains usable without it.
+	}
+}
+
+export function readV2MediaContext(): StoredMediaContext | null {
+	const storage = getStorage();
+	if (!storage) return null;
+
+	try {
+		const raw = storage.getItem(STORAGE_KEY);
+		if (!raw) return null;
+		const value: unknown = JSON.parse(raw);
+		if (!isRecord(value) || typeof value.returnPath !== "string") return null;
+		if (!Array.isArray(value.items)) return null;
+
+		const items = value.items.flatMap((item) => {
+			if (!isRecord(item)) return [];
+			const mediaId = mediaIdSchema.safeParse(item.id);
+			const mediaSourceId = mediaSourceIdSchema.safeParse(item.mediaSourceId);
+			return mediaId.success && mediaSourceId.success
+				? [{ id: mediaId.data, mediaSourceId: mediaSourceId.data }]
+				: [];
+		});
+		return {
+			items,
+			returnPath: value.returnPath,
+			updatedAt:
+				typeof value.updatedAt === "number" ? value.updatedAt : Date.now(),
+		};
+	} catch {
+		return null;
+	}
+}
+
+export function findV2MediaNeighbors(mediaId: string): {
+	next: V2MediaContextItem | undefined;
+	previous: V2MediaContextItem | undefined;
+} {
+	const context = readV2MediaContext();
+	if (!context) return { next: undefined, previous: undefined };
+	const index = context.items.findIndex((item) => item.id === mediaId);
+	if (index < 0) return { next: undefined, previous: undefined };
+	return {
+		next: context.items[index + 1],
+		previous: index > 0 ? context.items[index - 1] : undefined,
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/apps/server/src/routes/v2/search.tsx
+++ b/apps/server/src/routes/v2/search.tsx
@@ -31,6 +31,7 @@ import {
 	searchState,
 	setSearchState,
 } from "~/presentation/store/search-store";
+import { saveV2MediaContext } from "./media-context";
 
 const SEARCH_RESULTS_REFRESH_DEBOUNCE_MS = 300;
 const V2_SEARCH_RESULTS_PER_PAGE = 200;
@@ -103,10 +104,16 @@ function V2SearchRoute() {
 					media={media}
 					onPreviewSelect={options?.onPreviewSelect}
 					priority={options?.priority}
+					onPrepareMediaDetail={options?.onPrepareMediaDetail}
 				/>
 			)}
-			onOpenMediaDetail={(media) => {
+			onPrepareMediaDetail={(media, context) => {
 				sessionStorage.setItem("v2:media-return", location().href);
+				saveV2MediaContext(location().href, context ?? [media]);
+			}}
+			onOpenMediaDetail={(media, context) => {
+				sessionStorage.setItem("v2:media-return", location().href);
+				saveV2MediaContext(location().href, context ?? [media]);
 				void navigate({
 					params: {
 						mediaId: media.id,

--- a/apps/server/src/routes/v2/sources/$mediaSourceId/$mediaId/index.tsx
+++ b/apps/server/src/routes/v2/sources/$mediaSourceId/$mediaId/index.tsx
@@ -17,6 +17,7 @@ import {
 	mediaDetailsQueryOptions,
 	mediaSourcesQueryOptions,
 } from "~/infrastructure/api-clients/queries";
+import { findV2MediaNeighbors } from "~/routes/v2/media-context";
 
 interface MediaRouteParams {
 	mediaId: string;
@@ -47,6 +48,18 @@ function MediaDetailHeader(props: {
 	sourceName: string;
 }) {
 	const navigate = useNavigate();
+	const neighbors = () => findV2MediaNeighbors(props.media.id);
+	const navigateToNeighbor = (direction: "next" | "previous") => {
+		const neighbor = neighbors()[direction];
+		if (!neighbor) return;
+		void navigate({
+			params: {
+				mediaId: neighbor.id,
+				mediaSourceId: neighbor.mediaSourceId,
+			},
+			to: "/v2/sources/$mediaSourceId/$mediaId",
+		});
+	};
 	const returnToCollection = () => {
 		const returnPath = sessionStorage.getItem("v2:media-return");
 		if (
@@ -89,21 +102,27 @@ function MediaDetailHeader(props: {
 
 				<div
 					class="flex shrink-0 items-center rounded-md border border-[var(--v2-border)] bg-white p-0.5"
-					title="一覧コンテキストがないため前後移動は利用できません"
+					title={
+						neighbors().previous || neighbors().next
+							? "一覧の前後のメディアへ移動"
+							: "一覧コンテキストがないため前後移動は利用できません"
+					}
 				>
 					<Button
-						aria-label="前のメディア（利用不可）"
+						aria-label="前のメディア"
 						class="size-9 p-0 md:size-8"
-						disabled
+						disabled={!neighbors().previous}
+						onClick={() => navigateToNeighbor("previous")}
 						size="icon"
 						variant="ghost"
 					>
 						<ChevronLeft aria-hidden="true" size={16} />
 					</Button>
 					<Button
-						aria-label="次のメディア（利用不可）"
+						aria-label="次のメディア"
 						class="size-9 p-0 md:size-8"
-						disabled
+						disabled={!neighbors().next}
+						onClick={() => navigateToNeighbor("next")}
 						size="icon"
 						variant="ghost"
 					>

--- a/apps/server/src/routes/v2/sources/$mediaSourceId/$mediaId/index.tsx
+++ b/apps/server/src/routes/v2/sources/$mediaSourceId/$mediaId/index.tsx
@@ -57,6 +57,7 @@ function MediaDetailHeader(props: {
 				mediaId: neighbor.id,
 				mediaSourceId: neighbor.mediaSourceId,
 			},
+			replace: true,
 			to: "/v2/sources/$mediaSourceId/$mediaId",
 		});
 	};

--- a/apps/server/src/tests/unit/application/services/directory-sync-service.test.ts
+++ b/apps/server/src/tests/unit/application/services/directory-sync-service.test.ts
@@ -84,7 +84,9 @@ vi.mock("~/application/registry", () => ({
 }));
 
 import { MediaProcessingService } from "~/application/services/media-processing-service";
+import { RealtimeEventBus } from "~/infrastructure/events/realtime-event-bus";
 import { MediaRepository } from "~/infrastructure/repositories/media-repository";
+import { DrizzleSourceRepository } from "~/infrastructure/repositories/source-repository";
 
 describe("DirectorySyncService", () => {
 	beforeEach(() => {
@@ -118,6 +120,71 @@ describe("DirectorySyncService", () => {
 			// Verify deletion
 			expect(MediaRepository.delete).toHaveBeenCalledTimes(1);
 			expect(MediaRepository.delete).toHaveBeenCalledWith("id3");
+		});
+
+		it("coalesces concurrent syncs for the same source", async () => {
+			const mediaSourceId = "source-1";
+			const { DirectorySyncService } = await import(
+				"~/application/services/directory-sync-service"
+			);
+			let resolveProcessing: (() => void) | undefined;
+			let resolveStarted: (() => void) | undefined;
+			const started = new Promise<void>((resolve) => {
+				resolveStarted = resolve;
+			});
+			const processing = new Promise<void>((resolve) => {
+				resolveProcessing = resolve;
+			});
+			vi.mocked(
+				MediaProcessingService.registerAndProcess,
+			).mockImplementationOnce(async () => {
+				resolveStarted?.();
+				await processing;
+				const now = new Date();
+				return {
+					id: "media-new",
+					mediaSourceId,
+					filePath: "new_file.mp3",
+					fileName: "new_file.mp3",
+					mediaType: "audio",
+					width: 0,
+					height: 0,
+					fileSize: null,
+					description: null,
+					createdAt: now,
+					modifiedAt: now,
+					indexedAt: now,
+					status: "active",
+				};
+			});
+
+			const first = DirectorySyncService.syncMediaSource(mediaSourceId);
+			await started;
+			const second = DirectorySyncService.syncMediaSource(mediaSourceId);
+
+			expect(DrizzleSourceRepository.findById).toHaveBeenCalledTimes(1);
+			resolveProcessing?.();
+			await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+		});
+
+		it("publishes a safe message when sync fails", async () => {
+			const { DirectorySyncService } = await import(
+				"~/application/services/directory-sync-service"
+			);
+			vi.mocked(MediaRepository.findAllPathsBySourceId).mockRejectedValueOnce(
+				new Error("/secret/source-path and password=secret"),
+			);
+
+			await DirectorySyncService.syncMediaSource("source-1");
+
+			expect(RealtimeEventBus.publishSource).toHaveBeenCalledWith(
+				"source-1",
+				"source-sync-status",
+				expect.objectContaining({
+					message: "Directory sync failed",
+					status: "error",
+				}),
+			);
 		});
 	});
 });

--- a/apps/tauri/src/hooks/use-media-source-events.ts
+++ b/apps/tauri/src/hooks/use-media-source-events.ts
@@ -15,6 +15,7 @@ export type {
 	MediaCopiedEvent,
 	MediaDeletedEvent,
 	MediaMovedEvent,
+	SourceSyncStatusEvent,
 	ThumbnailGeneratedEvent,
 	WatcherErrorEvent,
 } from "@solid-imager/ui/hooks/use-media-source-events";

--- a/apps/tauri/src/routes/v2.tsx
+++ b/apps/tauri/src/routes/v2.tsx
@@ -1,0 +1,24 @@
+import {
+	createFileRoute,
+	Navigate,
+	Outlet,
+	useLocation,
+} from "@tanstack/solid-router";
+import { Show } from "solid-js";
+
+export const Route = createFileRoute("/v2")({
+	component: V2AdapterLayout,
+});
+
+function V2AdapterLayout() {
+	const location = useLocation();
+
+	return (
+		<Show
+			fallback={<Navigate replace to="/search" />}
+			when={location().pathname !== "/v2"}
+		>
+			<Outlet />
+		</Show>
+	);
+}

--- a/apps/tauri/src/routes/v2/$.tsx
+++ b/apps/tauri/src/routes/v2/$.tsx
@@ -26,16 +26,16 @@ function V2RouteAdapter() {
 
 	return (
 		<Switch fallback={<NotFoundScreen />}>
-			<Match when={first() === "search"}>
+			<Match when={first() === "search" && segments().length === 1}>
 				<Navigate replace to="/search" />
 			</Match>
-			<Match when={first() === "manager"}>
+			<Match when={first() === "manager" && segments().length === 1}>
 				<Navigate replace to="/manager" />
 			</Match>
-			<Match when={first() === "config"}>
+			<Match when={first() === "config" && segments().length === 1}>
 				<Navigate replace to="/config" />
 			</Match>
-			<Match when={first() === "about"}>
+			<Match when={first() === "about" && segments().length === 1}>
 				<Navigate replace to="/about" />
 			</Match>
 			<Match when={first() === "sources" && segments().length === 1}>
@@ -48,7 +48,7 @@ function V2RouteAdapter() {
 					to="/sources/$mediaSourceId"
 				/>
 			</Match>
-			<Match when={first() === "sources" && segments().length >= 3}>
+			<Match when={first() === "sources" && segments().length === 3}>
 				<Navigate
 					params={{
 						mediaId: segments()[2] ?? "",

--- a/apps/tauri/src/routes/v2/$.tsx
+++ b/apps/tauri/src/routes/v2/$.tsx
@@ -2,6 +2,14 @@ import { NotFoundScreen } from "@solid-imager/ui/screens/not-found-screen";
 import { createFileRoute, Navigate, useLocation } from "@tanstack/solid-router";
 import { Match, Switch } from "solid-js";
 
+function decodeSegment(segment: string): string {
+	try {
+		return decodeURIComponent(segment);
+	} catch {
+		return segment;
+	}
+}
+
 export const Route = createFileRoute("/v2/$")({
 	component: V2RouteAdapter,
 });
@@ -13,7 +21,7 @@ function V2RouteAdapter() {
 			.pathname.replace(/^\/v2\/?/, "")
 			.split("/")
 			.filter(Boolean)
-			.map((segment) => decodeURIComponent(segment));
+			.map(decodeSegment);
 	const first = () => segments()[0];
 
 	return (

--- a/apps/tauri/src/routes/v2/$.tsx
+++ b/apps/tauri/src/routes/v2/$.tsx
@@ -1,0 +1,55 @@
+import { NotFoundScreen } from "@solid-imager/ui/screens/not-found-screen";
+import { createFileRoute, Navigate, useLocation } from "@tanstack/solid-router";
+import { Match, Switch } from "solid-js";
+
+export const Route = createFileRoute("/v2/$")({
+	component: V2RouteAdapter,
+});
+
+function V2RouteAdapter() {
+	const location = useLocation();
+	const segments = () =>
+		location()
+			.pathname.replace(/^\/v2\/?/, "")
+			.split("/")
+			.filter(Boolean)
+			.map((segment) => decodeURIComponent(segment));
+	const first = () => segments()[0];
+
+	return (
+		<Switch fallback={<NotFoundScreen />}>
+			<Match when={first() === "search"}>
+				<Navigate replace to="/search" />
+			</Match>
+			<Match when={first() === "manager"}>
+				<Navigate replace to="/manager" />
+			</Match>
+			<Match when={first() === "config"}>
+				<Navigate replace to="/config" />
+			</Match>
+			<Match when={first() === "about"}>
+				<Navigate replace to="/about" />
+			</Match>
+			<Match when={first() === "sources" && segments().length === 1}>
+				<Navigate replace to="/sources" />
+			</Match>
+			<Match when={first() === "sources" && segments().length === 2}>
+				<Navigate
+					params={{ mediaSourceId: segments()[1] ?? "" }}
+					replace
+					to="/sources/$mediaSourceId"
+				/>
+			</Match>
+			<Match when={first() === "sources" && segments().length >= 3}>
+				<Navigate
+					params={{
+						mediaId: segments()[2] ?? "",
+						mediaSourceId: segments()[1] ?? "",
+					}}
+					replace
+					to="/sources/$mediaSourceId/$mediaId"
+				/>
+			</Match>
+		</Switch>
+	);
+}

--- a/packages/core/src/domain/characters/schemas.ts
+++ b/packages/core/src/domain/characters/schemas.ts
@@ -28,6 +28,7 @@ export const characterSchema = z.object({
 		.default([]),
 	createdAt: z.coerce.date(),
 	updatedAt: z.coerce.date(),
+	mediaCount: z.number().int().nonnegative().optional(),
 });
 
 export type Character = z.infer<typeof characterSchema>;

--- a/packages/core/src/domain/contract/ai.contract.ts
+++ b/packages/core/src/domain/contract/ai.contract.ts
@@ -1,6 +1,7 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
 import {
+	aiHealthResponseSchema,
 	batchCcipExtractionRequestSchema,
 	batchTaggingRequestSchema,
 	batchTargetCountResponseSchema,
@@ -19,6 +20,7 @@ import {
 } from "../tagging/schemas";
 
 export const aiContract = {
+	health: oc.output(aiHealthResponseSchema),
 	tag: oc
 		.input(
 			z.union([z.object({ file: z.instanceof(File) }), tagImageRequestSchema]),

--- a/packages/core/src/domain/contract/jobs.contract.ts
+++ b/packages/core/src/domain/contract/jobs.contract.ts
@@ -1,6 +1,15 @@
 import { eventIterator, oc } from "@orpc/contract";
+import {
+	jobDtoSchema,
+	jobIdRequestSchema,
+	jobListRequestSchema,
+	jobListResponseSchema,
+} from "../jobs/schemas";
 import { jobEventSchema } from "../sources/events";
 
 export const jobsContract = {
+	list: oc.input(jobListRequestSchema).output(jobListResponseSchema),
+	get: oc.input(jobIdRequestSchema).output(jobDtoSchema),
+	retry: oc.input(jobIdRequestSchema).output(jobDtoSchema),
 	events: oc.output(eventIterator(jobEventSchema)),
 };

--- a/packages/core/src/domain/ips/schemas.ts
+++ b/packages/core/src/domain/ips/schemas.ts
@@ -25,6 +25,7 @@ export const ipSchema = z.object({
 	source: z.string(),
 	createdAt: z.coerce.date(),
 	updatedAt: z.coerce.date(),
+	mediaCount: z.number().int().nonnegative().optional(),
 });
 
 export type Ip = z.infer<typeof ipSchema>;

--- a/packages/core/src/domain/jobs/schemas.ts
+++ b/packages/core/src/domain/jobs/schemas.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const jobStatusSchema = z.enum([
+	"pending",
+	"in_progress",
+	"completed",
+	"failed",
+]);
+export type JobStatus = z.infer<typeof jobStatusSchema>;
+
+export const jobProgressSchema = z
+	.object({
+		processed: z.number().int().nonnegative(),
+		failed: z.number().int().nonnegative(),
+		total: z.number().int().nonnegative(),
+	})
+	.nullable();
+
+/**
+ * Public job representation. Raw payload/result JSON is deliberately omitted
+ * because job payloads may contain local paths or other implementation data.
+ */
+export const jobDtoSchema = z.object({
+	id: z.string().uuid(),
+	type: z.string(),
+	mediaSourceId: z.string().uuid().nullable(),
+	status: jobStatusSchema,
+	createdAt: z.coerce.date(),
+	updatedAt: z.coerce.date(),
+	parentId: z.string().uuid().nullable(),
+	error: z.string().nullable(),
+	targetMediaId: z.string().uuid().nullable(),
+	progress: jobProgressSchema,
+});
+export type JobDto = z.infer<typeof jobDtoSchema>;
+
+export const jobListRequestSchema = z.object({
+	status: jobStatusSchema.optional(),
+	limit: z.number().int().min(1).max(200).default(50),
+	offset: z.number().int().min(0).default(0),
+});
+export type JobListRequest = z.infer<typeof jobListRequestSchema>;
+
+export const jobListResponseSchema = z.object({
+	items: z.array(jobDtoSchema),
+	total: z.number().int().nonnegative(),
+});
+export type JobListResponse = z.infer<typeof jobListResponseSchema>;
+
+export const jobIdRequestSchema = z.object({
+	id: z.string().uuid(),
+});
+export type JobIdRequest = z.infer<typeof jobIdRequestSchema>;

--- a/packages/core/src/domain/projects/schemas.ts
+++ b/packages/core/src/domain/projects/schemas.ts
@@ -21,6 +21,7 @@ export const projectSchema = z.object({
 	createdAt: z.coerce.date(),
 	updatedAt: z.coerce.date(),
 	archivedAt: z.coerce.date().nullable(),
+	mediaCount: z.number().int().nonnegative().optional(),
 });
 
 export type Project = z.infer<typeof projectSchema>;

--- a/packages/core/src/domain/sources/events.ts
+++ b/packages/core/src/domain/sources/events.ts
@@ -85,6 +85,12 @@ export const jobCompletedEventSchema = z.object({
 });
 export type JobCompletedEvent = z.infer<typeof jobCompletedEventSchema>;
 
+export const jobRetriedEventSchema = z.object({
+	jobId: z.string().optional(),
+	message: z.string().optional(),
+});
+export type JobRetriedEvent = z.infer<typeof jobRetriedEventSchema>;
+
 export const jobFailedEventSchema = z.object({
 	jobId: z.string().optional(),
 	error: z.string().optional(),
@@ -171,6 +177,7 @@ export type SourceEventCommand = {
 
 export const jobEventSchema = z.discriminatedUnion("event", [
 	z.object({ event: z.literal("job-progress"), data: jobProgressEventSchema }),
+	z.object({ event: z.literal("job-retried"), data: jobRetriedEventSchema }),
 	z.object({
 		event: z.literal("job-completed"),
 		data: jobCompletedEventSchema,

--- a/packages/core/src/domain/sources/events.ts
+++ b/packages/core/src/domain/sources/events.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { thumbnailSizeSchema } from "../thumbnails/schemas";
+import { mediaSourceSyncStateSchema } from "./schemas";
 
 const sourceScopedEventSchema = z.object({
 	mediaSourceId: z.string().uuid().optional(),
@@ -62,6 +63,14 @@ export const watcherErrorEventSchema = z.object({
 	timestamp: z.string().optional(),
 });
 export type WatcherErrorEvent = z.infer<typeof watcherErrorEventSchema>;
+
+export const sourceSyncStatusEventSchema = z.object({
+	mediaSourceId: z.string().uuid(),
+	status: mediaSourceSyncStateSchema,
+	message: z.string().optional(),
+	timestamp: z.string().optional(),
+});
+export type SourceSyncStatusEvent = z.infer<typeof sourceSyncStatusEventSchema>;
 
 export const jobProgressEventSchema = z.object({
 	jobId: z.string().optional(),
@@ -132,6 +141,10 @@ export const sourceEventSchema = z.discriminatedUnion("event", [
 	z.object({
 		event: z.literal("watcher-error"),
 		data: watcherErrorEventSchema,
+	}),
+	z.object({
+		event: z.literal("source-sync-status"),
+		data: sourceSyncStatusEventSchema,
 	}),
 	z.object({
 		event: z.literal("download-error"),

--- a/packages/core/src/domain/sources/schemas.ts
+++ b/packages/core/src/domain/sources/schemas.ts
@@ -45,6 +45,9 @@ export type ConnectionInfo = z.infer<typeof connectionInfoSchema>;
 export const mediaSourceTypeEnumSchema = z.enum(["local", "sftp", "s3"]);
 export type MediaSourceTypeEnum = z.infer<typeof mediaSourceTypeEnumSchema>;
 
+export const mediaSourceSyncStateSchema = z.enum(["idle", "syncing", "error"]);
+export type MediaSourceSyncState = z.infer<typeof mediaSourceSyncStateSchema>;
+
 export const mediaSourceInfoSchema = z.object({
 	id: z.uuid({ version: "v4" }).optional(),
 	name: z.string(),
@@ -111,6 +114,8 @@ export const safeConnectionInfoSchema = z.union([
 
 export const safeMediaSourceSchema = mediaSourceInfoSchema.extend({
 	connectionInfo: safeConnectionInfoSchema,
+	mediaCount: z.number().int().nonnegative().optional(),
+	syncStatus: mediaSourceSyncStateSchema.optional(),
 });
 
 export type SafeMediaSource = z.infer<typeof safeMediaSourceSchema>;

--- a/packages/core/src/domain/tagging/schemas.ts
+++ b/packages/core/src/domain/tagging/schemas.ts
@@ -1,5 +1,14 @@
 import { z } from "zod";
 
+export const aiHealthResponseSchema = z.object({
+	status: z.enum(["available", "unavailable"]),
+	mode: z.enum(["local", "remote"]),
+	latencyMs: z.number().int().nonnegative().nullable(),
+	message: z.string().nullable(),
+	checkedAt: z.coerce.date(),
+});
+export type AiHealthResponse = z.infer<typeof aiHealthResponseSchema>;
+
 export const oppaiOracleResponseSchema = z.object({
 	general: z.record(z.string(), z.number()),
 	rating: z.record(z.string(), z.number()),

--- a/packages/ui/src/hooks/use-batch-job-events.ts
+++ b/packages/ui/src/hooks/use-batch-job-events.ts
@@ -43,6 +43,8 @@ export function dispatchJobEvent(
 		case "job-progress":
 			handlers.handleJobProgress(event.data);
 			break;
+		case "job-retried":
+			break;
 		case "job-completed":
 			handlers.handleJobCompleted(event.data);
 			break;

--- a/packages/ui/src/hooks/use-job-events.ts
+++ b/packages/ui/src/hooks/use-job-events.ts
@@ -1,0 +1,23 @@
+import type { JobEvent } from "@solid-imager/core/domain/sources/events";
+import { createEffect, onCleanup } from "solid-js";
+import { isServer } from "solid-js/web";
+import { subscribeToEventStream } from "../event-stream";
+
+export type JobEventStreamFactory = (
+	signal: AbortSignal,
+) => Promise<AsyncIterable<JobEvent>>;
+
+export function useJobEvents(
+	openStream: JobEventStreamFactory,
+	onEvent: (event: JobEvent) => void,
+	enabled = true,
+): void {
+	createEffect(() => {
+		if (isServer || !enabled) {
+			return;
+		}
+
+		const cleanup = subscribeToEventStream(openStream, onEvent);
+		onCleanup(cleanup);
+	});
+}

--- a/packages/ui/src/hooks/use-job-events.ts
+++ b/packages/ui/src/hooks/use-job-events.ts
@@ -1,4 +1,5 @@
 import type { JobEvent } from "@solid-imager/core/domain/sources/events";
+import type { Accessor } from "solid-js";
 import { createEffect, onCleanup } from "solid-js";
 import { isServer } from "solid-js/web";
 import { subscribeToEventStream } from "../event-stream";
@@ -10,10 +11,10 @@ export type JobEventStreamFactory = (
 export function useJobEvents(
 	openStream: JobEventStreamFactory,
 	onEvent: (event: JobEvent) => void,
-	enabled = true,
+	enabled: Accessor<boolean> = () => true,
 ): void {
 	createEffect(() => {
-		if (isServer || !enabled) {
+		if (isServer || !enabled()) {
 			return;
 		}
 

--- a/packages/ui/src/hooks/use-media-source-events.ts
+++ b/packages/ui/src/hooks/use-media-source-events.ts
@@ -15,6 +15,8 @@ import {
 	mediaDeletedEventSchema,
 	mediaMovedEventSchema,
 	type SourceEvent,
+	type SourceSyncStatusEvent,
+	sourceSyncStatusEventSchema,
 	type ThumbnailGeneratedEvent,
 	thumbnailGeneratedEventSchema,
 	type WatcherErrorEvent,
@@ -33,6 +35,7 @@ export type {
 	MediaCopiedEvent,
 	MediaDeletedEvent,
 	MediaMovedEvent,
+	SourceSyncStatusEvent,
 	ThumbnailGeneratedEvent,
 	WatcherErrorEvent,
 };
@@ -87,6 +90,7 @@ export type UseMediaSourceEventsOptions = {
 	onThumbnailGenerated?: (data: ThumbnailGeneratedEvent) => void;
 	onAllJobsCompleted?: (data: AllJobsCompletedEvent) => void;
 	onWatcherError?: (data: WatcherErrorEvent) => void;
+	onSourceSyncStatus?: (data: SourceSyncStatusEvent) => void;
 	onDownloadError?: (data: DownloadErrorEvent) => void;
 };
 
@@ -208,6 +212,14 @@ export function useMediaSourceEvents(
 						watcherErrorEventSchema,
 						data,
 						options.onWatcherError,
+						event,
+					);
+					break;
+				case "source-sync-status":
+					validateAndDispatch(
+						sourceSyncStatusEventSchema,
+						data,
+						options.onSourceSyncStatus,
 						event,
 					);
 					break;

--- a/packages/ui/src/hooks/use-sources-events.ts
+++ b/packages/ui/src/hooks/use-sources-events.ts
@@ -1,6 +1,7 @@
 import {
 	allJobsCompletedEventSchema,
 	type SourceEvent,
+	sourceSyncStatusEventSchema,
 	watcherErrorEventSchema,
 } from "@solid-imager/core/domain/sources/events";
 import type { QueryClient, QueryKey } from "@tanstack/solid-query";
@@ -55,6 +56,14 @@ export function useSourcesEvents(options: UseSourcesEventsOptions): void {
 					});
 					break;
 				}
+				case "media-added":
+				case "media-deleted":
+				case "media-copied":
+				case "media-moved":
+					void options.queryClient.invalidateQueries({
+						queryKey: options.queryKey,
+					});
+					break;
 				case "watcher-error": {
 					const result = watcherErrorEventSchema.safeParse(event.data);
 					if (!result.success) {
@@ -73,6 +82,29 @@ export function useSourcesEvents(options: UseSourcesEventsOptions): void {
 					toast.error(
 						`Watcher Error for ${result.data.mediaSourceId?.slice(0, 4) ?? "unknown"}...: ${result.data.error || "Unknown error"}`,
 					);
+					break;
+				}
+				case "source-sync-status": {
+					const result = sourceSyncStatusEventSchema.safeParse(event.data);
+					if (!result.success) {
+						console.warn(
+							"[useSourcesEvents] Invalid source-sync-status payload:",
+							result.error,
+						);
+						return;
+					}
+					if (!activeSourceIds.has(result.data.mediaSourceId)) {
+						return;
+					}
+					void options.queryClient.invalidateQueries({
+						queryKey: options.queryKey,
+					});
+					if (result.data.status === "error") {
+						toast.error(
+							result.data.message ??
+								`Source sync failed for ${result.data.mediaSourceId.slice(0, 8)}`,
+						);
+					}
 					break;
 				}
 				default:

--- a/packages/ui/src/query-options/index.ts
+++ b/packages/ui/src/query-options/index.ts
@@ -19,6 +19,11 @@ export {
 	ipsQueryKeys,
 } from "./ips-query";
 export {
+	buildJobsQueryOptions,
+	defaultJobsQueryConfig,
+	jobsQueryKeys,
+} from "./jobs-query";
+export {
 	buildMediaDetailsQueryOptions,
 	defaultMediaDetailsQueryConfig,
 	mediaDetailsQueryKeys,

--- a/packages/ui/src/query-options/jobs-query.ts
+++ b/packages/ui/src/query-options/jobs-query.ts
@@ -1,0 +1,26 @@
+import type {
+	JobListRequest,
+	JobListResponse,
+} from "@solid-imager/core/domain/jobs/schemas";
+import { queryOptions } from "@tanstack/solid-query";
+
+export const jobsQueryKeys = {
+	all: () => ["jobs"] as const,
+	list: (input: JobListRequest) => ["jobs", "list", input] as const,
+	detail: (jobId: string) => ["jobs", "detail", jobId] as const,
+};
+
+export const defaultJobsQueryConfig = {
+	staleTime: 5_000,
+};
+
+export function buildJobsQueryOptions(
+	input: JobListRequest,
+	queryFn: (input: JobListRequest) => Promise<JobListResponse>,
+) {
+	return queryOptions({
+		queryKey: jobsQueryKeys.list(input),
+		queryFn: () => queryFn(input),
+		...defaultJobsQueryConfig,
+	});
+}

--- a/packages/ui/src/screens/search-screen.types.ts
+++ b/packages/ui/src/screens/search-screen.types.ts
@@ -10,6 +10,7 @@ import type { MediaGridImageLoadPolicy } from "../media-grid-item";
 export type SearchMediaItemOptions = {
 	imageLoadPolicy?: MediaGridImageLoadPolicy;
 	isPreviewSelected?: boolean;
+	onPrepareMediaDetail?: () => void;
 	onPreviewSelect?: () => void;
 	priority?: boolean;
 };

--- a/packages/ui/src/screens/source-media-screen.types.ts
+++ b/packages/ui/src/screens/source-media-screen.types.ts
@@ -22,7 +22,8 @@ export type SourceMediaScreenProps = {
 	onBulkAction?: () => void;
 	onClearSelection?: () => void;
 	onEnterBulkSelectMode?: () => void;
-	onOpenMediaDetail?: (media: Media) => void;
+	onOpenMediaDetail?: (media: Media, context?: Media[]) => void;
+	onPrepareMediaDetail?: (media: Media, context?: Media[]) => void;
 	onRetryFilters: () => void | Promise<void>;
 	onToggleSelect?: (mediaId: string) => void;
 	page: UseSourceMediaPageResult;
@@ -35,6 +36,7 @@ export type SourceMediaScreenProps = {
 			isPreviewSelected?: boolean;
 			isSelected?: boolean;
 			onContextMenu: () => void;
+			onPrepareMediaDetail?: () => void;
 			onPreviewSelect?: () => void;
 			priority?: boolean;
 		},

--- a/packages/ui/src/screens/v2-config-screen.tsx
+++ b/packages/ui/src/screens/v2-config-screen.tsx
@@ -1,5 +1,6 @@
 import type { AppConfig } from "@solid-imager/core/domain/config/config-schema";
 import { AppConfigSchema } from "@solid-imager/core/domain/config/config-schema";
+import type { AiHealthResponse } from "@solid-imager/core/domain/tagging/schemas";
 import { createForm } from "@tanstack/solid-form";
 // biome-ignore lint/suspicious/noDeprecatedImports: the object overload used below is current; TanStack's legacy overload annotation marks the re-export.
 import { useBlocker } from "@tanstack/solid-router";
@@ -78,6 +79,7 @@ function parseNumberInput(val: string): number | undefined {
 	return val === "" || Number.isNaN(n) ? undefined : n;
 }
 export type V2ConfigScreenProps = {
+	checkAiHealth: () => Promise<AiHealthResponse>;
 	data: AppConfig;
 	onSubmit: (value: Partial<AppConfig>) => Promise<void>;
 	onSubmitSuccess?: () => void;
@@ -85,6 +87,9 @@ export type V2ConfigScreenProps = {
 
 export function V2ConfigScreen(props: V2ConfigScreenProps) {
 	const [activeTab, setActiveTab] = createSignal("jobs");
+	const [aiHealth, setAiHealth] = createSignal<AiHealthResponse | null>(null);
+	const [aiHealthError, setAiHealthError] = createSignal<string | null>(null);
+	const [isCheckingAiHealth, setIsCheckingAiHealth] = createSignal(false);
 	const [submitError, setSubmitError] = createSignal<string | null>(null);
 	const sectionClass = "space-y-5 border-b border-[var(--v2-border)] pb-8";
 	const form = createForm(() => ({
@@ -113,6 +118,21 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 		enableBeforeUnload: () => form.state.isDirty,
 		withResolver: true,
 	});
+	const checkAiHealth = async () => {
+		if (isCheckingAiHealth()) return;
+		setIsCheckingAiHealth(true);
+		setAiHealthError(null);
+		try {
+			setAiHealth(await props.checkAiHealth());
+		} catch (error) {
+			setAiHealth(null);
+			setAiHealthError(
+				error instanceof Error ? error.message : "Health check failed",
+			);
+		} finally {
+			setIsCheckingAiHealth(false);
+		}
+	};
 
 	createEffect(() => {
 		const data = props.data;
@@ -280,12 +300,43 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 							<div class="flex flex-wrap items-center justify-between gap-3 rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface-muted)] px-3 py-2.5">
 								<div>
 									<div class="font-medium text-sm">Connection status</div>
-									<div class="text-[var(--v2-text-muted)] text-xs">
-										Health check API is not available yet.
-									</div>
+									<Show
+										fallback={
+											<div class="text-[var(--v2-text-muted)] text-xs">
+												{aiHealthError() ?? "Not checked yet."}
+											</div>
+										}
+										when={aiHealth()}
+									>
+										{(health) => (
+											<div
+												class={
+													health().status === "available"
+														? "text-emerald-700 text-xs dark:text-emerald-300"
+														: "text-red-700 text-xs dark:text-red-300"
+												}
+												role="status"
+											>
+												{health().status === "available"
+													? `${health().mode === "remote" ? "Remote" : "Local"} service available`
+													: (health().message ?? "AI service unavailable")}
+												<Show when={health().latencyMs !== null}>
+													<span class="ml-2 text-[var(--v2-text-muted)]">
+														{health().latencyMs} ms
+													</span>
+												</Show>
+											</div>
+										)}
+									</Show>
 								</div>
-								<Button disabled size="sm" variant="outline">
-									Not checked
+								<Button
+									aria-busy={isCheckingAiHealth()}
+									disabled={isCheckingAiHealth()}
+									onClick={() => void checkAiHealth()}
+									size="sm"
+									variant="outline"
+								>
+									{isCheckingAiHealth() ? "Checking..." : "Check now"}
 								</Button>
 							</div>
 							<form.Field name="ai.baseUrl">

--- a/packages/ui/src/screens/v2-config-state-screen.tsx
+++ b/packages/ui/src/screens/v2-config-state-screen.tsx
@@ -1,3 +1,4 @@
+import type { AiHealthResponse } from "@solid-imager/core/domain/tagging/schemas";
 import { Match, Show, Switch } from "solid-js";
 import { ErrorState, OfflineState, QueryStatus } from "../async-state";
 import { ConfigSkeleton, LoadingRegion } from "../skeleton";
@@ -6,7 +7,11 @@ import { V2ManagementHeader } from "../v2/management-layout";
 import type { ConfigStateScreenProps } from "./config-state-screen.types";
 import { V2ConfigScreen } from "./v2-config-screen";
 
-export function V2ConfigStateScreen(props: ConfigStateScreenProps) {
+export type V2ConfigStateScreenProps = ConfigStateScreenProps & {
+	checkAiHealth: () => Promise<AiHealthResponse>;
+};
+
+export function V2ConfigStateScreen(props: V2ConfigStateScreenProps) {
 	const hasData = () => props.data !== undefined;
 
 	return (
@@ -35,6 +40,7 @@ export function V2ConfigStateScreen(props: ConfigStateScreenProps) {
 					<Match when={props.data}>
 						{(data) => (
 							<V2ConfigScreen
+								checkAiHealth={props.checkAiHealth}
 								data={data()}
 								onSubmit={props.onSubmit}
 								onSubmitSuccess={props.onSubmitSuccess}

--- a/packages/ui/src/screens/v2-jobs-screen.tsx
+++ b/packages/ui/src/screens/v2-jobs-screen.tsx
@@ -1,13 +1,19 @@
-import Ban from "lucide-solid/icons/ban";
+import type {
+	JobDto,
+	JobListResponse,
+} from "@solid-imager/core/domain/jobs/schemas";
 import CircleAlert from "lucide-solid/icons/circle-alert";
 import CircleCheck from "lucide-solid/icons/circle-check";
 import Clock3 from "lucide-solid/icons/clock-3";
 import RefreshCw from "lucide-solid/icons/refresh-cw";
 import RotateCcw from "lucide-solid/icons/rotate-ccw";
-import { createSignal, For } from "solid-js";
+import type { Accessor } from "solid-js";
+import { createMemo, createSignal, For, Match, Show, Switch } from "solid-js";
+import { EmptyState, ErrorState, OfflineState } from "../async-state";
 import { Badge } from "../badge";
 import { Button } from "../button";
-import { Card, CardContent } from "../card";
+import type { QueryUiState } from "../query-state";
+import { LoadingRegion } from "../skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../tabs";
 import {
 	V2_CATEGORY_TABS_CLASS,
@@ -37,36 +43,189 @@ const JOB_FILTERS = [
 	},
 ] as const;
 
-function JobsUnavailableState(props: { filterLabel: string }) {
+type JobFilter = (typeof JOB_FILTERS)[number]["value"];
+
+export type V2JobsScreenProps = {
+	isRefreshing: Accessor<boolean>;
+	jobs: Accessor<JobDto[]>;
+	onRefresh: () => void | Promise<void>;
+	onRetry: (jobId: string) => void | Promise<void>;
+	state: Accessor<QueryUiState<JobListResponse>>;
+};
+
+const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
+	dateStyle: "medium",
+	timeStyle: "short",
+});
+
+function formatDate(value: Date): string {
+	return dateFormatter.format(value);
+}
+
+function jobTypeLabel(type: string): string {
+	return type
+		.replaceAll("_", " ")
+		.replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function statusLabel(status: JobDto["status"]): string {
+	return {
+		completed: "Completed",
+		failed: "Failed",
+		in_progress: "In progress",
+		pending: "Pending",
+	}[status];
+}
+
+function statusClass(status: JobDto["status"]): string {
+	return {
+		completed:
+			"border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
+		failed:
+			"border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300",
+		in_progress:
+			"border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300",
+		pending:
+			"border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300",
+	}[status];
+}
+
+function JobStatusBadge(props: { status: JobDto["status"] }) {
 	return (
-		<Card class="rounded-md border-[var(--v2-border)] border-dashed bg-[var(--v2-surface)] shadow-none">
-			<CardContent class="flex min-h-64 flex-col items-center justify-center px-5 py-10 text-center">
-				<span class="flex size-11 items-center justify-center rounded-full bg-[var(--v2-surface-muted)] text-[var(--v2-text-muted)]">
-					<Clock3 aria-hidden="true" size={20} />
-				</span>
-				<h2 class="mt-4 font-semibold text-base text-[var(--v2-text)]">
-					{props.filterLabel} jobsはまだ表示できません
-				</h2>
-				<p class="mt-2 max-w-xl text-sm leading-6 text-[var(--v2-text-secondary)]">
-					現在のバックエンドはジョブイベントのみを配信しており、一覧・詳細・履歴を取得するAPIは未実装です。
-					実データを取得できるようになるまで、この画面では状態を推測して表示しません。
-				</p>
-				<Badge
-					class="mt-4 border-[var(--v2-border-strong)] bg-[var(--v2-surface-muted)] text-[var(--v2-text-secondary)]"
-					variant="outline"
-				>
-					Backend support required
-				</Badge>
-			</CardContent>
-		</Card>
+		<Badge class={statusClass(props.status)} variant="outline">
+			{statusLabel(props.status)}
+		</Badge>
 	);
 }
 
-function JobsInspectorPlaceholder() {
+function JobProgress(props: { progress: JobDto["progress"] }) {
+	const percent = () => {
+		if (!props.progress || props.progress.total === 0) return 0;
+		return Math.min(
+			100,
+			Math.round((props.progress.processed / props.progress.total) * 100),
+		);
+	};
+
+	return (
+		<Show
+			fallback={<span class="text-[var(--v2-text-muted)]">—</span>}
+			when={props.progress}
+		>
+			{(progress) => (
+				<div class="min-w-28 space-y-1">
+					<div class="flex items-center justify-between gap-2 text-xs">
+						<span>{percent()}%</span>
+						<span class="text-[var(--v2-text-muted)]">
+							{progress().processed.toLocaleString()}/
+							{progress().total.toLocaleString()}
+						</span>
+					</div>
+					<div
+						aria-label={`${percent()}% complete`}
+						aria-valuemax="100"
+						aria-valuemin="0"
+						aria-valuenow={percent()}
+						class="h-1.5 overflow-hidden rounded-full bg-[var(--v2-border)]"
+						role="progressbar"
+					>
+						<div
+							class="h-full rounded-full bg-[var(--v2-primary)] transition-[width]"
+							style={{ width: `${percent()}%` }}
+						/>
+					</div>
+				</div>
+			)}
+		</Show>
+	);
+}
+
+function JobsTable(props: {
+	jobs: JobDto[];
+	onSelect: (job: JobDto) => void;
+	selectedJobId: string | null;
+}) {
+	return (
+		<div class="overflow-hidden rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface)]">
+			<div class="overflow-x-auto">
+				<table class="w-full min-w-[48rem] text-left text-sm">
+					<thead class="border-[var(--v2-border)] border-b bg-[var(--v2-surface-muted)] text-xs uppercase tracking-wide">
+						<tr>
+							<th class="px-4 py-3 font-medium">Type</th>
+							<th class="px-4 py-3 font-medium">Status</th>
+							<th class="px-4 py-3 font-medium">Progress</th>
+							<th class="px-4 py-3 font-medium">Updated</th>
+						</tr>
+					</thead>
+					<tbody class="divide-y divide-[var(--v2-border)]">
+						<For each={props.jobs}>
+							{(job) => (
+								<tr
+									class={
+										props.selectedJobId === job.id
+											? "bg-[var(--v2-primary-soft)]"
+											: ""
+									}
+									data-selected={props.selectedJobId === job.id}
+								>
+									<td class="px-2 py-2">
+										<button
+											class="w-full rounded px-2 py-2 text-left font-medium text-[var(--v2-text)] hover:bg-[var(--v2-surface-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-primary)]"
+											onClick={() => props.onSelect(job)}
+											type="button"
+										>
+											<div>{jobTypeLabel(job.type)}</div>
+											<div class="mt-0.5 font-normal text-[var(--v2-text-muted)] text-xs">
+												{job.id.slice(0, 8)}
+											</div>
+										</button>
+									</td>
+									<td class="px-4 py-3">
+										<JobStatusBadge status={job.status} />
+									</td>
+									<td class="px-4 py-3">
+										<JobProgress progress={job.progress} />
+									</td>
+									<td class="px-4 py-3 whitespace-nowrap text-[var(--v2-text-secondary)]">
+										{formatDate(job.updatedAt)}
+									</td>
+								</tr>
+							)}
+						</For>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+}
+
+function JobsInspector(props: {
+	class?: string;
+	job: JobDto | undefined;
+	onRetry: (jobId: string) => void | Promise<void>;
+}) {
+	const [isRetrying, setIsRetrying] = createSignal(false);
+
+	const retry = async () => {
+		const job = props.job;
+		if (job?.status !== "failed" || isRetrying()) return;
+		setIsRetrying(true);
+		try {
+			await props.onRetry(job.id);
+		} catch {
+			// The route reports mutation failures; keep the selected job visible.
+		} finally {
+			setIsRetrying(false);
+		}
+	};
+
 	return (
 		<aside
 			aria-label="Job details"
-			class="hidden min-h-0 overflow-y-auto overscroll-contain border-[var(--v2-border)] border-l bg-[var(--v2-surface-subtle)] p-5 [scrollbar-gutter:stable] xl:block"
+			class={
+				props.class ??
+				"hidden min-h-0 overflow-y-auto overscroll-contain border-[var(--v2-border)] border-l bg-[var(--v2-surface-subtle)] p-5 [scrollbar-gutter:stable] xl:block"
+			}
 		>
 			<div class="flex items-start justify-between gap-3">
 				<div>
@@ -75,75 +234,164 @@ function JobsInspectorPlaceholder() {
 						Job details
 					</h2>
 				</div>
-				<Badge
-					class="border-[var(--v2-border-strong)] text-[var(--v2-text-muted)]"
-					variant="outline"
-				>
-					Unavailable
-				</Badge>
+				<Show when={props.job}>
+					{(job) => <JobStatusBadge status={job().status} />}
+				</Show>
 			</div>
 
-			<p class="mt-3 text-sm leading-6 text-[var(--v2-text-secondary)]">
-				一覧APIの実装後、選択したジョブの進捗・対象・失敗理由をここに表示します。
-			</p>
+			<Show
+				fallback={
+					<p class="mt-3 text-sm leading-6 text-[var(--v2-text-secondary)]">
+						一覧からジョブを選択すると、対象と実行状態を表示します。
+					</p>
+				}
+				when={props.job}
+			>
+				{(job) => (
+					<>
+						<p class="mt-3 font-medium text-sm text-[var(--v2-text)]">
+							{jobTypeLabel(job().type)}
+						</p>
+						<dl class="mt-5 space-y-3 border-[var(--v2-border)] border-y py-4 text-xs">
+							<div class="flex justify-between gap-3">
+								<dt class="text-[var(--v2-text-muted)]">Status</dt>
+								<dd class="text-right text-[var(--v2-text-secondary)]">
+									{statusLabel(job().status)}
+								</dd>
+							</div>
+							<div class="flex justify-between gap-3">
+								<dt class="text-[var(--v2-text-muted)]">Source</dt>
+								<dd class="max-w-40 truncate text-right text-[var(--v2-text-secondary)]">
+									{job().mediaSourceId?.slice(0, 8) ?? "—"}
+								</dd>
+							</div>
+							<div class="flex justify-between gap-3">
+								<dt class="text-[var(--v2-text-muted)]">Created</dt>
+								<dd class="text-right text-[var(--v2-text-secondary)]">
+									{formatDate(job().createdAt)}
+								</dd>
+							</div>
+							<div class="flex justify-between gap-3">
+								<dt class="text-[var(--v2-text-muted)]">Updated</dt>
+								<dd class="text-right text-[var(--v2-text-secondary)]">
+									{formatDate(job().updatedAt)}
+								</dd>
+							</div>
+							<div class="flex justify-between gap-3">
+								<dt class="text-[var(--v2-text-muted)]">Target</dt>
+								<dd class="max-w-40 truncate text-right text-[var(--v2-text-secondary)]">
+									{job().targetMediaId?.slice(0, 8) ?? "—"}
+								</dd>
+							</div>
+							<div class="flex justify-between gap-3">
+								<dt class="text-[var(--v2-text-muted)]">Job ID</dt>
+								<dd class="max-w-40 truncate text-right text-[var(--v2-text-secondary)]">
+									{job().id}
+								</dd>
+							</div>
+						</dl>
 
-			<dl class="mt-5 space-y-3 border-[var(--v2-border)] border-y py-4 text-xs">
-				<div class="flex justify-between gap-3">
-					<dt class="text-[var(--v2-text-muted)]">Status</dt>
-					<dd class="text-[var(--v2-text-secondary)]">—</dd>
-				</div>
-				<div class="flex justify-between gap-3">
-					<dt class="text-[var(--v2-text-muted)]">Source</dt>
-					<dd class="text-[var(--v2-text-secondary)]">—</dd>
-				</div>
-				<div class="flex justify-between gap-3">
-					<dt class="text-[var(--v2-text-muted)]">Started</dt>
-					<dd class="text-[var(--v2-text-secondary)]">—</dd>
-				</div>
-				<div class="flex justify-between gap-3">
-					<dt class="text-[var(--v2-text-muted)]">Job ID</dt>
-					<dd class="text-[var(--v2-text-secondary)]">—</dd>
-				</div>
-			</dl>
+						<Show when={job().progress}>
+							{(progress) => (
+								<div class="mt-4">
+									<p class="mb-2 text-xs text-[var(--v2-text-muted)]">
+										Progress
+									</p>
+									<JobProgress progress={progress()} />
+								</div>
+							)}
+						</Show>
 
-			<div class="mt-5 rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface-muted)] p-3">
-				<div class="flex items-start gap-2 text-sm text-[var(--v2-text-secondary)]">
-					<CircleAlert aria-hidden="true" class="mt-0.5 shrink-0" size={16} />
-					<p>再実行とキャンセル用APIも未実装のため、操作は無効です。</p>
-				</div>
-			</div>
+						<Show when={job().error}>
+							{(error) => (
+								<div class="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
+									<div class="flex items-start gap-2">
+										<CircleAlert
+											aria-hidden="true"
+											class="mt-0.5 shrink-0"
+											size={16}
+										/>
+										<p class="break-words">{error()}</p>
+									</div>
+								</div>
+							)}
+						</Show>
 
-			<div class="mt-4 space-y-2">
-				<Button class="w-full" disabled variant="outline">
-					<RotateCcw aria-hidden="true" size={15} />
-					Retry job
-				</Button>
-				<Button class="w-full" disabled variant="outline">
-					<Ban aria-hidden="true" size={15} />
-					Cancel job
-				</Button>
-			</div>
+						<div class="mt-5 space-y-2">
+							<Show
+								fallback={
+									<p class="text-xs leading-5 text-[var(--v2-text-muted)]">
+										再実行できるのは失敗したジョブのみです。
+									</p>
+								}
+								when={job().status === "failed"}
+							>
+								<Button
+									aria-busy={isRetrying()}
+									class="w-full"
+									disabled={isRetrying()}
+									onClick={() => void retry()}
+									variant="outline"
+								>
+									<RotateCcw aria-hidden="true" size={15} />
+									{isRetrying() ? "Retrying..." : "Retry job"}
+								</Button>
+							</Show>
+						</div>
+					</>
+				)}
+			</Show>
 		</aside>
 	);
 }
 
-export function V2JobsScreen() {
-	const [activeFilter, setActiveFilter] = createSignal("all");
+export function V2JobsScreen(props: V2JobsScreenProps) {
+	const [activeFilter, setActiveFilter] = createSignal<JobFilter>("all");
+	const [selectedJobId, setSelectedJobId] = createSignal<string | null>(null);
+
+	const selectedJob = createMemo(() =>
+		props.jobs().find((job) => job.id === selectedJobId()),
+	);
+	const filteredJobs = createMemo(() => {
+		const jobs = props.jobs();
+		switch (activeFilter()) {
+			case "active":
+				return jobs.filter(
+					(job) => job.status === "pending" || job.status === "in_progress",
+				);
+			case "completed":
+				return jobs.filter((job) => job.status === "completed");
+			case "failed":
+				return jobs.filter((job) => job.status === "failed");
+			default:
+				return jobs;
+		}
+	});
+	const refresh = async () => {
+		await props.onRefresh();
+	};
 
 	return (
 		<section class="flex h-full min-h-0 min-w-0 flex-col bg-[var(--v2-canvas)]">
 			<V2ManagementHeader
 				actions={
 					<div class="flex items-center gap-2">
-						<Badge
-							class="border-[var(--v2-warning)] bg-[var(--v2-warning-surface)] text-[var(--v2-warning)]"
+						<Show when={props.state().data}>
+							{(data) => (
+								<span class="hidden text-xs text-[var(--v2-text-muted)] sm:inline">
+									{data().total.toLocaleString()} jobs
+								</span>
+							)}
+						</Show>
+						<Button
+							aria-busy={props.isRefreshing()}
+							disabled={props.isRefreshing()}
+							onClick={() => void refresh()}
+							size="sm"
 							variant="outline"
 						>
-							History API unavailable
-						</Badge>
-						<Button disabled size="sm" variant="outline">
 							<RefreshCw aria-hidden="true" size={14} />
-							Refresh
+							{props.isRefreshing() ? "Refreshing..." : "Refresh"}
 						</Button>
 					</div>
 				}
@@ -153,7 +401,10 @@ export function V2JobsScreen() {
 
 			<div class="grid min-h-0 flex-1 xl:grid-cols-[minmax(0,1fr)_22rem]">
 				<div class="min-h-0 overflow-y-auto overscroll-contain px-3 py-4 sm:px-4 lg:px-6 lg:py-5 xl:px-8 [scrollbar-gutter:stable]">
-					<Tabs onChange={setActiveFilter} value={activeFilter()}>
+					<Tabs
+						onChange={(value) => setActiveFilter(value as JobFilter)}
+						value={activeFilter()}
+					>
 						<div class="grid gap-6 lg:grid-cols-[12rem_minmax(0,1fr)] xl:gap-8">
 							<TabsList
 								aria-label="Job status filter"
@@ -182,7 +433,66 @@ export function V2JobsScreen() {
 								<For each={JOB_FILTERS}>
 									{(filter) => (
 										<TabsContent class="mt-0" value={filter.value}>
-											<JobsUnavailableState filterLabel={filter.label} />
+											<Switch>
+												<Match when={props.state().phase === "pending"}>
+													<LoadingRegion label="ジョブ一覧を読み込んでいます...">
+														<div class="h-64 rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface)]" />
+													</LoadingRegion>
+												</Match>
+												<Match when={props.state().phase === "error"}>
+													<ErrorState
+														description="接続を確認して、もう一度お試しください。"
+														onRetry={refresh}
+														title="ジョブ一覧を取得できませんでした"
+													/>
+												</Match>
+												<Match when={props.state().phase === "offline"}>
+													<OfflineState
+														description="接続が戻ったら再試行してください。"
+														onRetry={refresh}
+													/>
+												</Match>
+												<Match
+													when={
+														props.state().phase === "data" ||
+														props.state().phase === "empty"
+													}
+												>
+													<Show
+														fallback={
+															<EmptyState
+																description="ジョブが作成されると、ここに実行状態が表示されます。"
+																title={`${filter.label} jobsはありません`}
+															/>
+														}
+														when={filteredJobs().length > 0}
+													>
+														<JobsTable
+															jobs={filteredJobs()}
+															onSelect={(job) => setSelectedJobId(job.id)}
+															selectedJobId={selectedJobId()}
+														/>
+														<Show when={props.state().data?.total}>
+															{(total) => (
+																<p class="mt-3 text-xs text-[var(--v2-text-muted)]">
+																	Showing{" "}
+																	{filteredJobs().length.toLocaleString()} of{" "}
+																	{total().toLocaleString()} jobs
+																</p>
+															)}
+														</Show>
+														<Show when={selectedJob()}>
+															{(job) => (
+																<JobsInspector
+																	class="mt-4 rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface-subtle)] p-4 xl:hidden"
+																	job={job()}
+																	onRetry={props.onRetry}
+																/>
+															)}
+														</Show>
+													</Show>
+												</Match>
+											</Switch>
 										</TabsContent>
 									)}
 								</For>
@@ -191,7 +501,7 @@ export function V2JobsScreen() {
 					</Tabs>
 				</div>
 
-				<JobsInspectorPlaceholder />
+				<JobsInspector job={selectedJob()} onRetry={props.onRetry} />
 			</div>
 		</section>
 	);

--- a/packages/ui/src/screens/v2-jobs-screen.tsx
+++ b/packages/ui/src/screens/v2-jobs-screen.tsx
@@ -20,6 +20,7 @@ import {
 	V2CategoryLabel,
 	V2ManagementHeader,
 } from "../v2/management-layout";
+import { formatDate } from "./v2-manager/utils";
 
 const JOB_FILTERS = [
 	{ description: "すべての処理", icon: Clock3, label: "All", value: "all" },
@@ -52,15 +53,6 @@ export type V2JobsScreenProps = {
 	onRetry: (jobId: string) => void | Promise<void>;
 	state: Accessor<QueryUiState<JobListResponse>>;
 };
-
-const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
-	dateStyle: "medium",
-	timeStyle: "short",
-});
-
-function formatDate(value: Date): string {
-	return dateFormatter.format(value);
-}
 
 function jobTypeLabel(type: string): string {
 	return type
@@ -149,12 +141,23 @@ function JobsTable(props: {
 		<div class="overflow-hidden rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface)]">
 			<div class="overflow-x-auto">
 				<table class="w-full min-w-[48rem] text-left text-sm">
+					<caption class="sr-only">
+						ジョブの一覧。{props.jobs.length}件。
+					</caption>
 					<thead class="border-[var(--v2-border)] border-b bg-[var(--v2-surface-muted)] text-xs uppercase tracking-wide">
 						<tr>
-							<th class="px-4 py-3 font-medium">Type</th>
-							<th class="px-4 py-3 font-medium">Status</th>
-							<th class="px-4 py-3 font-medium">Progress</th>
-							<th class="px-4 py-3 font-medium">Updated</th>
+							<th class="px-4 py-3 font-medium" scope="col">
+								Type
+							</th>
+							<th class="px-4 py-3 font-medium" scope="col">
+								Status
+							</th>
+							<th class="px-4 py-3 font-medium" scope="col">
+								Progress
+							</th>
+							<th class="px-4 py-3 font-medium" scope="col">
+								Updated
+							</th>
 						</tr>
 					</thead>
 					<tbody class="divide-y divide-[var(--v2-border)]">
@@ -170,6 +173,7 @@ function JobsTable(props: {
 								>
 									<td class="px-2 py-2">
 										<button
+											aria-pressed={props.selectedJobId === job.id}
 											class="w-full rounded px-2 py-2 text-left font-medium text-[var(--v2-text)] hover:bg-[var(--v2-surface-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-primary)]"
 											onClick={() => props.onSelect(job)}
 											type="button"
@@ -187,7 +191,7 @@ function JobsTable(props: {
 										<JobProgress progress={job.progress} />
 									</td>
 									<td class="px-4 py-3 whitespace-nowrap text-[var(--v2-text-secondary)]">
-										{formatDate(job.updatedAt)}
+										{formatDate(job.updatedAt, { includeTime: true })}
 									</td>
 								</tr>
 							)}
@@ -268,13 +272,13 @@ function JobsInspector(props: {
 							<div class="flex justify-between gap-3">
 								<dt class="text-[var(--v2-text-muted)]">Created</dt>
 								<dd class="text-right text-[var(--v2-text-secondary)]">
-									{formatDate(job().createdAt)}
+									{formatDate(job().createdAt, { includeTime: true })}
 								</dd>
 							</div>
 							<div class="flex justify-between gap-3">
 								<dt class="text-[var(--v2-text-muted)]">Updated</dt>
 								<dd class="text-right text-[var(--v2-text-secondary)]">
-									{formatDate(job().updatedAt)}
+									{formatDate(job().updatedAt, { includeTime: true })}
 								</dd>
 							</div>
 							<div class="flex justify-between gap-3">

--- a/packages/ui/src/screens/v2-manager/entity-panel.tsx
+++ b/packages/ui/src/screens/v2-manager/entity-panel.tsx
@@ -88,6 +88,12 @@ function EntityInspector(props: {
 						</dd>
 					</div>
 				</Show>
+				<div class="grid grid-cols-[5rem_minmax(0,1fr)] gap-3">
+					<dt class="text-[var(--v2-text-muted)]">Media</dt>
+					<dd class="text-[var(--v2-text)]">
+						{props.item.mediaCount?.toLocaleString() ?? "—"}
+					</dd>
+				</div>
 			</dl>
 			<div class="mt-4 grid grid-cols-2 gap-2">
 				<Button
@@ -212,6 +218,9 @@ export function EntityTablePanel(props: {
 													: "Status"}
 										</th>
 										<th class="px-3 py-2 font-medium" scope="col">
+											Media
+										</th>
+										<th class="px-3 py-2 font-medium" scope="col">
 											Updated
 										</th>
 										<th class="px-3 py-2 text-right font-medium" scope="col">
@@ -254,6 +263,9 @@ export function EntityTablePanel(props: {
 																? "Active"
 																: relationSummary(item)}
 														</span>
+													</td>
+													<td class="whitespace-nowrap px-3 py-2 text-xs text-[var(--v2-text-secondary)]">
+														{item.mediaCount?.toLocaleString() ?? "—"}
 													</td>
 													<td class="whitespace-nowrap px-3 py-2 text-xs text-[var(--v2-text-muted)]">
 														{formatDate(item.updatedAt)}

--- a/packages/ui/src/screens/v2-manager/utils.test.ts
+++ b/packages/ui/src/screens/v2-manager/utils.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { formatDate } from "./utils";
+
+describe("formatDate", () => {
+	it("falls back for invalid date values", () => {
+		expect(formatDate("not-a-date")).toBe("—");
+		expect(formatDate(new Date(Number.NaN))).toBe("—");
+	});
+});

--- a/packages/ui/src/screens/v2-manager/utils.ts
+++ b/packages/ui/src/screens/v2-manager/utils.ts
@@ -40,12 +40,19 @@ export function singularLabel(value: ManagerEntityType): string {
 	}
 }
 
-export function formatDate(value: Date | string): string {
-	return new Date(value).toLocaleDateString("ja-JP", {
-		year: "numeric",
-		month: "short",
-		day: "numeric",
-	});
+export function formatDate(
+	value: Date | string | null | undefined,
+	options?: { includeTime?: boolean },
+): string {
+	if (value == null) {
+		return "—";
+	}
+	return new Intl.DateTimeFormat(
+		"ja-JP",
+		options?.includeTime
+			? { dateStyle: "medium", timeStyle: "short" }
+			: { year: "numeric", month: "short", day: "numeric" },
+	).format(value instanceof Date ? value : new Date(value));
 }
 
 export function formatBytes(bytes: number | null | undefined): string {

--- a/packages/ui/src/screens/v2-manager/utils.ts
+++ b/packages/ui/src/screens/v2-manager/utils.ts
@@ -47,12 +47,16 @@ export function formatDate(
 	if (value == null) {
 		return "—";
 	}
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return "—";
+	}
 	return new Intl.DateTimeFormat(
 		"ja-JP",
 		options?.includeTime
 			? { dateStyle: "medium", timeStyle: "short" }
 			: { year: "numeric", month: "short", day: "numeric" },
-	).format(value instanceof Date ? value : new Date(value));
+	).format(date);
 }
 
 export function formatBytes(bytes: number | null | undefined): string {

--- a/packages/ui/src/screens/v2-search-screen.tsx
+++ b/packages/ui/src/screens/v2-search-screen.tsx
@@ -2,19 +2,24 @@ import type { Media } from "@solid-imager/core/domain/media/schemas";
 import { createSignal, onMount, Show } from "solid-js";
 import { FilterErrorBanner, QueryStatus } from "../async-state";
 import { LoadingRegion, MediaGridSkeleton } from "../skeleton";
-import { SourceMediaGrid } from "../source-media-grid";
+import {
+	SourceMediaGrid,
+	type SourceMediaViewMode,
+} from "../source-media-grid";
 import { V2CollectionInspector } from "../v2/collection-inspector";
 import { V2SearchToolbar } from "../v2/search-toolbar";
 import type { SearchWorkspaceProps } from "./search-screen.types";
 
 export type V2SearchScreenProps = SearchWorkspaceProps & {
-	onOpenMediaDetail?: (media: Media) => void;
+	onOpenMediaDetail?: (media: Media, context?: Media[]) => void;
+	onPrepareMediaDetail?: (media: Media, context?: Media[]) => void;
 	renderMediaPreview?: (media: Media) => import("solid-js").JSX.Element;
 };
 
 export function V2SearchScreen(props: V2SearchScreenProps) {
 	const [isMounted, setIsMounted] = createSignal(false);
 	const [previewMediaId, setPreviewMediaId] = createSignal<string | null>(null);
+	const [viewMode, setViewMode] = createSignal<SourceMediaViewMode>("grid");
 	const page = () => props.page;
 	const filterStates = () => [
 		page().filterStates.tags(),
@@ -35,6 +40,8 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 	const previewSourceName = () =>
 		props.sources?.find((source) => source.id === previewMedia()?.mediaSourceId)
 			?.name;
+	const openMediaDetail = (media: Media) =>
+		props.onOpenMediaDetail?.(media, page().searchResults());
 
 	onMount(() => setIsMounted(true));
 
@@ -50,6 +57,8 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 				selectedSource={props.selectedSource ?? undefined}
 				sourceName={sourceName()}
 				sources={props.sources}
+				onViewModeChange={setViewMode}
+				viewMode={viewMode()}
 			/>
 			<div class="shrink-0 px-3 pt-3 sm:px-4">
 				<Show
@@ -98,6 +107,10 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 								itemAspectRatio={4 / 3}
 								mediaResults={page().searchResults}
 								mediaSourceId={() => undefined}
+								onOpenMediaDetail={openMediaDetail}
+								onPrepareMediaDetail={(media) =>
+									props.onPrepareMediaDetail?.(media, page().searchResults())
+								}
 								onLoadMore={page().fetchNextPage}
 								onRetry={async () => {
 									await page().searchResultQuery.refetch();
@@ -113,6 +126,7 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 								scrollMode="element"
 								state={page().contentState}
 								totalCount={page().totalCount()}
+								viewMode={viewMode}
 							/>
 						</Show>
 					</div>
@@ -122,7 +136,7 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 								{(media) => (
 									<V2CollectionInspector
 										media={media()}
-										onOpenDetail={props.onOpenMediaDetail}
+										onOpenDetail={openMediaDetail}
 										renderPreview={renderPreview()}
 										sourceName={previewSourceName()}
 									/>

--- a/packages/ui/src/screens/v2-source-media-screen.tsx
+++ b/packages/ui/src/screens/v2-source-media-screen.tsx
@@ -11,7 +11,10 @@ import {
 	DialogTitle,
 } from "../dialog";
 import { LoadingRegion, MediaGridSkeleton } from "../skeleton";
-import { SourceMediaGrid } from "../source-media-grid";
+import {
+	SourceMediaGrid,
+	type SourceMediaViewMode,
+} from "../source-media-grid";
 import { V2CollectionInspector } from "../v2/collection-inspector";
 import { V2SearchToolbar } from "../v2/search-toolbar";
 import type { SourceMediaScreenProps } from "./source-media-screen.types";
@@ -19,6 +22,7 @@ import type { SourceMediaScreenProps } from "./source-media-screen.types";
 export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 	const [isMounted, setIsMounted] = createSignal(false);
 	const [previewMediaId, setPreviewMediaId] = createSignal<string | null>(null);
+	const [viewMode, setViewMode] = createSignal<SourceMediaViewMode>("grid");
 	const page = () => props.page;
 	const filterStates = () => Object.values(page().filterStates());
 	const shouldRenderGrid = () => !props.enableVirtualization || isMounted();
@@ -26,6 +30,12 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 		page()
 			.mediaResults()
 			.find((media) => media.id === previewMediaId());
+	const openMediaDetail = (
+		media: import("@solid-imager/core/domain/media/schemas").Media,
+	) => props.onOpenMediaDetail?.(media, page().mediaResults());
+	const prepareMediaDetail = (
+		media: import("@solid-imager/core/domain/media/schemas").Media,
+	) => props.onPrepareMediaDetail?.(media, page().mediaResults());
 
 	onMount(() => setIsMounted(true));
 
@@ -74,6 +84,8 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 				onSearch={page().handleSearch}
 				presetClient={page().presetClient}
 				sourceName={props.mediaSourceName?.() ?? "メディア一覧"}
+				onViewModeChange={setViewMode}
+				viewMode={viewMode()}
 			/>
 
 			<Show when={props.renderJobProgress && page().jobProgress()}>
@@ -127,6 +139,8 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 								isSelected={props.isSelected}
 								mediaResults={page().mediaResults}
 								mediaSourceId={page().mediaSourceId}
+								onOpenMediaDetail={openMediaDetail}
+								onPrepareMediaDetail={prepareMediaDetail}
 								onBulkAction={props.onBulkAction}
 								onClearSelection={props.onClearSelection}
 								onCopyMove={page().handleCopyMove}
@@ -148,6 +162,7 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 								scrollMode="element"
 								state={page().contentState}
 								totalCount={page().totalCount()}
+								viewMode={viewMode}
 							/>
 						</Show>
 					</div>
@@ -157,7 +172,7 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 								{(media) => (
 									<V2CollectionInspector
 										media={media()}
-										onOpenDetail={props.onOpenMediaDetail}
+										onOpenDetail={openMediaDetail}
 										renderPreview={renderPreview()}
 										sourceName={props.mediaSourceName?.()}
 									/>

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -48,6 +48,8 @@ const INITIAL_PRIORITY_ROWS = 2;
 const INITIAL_HIGH_PRIORITY_MEDIA = 2;
 const INITIAL_SKELETON_ROWS = 3;
 
+export type SourceMediaViewMode = "grid" | "list";
+
 type ScrollDirection = "backward" | "forward" | null;
 
 function extractDirectionalRows(
@@ -102,6 +104,7 @@ type SourceMediaGridProps = {
 			isBulkSelectMode?: boolean;
 			isSelected?: boolean;
 			onPreviewSelect?: () => void;
+			onPrepareMediaDetail?: () => void;
 			isPreviewSelected?: boolean;
 		},
 	) => JSX.Element;
@@ -119,6 +122,12 @@ type SourceMediaGridProps = {
 	totalCount?: number;
 	/** Screen-specific copy for the initial error state. */
 	errorTitle?: string;
+	/** Optional collection presentation mode. */
+	viewMode?: Accessor<SourceMediaViewMode>;
+	/** Opens the media detail route from list rows. */
+	onOpenMediaDetail?: (media: Media) => void;
+	/** Saves the current collection context before a direct card navigation. */
+	onPrepareMediaDetail?: (media: Media) => void;
 };
 
 export function SourceMediaGrid(props: SourceMediaGridProps) {
@@ -128,6 +137,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 	const enableVirtualization = () => props.enableVirtualization ?? false;
 	const disableContextMenu = () => props.disableContextMenu ?? false;
 	const totalCount = () => props.totalCount ?? props.mediaResults().length;
+	const viewMode = () => props.viewMode?.() ?? "grid";
 	const errorMessage = () => {
 		const error = props.state().error;
 		return error instanceof Error ? error.message : "API接続に失敗しました";
@@ -472,6 +482,8 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 													}
 												: undefined,
 										onContextMenu: onContextMenuHandler(media.id),
+										onPrepareMediaDetail: () =>
+											props.onPrepareMediaDetail?.(media),
 										priority:
 											props.scrollMode === "element"
 												? index() < initialPriorityMediaCount()
@@ -525,6 +537,8 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 														)
 													: undefined,
 											onContextMenu: onContextMenuHandler(media.id),
+											onPrepareMediaDetail: () =>
+												props.onPrepareMediaDetail?.(media),
 											// Window virtualization keeps its established native lazy-loading
 											// behavior. Element mode supplies a separate direction-aware policy.
 											priority:
@@ -551,6 +565,101 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 					}}
 				</For>
 			</Show>
+		</div>
+	);
+	const formatFileSize = (bytes: number | null): string => {
+		if (bytes === null) return "—";
+		if (bytes < 1024) return `${bytes} B`;
+		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	};
+	const listContent = (
+		<div class="overflow-x-auto rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface)] [scrollbar-gutter:stable]">
+			<table class="w-full min-w-[52rem] border-collapse text-left text-sm">
+				<caption class="sr-only">
+					メディア一覧。{totalCount().toLocaleString()}件。
+				</caption>
+				<thead class="bg-[var(--v2-surface-muted)] text-xs text-[var(--v2-text-muted)]">
+					<tr>
+						<Show when={props.isBulkSelectMode?.()}>
+							<th class="w-10 px-3 py-2" scope="col">
+								<span class="sr-only">選択</span>
+							</th>
+						</Show>
+						<th class="px-3 py-2 font-medium" scope="col">
+							Name
+						</th>
+						<th class="px-3 py-2 font-medium" scope="col">
+							Type
+						</th>
+						<th class="px-3 py-2 font-medium" scope="col">
+							Dimensions
+						</th>
+						<th class="px-3 py-2 font-medium" scope="col">
+							Size
+						</th>
+						<th class="px-3 py-2 font-medium" scope="col">
+							Modified
+						</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y divide-[var(--v2-border)]">
+					<For each={props.mediaResults()}>
+						{(media) => (
+							<tr
+								class={
+									props.isSelected?.(media.id)
+										? "bg-[var(--v2-surface-selected)]"
+										: "hover:bg-[var(--v2-surface-muted)]"
+								}
+							>
+								<Show when={props.isBulkSelectMode?.()}>
+									<td class="px-3 py-2">
+										<input
+											aria-label={`${media.fileName}を選択`}
+											checked={props.isSelected?.(media.id) ?? false}
+											onChange={() => props.onToggleSelect?.(media.id)}
+											type="checkbox"
+										/>
+									</td>
+								</Show>
+								<th class="max-w-[28rem] px-3 py-2 font-normal" scope="row">
+									<button
+										class="block min-h-10 w-full rounded px-1 py-1 text-left outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-focus)]"
+										onClick={() => props.onOpenMediaDetail?.(media)}
+										type="button"
+									>
+										<span
+											class="block truncate font-medium text-[var(--v2-text)]"
+											title={media.fileName}
+										>
+											{media.fileName}
+										</span>
+										<span
+											class="mt-0.5 block truncate text-[var(--v2-text-muted)] text-xs"
+											title={media.filePath}
+										>
+											{media.filePath}
+										</span>
+									</button>
+								</th>
+								<td class="px-3 py-2 text-[var(--v2-text-secondary)]">
+									{media.mediaType}
+								</td>
+								<td class="whitespace-nowrap px-3 py-2 text-[var(--v2-text-secondary)]">
+									{media.width} × {media.height}
+								</td>
+								<td class="whitespace-nowrap px-3 py-2 text-[var(--v2-text-secondary)]">
+									{formatFileSize(media.fileSize)}
+								</td>
+								<td class="whitespace-nowrap px-3 py-2 text-[var(--v2-text-muted)]">
+									{media.modifiedAt.toLocaleDateString("ja-JP")}
+								</td>
+							</tr>
+						)}
+					</For>
+				</tbody>
+			</table>
 		</div>
 	);
 
@@ -595,121 +704,128 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 						</div>
 					</Show>
 
-					{/* Grid with optional context menu */}
-					<Show fallback={gridContent} when={!disableContextMenu()}>
-						<ContextMenu>
-							<ContextMenuTrigger class="block min-w-0 w-full">
-								{gridContent}
-							</ContextMenuTrigger>
-							<ContextMenuContent>
-								<Show
-									fallback={
-										<ContextMenuItem disabled>
-											No media selected
-										</ContextMenuItem>
-									}
-									when={contextMenuMediaId()}
-								>
-									<ContextMenuItem
-										onSelect={() => {
-											const id = contextMenuMediaId();
-											if (id) props.onToggleSelect?.(id);
-										}}
-									>
-										{(() => {
-											const id = contextMenuMediaId();
-											return id &&
-												props.isBulkSelectMode?.() &&
-												props.isSelected?.(id)
-												? "選択解除"
-												: "選択";
-										})()}
-									</ContextMenuItem>
-
-									<ContextMenuSeparator />
-
-									<Show
-										when={
-											props.isBulkSelectMode?.() &&
-											(props.selectedCount?.() ?? 0) > 0
-										}
-									>
-										<ContextMenuItem
-											onSelect={() => {
-												props.onBulkAction?.();
-											}}
+					{/* Grid/list with optional context menu for the grid presentation */}
+					<Show
+						fallback={
+							<Show fallback={gridContent} when={!disableContextMenu()}>
+								<ContextMenu>
+									<ContextMenuTrigger class="block min-w-0 w-full">
+										{gridContent}
+									</ContextMenuTrigger>
+									<ContextMenuContent>
+										<Show
+											fallback={
+												<ContextMenuItem disabled>
+													No media selected
+												</ContextMenuItem>
+											}
+											when={contextMenuMediaId()}
 										>
-											一括操作を実行 ({props.selectedCount?.()}件選択中)
-										</ContextMenuItem>
-										<ContextMenuItem
-											onSelect={() => {
-												props.onClearSelection?.();
-											}}
-										>
-											選択をクリア
-										</ContextMenuItem>
-										<ContextMenuSeparator />
-									</Show>
+											<ContextMenuItem
+												onSelect={() => {
+													const id = contextMenuMediaId();
+													if (id) props.onToggleSelect?.(id);
+												}}
+											>
+												{(() => {
+													const id = contextMenuMediaId();
+													return id &&
+														props.isBulkSelectMode?.() &&
+														props.isSelected?.(id)
+														? "選択解除"
+														: "選択";
+												})()}
+											</ContextMenuItem>
 
-									<Show when={showOpenInNewTab()}>
-										<ContextMenuItem
-											onSelect={() => {
-												const id = contextMenuMediaId();
-												const sourceId = props.mediaSourceId();
-												if (id && sourceId) {
-													window.open(
-														`${props.detailBasePath ?? "/sources"}/${sourceId}/${id}`,
-														"_blank",
-													);
+											<ContextMenuSeparator />
+
+											<Show
+												when={
+													props.isBulkSelectMode?.() &&
+													(props.selectedCount?.() ?? 0) > 0
 												}
-											}}
-										>
-											新しいタブで開く
-										</ContextMenuItem>
-									</Show>
+											>
+												<ContextMenuItem
+													onSelect={() => {
+														props.onBulkAction?.();
+													}}
+												>
+													一括操作を実行 ({props.selectedCount?.()}件選択中)
+												</ContextMenuItem>
+												<ContextMenuItem
+													onSelect={() => {
+														props.onClearSelection?.();
+													}}
+												>
+													選択をクリア
+												</ContextMenuItem>
+												<ContextMenuSeparator />
+											</Show>
 
-									<ContextMenuItem
-										class="text-red-600 focus:text-red-600"
-										onSelect={() => {
-											const id = contextMenuMediaId();
-											if (id) props.onDelete?.(id);
-										}}
-									>
-										削除
-									</ContextMenuItem>
+											<Show when={showOpenInNewTab()}>
+												<ContextMenuItem
+													onSelect={() => {
+														const id = contextMenuMediaId();
+														const sourceId = props.mediaSourceId();
+														if (id && sourceId) {
+															window.open(
+																`${props.detailBasePath ?? "/sources"}/${sourceId}/${id}`,
+																"_blank",
+															);
+														}
+													}}
+												>
+													新しいタブで開く
+												</ContextMenuItem>
+											</Show>
 
-									<ContextMenuSeparator />
+											<ContextMenuItem
+												class="text-red-600 focus:text-red-600"
+												onSelect={() => {
+													const id = contextMenuMediaId();
+													if (id) props.onDelete?.(id);
+												}}
+											>
+												削除
+											</ContextMenuItem>
 
-									<ContextMenuItem
-										onSelect={() => {
-											const id = contextMenuMediaId();
-											if (id) props.onCopyMove?.(id, "copy");
-										}}
-									>
-										他のソースへコピー
-									</ContextMenuItem>
-									<ContextMenuItem
-										onSelect={() => {
-											const id = contextMenuMediaId();
-											if (id) props.onCopyMove?.(id, "move");
-										}}
-									>
-										他のソースへ移動
-									</ContextMenuItem>
+											<ContextMenuSeparator />
 
-									<ContextMenuSeparator />
+											<ContextMenuItem
+												onSelect={() => {
+													const id = contextMenuMediaId();
+													if (id) props.onCopyMove?.(id, "copy");
+												}}
+											>
+												他のソースへコピー
+											</ContextMenuItem>
+											<ContextMenuItem
+												onSelect={() => {
+													const id = contextMenuMediaId();
+													if (id) props.onCopyMove?.(id, "move");
+												}}
+											>
+												他のソースへ移動
+											</ContextMenuItem>
 
-									<ContextMenuItem
-										onSelect={() => {
-											const id = contextMenuMediaId();
-											if (id) props.onSyncSingleMedia?.(id);
-										}}
-									>
-										メタデータを同期 (再処理)
-									</ContextMenuItem>
-								</Show>
-							</ContextMenuContent>
-						</ContextMenu>
+											<ContextMenuSeparator />
+
+											<ContextMenuItem
+												onSelect={() => {
+													const id = contextMenuMediaId();
+													if (id) props.onSyncSingleMedia?.(id);
+												}}
+											>
+												メタデータを同期 (再処理)
+											</ContextMenuItem>
+										</Show>
+									</ContextMenuContent>
+								</ContextMenu>
+							</Show>
+						}
+						when={viewMode() === "list"}
+					>
+						{listContent}
 					</Show>
 
 					{/* Empty state */}

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -54,6 +54,7 @@ export type SourceMediaPageProps = {
 	renderItem: SourceMediaScreenProps["renderItem"];
 	renderMediaPreview?: SourceMediaScreenProps["renderMediaPreview"];
 	onOpenMediaDetail?: SourceMediaScreenProps["onOpenMediaDetail"];
+	onPrepareMediaDetail?: SourceMediaScreenProps["onPrepareMediaDetail"];
 	showOpenInNewTab?: boolean;
 	onToggleSelect?: (mediaId: string) => void;
 	isBulkSelectMode?: () => boolean;
@@ -155,6 +156,7 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 			renderActions={renderActions}
 			renderItem={props.renderItem}
 			onOpenMediaDetail={props.onOpenMediaDetail}
+			onPrepareMediaDetail={props.onPrepareMediaDetail}
 			renderMediaPreview={props.renderMediaPreview}
 			moveCopyDialogComponent={props.moveCopyDialogComponent}
 			uploadModalComponent={props.uploadModalComponent}

--- a/packages/ui/src/v2/search-toolbar.tsx
+++ b/packages/ui/src/v2/search-toolbar.tsx
@@ -19,6 +19,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "../popover";
 import type { PresetManagerClient } from "../search-control-panel";
 import { SearchControlPanel } from "../search-control-panel";
 import { SortControls } from "../sort-controls";
+import type { SourceMediaViewMode } from "../source-media-grid";
 import {
 	clearPresetFilters,
 	searchState,
@@ -56,6 +57,8 @@ export type V2SearchToolbarProps = {
 	selectedSource?: string;
 	sourceName: string;
 	sources?: SafeMediaSource[];
+	viewMode?: SourceMediaViewMode;
+	onViewModeChange?: (mode: SourceMediaViewMode) => void;
 };
 
 function parseValues(value: string): string[] {
@@ -482,18 +485,27 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 				<div class="flex rounded-md border border-[var(--v2-border-strong)] bg-white p-0.5">
 					<Button
 						aria-label="グリッド表示"
-						aria-pressed="true"
-						class="size-11 bg-[var(--v2-primary)] p-0 text-white hover:bg-[var(--v2-primary-hover)] sm:size-8"
+						aria-pressed={(props.viewMode ?? "grid") === "grid"}
+						class={
+							(props.viewMode ?? "grid") === "grid"
+								? "size-11 bg-[var(--v2-primary)] p-0 text-white hover:bg-[var(--v2-primary-hover)] sm:size-8"
+								: "size-11 p-0 sm:size-8"
+						}
+						onClick={() => props.onViewModeChange?.("grid")}
 						size="icon"
 					>
 						<Grid3X3 aria-hidden="true" size={15} />
 					</Button>
 					<Button
-						aria-label="リスト表示（未実装）"
-						class="size-11 p-0 sm:size-8"
-						disabled
+						aria-label="リスト表示"
+						aria-pressed={(props.viewMode ?? "grid") === "list"}
+						class={
+							(props.viewMode ?? "grid") === "list"
+								? "size-11 bg-[var(--v2-primary)] p-0 text-white hover:bg-[var(--v2-primary-hover)] sm:size-8"
+								: "size-11 p-0 sm:size-8"
+						}
+						onClick={() => props.onViewModeChange?.("list")}
 						size="icon"
-						title="リスト表示は今後実装予定です"
 						variant="ghost"
 					>
 						<List aria-hidden="true" size={15} />


### PR DESCRIPTION
## 概要
REPORT.mdで不足していた機能のうち、DB migrationなしで自然に提供できる機能をV2へ接続します。このPRは既存のperf/v2-media-gallery-performance向けPR #662に積み上げています。

## 変更内容
- Jobs一覧・詳細・失敗JobのRetry・リアルタイム更新
- Sourceのメディア件数・同期状態
- Project / IP / Characterの利用件数
- AI接続確認とレイテンシ表示
- CollectionのGrid / List切り替え
- メディア詳細の前後移動用コンテキスト保存
- Tauri向けV2 route adapter
- OpenAPIとREPORT.mdの更新

## 未対応
- Job Cancelは永続的な状態遷移と権限制御が必要なため未対応
- Export / RestoreのJobs追跡は現行の直接転送方式に対して不自然なため未対応

## 検証
- bun run typecheck
- Biome check
- packages/ui unit tests: 66 passed
- apps/server unit tests: 164 passed
- apps/server integration tests: 68 passed
- Tauri build / typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ジョブの一覧・詳細表示、ステータス絞り込み、進捗確認、失敗ジョブの再試行に対応しました。
  * AIサービスのヘルスチェックを設定画面から実行できるようになりました。
  * メディアソースの同期状態とメディア件数を一覧で確認できます。
  * 検索結果やソース内メディアで、グリッド表示とリスト表示を切り替えられます。
  * メディア詳細画面で一覧内の前後メディアへ移動できるようになりました。

* **ドキュメント**
  * スタックブランチと依存PRの操作手順を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->