### PR TITLE
fix(xtracter): sync popup source selection display with storage

### DIFF
--- a/apps/xtracter/package.json
+++ b/apps/xtracter/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "bun x tsc --noEmit",
+    "test": "vitest run",
     "lint": "biome lint ./src",
     "format": "biome format --fix ./src",
     "check": "biome check --fix --unsafe ./src"

--- a/apps/xtracter/src/background/index.ts
+++ b/apps/xtracter/src/background/index.ts
@@ -9,6 +9,7 @@ import type {
 	PostDownloadMessage,
 	TweetMetadata,
 } from "@ext/schema";
+import { resolveEffectiveSourceId } from "@ext/utils/source-selection";
 
 const DATE_STRING_LENGTH = 19; // "YYYY-MM-DDTHH-mm-ss"
 
@@ -77,29 +78,33 @@ async function getMediaSources(): Promise<SafeMediaSource[]> {
 	}
 }
 
-// Determine which source ID to use
 async function getTargetSourceId(): Promise<string | null> {
-	// 1. Check local storage for user selection
 	const result: { selectedSourceId?: string } = await chrome.storage.local.get([
 		"selectedSourceId",
 	]);
-	if (result.selectedSourceId) {
-		return result.selectedSourceId;
-	}
 
-	// 2. Fallback
 	const sources = await getMediaSources();
-	const twitterSource = sources.find((s) => s.name === "twitter");
-	if (twitterSource?.id) {
-		await chrome.storage.local.set({ selectedSourceId: twitterSource.id });
-		return twitterSource.id;
-	}
-	if (sources.length > 0 && sources[0].id) {
-		await chrome.storage.local.set({ selectedSourceId: sources[0].id });
-		return sources[0].id;
+	if (sources.length === 0) {
+		return result.selectedSourceId ?? null;
 	}
 
-	return null;
+	const selectableSources = sources.filter(
+		(source): source is SafeMediaSource & { id: string } =>
+			typeof source.id === "string",
+	);
+	const resolved = resolveEffectiveSourceId(
+		selectableSources,
+		result.selectedSourceId,
+		"twitter",
+	);
+	if (!resolved?.id) {
+		return result.selectedSourceId ?? null;
+	}
+
+	if (resolved.id !== result.selectedSourceId) {
+		await chrome.storage.local.set({ selectedSourceId: resolved.id });
+	}
+	return resolved.id;
 }
 
 async function postDownloads(items: TweetMetadata[]) {

--- a/apps/xtracter/src/popup/index.tsx
+++ b/apps/xtracter/src/popup/index.tsx
@@ -1,5 +1,6 @@
 import { getClient } from "@ext/api";
 import type { MediaSource, TweetMetadata } from "@ext/schema";
+import { resolveEffectiveSourceId } from "@ext/utils/source-selection";
 import { createSignal, For, onMount, Show } from "solid-js";
 import { render } from "solid-js/web";
 
@@ -17,17 +18,19 @@ function Popup() {
 	const [exportStatus, setExportStatus] = createSignal("");
 	const [uploadStatus, setUploadStatus] = createSignal("");
 
+	let selectRef: HTMLSelectElement | undefined;
+	let fetchSeq = 0;
+
 	const loadSettings = async () => {
 		const settings: { apiUrl?: string; selectedSourceId?: string } =
 			await chrome.storage.local.get(["selectedSourceId", "apiUrl"]);
 		if (settings.apiUrl) setApiUrl(settings.apiUrl);
-		if (settings.selectedSourceId)
-			setSelectedSourceId(settings.selectedSourceId);
 
-		await fetchSources();
+		await fetchSources(settings.selectedSourceId);
 	};
 
-	const fetchSources = async () => {
+	const fetchSources = async (preferredId?: string) => {
+		const seq = ++fetchSeq;
 		setIsLoading(true);
 		setStatus("Loading sources...");
 		setStatusType("info");
@@ -36,24 +39,25 @@ function Popup() {
 			const resp: MediaSource[] = await chrome.runtime.sendMessage({
 				type: "GET_SOURCES",
 			});
+			if (seq !== fetchSeq) return;
 			setSources(resp || []);
 
-			const hasSelectedSource = resp?.some((s) => s.id === selectedSourceId());
-			if (
-				resp &&
-				resp.length > 0 &&
-				(!selectedSourceId() || !hasSelectedSource)
-			) {
-				const firstId = resp[0].id;
-				setSelectedSourceId(firstId);
-				await chrome.storage.local.set({ selectedSourceId: firstId });
+			const previousId = preferredId ?? selectedSourceId();
+			const resolved = resolveEffectiveSourceId(resp ?? [], previousId);
+			if (resolved) {
+				setSelectedSourceId(resolved.id);
+				if (selectRef) selectRef.value = resolved.id;
+				if (resolved.id !== previousId) {
+					await chrome.storage.local.set({ selectedSourceId: resolved.id });
+				}
 			}
 			setStatus("");
 		} catch (_err) {
+			if (seq !== fetchSeq) return;
 			setStatus("Failed to load sources. Check API URL.");
 			setStatusType("error");
 		} finally {
-			setIsLoading(false);
+			if (seq === fetchSeq) setIsLoading(false);
 		}
 	};
 
@@ -160,6 +164,7 @@ function Popup() {
 				</label>
 				<select
 					id="source-select"
+					ref={(el) => (selectRef = el)}
 					value={selectedSourceId()}
 					onChange={async (e) => {
 						const id = e.currentTarget.value;

--- a/apps/xtracter/src/utils/source-selection.test.ts
+++ b/apps/xtracter/src/utils/source-selection.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveEffectiveSourceId } from "./source-selection";
+
+const sources = [
+	{ id: "alpha-id", name: "alpha" },
+	{ id: "twitter-id", name: "twitter" },
+	{ id: "beta-id", name: "beta" },
+];
+
+describe("resolveEffectiveSourceId", () => {
+	it("returns null when the source list is empty", () => {
+		expect(resolveEffectiveSourceId([], "beta-id")).toBeNull();
+	});
+
+	it("keeps a valid preferred source", () => {
+		expect(resolveEffectiveSourceId(sources, "beta-id")).toEqual(sources[2]);
+	});
+
+	it("falls back to the first source when the preferred id is missing", () => {
+		expect(resolveEffectiveSourceId(sources, "deleted-id")).toEqual(sources[0]);
+	});
+
+	it("prefers the named fallback over the first source when no preferred id is given", () => {
+		expect(resolveEffectiveSourceId(sources, null, "twitter")).toEqual(
+			sources[1],
+		);
+	});
+
+	it("prefers a valid preferred id over the named fallback", () => {
+		expect(resolveEffectiveSourceId(sources, "beta-id", "twitter")).toEqual(
+			sources[2],
+		);
+	});
+
+	it("falls back to the first source when the named fallback is also absent", () => {
+		expect(resolveEffectiveSourceId(sources, undefined, "unknown")).toEqual(
+			sources[0],
+		);
+	});
+});

--- a/apps/xtracter/src/utils/source-selection.ts
+++ b/apps/xtracter/src/utils/source-selection.ts
@@ -1,0 +1,30 @@
+export interface SelectableSource {
+	id: string;
+	name: string;
+}
+
+export function resolveEffectiveSourceId(
+	sources: readonly SelectableSource[],
+	preferredId?: string | null,
+	fallbackName?: string,
+): SelectableSource | null {
+	if (sources.length === 0) {
+		return null;
+	}
+
+	if (preferredId) {
+		const preferred = sources.find((source) => source.id === preferredId);
+		if (preferred) {
+			return preferred;
+		}
+	}
+
+	if (fallbackName) {
+		const fallback = sources.find((source) => source.name === fallbackName);
+		if (fallback) {
+			return fallback;
+		}
+	}
+
+	return sources[0] ?? null;
+}

--- a/apps/xtracter/vitest.config.ts
+++ b/apps/xtracter/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		alias: {
+			"@ext": path.resolve(__dirname, "./src"),
+			"@": path.resolve(__dirname, "../../packages/core/src"),
+			"@solid-imager/core": path.resolve(__dirname, "../../packages/core/src"),
+			"@core": path.resolve(__dirname, "../../packages/core/src"),
+		},
+	},
+	test: {
+		environment: "node",
+		globals: true,
+	},
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check": "biome check . && bun run typecheck && bun run design:lint",
     "design:lint": "designmd lint DESIGN.md",
     "format": "biome format --write .",
-    "test": "bun run --cwd apps/server test:unit && bun run --cwd apps/server test:integration && bun run --cwd apps/cli test && bun run --cwd packages/core test && bun run --cwd packages/ui test",
+    "test": "bun run --cwd apps/server test:unit && bun run --cwd apps/server test:integration && bun run --cwd apps/cli test && bun run --cwd apps/xtracter test && bun run --cwd packages/core test && bun run --cwd packages/ui test",
     "typecheck": "bun --filter '*' typecheck",
     "prepare": "husky"
   },

--- a/packages/db/src/repositories/source-repository.ts
+++ b/packages/db/src/repositories/source-repository.ts
@@ -38,7 +38,10 @@ export function createSourceRepository(
 	return {
 		async findAll(): Promise<MediaSource[]> {
 			try {
-				const results = await getExecutor().select().from(mediaSources);
+				const results = await getExecutor()
+					.select()
+					.from(mediaSources)
+					.orderBy(mediaSources.name);
 				return results.map(mapToMediaSource);
 			} catch (error) {
 				throw new UnexpectedError("Failed to select media sources", error);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       "apps/cli/vitest.config.ts",
       "apps/server/vitest.unit.config.ts",
       "apps/server/vitest.integration.config.ts",
+      "apps/xtracter/vitest.config.ts",
       "packages/core/vitest.config.ts",
       "packages/ui/vitest.config.ts",
     ],


### PR DESCRIPTION
## 問題

xtracterのpopupでTarget Media Sourceを選択して閉じ、再度開くと表示が先頭のソースに戻っていた。ただし内部的には前回選択したidが `chrome.storage.local` に残っているため、単体upload(背景側の `getTargetSourceId()`)は表示と違うソースへ保存されることがあった。

## 原因

- popupが `selectedSourceId` を `<select value>` へ代入する時点でoptionsが未描画(空リスト)のため、ブラウザが存在しない値の代入を無視。その後 `<For>` がoptionsを描画してもvalueは再代入されず、表示は常に先頭へフォールバックしていた
- 再取得(例: API URL入力)のたびにoptionノードが再生成され、選択表示が再び先頭へリセットされる経路もあった
- `findAll()` に `ORDER BY` が無く「先頭」が非決定、backgroundは保存済みidの有効性を未検証

## 変更内容

- `apps/xtracter/src/popup/index.tsx`: 保存idの先行セットをやめ、`setSources()` 後に解決したidをシグナルへ反映しつつ `selectRef.value` を明示再代入して表示を同期。リクエスト連番ガードで古いレスポンスを破棄。storage永続化はidが変わった場合のみ
- `apps/xtracter/src/utils/source-selection.ts`: 解決ロジックを純関数 `resolveEffectiveSourceId(sources, preferredId?, fallbackName?)` に集約
- `apps/xtracter/src/background/index.ts`: upload前に保存idを現在のソース一覧で検証し、削除済みなら "twitter" → 先頭へフォールバックして永続化。サーバ到達不能時は保存idをそのまま使用(挙動維持)
- `packages/db/src/repositories/source-repository.ts`: `findAll()` に `.orderBy(mediaSources.name)` (一覧が名前順になる点に注意)
- テスト基盤: `apps/xtracter/vitest.config.ts` 新設、解決ロジックの単体テスト追加、ルートのvitest projects/test scriptに組み込み(既存 `twitter.test.ts` も実行対象に)

## 検証

- `bun run check` (biome + typecheck + design:lint) ✅
- `bun run --cwd apps/xtracter test` (10 tests) および他パッケージのテスト ✅
- `bun run --cwd apps/xtracter build` ✅
- 実ブラウザでの確認(選択保持・単体uploadの保存先)は未実施のため、ロード後に要確認