### PR TITLE
Remember the selected source for bulk imports

### DIFF
--- a/packages/ui/src/import-source-preference.ts
+++ b/packages/ui/src/import-source-preference.ts
@@ -1,0 +1,92 @@
+import type { SafeMediaSource } from "@solid-imager/core/domain/sources/schemas";
+
+const IMPORT_SOURCE_PREFERENCE_KEY = "solid-imager:import-source-preference";
+
+type StoredImportSourcePreference = {
+	remember: boolean;
+	sourceId?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function getStorage(): Storage | null {
+	if (typeof window === "undefined") {
+		return null;
+	}
+
+	try {
+		return window.localStorage;
+	} catch {
+		return null;
+	}
+}
+
+function readPreference(): StoredImportSourcePreference {
+	const storage = getStorage();
+	if (!storage) {
+		return { remember: false };
+	}
+
+	try {
+		const value = storage.getItem(IMPORT_SOURCE_PREFERENCE_KEY);
+		if (!value) {
+			return { remember: false };
+		}
+
+		const parsed: unknown = JSON.parse(value);
+		if (!isRecord(parsed) || typeof parsed.remember !== "boolean") {
+			return { remember: false };
+		}
+
+		return {
+			remember: parsed.remember,
+			sourceId:
+				typeof parsed.sourceId === "string" ? parsed.sourceId : undefined,
+		};
+	} catch {
+		return { remember: false };
+	}
+}
+
+export function getRememberedImportSourceId(
+	sources: readonly SafeMediaSource[],
+): string | null {
+	const preference = readPreference();
+	if (!preference.remember || !preference.sourceId) {
+		return null;
+	}
+
+	return sources.some((source) => source.id === preference.sourceId)
+		? preference.sourceId
+		: null;
+}
+
+export function isImportSourceRemembered(): boolean {
+	return readPreference().remember;
+}
+
+export function setImportSourcePreference(
+	remember: boolean,
+	sourceId?: string,
+): void {
+	const storage = getStorage();
+	if (!storage) {
+		return;
+	}
+
+	try {
+		if (!remember || !sourceId) {
+			storage.removeItem(IMPORT_SOURCE_PREFERENCE_KEY);
+			return;
+		}
+
+		storage.setItem(
+			IMPORT_SOURCE_PREFERENCE_KEY,
+			JSON.stringify({ remember: true, sourceId }),
+		);
+	} catch {
+		// Ignore unavailable or quota-limited browser storage.
+	}
+}

--- a/packages/ui/src/legacy-import-review-modal.tsx
+++ b/packages/ui/src/legacy-import-review-modal.tsx
@@ -5,6 +5,7 @@ import {
 	createSignal,
 	For,
 	Show,
+	untrack,
 } from "solid-js";
 import { Portal } from "solid-js/web";
 import {
@@ -21,6 +22,11 @@ import {
 	getPendingImportPrimaryAuthor,
 	getPreferredImportSourceId,
 } from "./import-inbox-helpers";
+import {
+	getRememberedImportSourceId,
+	isImportSourceRemembered,
+	setImportSourcePreference,
+} from "./import-source-preference";
 import type {
 	ImportReviewModalProps,
 	PendingImportJob,
@@ -51,6 +57,9 @@ export function LegacyImportReviewModal(props: ImportReviewModalProps) {
 		createEmptySelection(),
 	);
 	const [selectedSourceId, setSelectedSourceId] = createSignal("");
+	const [rememberSource, setRememberSource] = createSignal(
+		isImportSourceRemembered(),
+	);
 	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = createSignal(false);
 
 	const [pendingJobs, { refetch: refetchJobs }] = createResource(
@@ -69,13 +78,21 @@ export function LegacyImportReviewModal(props: ImportReviewModalProps) {
 	});
 
 	createEffect(() => {
+		if (!props.isOpen) return;
 		const sourceList = sources();
 		if (!sourceList?.length) {
 			setSelectedSourceId("");
 			return;
 		}
-		if (!selectedSourceId()) {
-			setSelectedSourceId(getPreferredImportSourceId(sourceList));
+		const shouldRememberSource = untrack(rememberSource);
+		const rememberedSourceId = shouldRememberSource
+			? getRememberedImportSourceId(sourceList)
+			: null;
+		const nextSourceId =
+			rememberedSourceId ?? getPreferredImportSourceId(sourceList);
+		setSelectedSourceId(nextSourceId);
+		if (shouldRememberSource && nextSourceId !== rememberedSourceId) {
+			setImportSourcePreference(true, nextSourceId);
 		}
 	});
 
@@ -97,6 +114,14 @@ export function LegacyImportReviewModal(props: ImportReviewModalProps) {
 		} catch (error) {
 			toast.error(`Failed to process imports: ${getErrorMessage(error)}`);
 		}
+	};
+
+	const handleRememberSourceChange = (remember: boolean) => {
+		setRememberSource(remember);
+		setImportSourcePreference(
+			remember,
+			remember ? selectedSourceId() : undefined,
+		);
 	};
 
 	const confirmDelete = async () => {
@@ -135,9 +160,13 @@ export function LegacyImportReviewModal(props: ImportReviewModalProps) {
 									<span class="text-gray-300">Target Source:</span>
 									<select
 										class="rounded border border-gray-600 bg-gray-800 p-1 text-white"
-										onChange={(event) =>
-											setSelectedSourceId(event.currentTarget.value)
-										}
+										onChange={(event) => {
+											const sourceId = event.currentTarget.value;
+											setSelectedSourceId(sourceId);
+											if (rememberSource()) {
+												setImportSourcePreference(true, sourceId);
+											}
+										}}
 										value={selectedSourceId()}
 									>
 										<For each={sources()}>
@@ -148,6 +177,17 @@ export function LegacyImportReviewModal(props: ImportReviewModalProps) {
 											)}
 										</For>
 									</select>
+									<label class="flex items-center gap-2 text-gray-400 text-sm">
+										<input
+											checked={rememberSource()}
+											class="h-4 w-4 accent-sky-600"
+											onChange={(event) =>
+												handleRememberSourceChange(event.currentTarget.checked)
+											}
+											type="checkbox"
+										/>
+										Remember this source
+									</label>
 								</div>
 								<div class="text-gray-400 text-sm">
 									Selected: {selectedJobIds().size} /{" "}

--- a/packages/ui/src/v2-import-review-modal.tsx
+++ b/packages/ui/src/v2-import-review-modal.tsx
@@ -5,6 +5,7 @@ import {
 	createSignal,
 	For,
 	Show,
+	untrack,
 } from "solid-js";
 import {
 	AlertDialog,
@@ -29,6 +30,11 @@ import {
 	getPendingImportPrimaryAuthor,
 	getPreferredImportSourceId,
 } from "./import-inbox-helpers";
+import {
+	getRememberedImportSourceId,
+	isImportSourceRemembered,
+	setImportSourcePreference,
+} from "./import-source-preference";
 import type { ImportReviewModalProps } from "./import-review-modal.types";
 import { toast } from "./toast";
 
@@ -59,6 +65,9 @@ export function V2ImportReviewModal(props: ImportReviewModalProps) {
 		createEmptySelection(),
 	);
 	const [selectedSourceId, setSelectedSourceId] = createSignal("");
+	const [rememberSource, setRememberSource] = createSignal(
+		isImportSourceRemembered(),
+	);
 	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = createSignal(false);
 	const [isDiscardDialogOpen, setIsDiscardDialogOpen] = createSignal(false);
 	const [isDirty, setIsDirty] = createSignal(false);
@@ -90,14 +99,22 @@ export function V2ImportReviewModal(props: ImportReviewModalProps) {
 	});
 
 	createEffect(() => {
+		if (!props.isOpen) return;
 		const sourceList = sources();
 		if (!sourceList?.length) {
 			setSelectedSourceId("");
 			return;
 		}
 
-		if (!selectedSourceId()) {
-			setSelectedSourceId(getPreferredImportSourceId(sourceList));
+		const shouldRememberSource = untrack(rememberSource);
+		const rememberedSourceId = shouldRememberSource
+			? getRememberedImportSourceId(sourceList)
+			: null;
+		const nextSourceId =
+			rememberedSourceId ?? getPreferredImportSourceId(sourceList);
+		setSelectedSourceId(nextSourceId);
+		if (shouldRememberSource && nextSourceId !== rememberedSourceId) {
+			setImportSourcePreference(true, nextSourceId);
 		}
 	});
 
@@ -156,6 +173,14 @@ export function V2ImportReviewModal(props: ImportReviewModalProps) {
 		}
 	};
 
+	const handleRememberSourceChange = (remember: boolean) => {
+		setRememberSource(remember);
+		setImportSourcePreference(
+			remember,
+			remember ? selectedSourceId() : undefined,
+		);
+	};
+
 	const confirmDelete = async () => {
 		try {
 			setActiveAction("delete");
@@ -193,26 +218,44 @@ export function V2ImportReviewModal(props: ImportReviewModalProps) {
 
 					<div class="flex min-h-0 flex-1 flex-col overflow-hidden">
 						<div class="flex flex-col gap-3 border-[var(--v2-border)] border-b bg-[var(--v2-surface-muted)] px-5 py-3 sm:flex-row sm:items-end sm:justify-between">
-							<label class="grid min-w-0 gap-1 font-medium text-sm sm:w-80">
-								Target source
-								<select
-									class="min-h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-									disabled={sources.loading || activeAction() !== null}
-									onChange={(event) => {
-										setSelectedSourceId(event.currentTarget.value);
-										setIsDirty(true);
-									}}
-									value={selectedSourceId()}
-								>
-									<For each={sources()}>
-										{(source) => (
-											<option value={source.id}>
-												{source.name} · {source.type}
-											</option>
-										)}
-									</For>
-								</select>
-							</label>
+							<div class="grid min-w-0 gap-2 sm:w-80">
+								<label class="grid gap-1 font-medium text-sm">
+									Target source
+									<select
+										class="min-h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+										disabled={sources.loading || activeAction() !== null}
+										onChange={(event) => {
+											const sourceId = event.currentTarget.value;
+											setSelectedSourceId(sourceId);
+											if (rememberSource()) {
+												setImportSourcePreference(true, sourceId);
+											}
+											setIsDirty(true);
+										}}
+										value={selectedSourceId()}
+									>
+										<For each={sources()}>
+											{(source) => (
+												<option value={source.id}>
+													{source.name} · {source.type}
+												</option>
+											)}
+										</For>
+									</select>
+								</label>
+								<label class="flex items-center gap-2 text-muted-foreground text-sm">
+									<input
+										checked={rememberSource()}
+										class="size-4 accent-primary"
+										disabled={sources.loading || activeAction() !== null}
+										onChange={(event) =>
+											handleRememberSourceChange(event.currentTarget.checked)
+										}
+										type="checkbox"
+									/>
+									Remember this source
+								</label>
+							</div>
 							<div class="flex flex-wrap items-center justify-between gap-2 sm:justify-end">
 								<div class="text-muted-foreground text-sm" aria-live="polite">
 									{selectedJobIds().size} of {pendingJobs()?.length ?? 0}{" "}


### PR DESCRIPTION
## Summary

- Add a shared preference for remembering the selected import source
- Restore the remembered source when opening legacy and V2 import review modals
- Persist source changes and provide a user-facing checkbox to enable or disable the preference

## Testing

Not run (not requested)