### PR TITLE
feat(tauri): add V2 Jobs route adapter

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -14,6 +14,6 @@
 | AI接続状態・latency | 実装済み | `ai.health` contract/router と V2 Config画面 |
 | リロード後の前後メディア移動 | 実装済み | `apps/server/src/routes/v2/media-context.ts` と sessionStorage |
 | Collectionのgrid / list表示 | 実装済み | `packages/ui/src/source-media-grid.tsx` と V2 Search / Source画面 |
-| Tauriの `/v2/*` route adapter | 対応済み（Jobsを除く） | `apps/tauri/src/routes/v2/`。既存Tauri画面へ検索、Manager、Config、About、Sourcesを接続 |
+| Tauriの `/v2/*` route adapter | 実装済み | `apps/tauri/src/routes/v2/` と `apps/tauri/src/routes/jobs.tsx`。既存Tauri画面へ検索、Manager、Jobs、Config、About、Sourcesを接続 |
 
 未対応の画面やAPIを追加する場合は、loading / error / offline / retryとリアルタイム更新まで同じ画面内で接続します。

--- a/apps/tauri/src/queries/index.ts
+++ b/apps/tauri/src/queries/index.ts
@@ -7,11 +7,13 @@ import {
 	defaultCharactersQueryConfig,
 	defaultConfigQueryConfig,
 	defaultIpsQueryConfig,
+	defaultJobsQueryConfig,
 	defaultMediaDetailsQueryConfig,
 	defaultProjectsQueryConfig,
 	defaultSourcesQueryConfig,
 	defaultTagsQueryConfig,
 	ipsQueryKeys,
+	jobsQueryKeys,
 	mediaDetailsQueryKeys,
 	projectsQueryKeys,
 	sourcesQueryKeys,
@@ -45,6 +47,11 @@ export const allIpsQueryOptions = () => ({
 	...utils.ips.list.queryOptions(),
 	queryKey: ipsQueryKeys.all(),
 	...defaultIpsQueryConfig,
+});
+export const jobsQueryOptions = (input = { limit: 200, offset: 0 }) => ({
+	...utils.jobs.list.queryOptions({ input }),
+	queryKey: jobsQueryKeys.list(input),
+	...defaultJobsQueryConfig,
 });
 export const allAuthorsQueryOptions = () => ({
 	...utils.authors.list.queryOptions(),

--- a/apps/tauri/src/routes/jobs.tsx
+++ b/apps/tauri/src/routes/jobs.tsx
@@ -1,0 +1,100 @@
+import { downloadCompletedJobArtifact } from "@solid-imager/client";
+import type {
+	JobDto,
+	JobListResponse,
+} from "@solid-imager/core/domain/jobs/schemas";
+import { useJobEvents } from "@solid-imager/ui/hooks/use-job-events";
+import { jobsQueryKeys } from "@solid-imager/ui/query-options";
+import { toQueryUiState } from "@solid-imager/ui/query-state";
+import { V2JobsScreen } from "@solid-imager/ui/screens/v2-jobs-screen";
+import { toast } from "@solid-imager/ui/toast";
+import { createQuery, useQueryClient } from "@tanstack/solid-query";
+import { createFileRoute } from "@tanstack/solid-router";
+import { orpc } from "~/infrastructure/api-clients/orpc-client";
+import { jobsQueryOptions } from "~/queries";
+
+export const Route = createFileRoute("/jobs")({
+	loader: ({ context }) => {
+		void context.queryClient.prefetchQuery(jobsQueryOptions());
+	},
+	component: JobsRoute,
+});
+
+async function downloadJobArtifact(job: JobDto): Promise<void> {
+	if (!job.artifact) return;
+
+	try {
+		const blob = await downloadCompletedJobArtifact(orpc.jobs, job.id);
+		const url = URL.createObjectURL(blob);
+		const anchor = document.createElement("a");
+		anchor.href = url;
+		anchor.download = job.artifact.fileName;
+		document.body.appendChild(anchor);
+		anchor.click();
+		anchor.remove();
+		URL.revokeObjectURL(url);
+		toast.success(`Downloaded ${job.artifact.fileName}`);
+	} catch (error) {
+		toast.error(
+			error instanceof Error ? error.message : "Failed to download artifact",
+		);
+		throw error;
+	}
+}
+
+function JobsRoute() {
+	const jobsQuery = createQuery<JobListResponse>(() => jobsQueryOptions());
+	const queryClient = useQueryClient();
+
+	useJobEvents(
+		(signal) => orpc.jobs.events(undefined, { signal }),
+		(event) => {
+			if (event.event === "job-progress") {
+				return;
+			}
+			void queryClient.invalidateQueries({ queryKey: jobsQueryKeys.all() });
+		},
+	);
+
+	return (
+		<div class="v2-theme min-h-[calc(100vh-4rem)]">
+			<V2JobsScreen
+				isRefreshing={() => jobsQuery.isFetching}
+				jobs={() => jobsQuery.data?.items ?? []}
+				onRefresh={async () => {
+					await jobsQuery.refetch();
+				}}
+				onRetry={async (jobId) => {
+					try {
+						await orpc.jobs.retry({ id: jobId });
+						await queryClient.invalidateQueries({
+							queryKey: jobsQueryKeys.all(),
+						});
+						toast.success("Job queued for retry");
+					} catch (error) {
+						toast.error(
+							error instanceof Error ? error.message : "Failed to retry job",
+						);
+						throw error;
+					}
+				}}
+				onCancel={async (jobId) => {
+					try {
+						await orpc.jobs.cancel({ id: jobId });
+						await queryClient.invalidateQueries({
+							queryKey: jobsQueryKeys.all(),
+						});
+						toast.success("Job cancellation requested");
+					} catch (error) {
+						toast.error(
+							error instanceof Error ? error.message : "Failed to cancel job",
+						);
+						throw error;
+					}
+				}}
+				onDownload={downloadJobArtifact}
+				state={() => toQueryUiState(jobsQuery)}
+			/>
+		</div>
+	);
+}

--- a/apps/tauri/src/routes/v2/$.tsx
+++ b/apps/tauri/src/routes/v2/$.tsx
@@ -32,6 +32,9 @@ function V2RouteAdapter() {
 			<Match when={first() === "manager" && segments().length === 1}>
 				<Navigate replace to="/manager" />
 			</Match>
+			<Match when={first() === "jobs" && segments().length === 1}>
+				<Navigate replace to="/jobs" />
+			</Match>
 			<Match when={first() === "config" && segments().length === 1}>
 				<Navigate replace to="/config" />
 			</Match>


### PR DESCRIPTION
## 概要

Tauri SPAでもV2 Jobs画面を利用できるようにし、REPORT.mdに残っていた唯一の例外を解消します。

## 変更内容

- TauriにJobs一覧・詳細、Retry、Cancel、artifact download、realtime更新を追加
- /v2/jobsからTauriのJobs routeへ遷移するadapterを追加
- Tauri用のJobs query optionsを追加
- REPORT.mdのTauri Jobs未対応表記を更新

## 検証

- bun run --cwd apps/tauri typecheck
- bun run --cwd apps/tauri lint
- bun run --cwd apps/tauri build:web
- rootのbun run checkは、既存環境のdghs-imgutils-rs未解決とServerの未生成route treeで失敗