### PR TITLE
Remove AbstractBar and consolidate media search navigation

### DIFF
--- a/packages/ui/src/import-source-preference.ts
+++ b/packages/ui/src/import-source-preference.ts
@@ -1,0 +1,92 @@
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+
+const IMPORT_SOURCE_PREFERENCE_KEY = "solid-imager:import-source-preference";
+
+type StoredImportSourcePreference = {
+	remember: boolean;
+	sourceId?: string;
+};
+
+function getStorage(): Storage | null {
+	if (typeof window === "undefined") {
+		return null;
+	}
+
+	try {
+		return window.localStorage;
+	} catch {
+		return null;
+	}
+}
+
+function readPreference(): StoredImportSourcePreference {
+	const storage = getStorage();
+	if (!storage) {
+		return { remember: false };
+	}
+
+	try {
+		const value = storage.getItem(IMPORT_SOURCE_PREFERENCE_KEY);
+		if (!value) {
+			return { remember: false };
+		}
+
+		const parsed: unknown = JSON.parse(value);
+		if (
+			typeof parsed !== "object" ||
+			parsed === null ||
+			typeof (parsed as Record<string, unknown>).remember !== "boolean"
+		) {
+			return { remember: false };
+		}
+
+		const record = parsed as Record<string, unknown>;
+		return {
+			remember: record.remember,
+			sourceId: typeof record.sourceId === "string" ? record.sourceId : undefined,
+		};
+	} catch {
+		return { remember: false };
+	}
+}
+
+export function getRememberedImportSourceId(
+	sources: readonly SafeMediaSource[],
+): string | null {
+	const preference = readPreference();
+	if (!preference.remember || !preference.sourceId) {
+		return null;
+	}
+
+	return sources.some((source) => source.id === preference.sourceId)
+		? preference.sourceId
+		: null;
+}
+
+export function isImportSourceRemembered(): boolean {
+	return readPreference().remember;
+}
+
+export function setImportSourcePreference(
+	remember: boolean,
+	sourceId?: string,
+): void {
+	const storage = getStorage();
+	if (!storage) {
+		return;
+	}
+
+	try {
+		if (!remember || !sourceId) {
+			storage.removeItem(IMPORT_SOURCE_PREFERENCE_KEY);
+			return;
+		}
+
+		storage.setItem(
+			IMPORT_SOURCE_PREFERENCE_KEY,
+			JSON.stringify({ remember: true, sourceId }),
+		);
+	} catch {
+		// Ignore unavailable or quota-limited browser storage.
+	}
+}

--- a/packages/ui/src/legacy-import-review-modal.tsx
+++ b/packages/ui/src/legacy-import-review-modal.tsx
@@ -21,6 +21,11 @@ import {
 	getPendingImportPrimaryAuthor,
 	getPreferredImportSourceId,
 } from "./import-inbox-helpers";
