### PR TITLE
Renew vector search controls and persistence

### DIFF
--- a/apps/server/public/openapi.json
+++ b/apps/server/public/openapi.json
@@ -10344,8 +10344,7 @@
           "mode": {
             "enum": [
               "simple",
-              "pro",
-              "vector"
+              "pro"
             ],
             "type": "string"
           },
@@ -10420,11 +10419,8 @@
             ]
           },
           "similarityTopK": {
-            "enum": [
-              20,
-              50,
-              100
-            ],
+            "maximum": 100,
+            "minimum": 1,
             "type": "integer"
           },
           "limit": {

--- a/apps/server/src/components/media/legacy-media-sidebar.tsx
+++ b/apps/server/src/components/media/legacy-media-sidebar.tsx
@@ -3,7 +3,7 @@ import { getErrorMessage } from "@solid-imager/core/utils";
 import { Badge } from "@solid-imager/ui/badge";
 import { ClipboardCopy } from "@solid-imager/ui/clipboard-copy";
 import { CollapsibleRoot as Collapsible } from "@solid-imager/ui/collapsible";
-import { activateVectorSearch } from "@solid-imager/ui/stores/search-store";
+import { activateSimilaritySearch } from "@solid-imager/ui/stores/search-store";
 import { toast } from "@solid-imager/ui/toast";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { useNavigate } from "@tanstack/solid-router";
@@ -428,7 +428,7 @@ export function LegacyMediaSidebar(props: MediaSidebarProps) {
 					<button
 						class="flex min-h-11 w-full items-center justify-center gap-2 rounded-md border px-3 py-2 font-medium text-sm transition-colors hover:bg-gray-100"
 						onClick={() => {
-							activateVectorSearch(props.media.id);
+							activateSimilaritySearch(props.media.id);
 							void navigate({ to: "/search" });
 						}}
 						type="button"

--- a/apps/server/src/components/media/v2-media-actions.tsx
+++ b/apps/server/src/components/media/v2-media-actions.tsx
@@ -15,7 +15,7 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@solid-imager/ui/popover";
-import { activateVectorSearch } from "@solid-imager/ui/stores/search-store";
+import { activateSimilaritySearch } from "@solid-imager/ui/stores/search-store";
 import { toast } from "@solid-imager/ui/toast";
 import {
 	Binary,
@@ -181,7 +181,7 @@ export function V2MediaActions(props: MediaActionsProps) {
 	});
 
 	const handleFindSimilar = () => {
-		activateVectorSearch(props.media.id, { surface: "v2" });
+		activateSimilaritySearch(props.media.id, { surface: "v2" });
 		void navigate({ to: "/v2/search" });
 	};
 	const handleDownload = () => {

--- a/apps/server/src/tests/e2e/ccip-flow.spec.ts
+++ b/apps/server/src/tests/e2e/ccip-flow.spec.ts
@@ -123,7 +123,7 @@ test("extracts real CCIP vectors and finds a similar seeded image", async ({
 	await page.getByRole("button", { name: "Find Similar", exact: true }).click();
 	await similarityResponse;
 
-	await expect(page).toHaveURL(/\/search$/);
+	await expect(page).toHaveURL(/\/search(?:\?.*)?$/);
 	await expect(
 		page.getByRole("link", { name: new RegExp(E2E_SIMILAR_FILE_NAME) }),
 	).toBeVisible({

--- a/apps/server/src/tests/e2e/search.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/search.responsive.spec.ts
@@ -68,23 +68,16 @@ test("search keeps controls usable without horizontal overflow", async ({
 		await expect(filterDialog).toBeVisible();
 		fileNameInput = filterDialog.getByPlaceholder("ファイル名を入力...");
 		await expect(fileNameInput).toHaveValue("");
-		const applyButton = filterDialog.getByRole("button", {
-			name: "適用",
-			exact: true,
-		});
-		await filterDialog
-			.getByRole("button", { name: "ベクトル類似", exact: true })
-			.click();
-		await expect(applyButton).toBeDisabled();
 		await filterDialog
 			.getByRole("button", { name: "条件をクリア", exact: true })
 			.click();
-		await expect(applyButton).toBeEnabled();
 		await expect(fileNameInput).toHaveValue("");
 		await expect(conditionSummary).toContainText("条件は指定されていません。");
 
 		await fileNameInput.fill("e2e");
-		await applyButton.click();
+		await filterDialog
+			.getByRole("button", { name: "適用", exact: true })
+			.click();
 		await expect(filterDialog).toBeHidden();
 	} else {
 		await expect(

--- a/apps/tauri/src/components/media/media-sidebar/media-sidebar-content.tsx
+++ b/apps/tauri/src/components/media/media-sidebar/media-sidebar-content.tsx
@@ -1,6 +1,6 @@
 import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
 import { MediaSidebarContent } from "@solid-imager/ui/media-sidebar-content";
-import { activateVectorSearch } from "@solid-imager/ui/stores/search-store";
+import { activateSimilaritySearch } from "@solid-imager/ui/stores/search-store";
 import { useNavigate } from "@tanstack/solid-router";
 import { useBatchJobEvents } from "~/hooks/use-batch-job-events";
 import {
@@ -98,7 +98,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 				})
 			}
 			onFindSimilar={() => {
-				activateVectorSearch(props.media.id);
+				activateSimilaritySearch(props.media.id);
 				void navigate({ to: "/search" });
 			}}
 			updateMediaDescription={(mediaSourceId, mediaId, description) =>

--- a/packages/core/src/domain/search/logic.ts
+++ b/packages/core/src/domain/search/logic.ts
@@ -10,17 +10,8 @@ import type { SearchState } from "./schema";
  */
 export const calculateNextModeState = (
 	currentState: SearchState,
-	nextMode: "simple" | "pro" | "vector",
+	nextMode: "simple" | "pro",
 ): Partial<SearchState> => {
-	if (nextMode === "vector") {
-		const condition = getSearchConditionFromState(currentState);
-		return {
-			mode: "vector",
-			offset: 0,
-			scrollY: 0,
-			advancedCondition: condition || null,
-		};
-	}
 	if (nextMode === "pro") {
 		// Switching from simple to pro: populate advancedCondition from current simple filters
 		const condition = getSearchConditionFromState(currentState);
@@ -131,7 +122,6 @@ const applyCriterionToState = (
 export const getSearchConditionFromState = (
 	state: SearchState,
 ): SearchGroup | undefined => {
-	if (state.mode === "vector") return;
 	if (state.mode === "pro") {
 		return state.advancedCondition || undefined;
 	}

--- a/packages/core/src/domain/search/schema.ts
+++ b/packages/core/src/domain/search/schema.ts
@@ -3,7 +3,7 @@ import { searchGroupSchema } from "@/domain/media/schemas";
 
 export const searchStateSchema = z.object({
 	// Modes
-	mode: z.enum(["simple", "pro", "vector"]),
+	mode: z.enum(["simple", "pro"]),
 	activePresetId: z.number().nullable(),
 
 	// Filters (Simple Mode)
@@ -19,8 +19,10 @@ export const searchStateSchema = z.object({
 
 	// Filters (Pro Mode)
 	advancedCondition: searchGroupSchema.nullable(),
+
+	// Similarity ordering
 	similarityAnchorMediaId: z.string().uuid().nullable(),
-	similarityTopK: z.union([z.literal(20), z.literal(50), z.literal(100)]),
+	similarityTopK: z.number().int().min(1).max(100),
 
 	// Pagination
 	limit: z.number(),

--- a/packages/ui/src/hooks/use-current-search-persistence.test.ts
+++ b/packages/ui/src/hooks/use-current-search-persistence.test.ts
@@ -1,7 +1,7 @@
 import { type Accessor, createRoot, createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	activateVectorSearch,
+	activateSimilaritySearch,
 	resetSearchState,
 	searchState,
 	setSearchState,
@@ -241,19 +241,19 @@ describe("useCurrentSearchPersistence", () => {
 		expect(sessionStorage.getItem("current-all")).toContain("legacy query");
 	});
 
-	it("restores a v2 vector search activated from the detail route", async () => {
-		activateVectorSearch("media-v2", { surface: "v2" });
+	it("restores v2 similarity ordering activated from the detail route", async () => {
+		activateSimilaritySearch("media-v2", { surface: "v2" });
 
 		const mounted = mountPersistence("all", { surface: "v2" });
 		await flushMicrotasks();
 
 		expect(mounted.isRestored()).toBe(true);
-		expect(searchState.mode).toBe("vector");
+		expect(searchState.mode).toBe("simple");
 		expect(searchState.similarityAnchorMediaId).toBe("media-v2");
 		expect(sessionStorage.getItem("current-all")).toBeNull();
 	});
 
-	it("does not inherit a source for legacy vector sessions", async () => {
+	it("migrates legacy similarity sessions without inheriting a source", async () => {
 		setSearchState("selectedSource", "stale-source");
 		sessionStorage.setItem(
 			"current-all",
@@ -267,7 +267,7 @@ describe("useCurrentSearchPersistence", () => {
 		mountPersistence("all");
 		await flushMicrotasks();
 
-		expect(searchState.mode).toBe("vector");
+		expect(searchState.mode).toBe("simple");
 		expect(searchState.selectedSource).toBe("");
 		expect(searchState.similarityTopK).toBe(100);
 	});

--- a/packages/ui/src/hooks/use-current-search-persistence.ts
+++ b/packages/ui/src/hooks/use-current-search-persistence.ts
@@ -78,6 +78,15 @@ function normalizeScrollPosition(value: number): number {
 	return Number.isFinite(value) && value >= 0 ? value : 0;
 }
 
+function normalizeSimilarityTopK(value: unknown): number {
+	return typeof value === "number" &&
+		Number.isInteger(value) &&
+		value >= 1 &&
+		value <= 100
+		? value
+		: 50;
+}
+
 /**
  * Persist the scroll owner explicitly when a route owns a non-window
  * collection scroller.  The reactive persistence effect remains the
@@ -227,16 +236,14 @@ function restoreCurrentSearchState(
 			typeof current.selectedSource === "string" ? current.selectedSource : "";
 		resetSearchState();
 		setSearchState({
-			mode: "vector",
+			// Migrate sessions written before similarity became an ordering option.
+			mode: "simple",
 			selectedSource,
 			similarityAnchorMediaId:
 				typeof current.similarityAnchorMediaId === "string"
 					? current.similarityAnchorMediaId
 					: null,
-			similarityTopK:
-				current.similarityTopK === 20 || current.similarityTopK === 100
-					? current.similarityTopK
-					: 50,
+			similarityTopK: normalizeSimilarityTopK(current.similarityTopK),
 			scrollY: preservedScrollY,
 		});
 		return;
@@ -263,6 +270,15 @@ function restoreCurrentSearchState(
 			: searchState.selectedSource;
 
 	applyPreset(localPresetResult.data, shouldApply, true, selectedSource);
+	if (shouldApply()) {
+		setSearchState({
+			similarityAnchorMediaId:
+				typeof current.similarityAnchorMediaId === "string"
+					? current.similarityAnchorMediaId
+					: null,
+			similarityTopK: normalizeSimilarityTopK(current.similarityTopK),
+		});
+	}
 }
 
 export function useCurrentSearchPersistence(

--- a/packages/ui/src/hooks/use-search-page.ts
+++ b/packages/ui/src/hooks/use-search-page.ts
@@ -76,7 +76,7 @@ export interface UseSearchPageOptions {
 	scrollY: () => number;
 	setScrollY: (y: number) => void;
 	setOffset: (o: number) => void;
-	mode?: () => "simple" | "pro" | "vector";
+	mode?: () => "simple" | "pro";
 	similarityAnchorMediaId?: () => string | null;
 	similarityTopK?: () => number;
 	gcTime?: number;

--- a/packages/ui/src/mobile-search-filter-dialog.tsx
+++ b/packages/ui/src/mobile-search-filter-dialog.tsx
@@ -35,9 +35,7 @@ function copySearchState(state: SearchState): SearchState {
 function createClearedSearchState(state: SearchState): SearchState {
 	return {
 		...defaultState,
-		// A cleared vector search has no valid anchor, so return to a mode that
-		// can be applied instead of leaving the dialog permanently disabled.
-		mode: state.mode === "vector" ? "simple" : state.mode,
+		mode: state.mode,
 		selectedSource: state.selectedSource,
 		sortBy: state.sortBy,
 		sortOrder: state.sortOrder,
@@ -56,6 +54,9 @@ function getActiveConditionLabels(
 			(item) => item.id === state.selectedSource,
 		);
 		labels.push(`ソース: ${source?.name ?? "選択済み"}`);
+	}
+	if (state.similarityAnchorMediaId) {
+		labels.push(`類似度順: ${state.similarityTopK}件`);
 	}
 
 	if (state.mode === "simple") {
@@ -90,9 +91,6 @@ function getActiveConditionLabels(
 		return labels;
 	}
 
-	if (state.similarityAnchorMediaId) {
-		labels.push("類似元メディアを設定済み");
-	}
 	return labels;
 }
 
@@ -162,9 +160,6 @@ export function MobileSearchFilterDialog(props: MobileSearchFilterDialogProps) {
 	const handleClear = () => {
 		setDraft(createClearedSearchState(draft));
 	};
-	const isApplyDisabled = () =>
-		draft.mode === "vector" && !draft.similarityAnchorMediaId;
-
 	return (
 		<Dialog onOpenChange={props.onOpenChange} open={props.open}>
 			<DialogContent class="max-w-lg gap-4 p-4 sm:p-6">
@@ -197,11 +192,7 @@ export function MobileSearchFilterDialog(props: MobileSearchFilterDialogProps) {
 					<Button onClick={handleClear} type="button" variant="outline">
 						条件をクリア
 					</Button>
-					<Button
-						disabled={isApplyDisabled()}
-						onClick={handleApply}
-						type="button"
-					>
+					<Button onClick={handleApply} type="button">
 						適用
 					</Button>
 				</DialogFooter>

--- a/packages/ui/src/query-options/search-query.test.ts
+++ b/packages/ui/src/query-options/search-query.test.ts
@@ -226,7 +226,7 @@ describe("buildSearchResultsQueryOptions", () => {
 		).toBeUndefined();
 	});
 
-	it("forwards vector search input and disables pagination", async () => {
+	it("forwards similarity ordering input and disables pagination", async () => {
 		const response = { media: [TEST_MEDIA], total: 10 };
 		const searchMedia = vi.fn(
 			async (): Promise<MediaSearchResponse> => EMPTY_RESPONSE,
@@ -235,7 +235,7 @@ describe("buildSearchResultsQueryOptions", () => {
 			async (): Promise<MediaSearchResponse> => response,
 		);
 		const options = buildSearchResultsQueryOptions({
-			mode: "vector",
+			mode: "simple",
 			sourceId: "source-2",
 			condition: TEST_CONDITION,
 			conditionKey: "vector-condition",
@@ -281,19 +281,19 @@ describe("buildSearchResultsQueryOptions", () => {
 		expect(options.placeholderData).toBeUndefined();
 	});
 
-	it("returns an empty result when vector search requirements are absent", async () => {
+	it("returns an empty result when the similarity client is unavailable", async () => {
 		const searchMedia = vi.fn(
 			async (): Promise<MediaSearchResponse> => EMPTY_RESPONSE,
 		);
 		const options = buildSearchResultsQueryOptions({
-			mode: "vector",
+			mode: "simple",
 			sourceId: undefined,
 			condition: undefined,
 			conditionKey: "null",
 			sort: undefined,
 			order: "desc",
 			limit: 100,
-			similarityAnchorMediaId: null,
+			similarityAnchorMediaId: "anchor-media",
 			similarityTopK: 50,
 			searchMedia,
 			searchSimilar: undefined,

--- a/packages/ui/src/query-options/search-query.ts
+++ b/packages/ui/src/query-options/search-query.ts
@@ -11,7 +11,7 @@ import {
 export const MEDIA_RESULTS_STALE_TIME_MS = 1000 * 60 * 5;
 
 export type SearchResultsQueryKeyInput = {
-	mode: "simple" | "pro" | "vector";
+	mode: "simple" | "pro";
 	sourceId: string | undefined;
 	conditionKey: string;
 	sort: string | undefined;
@@ -117,7 +117,7 @@ type SearchSimilar = (
 ) => Promise<MediaSearchResponse>;
 
 export type SearchResultsQueryOptionsInput = {
-	mode: "simple" | "pro" | "vector";
+	mode: "simple" | "pro";
 	sourceId: string | undefined;
 	condition: MediaSearchRequest["condition"];
 	conditionKey: string;
@@ -147,8 +147,8 @@ export function buildSearchResultsQueryOptions(
 			similarityTopK: input.similarityTopK,
 		}),
 		queryFn: async ({ pageParam, signal }): Promise<MediaSearchResponse> => {
-			if (input.mode === "vector") {
-				if (!(input.similarityAnchorMediaId && input.searchSimilar)) {
+			if (input.similarityAnchorMediaId) {
+				if (!input.searchSimilar) {
 					return { media: [], total: 0 };
 				}
 				return await input.searchSimilar(
@@ -175,7 +175,7 @@ export function buildSearchResultsQueryOptions(
 		},
 		initialPageParam: 0,
 		getNextPageParam: (lastPage, allPages) => {
-			if (input.mode === "vector") {
+			if (input.similarityAnchorMediaId) {
 				return;
 			}
 			const loadedCount = allPages.reduce(
@@ -184,9 +184,11 @@ export function buildSearchResultsQueryOptions(
 			);
 			return loadedCount < lastPage.total ? loadedCount : undefined;
 		},
-		// Vector result sets have a user-selected size. Keeping the previous
+		// Similarity result sets have a user-selected size. Keeping the previous
 		// result while changing topK makes selecting 100 look like a no-op.
-		placeholderData: input.mode === "vector" ? undefined : keepPreviousData,
+		placeholderData: input.similarityAnchorMediaId
+			? undefined
+			: keepPreviousData,
 		enabled: input.enabled,
 		gcTime: input.gcTime,
 		staleTime: MEDIA_RESULTS_STALE_TIME_MS,

--- a/packages/ui/src/screens/design-concept-screen.tsx
+++ b/packages/ui/src/screens/design-concept-screen.tsx
@@ -937,7 +937,7 @@ function MediaTile(props: {
 	);
 }
 
-type SearchMode = "simple" | "pro" | "vector";
+type SearchMode = "simple" | "pro";
 
 function parseFilterValues(value: string) {
 	return [
@@ -1041,13 +1041,12 @@ function DesignFilterPopover(props: {
 						<legend class="mb-2 font-medium text-[#555c58] text-xs">
 							検索モード
 						</legend>
-						<div class="grid grid-cols-3 rounded-md border border-[#d9dfdb] bg-white p-0.5">
+						<div class="grid grid-cols-2 rounded-md border border-[#d9dfdb] bg-white p-0.5">
 							<For
 								each={
 									[
 										["simple", "簡易"],
 										["pro", "詳細"],
-										["vector", "類似"],
 									] as const
 								}
 							>
@@ -1075,7 +1074,7 @@ function DesignFilterPopover(props: {
 							<div class="mt-4 rounded-md border border-[#dfe4e1] bg-white p-4 text-[#6d7470] text-xs leading-5">
 								{props.mode === "pro"
 									? "詳細検索は条件ビルダーを別パネルで開き、この一覧レイアウトは維持します。"
-									: "類似元メディアと表示件数をここで確認し、通常のソートは適用しません。"}
+									: "検索条件をここで確認し、一覧の並べ替えは維持します。"}
 							</div>
 						}
 						when={props.mode === "simple"}

--- a/packages/ui/src/search-control-panel.tsx
+++ b/packages/ui/src/search-control-panel.tsx
@@ -22,7 +22,7 @@ import {
 } from "./select";
 import { SortControls } from "./sort-controls";
 import {
-	clearVectorSearchAnchor,
+	clearSimilaritySearch,
 	type SearchPersistenceSurface,
 	searchState,
 	setSearchState,
@@ -68,12 +68,12 @@ export function SearchControlPanel(props: SearchControlPanelProps) {
 		}
 		props.onSelectSource?.(id);
 	};
-	const handleSetMode = (mode: "simple" | "pro" | "vector") => {
+	const handleSetMode = (mode: "simple" | "pro") => {
 		updateState(calculateNextModeState(currentState(), mode));
 	};
 	const clearSimilarityAnchor = () => {
 		if (!props.setState) {
-			clearVectorSearchAnchor({ surface: props.persistenceSurface });
+			clearSimilaritySearch({ surface: props.persistenceSurface });
 			return;
 		}
 		props.setState({
@@ -138,26 +138,25 @@ export function SearchControlPanel(props: SearchControlPanelProps) {
 					>
 						詳細
 					</Button>
-					<Button
-						class="min-h-11 md:min-h-9"
-						onClick={() => handleSetMode("vector")}
-						size="sm"
-						variant={currentState().mode === "vector" ? "default" : "outline"}
-					>
-						ベクトル類似
-					</Button>
 				</div>
 			</div>
 
-			<Show when={currentState().mode !== "vector"}>
-				<SortControls
-					className="mb-4"
-					onSortByChange={(value) => updateState("sortBy", value)}
-					onSortOrderChange={(value) => updateState("sortOrder", value)}
-					sortBy={currentState().sortBy}
-					sortOrder={currentState().sortOrder}
-				/>
-			</Show>
+			<SortControls
+				className="mb-4"
+				onClearSimilarity={clearSimilarityAnchor}
+				onSimilarityTopKChange={(value) => updateState("similarityTopK", value)}
+				onSortByChange={(value) => updateState("sortBy", value)}
+				onSortOrderChange={(value) => updateState("sortOrder", value)}
+				similarityAnchorMediaId={currentState().similarityAnchorMediaId}
+				similarityLimitId={
+					props.setState
+						? "mobile-search-panel-similarity-limit"
+						: "search-panel-similarity-limit"
+				}
+				similarityTopK={currentState().similarityTopK}
+				sortBy={currentState().sortBy}
+				sortOrder={currentState().sortOrder}
+			/>
 
 			<div class="my-4 h-px bg-border" />
 
@@ -199,58 +198,6 @@ export function SearchControlPanel(props: SearchControlPanelProps) {
 					/>
 				</div>
 			</Show>
-
-			<div class={currentState().mode === "vector" ? "block" : "hidden"}>
-				<div class="space-y-4">
-					<div class="space-y-2">
-						<Label>類似元メディア</Label>
-						<div class="rounded-md border p-3 text-sm">
-							{currentState().similarityAnchorMediaId ??
-								"メディア個別画面の「Find Similar」から選択してください。"}
-						</div>
-						<Show when={currentState().similarityAnchorMediaId}>
-							<Button
-								class="w-full"
-								onClick={clearSimilarityAnchor}
-								size="sm"
-								variant="outline"
-							>
-								類似元を解除
-							</Button>
-						</Show>
-					</div>
-					<div class="space-y-2">
-						<Label>表示件数</Label>
-						<div class="flex gap-2">
-							{([20, 50, 100] as const).map((value) => (
-								<Button
-									class="min-h-11 md:min-h-9"
-									onClick={() => updateState("similarityTopK", value)}
-									size="sm"
-									variant={
-										currentState().similarityTopK === value
-											? "default"
-											: "outline"
-									}
-								>
-									{value}
-								</Button>
-							))}
-						</div>
-					</div>
-					<Show when={props.showSearchButton !== false}>
-						<Button
-							disabled={!currentState().similarityAnchorMediaId}
-							onClick={props.onSearch}
-						>
-							類似メディアを検索
-						</Button>
-					</Show>
-					<p class="text-muted-foreground text-xs">
-						CCIPによるキャラクター類似検索です。一般的な画像重複検索とは異なります。
-					</p>
-				</div>
-			</div>
 		</div>
 	);
 }

--- a/packages/ui/src/sort-controls.tsx
+++ b/packages/ui/src/sort-controls.tsx
@@ -1,3 +1,6 @@
+import { Show } from "solid-js";
+import { Button } from "./button";
+import { Input } from "./input";
 import { Label } from "./label";
 import {
 	Select,
@@ -17,6 +20,11 @@ type SortControlsProps = {
 	sortOrder: "asc" | "desc";
 	onSortByChange: (value: SortOption) => void;
 	onSortOrderChange: (value: "asc" | "desc") => void;
+	similarityAnchorMediaId?: string | null;
+	similarityTopK?: number;
+	onSimilarityTopKChange?: (value: number) => void;
+	onClearSimilarity?: () => void;
+	similarityLimitId?: string;
 	className?: string;
 };
 
@@ -43,6 +51,7 @@ export function SortControls(props: SortControlsProps) {
 				<Label>ソート</Label>
 				<div class="grid grid-cols-2 gap-2">
 					<Select
+						disabled={Boolean(props.similarityAnchorMediaId)}
 						itemComponent={(itemProps) => (
 							<SelectItem item={itemProps.item}>
 								{getSortLabel(itemProps.item.rawValue as SortOption)}
@@ -73,6 +82,7 @@ export function SortControls(props: SortControlsProps) {
 						<SelectContent />
 					</Select>
 					<Select
+						disabled={Boolean(props.similarityAnchorMediaId)}
 						itemComponent={(itemProps) => (
 							<SelectItem item={itemProps.item}>
 								{itemProps.item.rawValue === "asc" ? "昇順" : "降順"}
@@ -94,6 +104,61 @@ export function SortControls(props: SortControlsProps) {
 					</Select>
 				</div>
 			</div>
+			<Show
+				when={
+					props.similarityAnchorMediaId &&
+					props.similarityTopK !== undefined &&
+					props.onSimilarityTopKChange
+				}
+			>
+				<div class="mt-4 space-y-2 border-border border-t pt-4">
+					<div class="flex items-center justify-between gap-2">
+						<Label for={props.similarityLimitId ?? "similarity-limit"}>
+							類似度順
+						</Label>
+						<Show when={props.onClearSimilarity}>
+							<Button
+								class="h-7 px-2 text-xs"
+								onClick={props.onClearSimilarity}
+								size="sm"
+								variant="ghost"
+							>
+								解除
+							</Button>
+						</Show>
+					</div>
+					<p class="truncate text-muted-foreground text-xs">
+						類似元: {props.similarityAnchorMediaId}
+					</p>
+					<div class="flex items-center gap-2">
+						<Input
+							aria-describedby={`${props.similarityLimitId ?? "similarity-limit"}-help`}
+							class="min-h-9"
+							id={props.similarityLimitId ?? "similarity-limit"}
+							inputmode="numeric"
+							max={100}
+							min={1}
+							name={props.similarityLimitId ?? "similarity-limit"}
+							onInput={(event) => {
+								const value = Number(event.currentTarget.value);
+								if (Number.isInteger(value) && value >= 1 && value <= 100) {
+									props.onSimilarityTopKChange?.(value);
+								}
+							}}
+							step={1}
+							type="number"
+							value={props.similarityTopK}
+						/>
+						<span class="text-muted-foreground text-xs">件</span>
+					</div>
+					<p
+						class="text-muted-foreground text-xs"
+						id={`${props.similarityLimitId ?? "similarity-limit"}-help`}
+					>
+						1〜100の整数を指定できます。
+					</p>
+				</div>
+			</Show>
 		</div>
 	);
 }

--- a/packages/ui/src/stores/search-store.test.ts
+++ b/packages/ui/src/stores/search-store.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-	activateVectorSearch,
-	clearVectorSearchAnchor,
+	activateSimilaritySearch,
+	clearSimilaritySearch,
 	searchState,
 	setSearchState,
 } from "./search-store";
@@ -34,7 +34,7 @@ class MemoryStorage implements Storage {
 	}
 }
 
-describe("activateVectorSearch", () => {
+describe("activateSimilaritySearch", () => {
 	beforeEach(() => {
 		Object.defineProperty(globalThis, "sessionStorage", {
 			configurable: true,
@@ -49,14 +49,18 @@ describe("activateVectorSearch", () => {
 	});
 
 	it("persists v2 activation without writing the legacy state key", () => {
-		activateVectorSearch("media-v2", { surface: "v2" });
+		activateSimilaritySearch("media-v2", { surface: "v2" });
 
-		expect(searchState.mode).toBe("vector");
+		expect(searchState.mode).toBe("simple");
 		expect(searchState.similarityAnchorMediaId).toBe("media-v2");
 		expect(
 			JSON.parse(sessionStorage.getItem("v2:current-all") ?? "{}"),
 		).toEqual({
-			mode: "vector",
+			value: { type: "group", operator: "and", children: [] },
+			selectedSource: "",
+			sort: "date",
+			order: "desc",
+			mode: "simple",
 			similarityAnchorMediaId: "media-v2",
 			similarityTopK: 50,
 		});
@@ -64,37 +68,45 @@ describe("activateVectorSearch", () => {
 	});
 });
 
-describe("clearVectorSearchAnchor", () => {
+describe("clearSimilaritySearch", () => {
 	beforeEach(() => {
 		Object.defineProperty(globalThis, "sessionStorage", {
 			configurable: true,
 			value: new MemoryStorage(),
 		});
 		setSearchState({
-			mode: "vector",
+			mode: "simple",
 			similarityAnchorMediaId: "media-1",
 			offset: 10,
 			scrollY: 100,
 		});
 	});
 
-	it("clears both the store and persisted vector anchor", () => {
+	it("clears both the store and persisted similarity anchor", () => {
 		sessionStorage.setItem(
 			"current-all",
 			JSON.stringify({
-				mode: "vector",
+				value: { type: "group", operator: "and", children: [] },
+				selectedSource: "",
+				sort: "date",
+				order: "desc",
+				mode: "simple",
 				similarityAnchorMediaId: "media-1",
 				similarityTopK: 50,
 			}),
 		);
 
-		clearVectorSearchAnchor();
+		clearSimilaritySearch();
 
 		expect(searchState.similarityAnchorMediaId).toBeNull();
 		expect(searchState.offset).toBe(0);
 		expect(searchState.scrollY).toBe(0);
 		expect(JSON.parse(sessionStorage.getItem("current-all") ?? "{}")).toEqual({
-			mode: "vector",
+			value: { type: "group", operator: "and", children: [] },
+			selectedSource: "",
+			sort: "date",
+			order: "desc",
+			mode: "simple",
 			similarityAnchorMediaId: null,
 			similarityTopK: 50,
 		});
@@ -103,9 +115,9 @@ describe("clearVectorSearchAnchor", () => {
 	it("removes malformed persisted state", () => {
 		sessionStorage.setItem("current-all", "not-json");
 
-		clearVectorSearchAnchor();
+		clearSimilaritySearch();
 
-		expect(sessionStorage.getItem("current-all")).toBeNull();
+		expect(sessionStorage.getItem("current-all")).toContain('"mode":"simple"');
 	});
 
 	it("clears the v2 persisted anchor without touching the legacy key", () => {
@@ -116,23 +128,83 @@ describe("clearVectorSearchAnchor", () => {
 		sessionStorage.setItem(
 			"v2:current-all",
 			JSON.stringify({
-				mode: "vector",
+				value: { type: "group", operator: "and", children: [] },
+				selectedSource: "",
+				sort: "date",
+				order: "desc",
+				mode: "simple",
 				similarityAnchorMediaId: "media-v2",
 				similarityTopK: 50,
 			}),
 		);
 
-		clearVectorSearchAnchor({ surface: "v2" });
+		clearSimilaritySearch({ surface: "v2" });
 
 		expect(
 			JSON.parse(sessionStorage.getItem("v2:current-all") ?? "{}"),
 		).toEqual({
-			mode: "vector",
+			value: { type: "group", operator: "and", children: [] },
+			selectedSource: "",
+			sort: "date",
+			order: "desc",
+			mode: "simple",
 			similarityAnchorMediaId: null,
 			similarityTopK: 50,
 		});
 		expect(JSON.parse(sessionStorage.getItem("current-all") ?? "{}")).toEqual({
 			similarityAnchorMediaId: "legacy-media",
+		});
+	});
+});
+
+describe("clearSimilaritySearch preserves the selected mode", () => {
+	beforeEach(() => {
+		Object.defineProperty(globalThis, "sessionStorage", {
+			configurable: true,
+			value: new MemoryStorage(),
+		});
+		setSearchState({
+			mode: "pro",
+			similarityAnchorMediaId: "11111111-1111-4111-8111-111111111111",
+			offset: 10,
+			scrollY: 100,
+		});
+	});
+
+	it("clears the anchor without changing the selected mode", () => {
+		sessionStorage.setItem(
+			"v2:current-all",
+			JSON.stringify({
+				value: { type: "group", operator: "and", children: [] },
+				selectedSource: "",
+				sort: "date",
+				order: "desc",
+				mode: "pro",
+				similarityAnchorMediaId: "11111111-1111-4111-8111-111111111111",
+				similarityTopK: 50,
+			}),
+		);
+
+		clearSimilaritySearch({ surface: "v2" });
+
+		expect(searchState.mode).toBe("pro");
+		expect(searchState.similarityAnchorMediaId).toBeNull();
+		expect(searchState.offset).toBe(0);
+		expect(searchState.scrollY).toBe(0);
+		expect(
+			JSON.parse(sessionStorage.getItem("v2:current-all") ?? "{}"),
+		).toEqual({
+			value: {
+				type: "group",
+				operator: "and",
+				children: [],
+			},
+			selectedSource: "",
+			sort: "date",
+			order: "desc",
+			mode: "pro",
+			similarityAnchorMediaId: null,
+			similarityTopK: 50,
 		});
 	});
 });

--- a/packages/ui/src/stores/search-store.ts
+++ b/packages/ui/src/stores/search-store.ts
@@ -44,65 +44,71 @@ export const loadPreset = (preset: Preset) => {
 	setSearchState(nextState);
 };
 
-export const setSearchMode = (mode: "simple" | "pro" | "vector") => {
+export const setSearchMode = (mode: "simple" | "pro") => {
 	const nextState = calculateNextModeState(searchState, mode);
 	setSearchState(nextState);
 };
 
-export const activateVectorSearch = (
+function persistSearchState(
+	state: SearchState,
+	surface: SearchPersistenceSurface,
+): void {
+	if (typeof sessionStorage === "undefined") return;
+
+	const condition = getSearchConditionFromState(state) ?? {
+		type: "group" as const,
+		operator: "and" as const,
+		children: [],
+	};
+	const storageKey = getSearchStateStorageKey(surface);
+	sessionStorage.setItem(
+		storageKey,
+		JSON.stringify({
+			value: condition,
+			selectedSource: state.selectedSource,
+			sort: state.sortBy,
+			order: state.sortOrder,
+			mode: state.mode,
+			similarityAnchorMediaId: state.similarityAnchorMediaId,
+			similarityTopK: state.similarityTopK,
+		}),
+	);
+}
+
+export const activateSimilaritySearch = (
 	mediaId: string,
 	options: SearchStorePersistenceOptions = {},
 ) => {
-	const nextState = {
-		mode: "vector" as const,
+	const nextState: SearchState = {
+		...searchState,
 		similarityAnchorMediaId: mediaId,
-		similarityTopK: 50 as const,
+		similarityTopK: 50,
 		selectedSource: "",
 		offset: 0,
 		scrollY: 0,
 	};
 	setSearchState(nextState);
-	if (typeof sessionStorage !== "undefined") {
-		const storageKey = getSearchStateStorageKey(options.surface ?? "legacy");
-		sessionStorage.setItem(
-			storageKey,
-			JSON.stringify({
-				mode: nextState.mode,
-				similarityAnchorMediaId: nextState.similarityAnchorMediaId,
-				similarityTopK: nextState.similarityTopK,
-			}),
-		);
+	try {
+		persistSearchState(nextState, options.surface ?? "legacy");
+	} catch {
+		// Persistence errors must not disrupt opening similarity ordering.
 	}
 };
 
-export const clearVectorSearchAnchor = (
+export const clearSimilaritySearch = (
 	options: SearchStorePersistenceOptions = {},
 ) => {
-	setSearchState({
+	const nextState: SearchState = {
+		...searchState,
 		similarityAnchorMediaId: null,
 		offset: 0,
 		scrollY: 0,
-	});
-	if (typeof sessionStorage !== "undefined") {
-		const storageKey = getSearchStateStorageKey(options.surface ?? "legacy");
-		const stored = sessionStorage.getItem(storageKey);
-		if (!stored) return;
-		try {
-			const current: unknown = JSON.parse(stored);
-			if (typeof current !== "object" || current === null) {
-				sessionStorage.removeItem(storageKey);
-				return;
-			}
-			sessionStorage.setItem(
-				storageKey,
-				JSON.stringify({
-					...current,
-					similarityAnchorMediaId: null,
-				}),
-			);
-		} catch {
-			sessionStorage.removeItem(storageKey);
-		}
+	};
+	setSearchState(nextState);
+	try {
+		persistSearchState(nextState, options.surface ?? "legacy");
+	} catch {
+		// Persistence errors must not disrupt clearing similarity ordering.
 	}
 };
 

--- a/packages/ui/src/v2/search-composer-utils.ts
+++ b/packages/ui/src/v2/search-composer-utils.ts
@@ -1,3 +1,4 @@
+import type { SearchState } from "@solid-imager/core/domain/search/schema";
 import type { SearchPageFilterData } from "../hooks/use-search-page";
 
 export type SearchArrayKey =
@@ -10,9 +11,14 @@ export type SearchArrayKey =
 
 export type SearchToken = {
 	destructive?: boolean;
-	key: SearchArrayKey | "searchQuery";
+	key:
+		| SearchArrayKey
+		| "searchQuery"
+		| "similarityAnchorMediaId"
+		| "similarityTopK";
 	prefix: string;
 	value: string;
+	removable?: boolean;
 };
 
 export type SearchSuggestion = {
@@ -21,6 +27,74 @@ export type SearchSuggestion = {
 	prefix: string;
 	value: string;
 };
+
+export function getSearchComposerTokens(state: SearchState): SearchToken[] {
+	const similarityTokens: SearchToken[] = state.similarityAnchorMediaId
+		? [
+				{
+					key: "similarityAnchorMediaId",
+					prefix: "similar",
+					value: state.similarityAnchorMediaId,
+				},
+				{
+					key: "similarityTopK",
+					prefix: "limit",
+					value: String(state.similarityTopK),
+					removable: false,
+				},
+			]
+		: [];
+	const normalTokens: SearchToken[] = [
+		...(state.searchQuery
+			? [
+					{
+						key: "searchQuery" as const,
+						prefix: "name",
+						value: state.searchQuery,
+					},
+				]
+			: []),
+		...state.selectedTags.map((value) => ({
+			key: "selectedTags" as const,
+			prefix: "tag",
+			value,
+		})),
+		...state.excludeTags.map((value) => ({
+			destructive: true,
+			key: "excludeTags" as const,
+			prefix: "-tag",
+			value,
+		})),
+		...state.selectedCharacters.map((value) => ({
+			key: "selectedCharacters" as const,
+			prefix: "character",
+			value,
+		})),
+		...state.selectedIps.map((value) => ({
+			key: "selectedIps" as const,
+			prefix: "ip",
+			value,
+		})),
+		...state.selectedAuthors.map((value) => ({
+			key: "selectedAuthors" as const,
+			prefix: "author",
+			value,
+		})),
+		...state.selectedProjects.map((value) => ({
+			key: "selectedProjects" as const,
+			prefix: "project",
+			value,
+		})),
+	];
+	return [...similarityTokens, ...normalTokens];
+}
+
+export function parseSimilarityTopK(value: string): number | undefined {
+	const parsed = Number(value);
+	return Number.isInteger(parsed) && parsed >= 1 && parsed <= 100
+		? parsed
+		: undefined;
+}
 
 type SuggestionSource = keyof SearchPageFilterData;
 

--- a/packages/ui/src/v2/search-composer-utils.ts
+++ b/packages/ui/src/v2/search-composer-utils.ts
@@ -1,3 +1,4 @@
+import { mediaIdSchema } from "@solid-imager/core/domain/media/schemas";
 import type { SearchState } from "@solid-imager/core/domain/search/schema";
 import type { SearchPageFilterData } from "../hooks/use-search-page";
 
@@ -94,6 +95,11 @@ export function parseSimilarityTopK(value: string): number | undefined {
 	return Number.isInteger(parsed) && parsed >= 1 && parsed <= 100
 		? parsed
 		: undefined;
+}
+
+export function parseSimilarityAnchor(value: string): string | undefined {
+	const parsed = mediaIdSchema.safeParse(value);
+	return parsed.success ? parsed.data : undefined;
 }
 
 type SuggestionSource = keyof SearchPageFilterData;

--- a/packages/ui/src/v2/search-composer.test.ts
+++ b/packages/ui/src/v2/search-composer.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { defaultState } from "@solid-imager/core/domain/search/schema";
 import type { SearchPageFilterData } from "../hooks/use-search-page";
 import {
 	getSearchComposerSuggestions,
+	getSearchComposerTokens,
+	parseSimilarityTopK,
 	type SearchToken,
 } from "./search-composer-utils";
 
@@ -60,5 +63,48 @@ describe("getSearchComposerSuggestions", () => {
 		expect(
 			getSearchComposerSuggestions("tag:blue,red", filterData, []),
 		).toEqual([]);
+	});
+});
+
+describe("getSearchComposerTokens", () => {
+	it("exposes similarity ordering as similarity and limit tokens", () => {
+		const state = {
+			...defaultState,
+			similarityAnchorMediaId: "11111111-1111-4111-8111-111111111111",
+			similarityTopK: 37,
+		};
+
+		expect(getSearchComposerTokens(state)).toEqual([
+			{
+				key: "similarityAnchorMediaId",
+				prefix: "similar",
+				value: "11111111-1111-4111-8111-111111111111",
+			},
+			{
+				key: "similarityTopK",
+				prefix: "limit",
+				value: "37",
+				removable: false,
+			},
+		]);
+	});
+
+	it("does not expose similarity options when no anchor is set", () => {
+		expect(getSearchComposerTokens(defaultState)).toEqual([]);
+	});
+});
+
+describe("parseSimilarityTopK", () => {
+	it("accepts arbitrary supported result sizes", () => {
+		expect(parseSimilarityTopK("20")).toBe(20);
+		expect(parseSimilarityTopK("50")).toBe(50);
+		expect(parseSimilarityTopK("100")).toBe(100);
+		expect(parseSimilarityTopK("37")).toBe(37);
+	});
+
+	it("rejects unsupported result sizes", () => {
+		expect(parseSimilarityTopK("0")).toBeUndefined();
+		expect(parseSimilarityTopK("200")).toBeUndefined();
+		expect(parseSimilarityTopK("abc")).toBeUndefined();
 	});
 });

--- a/packages/ui/src/v2/search-composer.test.ts
+++ b/packages/ui/src/v2/search-composer.test.ts
@@ -4,6 +4,7 @@ import type { SearchPageFilterData } from "../hooks/use-search-page";
 import {
 	getSearchComposerSuggestions,
 	getSearchComposerTokens,
+	parseSimilarityAnchor,
 	parseSimilarityTopK,
 	type SearchToken,
 } from "./search-composer-utils";
@@ -63,6 +64,18 @@ describe("getSearchComposerSuggestions", () => {
 		expect(
 			getSearchComposerSuggestions("tag:blue,red", filterData, []),
 		).toEqual([]);
+	});
+});
+
+describe("parseSimilarityAnchor", () => {
+	it("accepts UUID media IDs", () => {
+		expect(parseSimilarityAnchor("11111111-1111-4111-8111-111111111111")).toBe(
+			"11111111-1111-4111-8111-111111111111",
+		);
+	});
+
+	it("rejects non-UUID values", () => {
+		expect(parseSimilarityAnchor("not-a-media-id")).toBeUndefined();
 	});
 });
 

--- a/packages/ui/src/v2/search-composer.tsx
+++ b/packages/ui/src/v2/search-composer.tsx
@@ -20,6 +20,10 @@ export type {
 	SearchSuggestion,
 	SearchToken,
 } from "./search-composer-utils";
+export {
+	getSearchComposerTokens,
+	parseSimilarityTopK,
+} from "./search-composer-utils";
 
 import {
 	getSearchComposerSuggestions,
@@ -93,7 +97,9 @@ export function SearchComposer(props: SearchComposerProps) {
 		event,
 	) => {
 		if (event.key === "Backspace" && props.draft.length === 0) {
-			const token = props.tokens[props.tokens.length - 1];
+			const token = props.tokens
+				.filter((item) => item.removable !== false)
+				.at(-1);
 			if (token) {
 				event.preventDefault();
 				props.onRemoveToken(token);
@@ -163,14 +169,16 @@ export function SearchComposer(props: SearchComposerProps) {
 								<span class="truncate">
 									{token.prefix}:{token.value}
 								</span>
-								<button
-									aria-label={`${token.prefix}:${token.value}を解除`}
-									class="flex size-4 shrink-0 items-center justify-center rounded hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-focus)]"
-									onClick={() => props.onRemoveToken(token)}
-									type="button"
-								>
-									×
-								</button>
+								<Show when={token.removable !== false}>
+									<button
+										aria-label={`${token.prefix}:${token.value}を解除`}
+										class="flex size-4 shrink-0 items-center justify-center rounded hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-focus)]"
+										onClick={() => props.onRemoveToken(token)}
+										type="button"
+									>
+										×
+									</button>
+								</Show>
 							</span>
 						)}
 					</For>
@@ -186,7 +194,7 @@ export function SearchComposer(props: SearchComposerProps) {
 							if (suggestions().length > 0) setMenuOpen(true);
 						}}
 						onKeyDown={handleKeyDown}
-						placeholder="検索、または tag: / author: / ip: …"
+						placeholder="検索、または tag: / author: / similar: / limit:100 …"
 						ref={props.inputRef}
 					/>
 				</ComboboxControl>

--- a/packages/ui/src/v2/search-composer.tsx
+++ b/packages/ui/src/v2/search-composer.tsx
@@ -22,6 +22,7 @@ export type {
 } from "./search-composer-utils";
 export {
 	getSearchComposerTokens,
+	parseSimilarityAnchor,
 	parseSimilarityTopK,
 } from "./search-composer-utils";
 

--- a/packages/ui/src/v2/search-toolbar.tsx
+++ b/packages/ui/src/v2/search-toolbar.tsx
@@ -24,6 +24,7 @@ import {
 	type SearchArrayKey,
 	SearchComposer,
 	getSearchComposerTokens,
+	parseSimilarityAnchor,
 	parseSimilarityTopK,
 	type SearchSuggestion,
 	type SearchToken,
@@ -118,6 +119,18 @@ function submitComposerDraft(rawDraft: string): boolean {
 		if (!value) continue;
 
 		switch (prefix) {
+			case "similar": {
+				const anchorMediaId = parseSimilarityAnchor(value);
+				if (!anchorMediaId) {
+					freeText.push(part);
+					break;
+				}
+				if (searchState.similarityAnchorMediaId !== anchorMediaId) {
+					setSearchState("similarityAnchorMediaId", anchorMediaId);
+					changed = true;
+				}
+				break;
+			}
 			case "name":
 				setSearchState("searchQuery", value);
 				changed = true;

--- a/packages/ui/src/v2/search-toolbar.tsx
+++ b/packages/ui/src/v2/search-toolbar.tsx
@@ -16,12 +16,15 @@ import { SortControls } from "../sort-controls";
 import type { SourceMediaViewMode } from "../source-media-grid";
 import {
 	clearPresetFilters,
+	clearSimilaritySearch,
 	searchState,
 	setSearchState,
 } from "../stores/search-store";
 import {
 	type SearchArrayKey,
 	SearchComposer,
+	getSearchComposerTokens,
+	parseSimilarityTopK,
 	type SearchSuggestion,
 	type SearchToken,
 } from "./search-composer";
@@ -75,6 +78,13 @@ function appendValues(key: SearchArrayKey, rawValue: string) {
 function removeToken(token: SearchToken) {
 	if (token.key === "searchQuery") {
 		setSearchState("searchQuery", "");
+		return;
+	}
+	if (token.key === "similarityAnchorMediaId") {
+		clearSimilaritySearch({ surface: "v2" });
+		return;
+	}
+	if (token.key === "similarityTopK") {
 		return;
 	}
 	setSearchState(
@@ -136,6 +146,18 @@ function submitComposerDraft(rawDraft: string): boolean {
 				appendValues("selectedProjects", value);
 				changed = true;
 				break;
+			case "limit": {
+				const topK = parseSimilarityTopK(value);
+				if (searchState.similarityAnchorMediaId && topK !== undefined) {
+					if (searchState.similarityTopK !== topK) {
+						setSearchState("similarityTopK", topK);
+						changed = true;
+					}
+				} else {
+					freeText.push(part);
+				}
+				break;
+			}
 			default:
 				freeText.push(part);
 		}
@@ -148,52 +170,10 @@ function submitComposerDraft(rawDraft: string): boolean {
 	return changed;
 }
 
-function tokensFromState(state: SearchState): SearchToken[] {
-	return [
-		...(state.searchQuery
-			? [
-					{
-						key: "searchQuery" as const,
-						prefix: "name",
-						value: state.searchQuery,
-					},
-				]
-			: []),
-		...state.selectedTags.map((value) => ({
-			key: "selectedTags" as const,
-			prefix: "tag",
-			value,
-		})),
-		...state.excludeTags.map((value) => ({
-			destructive: true,
-			key: "excludeTags" as const,
-			prefix: "-tag",
-			value,
-		})),
-		...state.selectedCharacters.map((value) => ({
-			key: "selectedCharacters" as const,
-			prefix: "character",
-			value,
-		})),
-		...state.selectedIps.map((value) => ({
-			key: "selectedIps" as const,
-			prefix: "ip",
-			value,
-		})),
-		...state.selectedAuthors.map((value) => ({
-			key: "selectedAuthors" as const,
-			prefix: "author",
-			value,
-		})),
-		...state.selectedProjects.map((value) => ({
-			key: "selectedProjects" as const,
-			prefix: "project",
-			value,
-		})),
-	];
-}
-
 function sortLabel(state: SearchState): string {
+	if (state.similarityAnchorMediaId) {
+		return `類似度順・${state.similarityTopK}件`;
+	}
 	const labels: Record<SearchState["sortBy"], string> = {
 		date: "作成日",
 		name: "名前",
@@ -216,7 +196,7 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 	const tokens = createMemo(() => {
 		const removalIds = new Set(pendingRemovals().map(tokenId));
 		return [
-			...tokensFromState(searchState).filter(
+			...getSearchComposerTokens(searchState).filter(
 				(token) => !removalIds.has(tokenId(token)),
 			),
 			...pendingSuggestions().map((suggestion) => ({
@@ -331,6 +311,7 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 					filterData={props.filterData}
 					onDraftChange={(value) => setDraft(value)}
 					onRemoveToken={(token) => {
+						if (token.removable === false) return;
 						const id = tokenId(token);
 						const pending = pendingSuggestions();
 						if (pending.some((item) => tokenId(item) === id)) {
@@ -424,10 +405,6 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 								閉じる
 							</Button>
 							<Button
-								disabled={
-									searchState.mode === "vector" &&
-									!searchState.similarityAnchorMediaId
-								}
 								onClick={() => {
 									props.onSearch();
 									setFilterOpen(false);
@@ -460,8 +437,15 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 					</PopoverTrigger>
 					<PopoverContent class="v2-theme w-72 p-4 shadow-xl">
 						<SortControls
+							onClearSimilarity={() => clearSimilaritySearch({ surface: "v2" })}
 							onSortByChange={(value) => setSearchState("sortBy", value)}
 							onSortOrderChange={(value) => setSearchState("sortOrder", value)}
+							onSimilarityTopKChange={(value) =>
+								setSearchState("similarityTopK", value)
+							}
+							similarityAnchorMediaId={searchState.similarityAnchorMediaId}
+							similarityLimitId="v2-sort-similarity-limit"
+							similarityTopK={searchState.similarityTopK}
 							sortBy={searchState.sortBy}
 							sortOrder={searchState.sortOrder}
 						/>


### PR DESCRIPTION
## Summary

- Refresh search schemas, logic, query options, and vector-search composer behavior
- Improve search state persistence, sorting, responsive filters, and media sidebar actions
- Update server, Tauri, and shared UI search flows
- Regenerate the OpenAPI specification

## Testing

- Added or updated unit tests for search persistence, query options, store behavior, and search composer flows
- Updated end-to-end coverage for CCIP and responsive search behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 類似検索を通常の検索モード内で利用できるようになりました。
  * 類似検索の結果件数を1～100件で指定できるようになりました。
  * 検索バーで `similar:` や `limit:` の入力に対応しました。
  * 類似検索の条件や結果件数を確認・解除できるようになりました。

* **改善**
  * 検索モードから「ベクトル類似」を削除し、画面構成を簡素化しました。
  * 保存済みの検索状態を新しい類似検索仕様へ自動調整します。
  * モバイルの検索条件適用操作を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->