### PR TITLE
fix(ui): prevent media context menu route errors

### DIFF
--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -3,7 +3,5 @@ FROM oven/bun:debian
 # youtube-dl-exec bundles yt-dlp as a Python zipapp.  The application artifact
 # is mounted at runtime, so only the runtime dependency belongs in this image.
 RUN apt-get update \
-    && apt-get install --no-install-recommends --yes python3 ca-certificates \
+    && apt-get install --no-install-recommends --yes python3 ffmpeg ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-
-USER bun

--- a/apps/server/src/components/media/bulk-action-dialog.tsx
+++ b/apps/server/src/components/media/bulk-action-dialog.tsx
@@ -21,8 +21,9 @@ import { fetchMediaSources } from "~/infrastructure/api-clients/sources-api";
 type BulkActionDialogProps = {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	mediaSourceId: string;
+	mediaSourceId?: string;
 	mediaIds: string[];
+	mediaItems?: Array<{ mediaId: string; mediaSourceId: string }>;
 	onSuccess: () => void;
 };
 
@@ -43,46 +44,72 @@ export function BulkActionDialog(props: BulkActionDialogProps) {
 		{ initialValue: [] },
 	);
 
+	const selectedItems = () => {
+		const sourceId = props.mediaSourceId;
+		return (
+			props.mediaItems ??
+			(sourceId
+				? props.mediaIds.map((mediaId) => ({
+						mediaId,
+						mediaSourceId: sourceId,
+					}))
+				: [])
+		);
+	};
+
+	const selectedSourceIds = () =>
+		new Set(selectedItems().map((item) => item.mediaSourceId));
+
+	const groupedMediaIds = () => {
+		const groups = new Map<string, string[]>();
+		for (const item of selectedItems()) {
+			const mediaIds = groups.get(item.mediaSourceId) ?? [];
+			mediaIds.push(item.mediaId);
+			groups.set(item.mediaSourceId, mediaIds);
+		}
+		return groups;
+	};
+
 	const usableSources = () =>
 		(sources() ?? []).filter(
 			(s): s is SafeMediaSource & { id: string } =>
-				!!s.id && s.id !== props.mediaSourceId,
+				!!s.id && !selectedSourceIds().has(s.id),
 		);
 
 	const handleConfirm = async () => {
 		setIsSubmitting(true);
 		setErrorMsg("");
 		try {
+			const groups = groupedMediaIds();
+			if (groups.size === 0) {
+				throw new Error("No media items are selected.");
+			}
 			const currentAction = action();
 			if (currentAction === "copy-source") {
 				if (!targetSourceId()) {
 					throw new Error("Target source is required.");
 				}
-				await bulkCopyToSource(
-					props.mediaSourceId,
-					props.mediaIds,
-					targetSourceId(),
-				);
+				for (const [sourceId, mediaIds] of groups) {
+					await bulkCopyToSource(sourceId, mediaIds, targetSourceId());
+				}
 			} else if (currentAction === "move-source") {
 				if (!targetSourceId()) {
 					throw new Error("Target source is required.");
 				}
-				await bulkMoveToSource(
-					props.mediaSourceId,
-					props.mediaIds,
-					targetSourceId(),
-				);
+				for (const [sourceId, mediaIds] of groups) {
+					await bulkMoveToSource(sourceId, mediaIds, targetSourceId());
+				}
 			} else if (currentAction === "move-folder") {
 				if (!destinationPath().trim()) {
 					throw new Error("Destination path is required.");
 				}
-				await bulkMoveMedia(
-					props.mediaSourceId,
-					props.mediaIds,
-					destinationPath(),
-				);
+				for (const [sourceId, mediaIds] of groups) {
+					await bulkMoveMedia(sourceId, mediaIds, destinationPath());
+				}
 			} else if (currentAction === "delete") {
-				await bulkDeleteMedia(props.mediaSourceId, props.mediaIds);
+				for (const [sourceId, mediaIds] of groups) {
+					await bulkDeleteMedia(sourceId, mediaIds);
+				}
 			}
 			props.onSuccess();
 			props.onOpenChange(false);
@@ -99,7 +126,7 @@ export function BulkActionDialog(props: BulkActionDialogProps) {
 				<DialogHeader>
 					<DialogTitle>一括操作を実行</DialogTitle>
 					<DialogDescription>
-						選択された {props.mediaIds.length}{" "}
+						選択された {selectedItems().length}{" "}
 						件のメディアに対して一括操作を実行します。
 					</DialogDescription>
 				</DialogHeader>

--- a/apps/server/src/components/media/bulk-action-dialog.tsx
+++ b/apps/server/src/components/media/bulk-action-dialog.tsx
@@ -9,6 +9,7 @@ import {
 	DialogTitle,
 } from "@solid-imager/ui/dialog";
 import { Input } from "@solid-imager/ui/input";
+import { toast } from "@solid-imager/ui/toast";
 import { createResource, createSignal, For, Show } from "solid-js";
 import {
 	bulkCopyToSource,
@@ -85,32 +86,62 @@ export function BulkActionDialog(props: BulkActionDialogProps) {
 				throw new Error("No media items are selected.");
 			}
 			const currentAction = action();
+			const failures: Array<{ mediaCount: number; message: string }> = [];
+			let succeededMediaCount = 0;
+			const runGroup = async (sourceId: string, mediaIds: string[]) => {
+				if (currentAction === "copy-source") {
+					await bulkCopyToSource(sourceId, mediaIds, targetSourceId());
+				} else if (currentAction === "move-source") {
+					await bulkMoveToSource(sourceId, mediaIds, targetSourceId());
+				} else if (currentAction === "move-folder") {
+					await bulkMoveMedia(sourceId, mediaIds, destinationPath());
+				} else {
+					await bulkDeleteMedia(sourceId, mediaIds);
+				}
+			};
 			if (currentAction === "copy-source") {
 				if (!targetSourceId()) {
 					throw new Error("Target source is required.");
-				}
-				for (const [sourceId, mediaIds] of groups) {
-					await bulkCopyToSource(sourceId, mediaIds, targetSourceId());
 				}
 			} else if (currentAction === "move-source") {
 				if (!targetSourceId()) {
 					throw new Error("Target source is required.");
 				}
-				for (const [sourceId, mediaIds] of groups) {
-					await bulkMoveToSource(sourceId, mediaIds, targetSourceId());
-				}
 			} else if (currentAction === "move-folder") {
 				if (!destinationPath().trim()) {
 					throw new Error("Destination path is required.");
 				}
-				for (const [sourceId, mediaIds] of groups) {
-					await bulkMoveMedia(sourceId, mediaIds, destinationPath());
-				}
-			} else if (currentAction === "delete") {
-				for (const [sourceId, mediaIds] of groups) {
-					await bulkDeleteMedia(sourceId, mediaIds);
+			}
+
+			for (const [sourceId, mediaIds] of groups) {
+				try {
+					await runGroup(sourceId, mediaIds);
+					succeededMediaCount += mediaIds.length;
+				} catch (error) {
+					failures.push({
+						mediaCount: mediaIds.length,
+						message:
+							error instanceof Error ? error.message : "An error occurred.",
+					});
 				}
 			}
+
+			if (failures.length > 0) {
+				const failedMediaCount = failures.reduce(
+					(total, failure) => total + failure.mediaCount,
+					0,
+				);
+				if (succeededMediaCount > 0) {
+					toast.error(
+						`一部の操作に失敗しました（成功 ${succeededMediaCount} 件、失敗 ${failedMediaCount} 件）。`,
+					);
+					props.onSuccess();
+					props.onOpenChange(false);
+					return;
+				}
+				throw new Error(failures[0]?.message ?? "An error occurred.");
+			}
+
 			props.onSuccess();
 			props.onOpenChange(false);
 		} catch (e) {

--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -28,6 +28,17 @@ import { resolveFfmpegPath } from "~/infrastructure/utils/ffmpeg";
 
 const DATE_REGEX = /(\d{4})(\d{2})(\d{2})/;
 const TWITTER_URL_REGEX = /(twitter|x)\.com\/\w+\/status\/\d+/;
+const IMAGE_EXTENSION_BY_CONTENT_TYPE: Readonly<Record<string, string>> = {
+	"image/avif": ".avif",
+	"image/bmp": ".bmp",
+	"image/gif": ".gif",
+	"image/jpeg": ".jpg",
+	"image/jpg": ".jpg",
+	"image/png": ".png",
+	"image/svg+xml": ".svg",
+	"image/tiff": ".tiff",
+	"image/webp": ".webp",
+};
 
 let ytDlpPathCache: string | null = null;
 let ytDlpResolvePromise: Promise<string> | null = null;
@@ -503,6 +514,20 @@ function buildFetchHeaders(item: DownloadItem): Record<string, string> {
 	return headers;
 }
 
+function getDirectImageExtension(url: URL, contentType: string): string {
+	const pathnameExtension = path.extname(url.pathname).toLowerCase();
+	if (pathnameExtension) {
+		return pathnameExtension;
+	}
+
+	const format = url.searchParams.get("format")?.trim().toLowerCase();
+	if (format && /^[a-z0-9]+$/.test(format)) {
+		return `.${format}`;
+	}
+
+	return IMAGE_EXTENSION_BY_CONTENT_TYPE[contentType] ?? ".png";
+}
+
 /**
  * Handles direct image download (non-twitter)
  */
@@ -519,11 +544,6 @@ async function handleDirectImageDownload(
 		{ url: item.targetUrl },
 		"[DownloadJob] Using direct image download method",
 	);
-
-	// Generate unified filename
-	const urlPath = new URL(item.targetUrl).pathname;
-	const extension = path.extname(urlPath) || ".png";
-	const filename = generateMediaFilename(item, extension);
 
 	try {
 		// Download the image
@@ -547,6 +567,22 @@ async function handleDirectImageDownload(
 				`Failed to download image: ${response.status} ${response.statusText}`,
 			);
 		}
+
+		const contentType = response.headers
+			.get("content-type")
+			?.split(";", 1)[0]
+			.trim()
+			.toLowerCase();
+		if (!contentType?.startsWith("image/")) {
+			throw new Error(
+				`Direct image URL returned a non-image response: ${contentType ?? "unknown content type"}`,
+			);
+		}
+
+		// Use the response MIME type when a CDN URL has no file extension.
+		const targetUrl = new URL(item.targetUrl);
+		const extension = getDirectImageExtension(targetUrl, contentType);
+		const filename = generateMediaFilename(item, extension);
 
 		const arrayBuffer = await response.arrayBuffer();
 

--- a/apps/server/src/infrastructure/jobs/download-jobs.ts
+++ b/apps/server/src/infrastructure/jobs/download-jobs.ts
@@ -514,17 +514,7 @@ function buildFetchHeaders(item: DownloadItem): Record<string, string> {
 	return headers;
 }
 
-function getDirectImageExtension(url: URL, contentType: string): string {
-	const pathnameExtension = path.extname(url.pathname).toLowerCase();
-	if (pathnameExtension) {
-		return pathnameExtension;
-	}
-
-	const format = url.searchParams.get("format")?.trim().toLowerCase();
-	if (format && /^[a-z0-9]+$/.test(format)) {
-		return `.${format}`;
-	}
-
+function getDirectImageExtension(contentType: string): string {
 	return IMAGE_EXTENSION_BY_CONTENT_TYPE[contentType] ?? ".png";
 }
 
@@ -580,8 +570,7 @@ async function handleDirectImageDownload(
 		}
 
 		// Use the response MIME type when a CDN URL has no file extension.
-		const targetUrl = new URL(item.targetUrl);
-		const extension = getDirectImageExtension(targetUrl, contentType);
+		const extension = getDirectImageExtension(contentType);
 		const filename = generateMediaFilename(item, extension);
 
 		const arrayBuffer = await response.arrayBuffer();

--- a/apps/server/src/routes/v2/components/v2-search-content.tsx
+++ b/apps/server/src/routes/v2/components/v2-search-content.tsx
@@ -1,3 +1,14 @@
+import type { Media } from "@solid-imager/core/domain/media/schemas";
+import { getErrorMessage } from "@solid-imager/core/utils";
+import { Button } from "@solid-imager/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@solid-imager/ui/dialog";
 import { persistSearchScrollPosition } from "@solid-imager/ui/hooks/use-current-search-persistence";
 import {
 	type MediaCollectionSelectionMode,
@@ -8,13 +19,21 @@ import { useSearchPage } from "@solid-imager/ui/hooks/use-search-page";
 import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { V2SearchScreen } from "@solid-imager/ui/screens/v2-search-screen";
 import { createSearchHistoryClient } from "@solid-imager/ui/search-history-client";
+import { toast } from "@solid-imager/ui/toast";
 import { useLocation, useNavigate } from "@tanstack/solid-router";
 import { createSignal } from "solid-js";
+import { BulkActionDialog } from "~/components/media/bulk-action-dialog";
+import { MoveCopyMediaDialog } from "~/components/media/move-copy-media-dialog";
 import { ThumbnailImage } from "~/components/media/thumbnail-image";
 import { V2MediaGridItem } from "~/components/media/v2-media-grid-item";
 import { useMediaSourceEvents } from "~/hooks/use-media-source-events";
 import { PresetClient as rawPresetClient } from "~/infrastructure/api/clients/preset-client";
 import { SearchHistoryClient as rawSearchHistoryClient } from "~/infrastructure/api/clients/search-history-client";
+import {
+	copyMedia,
+	deleteMedia,
+	moveMedia,
+} from "~/infrastructure/api-clients/media-api";
 import {
 	allAuthorsQueryOptions,
 	allCharactersQueryOptions,
@@ -66,6 +85,13 @@ export default function V2SearchContent() {
 		setIsBulkSelectMode(false);
 		selection.clear();
 	};
+	const [isBulkActionOpen, setIsBulkActionOpen] = createSignal(false);
+	const [deleteTarget, setDeleteTarget] = createSignal<Media | null>(null);
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = createSignal(false);
+	const [isDeleteSubmitting, setIsDeleteSubmitting] = createSignal(false);
+	const [moveCopyTarget, setMoveCopyTarget] = createSignal<Media | null>(null);
+	const [moveCopyMode, setMoveCopyMode] = createSignal<"copy" | "move">("copy");
+	const [isMoveCopyDialogOpen, setIsMoveCopyDialogOpen] = createSignal(false);
 	const searchHistory = useSearchHistoryPersistence("all", {
 		client: SearchHistoryClient,
 		surface: "v2",
@@ -107,6 +133,75 @@ export default function V2SearchContent() {
 		enableVirtualization: true,
 		scrollContainerSelector: '[data-media-scroll="v2-search"]',
 	});
+	const selectedMediaItems = () =>
+		page
+			.searchResults()
+			.filter((media) => selection.isSelected(media.id))
+			.map((media) => ({
+				mediaId: media.id,
+				mediaSourceId: media.mediaSourceId,
+			}));
+	const findSearchMedia = (mediaId: string) =>
+		page.searchResults().find((media) => media.id === mediaId);
+	const handleDelete = (mediaId: string) => {
+		const media = findSearchMedia(mediaId);
+		if (!media) return;
+		setDeleteTarget(media);
+		setIsDeleteSubmitting(false);
+		setIsDeleteDialogOpen(true);
+	};
+	const handleCopyMove = (mediaId: string, mode: "copy" | "move") => {
+		const media = findSearchMedia(mediaId);
+		if (!media) return;
+		setMoveCopyTarget(media);
+		setMoveCopyMode(mode);
+		setIsMoveCopyDialogOpen(true);
+	};
+	const forgetSelectedMedia = (mediaId: string) => {
+		if (selection.isSelected(mediaId)) {
+			selection.select(mediaId, "toggle");
+		}
+		if (selection.selectedIds().size === 0) {
+			setIsBulkSelectMode(false);
+		}
+	};
+	const confirmDelete = async () => {
+		const media = deleteTarget();
+		if (!media || isDeleteSubmitting()) return;
+		setIsDeleteSubmitting(true);
+		try {
+			await deleteMedia(media.mediaSourceId, media.id);
+			forgetSelectedMedia(media.id);
+			toast.success("Media deleted");
+			page.refreshSearchResults();
+		} catch (error) {
+			toast.error(`Failed to delete media: ${getErrorMessage(error)}`);
+		} finally {
+			setIsDeleteSubmitting(false);
+			setIsDeleteDialogOpen(false);
+			setDeleteTarget(null);
+		}
+	};
+	const handleConfirmCopyMove = async (targetSourceId: string) => {
+		const media = moveCopyTarget();
+		if (!media) return;
+		const mode = moveCopyMode();
+		const action = mode === "copy" ? copyMedia : moveMedia;
+		try {
+			await action(media.mediaSourceId, media.id, targetSourceId);
+			toast.success(`Media ${mode === "copy" ? "copied" : "moved"}`);
+			page.refreshSearchResults();
+		} catch (error) {
+			toast.error(`Failed to ${mode} media: ${getErrorMessage(error)}`);
+		} finally {
+			setMoveCopyTarget(null);
+			setIsMoveCopyDialogOpen(false);
+		}
+	};
+	const handleBulkSuccess = () => {
+		clearSelection();
+		page.refreshSearchResults();
+	};
 
 	useMediaSourceEvents(() => searchState.selectedSource || "*", {
 		onMediaAdded: page.refreshSearchResults,
@@ -118,67 +213,122 @@ export default function V2SearchContent() {
 	});
 
 	return (
-		<V2SearchScreen
-			enableVirtualization
-			filterData={page.filterData}
-			isBulkSelectMode={isBulkSelectMode}
-			isSelected={selection.isSelected}
-			onClearSelection={clearSelection}
-			onSelectAll={() => {
-				setIsBulkSelectMode(true);
-				selection.selectAll();
-			}}
-			onSelectMedia={handleSelection}
-			onSelectSource={(id) => setSearchState("selectedSource", id)}
-			onToggleSelect={(mediaId) => handleSelection(mediaId, "toggle")}
-			onVisibleMediaIdsChange={setVisibleMediaIds}
-			page={page}
-			presetClient={PresetClient}
-			renderMediaItem={(media, options) => (
-				<V2MediaGridItem
-					imageLoadPolicy={options?.imageLoadPolicy}
-					isBulkSelectMode={options?.isBulkSelectMode}
-					isSelected={options?.isSelected}
-					isPreviewSelected={options?.isPreviewSelected}
-					media={media}
-					onOpenMediaDetail={options?.onOpenMediaDetail}
-					onPreviewSelect={options?.onPreviewSelect}
-					onSelectGesture={options?.onSelectGesture}
-					onToggleSelect={options?.onToggleSelect}
-					priority={options?.priority}
-					onPrepareMediaDetail={options?.onPrepareMediaDetail}
-				/>
-			)}
-			onPrepareMediaDetail={(media, context) => {
-				rememberReturnPath(location().href);
-				saveV2MediaContext(location().href, context ?? [media]);
-			}}
-			onOpenMediaDetail={(media, context) => {
-				rememberReturnPath(location().href);
-				saveV2MediaContext(location().href, context ?? [media]);
-				void navigate({
-					params: {
-						mediaId: media.id,
-						mediaSourceId: media.mediaSourceId,
-					},
-					to: "/v2/sources/$mediaSourceId/$mediaId",
-				});
-			}}
-			renderMediaPreview={(media) => (
-				<ThumbnailImage
-					alt={media.fileName}
-					class="h-full w-full object-contain"
-					height={media.height}
-					loading="eager"
-					media={media}
-					requestedSize={512}
-					width={media.width}
-				/>
-			)}
-			selectedSource={searchState.selectedSource}
-			selectedCount={() => selection.selectedIds().size}
-			ssrGuard
-			sources={page.sources()}
-		/>
+		<>
+			<V2SearchScreen
+				enableVirtualization
+				filterData={page.filterData}
+				isBulkSelectMode={isBulkSelectMode}
+				isSelected={selection.isSelected}
+				onBulkAction={() => setIsBulkActionOpen(true)}
+				onClearSelection={clearSelection}
+				onCopyMove={handleCopyMove}
+				onDelete={handleDelete}
+				onSelectAll={() => {
+					setIsBulkSelectMode(true);
+					selection.selectAll();
+				}}
+				onSelectMedia={handleSelection}
+				onSelectSource={(id) => setSearchState("selectedSource", id)}
+				onToggleSelect={(mediaId) => handleSelection(mediaId, "toggle")}
+				onVisibleMediaIdsChange={setVisibleMediaIds}
+				page={page}
+				presetClient={PresetClient}
+				renderMediaItem={(media, options) => (
+					<V2MediaGridItem
+						imageLoadPolicy={options?.imageLoadPolicy}
+						isBulkSelectMode={options?.isBulkSelectMode}
+						isSelected={options?.isSelected}
+						isPreviewSelected={options?.isPreviewSelected}
+						media={media}
+						onOpenMediaDetail={options?.onOpenMediaDetail}
+						onPreviewSelect={options?.onPreviewSelect}
+						onSelectGesture={options?.onSelectGesture}
+						onToggleSelect={options?.onToggleSelect}
+						priority={options?.priority}
+						onPrepareMediaDetail={options?.onPrepareMediaDetail}
+					/>
+				)}
+				onPrepareMediaDetail={(media, context) => {
+					rememberReturnPath(location().href);
+					saveV2MediaContext(location().href, context ?? [media]);
+				}}
+				onOpenMediaDetail={(media, context) => {
+					rememberReturnPath(location().href);
+					saveV2MediaContext(location().href, context ?? [media]);
+					void navigate({
+						params: {
+							mediaId: media.id,
+							mediaSourceId: media.mediaSourceId,
+						},
+						to: "/v2/sources/$mediaSourceId/$mediaId",
+					});
+				}}
+				renderMediaPreview={(media) => (
+					<ThumbnailImage
+						alt={media.fileName}
+						class="h-full w-full object-contain"
+						height={media.height}
+						loading="eager"
+						media={media}
+						requestedSize={512}
+						width={media.width}
+					/>
+				)}
+				selectedSource={searchState.selectedSource}
+				selectedCount={() => selection.selectedIds().size}
+				ssrGuard
+				sources={page.sources()}
+			/>
+			<Dialog
+				onOpenChange={(open) => {
+					setIsDeleteDialogOpen(open);
+					if (!open && !isDeleteSubmitting()) setDeleteTarget(null);
+				}}
+				open={isDeleteDialogOpen()}
+			>
+				<DialogContent class="v2-theme">
+					<DialogHeader>
+						<DialogTitle>メディアを削除</DialogTitle>
+						<DialogDescription>
+							この操作は取り消せません。
+							{deleteTarget()?.fileName ?? "選択したメディア"}を削除しますか？
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							disabled={isDeleteSubmitting()}
+							onClick={() => setIsDeleteDialogOpen(false)}
+							variant="outline"
+						>
+							キャンセル
+						</Button>
+						<Button
+							disabled={isDeleteSubmitting()}
+							onClick={confirmDelete}
+							variant="destructive"
+						>
+							{isDeleteSubmitting() ? "削除中..." : "削除"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+			<MoveCopyMediaDialog
+				currentSourceId={moveCopyTarget()?.mediaSourceId ?? ""}
+				mode={moveCopyMode()}
+				onConfirm={handleConfirmCopyMove}
+				onOpenChange={(open) => {
+					setIsMoveCopyDialogOpen(open);
+					if (!open) setMoveCopyTarget(null);
+				}}
+				open={isMoveCopyDialogOpen()}
+			/>
+			<BulkActionDialog
+				mediaIds={selectedMediaItems().map((item) => item.mediaId)}
+				mediaItems={selectedMediaItems()}
+				onOpenChange={setIsBulkActionOpen}
+				onSuccess={handleBulkSuccess}
+				open={isBulkActionOpen()}
+			/>
+		</>
 	);
 }

--- a/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
@@ -1,11 +1,17 @@
 import type { Locator, Page } from "@playwright/test";
 import {
 	E2E_PRIMARY_FILE_NAME,
+	E2E_SOURCE_ID,
 	E2E_SOURCE_NAME,
 	getFixtureMediaPath,
 	sourcePath,
 } from "./support/fixture";
-import { expect, test, waitForAppHydration } from "./support/test";
+import {
+	expect,
+	expectRouteHealthy,
+	test,
+	waitForAppHydration,
+} from "./support/test";
 
 function usesMobileControls(projectName: string): boolean {
 	return ["responsive-320", "responsive-375"].includes(projectName);
@@ -244,3 +250,20 @@ test("source media exposes mobile filters and touch selection", async ({
 
 	await expectNoHorizontalOverflow(page);
 });
+
+for (const route of [
+	{ name: "v1", path: sourcePath() },
+	{ name: "v2", path: `/v2/sources/${E2E_SOURCE_ID}` },
+]) {
+	test(`${route.name} media grid opens its context menu`, async ({ page }) => {
+		await page.goto(route.path);
+		await waitForAppHydration(page);
+
+		const firstMedia = page.locator("[data-media-id]").first();
+		await expect(firstMedia).toBeVisible();
+		await firstMedia.click({ button: "right" });
+
+		await expectRouteHealthy(page);
+		await expect(page.getByRole("menu")).toBeVisible();
+	});
+}

--- a/apps/server/src/tests/e2e/v2-interface-interactions.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/v2-interface-interactions.responsive.spec.ts
@@ -132,6 +132,59 @@ test("V2 global search keeps collection selection independent from preview", asy
 	await expect(bulkActions).toContainText("2 件選択中");
 });
 
+test("V2 global search exposes media and bulk actions", async ({
+	page,
+}, testInfo) => {
+	test.skip(
+		testInfo.project.name !== "responsive-desktop",
+		"Context-menu and modifier selection actions are exercised on desktop.",
+	);
+	await page.setViewportSize({ width: 1600, height: 900 });
+	await openV2Search(page);
+
+	const mediaItem = page.locator(`[data-media-id="${E2E_PRIMARY_MEDIA_ID}"]`);
+	await mediaItem.click({ button: "right" });
+	await expect(
+		page.getByRole("menuitem", { name: "削除", exact: true }),
+	).toBeVisible();
+	await expect(
+		page.getByRole("menuitem", { name: "他のソースへコピー", exact: true }),
+	).toBeVisible();
+	await expect(
+		page.getByRole("menuitem", { name: "他のソースへ移動", exact: true }),
+	).toBeVisible();
+
+	await page
+		.getByRole("menuitem", { name: "他のソースへ移動", exact: true })
+		.click();
+	const moveDialog = page.getByRole("dialog");
+	await expect(moveDialog).toContainText("Move Media");
+	await moveDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+
+	await mediaItem.click({ button: "right" });
+	await page.getByRole("menuitem", { name: "削除", exact: true }).click();
+	const deleteDialog = page.getByRole("dialog");
+	await expect(deleteDialog).toContainText(E2E_PRIMARY_FILE_NAME);
+	await deleteDialog
+		.getByRole("button", { name: "キャンセル", exact: true })
+		.click();
+
+	const bulkActions = page.getByTestId("search-bulk-actions-bar");
+	await mediaItem.click({ modifiers: ["Control"] });
+	await expect(bulkActions).toContainText("1 件選択中");
+	const bulkActionButton = bulkActions.getByRole("button", {
+		name: "一括操作を実行",
+		exact: true,
+	});
+	await expect(bulkActionButton).toBeEnabled();
+	await bulkActionButton.click();
+	const bulkDialog = page.getByRole("dialog");
+	await expect(bulkDialog).toContainText("一括削除");
+	await bulkDialog
+		.getByRole("button", { name: "キャンセル", exact: true })
+		.click();
+});
+
 test("V2 fine-pointer collection separates selection from opening detail", async ({
 	page,
 }, testInfo) => {

--- a/apps/server/src/tests/unit/infrastructure/jobs/download-jobs.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/download-jobs.test.ts
@@ -95,6 +95,7 @@ describe("processDownloadJob", () => {
 		vi.resetAllMocks();
 		fetchMock.mockResolvedValue({
 			ok: true,
+			headers: new Headers({ "content-type": "image/jpeg" }),
 			arrayBuffer: async () => new ArrayBuffer(10),
 		});
 
@@ -215,6 +216,29 @@ describe("processDownloadJob", () => {
 				authors: [{ name: "User", accountId: "@user" }],
 			}),
 		);
+	});
+
+	it("should reject non-image direct download responses", async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			headers: new Headers({ "content-type": "text/html" }),
+			arrayBuffer: async () => new ArrayBuffer(10),
+		});
+
+		const job = {
+			id: "job-non-image",
+			mediaSourceId: "source-1",
+			type: "downloadImage",
+			payload: {
+				targetUrl: "https://x.com/home",
+			},
+		} as any;
+
+		await expect(processDownloadJob(job)).rejects.toThrow(
+			"non-image response: text/html",
+		);
+		expect(mockSaveFile).not.toHaveBeenCalled();
+		expect(mockMediaRegisterAndProcess).not.toHaveBeenCalled();
 	});
 
 	it("should use description if provided", async () => {

--- a/apps/server/src/tests/unit/infrastructure/jobs/download-jobs.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/jobs/download-jobs.test.ts
@@ -241,6 +241,48 @@ describe("processDownloadJob", () => {
 		expect(mockMediaRegisterAndProcess).not.toHaveBeenCalled();
 	});
 
+	it.each([
+		{
+			targetUrl: "https://example.com/page.html",
+			contentType: "image/jpeg",
+			expectedExtension: /\.jpg$/,
+		},
+		{
+			targetUrl: "https://example.com/image?format=html",
+			contentType: "image/jpeg",
+			expectedExtension: /\.jpg$/,
+		},
+		{
+			targetUrl: "https://example.com/page.html",
+			contentType: "image/x-custom",
+			expectedExtension: /\.png$/,
+		},
+	])(
+		"should derive the direct download extension from the response MIME type ($targetUrl, $contentType)",
+		async ({ targetUrl, contentType, expectedExtension }) => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers({ "content-type": contentType }),
+				arrayBuffer: async () => new ArrayBuffer(10),
+			});
+
+			const job = {
+				id: "job-extension",
+				mediaSourceId: "source-1",
+				type: "downloadImage",
+				payload: { targetUrl },
+			} as any;
+
+			await processDownloadJob(job);
+
+			expect(mockMediaRegisterAndProcess).toHaveBeenCalledWith(
+				"source-1",
+				expect.stringMatching(expectedExtension),
+				expect.anything(),
+			);
+		},
+	);
+
 	it("should use description if provided", async () => {
 		const { MediaProcessingService } = await import(
 			"~/infrastructure/services/media-processing-service"

--- a/apps/xtracter/src/content/twitter.ts
+++ b/apps/xtracter/src/content/twitter.ts
@@ -101,6 +101,11 @@ function processVideos(
 
 		const tweetArticle = findTweetArticle(videoComponent);
 		const metadata = extractMetadata(tweetArticle, container, "VIDEO");
+		if (!metadata.targetUrl) {
+			// A video can only be downloaded through its post URL. Do not
+			// enqueue the current timeline URL (for example /home) as a video.
+			continue;
+		}
 
 		// Store metadata for bulk export
 		if (metadata.targetUrl && !processedMetadata.has(metadata.targetUrl)) {
@@ -147,9 +152,12 @@ function findTweetArticle(element: HTMLElement): HTMLElement | null {
 }
 
 function extractMetadataFromUrl(): { authorId: string; tweetUrl: string } {
+	const tweetUrl = window.location.href;
+	const authorId = extractTwitterAuthorIdFromStatusUrl(tweetUrl);
+
 	return {
-		authorId: extractTwitterAuthorIdFromStatusUrl(window.location.href),
-		tweetUrl: window.location.href,
+		authorId,
+		tweetUrl: authorId ? tweetUrl : "",
 	};
 }
 
@@ -160,7 +168,7 @@ function extractMetadata(
 ): TweetMetadata {
 	let tweetText = "";
 	let timestamp = "";
-	let tweetUrl = window.location.href;
+	let tweetUrl = "";
 	let authorName = "";
 	let authorId = "";
 
@@ -173,10 +181,10 @@ function extractMetadata(
 		authorId = extracted.authorId;
 	}
 
-	if (!(authorId && tweetUrl) || tweetUrl === window.location.href) {
+	if (!tweetUrl) {
 		const urlMetadata = extractMetadataFromUrl();
 		authorId = authorId || urlMetadata.authorId;
-		tweetUrl = urlMetadata.tweetUrl || tweetUrl;
+		tweetUrl = urlMetadata.tweetUrl;
 	}
 
 	const targetUrl = determineTargetUrl(element, mediaType, tweetUrl);
@@ -190,7 +198,7 @@ function extractMetadata(
 		});
 	}
 
-	const sourceUrls = [tweetUrl];
+	const sourceUrls = tweetUrl ? [tweetUrl] : [];
 	if (mediaType === "IMAGE") {
 		sourceUrls.unshift(targetUrl);
 	}
@@ -211,7 +219,7 @@ function determineTargetUrl(
 	tweetUrl: string,
 ): string {
 	if (mediaType === "VIDEO") {
-		return tweetUrl;
+		return extractTwitterAuthorIdFromStatusUrl(tweetUrl) ? tweetUrl : "";
 	}
 
 	try {
@@ -239,10 +247,19 @@ function extractFromArticle(article: HTMLElement) {
 	const timeNode = article.querySelector("time");
 	const timestamp = timeNode ? timeNode.getAttribute("datetime") || "" : "";
 
-	let tweetUrl = window.location.href;
-	const timeLink = timeNode?.closest("a");
+	let tweetUrl = "";
+	const timeLink = timeNode?.closest<HTMLAnchorElement>("a");
+	const links = Array.from(
+		article.querySelectorAll<HTMLAnchorElement>("a[href]"),
+	);
 	if (timeLink) {
-		tweetUrl = timeLink.href;
+		links.unshift(timeLink);
+	}
+	for (const link of links) {
+		if (extractTwitterAuthorIdFromStatusUrl(link.href)) {
+			tweetUrl = link.href;
+			break;
+		}
 	}
 
 	const userNameNode = article.querySelector('div[data-testid="User-Name"]');

--- a/packages/ui/src/screens/v2-search-screen.tsx
+++ b/packages/ui/src/screens/v2-search-screen.tsx
@@ -16,7 +16,10 @@ import type { SearchWorkspaceProps } from "./search-screen.types";
 export type V2SearchScreenProps = SearchWorkspaceProps & {
 	isBulkSelectMode?: () => boolean;
 	isSelected?: (mediaId: string) => boolean;
+	onBulkAction?: () => void;
 	onClearSelection?: () => void;
+	onCopyMove?: (mediaId: string, mode: "copy" | "move") => void;
+	onDelete?: (mediaId: string) => void;
 	onOpenMediaDetail?: (media: Media, context?: Media[]) => void;
 	onPrepareMediaDetail?: (media: Media, context?: Media[]) => void;
 	onSelectAll?: () => void;
@@ -164,7 +167,10 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 								isSelected={props.isSelected}
 								mediaResults={page().searchResults}
 								mediaSourceId={() => undefined}
+								onBulkAction={props.onBulkAction}
 								onClearSelection={props.onClearSelection}
+								onCopyMove={props.onCopyMove}
+								onDelete={props.onDelete}
 								onOpenMediaDetail={
 									props.onOpenMediaDetail ? openMediaDetail : undefined
 								}
@@ -233,6 +239,15 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 					>
 						表示分をすべて選択
 					</Button>
+					<Show when={props.onBulkAction}>
+						<Button
+							class="flex-1 sm:flex-none"
+							disabled={(props.selectedCount?.() ?? 0) === 0}
+							onClick={props.onBulkAction}
+						>
+							一括操作を実行
+						</Button>
+					</Show>
 					<Button
 						class="flex-1 sm:flex-none"
 						onClick={props.onClearSelection}

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -21,6 +21,7 @@ import { EmptyState, ErrorState, OfflineState } from "./async-state";
 import {
 	ContextMenu,
 	ContextMenuContent,
+	ContextMenuGroup,
 	ContextMenuGroupLabel,
 	ContextMenuItem,
 	ContextMenuSeparator,
@@ -1093,99 +1094,105 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 								>
 									{(media) => (
 										<>
-											<ContextMenuGroupLabel
-												class="max-w-72 truncate text-[var(--v2-text-muted)]"
-												title={media.fileName}
-											>
-												{media.fileName}
-											</ContextMenuGroupLabel>
-											<ContextMenuSeparator />
-											<Show when={!hasContextMenuActions()}>
-												<ContextMenuItem disabled>
-													利用できる操作はありません
-												</ContextMenuItem>
-											</Show>
-											<Show when={props.onOpenMediaDetail}>
-												<ContextMenuItem
-													onSelect={() => props.onOpenMediaDetail?.(media)}
+											<ContextMenuGroup>
+												<ContextMenuGroupLabel
+													class="max-w-72 truncate text-[var(--v2-text-muted)]"
+													title={media.fileName}
 												>
-													詳細を開く
-													<ContextMenuShortcut>Enter</ContextMenuShortcut>
-												</ContextMenuItem>
-											</Show>
-											<Show
-												when={showOpenInNewTab() && props.onOpenMediaDetail}
-											>
-												<ContextMenuItem
-													onSelect={() => openMediaInNewTab(media)}
-												>
-													新しいタブで開く
-												</ContextMenuItem>
-											</Show>
-											<Show when={props.onToggleSelect}>
-												<ContextMenuItem
-													onSelect={() => props.onToggleSelect?.(media.id)}
-												>
-													{props.isBulkSelectMode?.() &&
-													props.isSelected?.(media.id)
-														? "選択解除"
-														: "選択"}
-													<ContextMenuShortcut>Space</ContextMenuShortcut>
-												</ContextMenuItem>
-											</Show>
-											<Show
-												when={
-													props.isBulkSelectMode?.() &&
-													(props.selectedCount?.() ?? 0) > 0 &&
-													(props.onBulkAction || props.onClearSelection)
-												}
-											>
-												<Show when={props.onBulkAction}>
-													<ContextMenuItem
-														onSelect={() => props.onBulkAction?.()}
-													>
-														一括操作を実行 ({props.selectedCount?.()}件選択中)
+													{media.fileName}
+												</ContextMenuGroupLabel>
+												<ContextMenuSeparator />
+												<Show when={!hasContextMenuActions()}>
+													<ContextMenuItem disabled>
+														利用できる操作はありません
 													</ContextMenuItem>
 												</Show>
-												<Show when={props.onClearSelection}>
+												<Show when={props.onOpenMediaDetail}>
 													<ContextMenuItem
-														onSelect={() => props.onClearSelection?.()}
+														onSelect={() => props.onOpenMediaDetail?.(media)}
 													>
-														選択をクリア
+														詳細を開く
+														<ContextMenuShortcut>Enter</ContextMenuShortcut>
 													</ContextMenuItem>
 												</Show>
-											</Show>
-											<Show when={props.onDelete}>
-												<ContextMenuSeparator />
-												<ContextMenuItem
-													class="text-destructive focus:text-destructive"
-													onSelect={() => props.onDelete?.(media.id)}
+												<Show
+													when={showOpenInNewTab() && props.onOpenMediaDetail}
 												>
-													削除
-													<ContextMenuShortcut>Delete</ContextMenuShortcut>
-												</ContextMenuItem>
-											</Show>
-											<Show when={props.onCopyMove}>
-												<ContextMenuSeparator />
-												<ContextMenuItem
-													onSelect={() => props.onCopyMove?.(media.id, "copy")}
+													<ContextMenuItem
+														onSelect={() => openMediaInNewTab(media)}
+													>
+														新しいタブで開く
+													</ContextMenuItem>
+												</Show>
+												<Show when={props.onToggleSelect}>
+													<ContextMenuItem
+														onSelect={() => props.onToggleSelect?.(media.id)}
+													>
+														{props.isBulkSelectMode?.() &&
+														props.isSelected?.(media.id)
+															? "選択解除"
+															: "選択"}
+														<ContextMenuShortcut>Space</ContextMenuShortcut>
+													</ContextMenuItem>
+												</Show>
+												<Show
+													when={
+														props.isBulkSelectMode?.() &&
+														(props.selectedCount?.() ?? 0) > 0 &&
+														(props.onBulkAction || props.onClearSelection)
+													}
 												>
-													他のソースへコピー
-												</ContextMenuItem>
-												<ContextMenuItem
-													onSelect={() => props.onCopyMove?.(media.id, "move")}
-												>
-													他のソースへ移動
-												</ContextMenuItem>
-											</Show>
-											<Show when={props.onSyncSingleMedia}>
-												<ContextMenuSeparator />
-												<ContextMenuItem
-													onSelect={() => props.onSyncSingleMedia?.(media.id)}
-												>
-													メタデータを同期 (再処理)
-												</ContextMenuItem>
-											</Show>
+													<Show when={props.onBulkAction}>
+														<ContextMenuItem
+															onSelect={() => props.onBulkAction?.()}
+														>
+															一括操作を実行 ({props.selectedCount?.()}件選択中)
+														</ContextMenuItem>
+													</Show>
+													<Show when={props.onClearSelection}>
+														<ContextMenuItem
+															onSelect={() => props.onClearSelection?.()}
+														>
+															選択をクリア
+														</ContextMenuItem>
+													</Show>
+												</Show>
+												<Show when={props.onDelete}>
+													<ContextMenuSeparator />
+													<ContextMenuItem
+														class="text-destructive focus:text-destructive"
+														onSelect={() => props.onDelete?.(media.id)}
+													>
+														削除
+														<ContextMenuShortcut>Delete</ContextMenuShortcut>
+													</ContextMenuItem>
+												</Show>
+												<Show when={props.onCopyMove}>
+													<ContextMenuSeparator />
+													<ContextMenuItem
+														onSelect={() =>
+															props.onCopyMove?.(media.id, "copy")
+														}
+													>
+														他のソースへコピー
+													</ContextMenuItem>
+													<ContextMenuItem
+														onSelect={() =>
+															props.onCopyMove?.(media.id, "move")
+														}
+													>
+														他のソースへ移動
+													</ContextMenuItem>
+												</Show>
+												<Show when={props.onSyncSingleMedia}>
+													<ContextMenuSeparator />
+													<ContextMenuItem
+														onSelect={() => props.onSyncSingleMedia?.(media.id)}
+													>
+														メタデータを同期 (再処理)
+													</ContextMenuItem>
+												</Show>
+											</ContextMenuGroup>
 										</>
 									)}
 								</Show>


### PR DESCRIPTION
## Summary
- wrap media context-menu labels and actions in the required Kobalte menu group
- add v1/v2 source media right-click regression coverage

## Validation
- bun run check
- packages/ui unit tests: 96 passed
- v1 source-media right-click E2E passed
- v2 E2E was attempted, but Vite dependency optimization returned 504 Outdated Optimize Dep before the test; production E2E was blocked by the harness failing to resolve @electric-sql/pglite before tests started

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * V2検索画面で、メディアの削除・コピー・移動や一括操作を利用できるようになりました。
  * 複数ソースにまたがるメディアをまとめて操作できます。

* **改善**
  * メディアグリッドのコンテキストメニューを整理しました。
  * 画像ダウンロード時の形式判定を改善し、動画処理に必要な環境を追加しました。
  * 投稿URLの判定精度を向上しました。

* **テスト**
  * V2画面と新しいソース画面で各操作を確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->