+import {
+	getRememberedImportSourceId,
+	isImportSourceRemembered,
+	setImportSourcePreference,
+} from "./import-source-preference";
 import type {
 	ImportReviewModalProps,
 	PendingImportJob,
@@ -51,6 +56,9 @@ export function LegacyImportReviewModal(props: ImportReviewModalProps) {
 		createEmptySelection(),
 	);
 	const [selectedSourceId, setSelectedSourceId] = createSignal("");
+	const [rememberSource, setRememberSource] = createSignal(
+		isImportSourceRemembered(),
+	);
 	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = createSignal(false);
 
 	const [pendingJobs, { refetch: refetchJobs }] = createResource(
@@ -69,13 +77,19 @@ export function LegacyImportReviewModal(props: ImportReviewModalProps) {
 	});
 
 	createEffect(() => {
+		if (!props.isOpen) return;
 		const sourceList = sources();
 		if (!sourceList?.length) {
 			setSelectedSourceId("");
 			return;
 		}
-		if (!selectedSourceId()) {
-			setSelectedSourceId(getPreferredImportSourceId(sourceList));
+		const rememberedSourceId = rememberSource()
+			? getRememberedImportSourceId(sourceList)
+			: null;
+		const nextSourceId = rememberedSourceId ?? getPreferredImportSourceId(sourceList);
+		setSelectedSourceId(nextSourceId);
+		if (rememberSource() && nextSourceId !== rememberedSourceId) {
+			setImportSourcePreference(true, nextSourceId);
 		}
 	});
 
@@ -97,6 +111,11 @@ export function LegacyImportReviewModal(props: ImportReviewModalProps) {
 		} catch (error) {
 			toast.error(`Failed to process imports: ${getErrorMessage(error)}`);
 		}
+	};
+
+	const handleRememberSourceChange = (remember: boolean) => {
+		setRememberSource(remember);
+		setImportSourcePreference(remember, remember ? selectedSourceId() : undefined);
 	};
 
 	const confirmDelete = async () => {
@@ -135,8 +154,12 @@ export function LegacyImportReviewModal(props: ImportReviewModalProps) {
 									<span class="text-gray-300">Target Source:</span>
 									<select
 										class="rounded border border-gray-600 bg-gray-800 p-1 text-white"
-										onChange={(event) =>
-											setSelectedSourceId(event.currentTarget.value)
+											 onChange={(event) =>
+											setSelectedSourceId(event.currentTarget.value);
+											if (rememberSource()) {
+												setImportSourcePreference(true, event.currentTarget.value);
+											}
+										}
 										}
 										value={selectedSourceId()}
 									>
@@ -148,6 +171,17 @@ export function LegacyImportReviewModal(props: ImportReviewModalProps) {
 											)}
 										</For>
 									</select>
+									<label class="flex items-center gap-2 text-gray-400 text-sm">
+										<input
+											checked={rememberSource()}
+											class="h-4 w-4 accent-sky-600"
+											onChange={(event) =>
+												handleRememberSourceChange(event.currentTarget.checked)
+											}
+											type="checkbox"
+										/>
+										Remember this source
+									</label>
 								</div>
 								<div class="text-gray-400 text-sm">
 									Selected: {selectedJobIds().size} /{" "}

--- a/packages/ui/src/v2-import-review-modal.tsx
+++ b/packages/ui/src/v2-import-review-modal.tsx
@@ -29,6 +29,11 @@ import {
 	getPendingImportPrimaryAuthor,
 	getPreferredImportSourceId,
 } from "./import-inbox-helpers";
+import {
+	getRememberedImportSourceId,
+	isImportSourceRemembered,
+	setImportSourcePreference,
+} from "./import-source-preference";
 import type { ImportReviewModalProps } from "./import-review-modal.types";
 import { toast } from "./toast";
 
@@ -59,6 +64,9 @@ export function V2ImportReviewModal(props: ImportReviewModalProps) {
 		createEmptySelection(),
 	);
 	const [selectedSourceId, setSelectedSourceId] = createSignal("");
+	const [rememberSource, setRememberSource] = createSignal(
+		isImportSourceRemembered(),
+	);
 	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = createSignal(false);
 	const [isDiscardDialogOpen, setIsDiscardDialogOpen] = createSignal(false);
 	const [isDirty, setIsDirty] = createSignal(false);
@@ -90,14 +98,20 @@ export function V2ImportReviewModal(props: ImportReviewModalProps) {
 	});
 
 	createEffect(() => {
+		if (!props.isOpen) return;
 		const sourceList = sources();
 		if (!sourceList?.length) {
 			setSelectedSourceId("");
 			return;
 		}
 
-		if (!selectedSourceId()) {
-			setSelectedSourceId(getPreferredImportSourceId(sourceList));
+		const rememberedSourceId = rememberSource()
+			? getRememberedImportSourceId(sourceList)
+			: null;
+		const nextSourceId = rememberedSourceId ?? getPreferredImportSourceId(sourceList);
+		setSelectedSourceId(nextSourceId);
+		if (rememberSource() && nextSourceId !== rememberedSourceId) {
+			setImportSourcePreference(true, nextSourceId);
 		}
 	});
 
@@ -156,6 +170,11 @@ export function V2ImportReviewModal(props: ImportReviewModalProps) {
 		}
 	};
 
+	const handleRememberSourceChange = (remember: boolean) => {
+		setRememberSource(remember);
+		setImportSourcePreference(remember, remember ? selectedSourceId() : undefined);
+	};
+
 	const confirmDelete = async () => {
 		try {
 			setActiveAction("delete");
@@ -199,7 +218,11 @@ export function V2ImportReviewModal(props: ImportReviewModalProps) {
 									class="min-h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 									disabled={sources.loading || activeAction() !== null}
 									onChange={(event) => {
-										setSelectedSourceId(event.currentTarget.value);
+										const sourceId = event.currentTarget.value;
+										setSelectedSourceId(sourceId);
+										if (rememberSource()) {
+											setImportSourcePreference(true, sourceId);
+										}
 										setIsDirty(true);
 									}}
 									value={selectedSourceId()}
@@ -212,6 +235,18 @@ export function V2ImportReviewModal(props: ImportReviewModalProps) {
 										)}
 									</For>
 								</select>
+								<label class="flex items-center gap-2 text-muted-foreground text-sm">
+									<input
+										checked={rememberSource()}
+										class="size-4 accent-primary"
+										disabled={sources.loading || activeAction() !== null}
+										onChange={(event) =>
+											handleRememberSourceChange(event.currentTarget.checked)
+										}
+										type="checkbox"
+									/>
+									Remember this source
+								</label>
 							</label>
 							<div class="flex flex-wrap items-center justify-between gap-2 sm:justify-end">
 								<div class="text-muted-foreground text-sm" aria-live="polite">

--- a/packages/ui/src/v2/collection-inspector.tsx
+++ b/packages/ui/src/v2/collection-inspector.tsx
@@ -38,135 +38,97 @@ export function V2CollectionInspector(props: V2CollectionInspectorProps) {
 		owner ? runWithOwner(owner, render) : render();
 
 	return (
-		<>
-			<Show keyed when={props.media}>
-				{(media) => (
-					<aside
-						aria-label="選択中のメディア"
-						class="sticky bottom-0 z-20 mt-3 flex min-w-0 items-center gap-2 rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface)]/95 p-2 shadow-sm backdrop-blur-sm 2xl:hidden"
+		<aside
+			aria-label="選択中のメディア"
+			class="sticky top-0 hidden max-h-[calc(100dvh-8rem)] min-h-0 min-w-0 overflow-hidden rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface)] 2xl:flex 2xl:flex-col"
+		>
+			<header class="z-10 flex h-12 shrink-0 items-center border-[var(--v2-border)] border-b bg-[var(--v2-surface)]/95 px-4 backdrop-blur-sm">
+				<h2 class="min-w-0 flex-1 truncate font-semibold text-[var(--v2-text)] text-sm">
+					選択中のメディア
+				</h2>
+				<Show when={props.onClose}>
+					<Button
+						aria-label="インスペクターを閉じる"
+						class="size-8 shrink-0 p-0 text-[var(--v2-text-muted)]"
+						onClick={() => props.onClose?.()}
+						size="icon"
+						variant="ghost"
 					>
-						<p
-							class="min-w-0 flex-1 truncate px-1 font-medium text-[var(--v2-text)] text-xs"
-							title={media.fileName}
-						>
-							{media.fileName}
-						</p>
-						<Show when={props.onOpenDetail}>
-							<Button
-								class="h-9 shrink-0"
-								onClick={() => props.onOpenDetail?.(media)}
-								size="sm"
-							>
-								詳細を開く
-							</Button>
-						</Show>
-						<Show when={props.onClose}>
-							<Button
-								aria-label="選択中のメディアを閉じる"
-								class="size-9 shrink-0 p-0 text-[var(--v2-text-muted)]"
-								onClick={() => props.onClose?.()}
-								size="icon"
-								variant="ghost"
-							>
-								<X aria-hidden="true" size={15} />
-							</Button>
-						</Show>
-					</aside>
-				)}
-			</Show>
+						<X aria-hidden="true" size={15} />
+					</Button>
+				</Show>
+			</header>
 
-			<aside
-				aria-label="選択中のメディア"
-				class="sticky top-0 hidden max-h-[calc(100dvh-8rem)] min-h-0 min-w-0 overflow-hidden rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface)] 2xl:flex 2xl:flex-col"
-			>
-				<header class="z-10 flex h-12 shrink-0 items-center border-[var(--v2-border)] border-b bg-[var(--v2-surface)]/95 px-4 backdrop-blur-sm">
-					<h2 class="min-w-0 flex-1 truncate font-semibold text-[var(--v2-text)] text-sm">
-						選択中のメディア
-					</h2>
-					<Show when={props.onClose}>
-						<Button
-							aria-label="インスペクターを閉じる"
-							class="size-8 shrink-0 p-0 text-[var(--v2-text-muted)]"
-							onClick={() => props.onClose?.()}
-							size="icon"
-							variant="ghost"
-						>
-							<X aria-hidden="true" size={15} />
-						</Button>
-					</Show>
-				</header>
-
-				<div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4 [scrollbar-gutter:stable]">
-					<Show
-						keyed
-						fallback={
-							<div class="space-y-4">
-								<div class="flex aspect-[4/3] items-center justify-center rounded-md bg-[var(--v2-surface-muted)] px-6 text-center text-[var(--v2-text-muted)] text-sm">
-									メディアを選択するとプレビューを表示します
-								</div>
-								<p class="text-center text-[var(--v2-text-muted)] text-xs leading-5">
-									一覧からメディアを選択してください
+			<div class="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4 [scrollbar-gutter:stable]">
+				<Show
+					keyed
+					fallback={
+						<div class="space-y-4">
+							<div class="flex aspect-[4/3] items-center justify-center rounded-md bg-[var(--v2-surface-muted)] px-6 text-center text-[var(--v2-text-muted)] text-sm">
+								メディアを選択するとプレビューを表示します
+							</div>
+							<p class="text-center text-[var(--v2-text-muted)] text-xs leading-5">
+								一覧からメディアを選択してください
+							</p>
+						</div>
+					}
+					when={props.media}
+				>
+					{(media) => (
+						<div>
+							<div class="aspect-[4/3] overflow-hidden rounded-md bg-[var(--v2-surface-muted)]">
+								{renderOwned(() => props.renderPreview(media))}
+							</div>
+							<section class="border-[var(--v2-border)] border-b py-4">
+								<h3
+									class="break-words font-semibold text-[var(--v2-text)] text-sm"
+									title={media.fileName}
+								>
+									{media.fileName}
+								</h3>
+								<p class="mt-2 whitespace-pre-wrap break-words text-[var(--v2-text-secondary)] text-xs leading-5">
+									{media.description?.trim() || "説明はありません"}
 								</p>
-							</div>
-						}
-						when={props.media}
-					>
-						{(media) => (
-							<div>
-								<div class="aspect-[4/3] overflow-hidden rounded-md bg-[var(--v2-surface-muted)]">
-									{renderOwned(() => props.renderPreview(media))}
-								</div>
-								<section class="border-[var(--v2-border)] border-b py-4">
-									<h3
-										class="break-words font-semibold text-[var(--v2-text)] text-sm"
-										title={media.fileName}
-									>
-										{media.fileName}
-									</h3>
-									<p class="mt-2 whitespace-pre-wrap break-words text-[var(--v2-text-secondary)] text-xs leading-5">
-										{media.description?.trim() || "説明はありません"}
-									</p>
-								</section>
-								<dl class="grid grid-cols-[5rem_minmax(0,1fr)] gap-x-3 gap-y-2.5 border-[var(--v2-border)] border-b py-4 text-xs">
-									<dt class="text-[var(--v2-text-muted)]">解像度</dt>
-									<dd class="text-right text-[var(--v2-text)]">
-										{media.width} × {media.height}
-									</dd>
-									<dt class="text-[var(--v2-text-muted)]">サイズ</dt>
-									<dd class="text-right text-[var(--v2-text)]">
-										{formatFileSize(media.fileSize)}
-									</dd>
-									<dt class="text-[var(--v2-text-muted)]">ソース</dt>
-									<dd
-										class="truncate text-right text-[var(--v2-text)]"
-										title={props.sourceName}
-									>
-										{props.sourceName ?? "—"}
-									</dd>
-									<dt class="text-[var(--v2-text-muted)]">作成日</dt>
-									<dd class="text-right text-[var(--v2-text)]">
-										{formatDate(media.createdAt)}
-									</dd>
-									<dt class="text-[var(--v2-text-muted)]">更新日</dt>
-									<dd class="text-right text-[var(--v2-text)]">
-										{formatDate(media.modifiedAt)}
-									</dd>
-								</dl>
-								<Show when={props.onOpenDetail}>
-									<Button
-										class="mt-4 min-h-11 w-full sm:min-h-9"
-										onClick={() => props.onOpenDetail?.(media)}
-										size="sm"
-									>
-										<ExternalLink aria-hidden="true" size={14} />
-										詳細を開く
-									</Button>
-								</Show>
-							</div>
-						)}
-					</Show>
-				</div>
-			</aside>
-		</>
+							</section>
+							<dl class="grid grid-cols-[5rem_minmax(0,1fr)] gap-x-3 gap-y-2.5 border-[var(--v2-border)] border-b py-4 text-xs">
+								<dt class="text-[var(--v2-text-muted)]">解像度</dt>
+								<dd class="text-right text-[var(--v2-text)]">
+									{media.width} × {media.height}
+								</dd>
+								<dt class="text-[var(--v2-text-muted)]">サイズ</dt>
+								<dd class="text-right text-[var(--v2-text)]">
+									{formatFileSize(media.fileSize)}
+								</dd>
+								<dt class="text-[var(--v2-text-muted)]">ソース</dt>
+								<dd
+									class="truncate text-right text-[var(--v2-text)]"
+									title={props.sourceName}
+								>
+									{props.sourceName ?? "—"}
+								</dd>
+								<dt class="text-[var(--v2-text-muted)]">作成日</dt>
+								<dd class="text-right text-[var(--v2-text)]">
+									{formatDate(media.createdAt)}
+								</dd>
+								<dt class="text-[var(--v2-text-muted)]">更新日</dt>
+								<dd class="text-right text-[var(--v2-text)]">
+									{formatDate(media.modifiedAt)}
+								</dd>
+							</dl>
+							<Show when={props.onOpenDetail}>
+								<Button
+									class="mt-4 min-h-11 w-full sm:min-h-9"
+									onClick={() => props.onOpenDetail?.(media)}
+									size="sm"
+								>
+									<ExternalLink aria-hidden="true" size={14} />
+									詳細を開く
+								</Button>
+							</Show>
+						</div>
+					)}
+				</Show>
+			</div>
+		</aside>
 	);
 }


### PR DESCRIPTION
## Summary

- Remove the AbstractBar-based navigation and related legacy UI paths
- Consolidate media sidebar, search toolbar, composer, sorting, and filtering flows
- Update search state persistence, query options, schemas, and domain logic
- Refresh affected server, Tauri, API, dependency, and formatting configuration
- Adjust responsive and CCIP E2E coverage plus search-related unit tests

## Testing

Not run (not requested)