### PR TITLE
Prevent image dragging from conflicting with media viewer interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ apps/server/src/routeTree.gen.ts
 # Systemd & Certbot & Nginx (for production deployment, not committed)
 /nginx.conf
 /compose.production.override.yml
+
+.indexion/

--- a/packages/ui/src/v2-media-viewer.tsx
+++ b/packages/ui/src/v2-media-viewer.tsx
@@ -128,6 +128,11 @@ export function V2MediaViewer(props: MediaViewerProps) {
 		lastPointer = undefined;
 		setIsPanning(false);
 	};
+	const handleDragStart = (event: DragEvent) => {
+		if (props.source.type === "image") {
+			event.preventDefault();
+		}
+	};
 	const toggleFullscreen = async () => {
 		if (!viewer) return;
 		try {
@@ -198,6 +203,7 @@ export function V2MediaViewer(props: MediaViewerProps) {
 				if (zoom() > 1) resetView();
 				else setZoomAroundPoint(2);
 			}}
+			onDragStart={handleDragStart}
 			onKeyDown={(event) => {
 				if (props.source.type !== "image") return;
 				if (event.key === "+" || event.key === "=") {


### PR DESCRIPTION
## Summary

- Prevent native drag behavior for image sources in the media viewer.
- Ignore generated `.indexion/` files in Git.

## Testing

- Not run (not requested).