### PR TITLE
Prevent native image dragging from conflicting with media interactions

### DIFF
--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -563,6 +563,13 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 			target.closest<HTMLElement>("[data-media-id]")?.dataset.mediaId;
 		return findCollectionItemById(props.mediaResults(), mediaId);
 	};
+	const handleMediaDragStart: JSX.EventHandler<HTMLElement, DragEvent> = (
+		event,
+	) => {
+		if (findMediaFromEventTarget(event.target)) {
+			event.preventDefault();
+		}
+	};
 
 	const findRenderedMediaElement = (mediaId: string) =>
 		Array.from(
@@ -989,6 +996,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 	return (
 		<div
 			class="min-h-0 min-w-0 space-y-4"
+			onDragStart={handleMediaDragStart}
 			ref={(element) => {
 				collectionRootRef = element;
 				const resolvedScrollElement = resolveScrollElement();

--- a/packages/ui/src/thumbnail-image.tsx
+++ b/packages/ui/src/thumbnail-image.tsx
@@ -149,9 +149,11 @@ export function ThumbnailImage(props: ThumbnailImageProps) {
 					alt={props.alt}
 					class={props.class}
 					decoding="async"
+					draggable={false}
 					fetchpriority={props.fetchpriority}
 					height={props.height ?? undefined}
 					loading={props.loading}
+					onDragStart={(event) => event.preventDefault()}
 					onError={handleError}
 					onLoad={handleLoad}
 					sizes={srcSet() ? props.sizes : undefined}


### PR DESCRIPTION
## Summary

- Disable native dragging for thumbnail images.
- Prevent drag events originating from media items in the source media grid.

## Testing

- Not run (not requested)