### PR TITLE
fix: restore workspace typecheck after dependency update

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -10,6 +10,7 @@
     "dev": "bun run src/index.ts",
     "build": "bun build ./src/index.ts --compile --outfile dist/imager-cli",
     "start": "bun run dist/imager-cli",
+    "typecheck": "sh -c 'tsc --noEmit'",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@types/bun": "1.4.0",
+    "@types/node": "^26.4.0",
     "typescript": "rc",
     "vitest": "^4.1.10"
   }

--- a/apps/cli/src/commands/db.ts
+++ b/apps/cli/src/commands/db.ts
@@ -33,7 +33,7 @@ async function runDatabaseCommand(
 ): Promise<void> {
 	const { docker, outputFile, inputFile, agent } = options;
 
-	let spawnCmd = command;
+	let spawnCmd: string = command;
 	let spawnArgs = args;
 
 	if (docker) {

--- a/apps/cli/src/commands/media.ts
+++ b/apps/cli/src/commands/media.ts
@@ -92,22 +92,12 @@ export interface BasicContext<
 > {
 	agent: boolean;
 	args: TArgs;
-	displayName: string;
-	env: Record<string, unknown>;
 	error: (options: {
 		code: string;
-		cta?: unknown;
-		exitCode?: number;
 		message: string;
-		retryable?: boolean;
 	}) => never;
-	format: string;
-	formatExplicit: boolean;
-	name: string;
-	ok: (data: unknown, meta?: { cta?: unknown }) => never;
+	ok: (data: unknown) => unknown;
 	options: TOptions;
-	var: Record<string, unknown>;
-	version?: string;
 }
 
 export const getHandler = async (
@@ -268,7 +258,9 @@ export const downloadHandler = async (
 		const fileStream = createWriteStream(filename);
 
 		await finished(
-			Readable.fromWeb(res.body as import("stream/web").ReadableStream).pipe(
+			Readable.fromWeb(
+				res.body as unknown as import("node:stream/web").ReadableStream,
+			).pipe(
 				fileStream,
 			),
 		);

--- a/apps/cli/src/commands/media.ts
+++ b/apps/cli/src/commands/media.ts
@@ -92,10 +92,7 @@ export interface BasicContext<
 > {
 	agent: boolean;
 	args: TArgs;
-	error: (options: {
-		code: string;
-		message: string;
-	}) => never;
+	error: (options: { code: string; message: string }) => never;
 	ok: (data: unknown) => unknown;
 	options: TOptions;
 }
@@ -260,9 +257,7 @@ export const downloadHandler = async (
 		await finished(
 			Readable.fromWeb(
 				res.body as unknown as import("node:stream/web").ReadableStream,
-			).pipe(
-				fileStream,
-			),
+			).pipe(fileStream),
 		);
 
 		return c.ok({ message: `Downloaded to ${filename}` });

--- a/apps/cli/src/orpc-client.ts
+++ b/apps/cli/src/orpc-client.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@solid-imager/client";
+import type { AppContract } from "@solid-imager/core/domain/contract";
 
 export function getClient(url: string) {
 	const remoteUrl = url || "http://localhost:3000";
@@ -6,5 +7,5 @@ export function getClient(url: string) {
 	if (!/^https?:\/\//.test(base)) {
 		base = `http://${base}`;
 	}
-	return createClient({ url: base });
+	return createClient<AppContract>({ url: base });
 }

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -4,12 +4,18 @@
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "../..",
+    "paths": {
+      "@/*": ["../../packages/core/src/*"]
+    },
+    "types": ["node", "bun-types", "vitest/globals"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/apps/server/src/tests/unit/infrastructure/storage/server-media-storage-formats.test.ts
+++ b/apps/server/src/tests/unit/infrastructure/storage/server-media-storage-formats.test.ts
@@ -61,11 +61,7 @@ describe.each([".svg", ".tiff"] as const)(
 			const sourcePath = await createFixture(fileName, sourceDirectory);
 			const file = new File([await fs.readFile(sourcePath)], fileName);
 
-			const result = await ServerMediaStorage.saveFile(
-				tempDirectory,
-				file,
-				{},
-			);
+			const result = await ServerMediaStorage.saveFile(tempDirectory, file, {});
 
 			expect(result.width).toBe(IMAGE_WIDTH);
 			expect(result.height).toBe(IMAGE_HEIGHT);

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.0
+        specifier: ^2.5.11
         version: 2.5.11
       '@google/design.md':
         specifier: ^0.4.0
@@ -24,20 +24,20 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^17.3.0
+        specifier: ^17.4.1
         version: 17.4.1
       nitro:
         specifier: npm:nitro-nightly@3.0.1-20260601-173724-a2597363
-        version: 3.0.1-20260601-173724-a2597363(vite@8.2.2)
+        version: 3.0.1-20260601-173724-a2597363(dotenv@17.4.2)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       typescript:
-        specifier: ^7.0.0
+        specifier: ^7.0.2
         version: 7.0.2
       vite:
         specifier: ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 8.2.2
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.11(vite@8.2.2)
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
   apps/cli:
     dependencies:
@@ -55,20 +55,23 @@ importers:
         version: 0.5.1
       zod:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.5.2
     devDependencies:
       '@types/bun':
-        specifier: ^1.3.14
+        specifier: 1.4.0
         version: 1.4.0
+      '@types/node':
+        specifier: ^26.4.0
+        version: 26.4.0
       typescript:
         specifier: rc
         version: 7.0.1-rc
       vite:
         specifier: ^6.0.0 || ^7.0.0 || ^8.0.0
-        version: 8.2.2
+        version: 8.2.2(@types/node@26.4.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.11(vite@8.2.2)
+        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
   apps/server:
     dependencies:
@@ -98,7 +101,7 @@ importers:
         version: 1.15.0(@orpc/client@1.15.0)(@tanstack/query-core@5.102.0)
       '@orpc/zod':
         specifier: ^1.14.4
-        version: 1.15.0(@orpc/contract@1.15.0)(@orpc/server@1.15.0)(zod@4.4.3)
+        version: 1.15.0(@orpc/contract@1.15.0)(@orpc/server@1.15.0)(zod@4.5.2)
       '@solid-imager/application':
         specifier: workspace:*
         version: 0.0.0
@@ -119,7 +122,7 @@ importers:
         version: 5.102.0
       '@tanstack/router-plugin':
         specifier: ^1.168.14
-        version: 1.168.35(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))(vite-plugin-solid@2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12)))
+        version: 1.168.35(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))(vite-plugin-solid@2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13)))
       '@tanstack/solid-form':
         specifier: ^1.33.0
         version: 1.33.5(solid-js@1.9.15)
@@ -137,7 +140,7 @@ importers:
         version: 1.167.2(@tanstack/query-core@5.102.0)(@tanstack/solid-query@5.102.0(solid-js@1.9.15))(@tanstack/solid-router@1.170.30(solid-js@1.9.15))(solid-js@1.9.15)
       '@tanstack/solid-start':
         specifier: ^1.168.19
-        version: 1.168.47(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+        version: 1.168.47(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       archiver:
         specifier: ^8.0.0
         version: 8.0.0
@@ -145,8 +148,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       dghs-imgutils-rs:
-        specifier: github:hmjn023/dghs-imgutils-rs#457553648518c8df370391391443b6302e19b05a
-        version: https://codeload.github.com/hmjn023/dghs-imgutils-rs/tar.gz/457553648518c8df370391391443b6302e19b05a
+        specifier: github:hmjn023/dghs-imgutils-rs#v0.5.2
+        version: https://codeload.github.com/hmjn023/dghs-imgutils-rs/tar.gz/49f435e51577ad26cb5e818aaa973a58902e1b1b
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.5.7)(@types/pg@8.23.1)(bun-types@1.4.0)(pg@8.23.0)
@@ -158,7 +161,7 @@ importers:
         version: 2.1.3
       nitro:
         specifier: npm:nitro-nightly@3.0.1-20260601-173724-a2597363
-        version: 3.0.1-20260601-173724-a2597363(dotenv@17.4.2)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+        version: 3.0.1-20260601-173724-a2597363(dotenv@17.4.2)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       pg:
         specifier: ^8.22.0
         version: 8.23.0
@@ -188,7 +191,7 @@ importers:
         version: 3.1.13(debug@4.4.3)
       zod:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.5.2
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.16
@@ -201,10 +204,10 @@ importers:
         version: 1.62.1
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+        version: 4.3.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       '@tanstack/devtools-vite':
         specifier: ^0.8.3
-        version: 0.8.5(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+        version: 0.8.5(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       '@types/archiver':
         specifier: ^8.0.0
         version: 8.0.0
@@ -236,7 +239,7 @@ importers:
         specifier: ^2.10.33
         version: 2.11.20
       bun-types:
-        specifier: ^1.3.14
+        specifier: 1.4.0
         version: 1.4.0
       dotenv:
         specifier: ^17.4.2
@@ -258,7 +261,7 @@ importers:
         version: 1.0.7(tailwindcss@4.3.3)
       tsx:
         specifier: ^4.22.4
-        version: 4.23.12
+        version: 4.23.13
       typedoc:
         specifier: ^0.28.19
         version: 0.28.20(typescript@7.0.1-rc)
@@ -267,16 +270,16 @@ importers:
         version: 7.0.1-rc
       vite:
         specifier: ^8.1.5
-        version: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
+        version: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
       vite-plugin-mkcert:
         specifier: ^2.1.0
-        version: 2.1.0(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+        version: 2.1.0(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       vite-plugin-solid:
         specifier: ^2.11.12
-        version: 2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+        version: 2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
   apps/tauri:
     dependencies:
@@ -330,17 +333,17 @@ importers:
         version: 1.9.15
       zod:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.5.2
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.16
         version: 2.5.11
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+        version: 4.3.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       '@tanstack/router-plugin':
         specifier: latest
-        version: 1.168.35(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))(vite-plugin-solid@2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12)))
+        version: 1.168.35(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))(vite-plugin-solid@2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13)))
       '@tauri-apps/cli':
         specifier: ^2.11.2
         version: 2.11.4
@@ -361,7 +364,7 @@ importers:
         version: 8.2.2(@types/node@26.4.0)
       vite-plugin-solid:
         specifier: ^2.11.12
-        version: 2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+        version: 2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
   apps/xtracter:
     dependencies:
@@ -376,7 +379,7 @@ importers:
         version: 0.0.0
       zod:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.5.2
     devDependencies:
       '@types/chrome':
         specifier: ^0.2.6
@@ -395,7 +398,7 @@ importers:
         version: 8.2.2(@types/node@26.4.0)
       vite-plugin-solid:
         specifier: ^2.11.12
-        version: 2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+        version: 2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
   packages/application:
     dependencies:
@@ -414,7 +417,7 @@ importers:
         version: 8.2.2(@types/node@26.4.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0))
+        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
   packages/client:
     dependencies:
@@ -433,7 +436,7 @@ importers:
         version: 8.2.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.11(vite@8.2.2)
+        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
   packages/core:
     dependencies:
@@ -442,7 +445,7 @@ importers:
         version: 1.15.0
       zod:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.5.2
     devDependencies:
       '@types/node':
         specifier: ^26.2.0
@@ -455,7 +458,7 @@ importers:
         version: 8.2.2(@types/node@26.4.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0))
+        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
   packages/db:
     dependencies:
@@ -474,7 +477,7 @@ importers:
         version: 8.2.2(@types/node@26.4.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0))
+        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
   packages/ui:
     dependencies:
@@ -510,10 +513,10 @@ importers:
         version: 2.1.1
       cmdk-solid:
         specifier: ^1.1.2
-        version: 1.1.2(solid-js@1.9.15)
+        version: 1.2.0(@kobalte/core@0.13.13(solid-js@1.9.15))(solid-js@1.9.15)
       lucide-solid:
         specifier: ^1.17.0
-        version: 1.35.0(solid-js@1.9.15)
+        version: 1.37.0(solid-js@1.9.15)
       solid-js:
         specifier: ^1.9.13
         version: 1.9.15
@@ -531,7 +534,7 @@ importers:
         version: 1.0.7(tailwindcss@4.3.3)
       zod:
         specifier: ^4.4.3
-        version: 4.4.3
+        version: 4.5.2
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.16
@@ -544,7 +547,7 @@ importers:
         version: 8.2.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.11(vite@8.2.2)
+        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
 packages:
 
@@ -1379,9 +1382,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@internationalized/date@3.12.3':
-    resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
-
   '@internationalized/number@3.6.7':
     resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
 
@@ -1408,11 +1408,6 @@ packages:
   '@kikobeats/time-span@1.0.13':
     resolution: {integrity: sha512-CfBK4/EZ73uN/6b5/wOfvWju1Ev/6H+uXqS2Vqd7/dEQTyOsvv4BdOHDqESp4Efa9YyrPPvN3IHU+C4z9FAo3Q==}
     engines: {node: '>= 18'}
-
-  '@kobalte/core@0.12.6':
-    resolution: {integrity: sha512-+Ta2o2wEqZ2fCqLMkvjT40VHNmcFKdGe8TNDVQbbMPk66qoU6g/DDRFR/Ib7eAjb+C95VoIyk6zaafos2VOo0w==}
-    peerDependencies:
-      solid-js: ^1.8.15
 
   '@kobalte/core@0.13.13':
     resolution: {integrity: sha512-czBC+IQdOgJoW7DJjeh0rht7SPmTPgWsKg7Jo3RHMfwx028WxJtDylx9dJuJuD/GUae15+E4nYafu8LwuixFYQ==}
@@ -1810,11 +1805,6 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@solid-primitives/deep@0.2.10':
-    resolution: {integrity: sha512-uzhXr/cMABsGkTcV3yuviZjTDmj44wb2JetuJ5O8NCugz4Ug/6XlPjT8ISMPYV7eCbC/gFhgt7e60+TRpl2Upg==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
   '@solid-primitives/event-listener@2.4.6':
     resolution: {integrity: sha512-5I0YJcTVYIWoMmgBSROBZGcz+ymhew/pGTg2dHW74BUjFKsV8Li4bOZYl0YAGP4mHw5o4UBd9/BEesqBci3wxw==}
     peerDependencies:
@@ -1840,16 +1830,6 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
-  '@solid-primitives/memo@1.5.1':
-    resolution: {integrity: sha512-VDPrkl9epp0tbby9MvsqphGFCYCtDRC5J8FKzTqHbQiG5hhR8n6xv4MfjhTW231IaBxxPHLxS43EE8c5Q23mSQ==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/mutation-observer@1.2.4':
-    resolution: {integrity: sha512-CVKOLDj09ZLoN9Hq+o5BTNVBCVM1vKcpRhaZnvpSuXguQBaAz75R8nkaEhkIdMcpENueLivPIJbUqAA1BAaOGw==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
   '@solid-primitives/props@3.2.4':
     resolution: {integrity: sha512-MXXdvi2TSB6d+0N6ueA/HP1j/Kh9SEc4WdF1ZDMLwPagxW6pIHHSS9xbRO0RjqSVpNP4j0nxCWT1hx3CkJNhNA==}
     peerDependencies:
@@ -1867,11 +1847,6 @@ packages:
 
   '@solid-primitives/rootless@1.5.4':
     resolution: {integrity: sha512-TOIZa1VUfVJ+9nkCcRajw3U4t9vBOP1HxX1WHNTbXq32mXwlqTvUnC4CRIilohcryBkT9u2ZkhUDSHRTaGp55g==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/scheduled@1.5.3':
-    resolution: {integrity: sha512-oNwLE6E6lxJAWrc8QXuwM0k2oU1BnANnkChwMw82aK1j3+mWGJkG1IFe5gCwbV+afYmjI76t9JJV3md/8tLw+g==}
     peerDependencies:
       solid-js: ^1.6.12
 
@@ -2942,9 +2917,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cmdk-solid@1.1.2:
-    resolution: {integrity: sha512-E0g6bwr2Z92Ib1K2WHwGsq6xsrkVVSN1oe5YTg8LCV3iIwtyZORwmR+8n0xrecqycdhgAar8vWUjtB1OJt9tiA==}
+  cmdk-solid@1.2.0:
+    resolution: {integrity: sha512-eOao2VrS+AF0oCgzsCgHJ25ZSoY7Sa6lU9U4Tb6dcPJ1NpZG7twbdTG04+g21KzKQWhF1F8M1Fr3qPJv9hLBqw==}
     peerDependencies:
+      '@kobalte/core': '>=0.12.4 <1'
       solid-js: ^1.8.0
 
   colorette@2.0.20:
@@ -3073,9 +3049,9 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dghs-imgutils-rs@https://codeload.github.com/hmjn023/dghs-imgutils-rs/tar.gz/457553648518c8df370391391443b6302e19b05a:
-    resolution: {gitHosted: true, integrity: sha512-a+P7BQvxEfpO+WvSnbw5O+DkMSJmmCu15INYEM6y9fSjYd955bt2qxX4u/EsRPfcTSI1w3tuniYSs2a+56UBqQ==, tarball: https://codeload.github.com/hmjn023/dghs-imgutils-rs/tar.gz/457553648518c8df370391391443b6302e19b05a}
-    version: 0.5.1
+  dghs-imgutils-rs@https://codeload.github.com/hmjn023/dghs-imgutils-rs/tar.gz/49f435e51577ad26cb5e818aaa973a58902e1b1b:
+    resolution: {gitHosted: true, integrity: sha512-ymgaxx3YDp8YpW4ysHE5BwjI0qt3yFYzbtLWFnGtbkKtd9Rm/2NSsI3yP+a0f8N8IjRWGK7mEIAawMgeLHnE1A==, tarball: https://codeload.github.com/hmjn023/dghs-imgutils-rs/tar.gz/49f435e51577ad26cb5e818aaa973a58902e1b1b}
+    version: 0.5.2
 
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
@@ -3790,8 +3766,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-solid@1.35.0:
-    resolution: {integrity: sha512-pUp3IKTCpM90K4ofE1mGiG/axf6xbRgCb7bjBEsWqc8zUujZf2co2NbejUhfmYnbeiLNLZMImT7xTFktq4mV4Q==}
+  lucide-solid@1.37.0:
+    resolution: {integrity: sha512-RjyHbI3IqMAdQKpm6FS0zxsIKEdF8Oz1V4AtHLSE95N3n9AqFJWKvktqnaFVno8grNp7L18WqyrisZbfvlY5MA==}
     peerDependencies:
       solid-js: ^1.4.7
 
@@ -4201,8 +4177,8 @@ packages:
     resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
     engines: {node: '>=10'}
 
-  pretty-ms@9.3.0:
-    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+  pretty-ms@9.3.1:
+    resolution: {integrity: sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==}
     engines: {node: '>=18'}
 
   process-nextick-args@2.0.1:
@@ -4570,8 +4546,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.23.12:
-    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+  tsx@4.23.13:
+    resolution: {integrity: sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -4898,8 +4874,11 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.5.2:
+    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
+
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -5499,10 +5478,6 @@ snapshots:
   '@img/sharp-win32-x64@0.35.4':
     optional: true
 
-  '@internationalized/date@3.12.3':
-    dependencies:
-      '@swc/helpers': 0.5.23
-
   '@internationalized/number@3.6.7':
     dependencies:
       '@swc/helpers': 0.5.23
@@ -5530,15 +5505,6 @@ snapshots:
 
   '@kikobeats/time-span@1.0.13': {}
 
-  '@kobalte/core@0.12.6(solid-js@1.9.15)':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      '@internationalized/date': 3.12.3
-      '@internationalized/number': 3.6.7
-      '@kobalte/utils': 0.9.2(solid-js@1.9.15)
-      solid-js: 1.9.15
-      solid-prevent-scroll: 0.1.11(solid-js@1.9.15)
-
   '@kobalte/core@0.13.13(solid-js@1.9.15)':
     dependencies:
       '@floating-ui/dom': 1.8.0
@@ -5563,7 +5529,7 @@ snapshots:
 
   '@modelcontextprotocol/server@2.0.0-alpha.4':
     dependencies:
-      zod: 4.4.3
+      zod: 4.5.2
 
   '@napi-rs/cli@2.18.4': {}
 
@@ -5748,7 +5714,7 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/zod@1.15.0(@orpc/contract@1.15.0)(@orpc/server@1.15.0)(zod@4.4.3)':
+  '@orpc/zod@1.15.0(@orpc/contract@1.15.0)(@orpc/server@1.15.0)(zod@4.5.2)':
     dependencies:
       '@orpc/contract': 1.15.0
       '@orpc/json-schema': 1.15.0
@@ -5757,7 +5723,7 @@ snapshots:
       '@orpc/shared': 1.15.0
       escape-string-regexp: 5.0.0
       wildcard-match: 5.1.4
-      zod: 4.4.3
+      zod: 4.5.2
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - crossws
@@ -5911,11 +5877,6 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@solid-primitives/deep@0.2.10(solid-js@1.9.15)':
-    dependencies:
-      '@solid-primitives/memo': 1.5.1(solid-js@1.9.15)
-      solid-js: 1.9.15
-
   '@solid-primitives/event-listener@2.4.6(solid-js@1.9.15)':
     dependencies:
       '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
@@ -5943,17 +5904,6 @@ snapshots:
       '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
       solid-js: 1.9.15
 
-  '@solid-primitives/memo@1.5.1(solid-js@1.9.15)':
-    dependencies:
-      '@solid-primitives/scheduled': 1.5.3(solid-js@1.9.15)
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
-      solid-js: 1.9.15
-
-  '@solid-primitives/mutation-observer@1.2.4(solid-js@1.9.15)':
-    dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
-      solid-js: 1.9.15
-
   '@solid-primitives/props@3.2.4(solid-js@1.9.15)':
     dependencies:
       '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
@@ -5975,10 +5925,6 @@ snapshots:
   '@solid-primitives/rootless@1.5.4(solid-js@1.9.15)':
     dependencies:
       '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
-      solid-js: 1.9.15
-
-  '@solid-primitives/scheduled@1.5.3(solid-js@1.9.15)':
-    dependencies:
       solid-js: 1.9.15
 
   '@solid-primitives/static-store@0.1.4(solid-js@1.9.15)':
@@ -6077,12 +6023,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/vite@4.3.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))':
+  '@tailwindcss/vite@4.3.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
 
   '@tanstack/cli@0.70.2':
     dependencies:
@@ -6154,13 +6100,13 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.5.0': {}
 
-  '@tanstack/devtools-vite@0.8.5(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))':
+  '@tanstack/devtools-vite@0.8.5(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))':
     dependencies:
       '@tanstack/devtools-bundler-core': 0.1.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@tanstack/devtools-client': 0.0.8
       '@tanstack/devtools-event-bus': 0.4.3
       chalk: 5.6.2
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6212,11 +6158,11 @@ snapshots:
       jiti: 2.7.0
       magic-string: 0.30.21
       prettier: 3.9.6
-      zod: 4.4.3
+      zod: 4.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.35(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))(vite-plugin-solid@2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12)))':
+  '@tanstack/router-plugin@1.168.35(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))(vite-plugin-solid@2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13)))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/template': 7.29.7
@@ -6225,10 +6171,10 @@ snapshots:
       '@tanstack/router-generator': 1.167.33
       '@tanstack/router-utils': 1.162.2
       chokidar: 5.0.0
-      unplugin: 3.3.0(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
-      vite-plugin-solid: 2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
-      zod: 4.4.3
+      unplugin: 3.3.0(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
+      vite-plugin-solid: 2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
+      zod: 4.5.4
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -6322,17 +6268,17 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/solid-start@1.168.47(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))':
+  '@tanstack/solid-start@1.168.47(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))':
     dependencies:
       '@tanstack/solid-router': 1.170.30(solid-js@1.9.15)
       '@tanstack/solid-start-client': 1.168.29(solid-js@1.9.15)
       '@tanstack/solid-start-server': 1.167.36(solid-js@1.9.15)
       '@tanstack/start-client-core': 1.170.27
-      '@tanstack/start-plugin-core': 1.171.39(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+      '@tanstack/start-plugin-core': 1.171.39(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       '@tanstack/start-server-core': 1.169.31
       pathe: 2.0.3
       solid-js: 1.9.15
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rsbuild/core'
@@ -6366,14 +6312,14 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.39(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))':
+  '@tanstack/start-plugin-core@1.171.39(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7
       '@babel/types': 7.29.8
       '@tanstack/router-core': 1.171.27
       '@tanstack/router-generator': 1.167.33
-      '@tanstack/router-plugin': 1.168.35(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))(vite-plugin-solid@2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12)))
+      '@tanstack/router-plugin': 1.168.35(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))(vite-plugin-solid@2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13)))
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-server-core': 1.169.31
       exsolve: 1.1.1
@@ -6385,10 +6331,10 @@ snapshots:
       srvx: 0.11.22
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
-      vitefu: 1.1.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
+      vitefu: 1.1.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       xmlbuilder2: 4.0.3
-      zod: 4.4.3
+      zod: 4.5.2
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rsbuild/core'
@@ -6737,7 +6683,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+      vitest: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -6748,12 +6694,12 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))':
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -7003,12 +6949,9 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cmdk-solid@1.1.2(solid-js@1.9.15):
+  cmdk-solid@1.2.0(@kobalte/core@0.13.13(solid-js@1.9.15))(solid-js@1.9.15):
     dependencies:
-      '@kobalte/core': 0.12.6(solid-js@1.9.15)
-      '@kobalte/utils': 0.9.2(solid-js@1.9.15)
-      '@solid-primitives/deep': 0.2.10(solid-js@1.9.15)
-      '@solid-primitives/mutation-observer': 1.2.4(solid-js@1.9.15)
+      '@kobalte/core': 0.13.13(solid-js@1.9.15)
       solid-js: 1.9.15
 
   colorette@2.0.20: {}
@@ -7075,8 +7018,6 @@ snapshots:
 
   dateformat@4.6.3: {}
 
-  db0@0.3.4: {}
-
   db0@0.3.4(@electric-sql/pglite@0.5.7)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.7)(@types/pg@8.23.1)(bun-types@1.4.0)(pg@8.23.0)):
     dependencies:
       '@electric-sql/pglite': 0.5.7
@@ -7110,7 +7051,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dghs-imgutils-rs@https://codeload.github.com/hmjn023/dghs-imgutils-rs/tar.gz/457553648518c8df370391391443b6302e19b05a:
+  dghs-imgutils-rs@https://codeload.github.com/hmjn023/dghs-imgutils-rs/tar.gz/49f435e51577ad26cb5e818aaa973a58902e1b1b:
     dependencies:
       '@napi-rs/cli': 2.18.4
 
@@ -7129,7 +7070,7 @@ snapshots:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
       esbuild: 0.25.12
-      tsx: 4.23.12
+      tsx: 4.23.13
 
   drizzle-orm@0.45.2(@electric-sql/pglite@0.5.7)(@types/pg@8.23.1)(bun-types@1.4.0)(pg@8.23.0):
     dependencies:
@@ -7300,7 +7241,7 @@ snapshots:
       is-plain-obj: 4.1.0
       is-stream: 4.0.1
       npm-run-path: 6.0.0
-      pretty-ms: 9.3.0
+      pretty-ms: 9.3.1
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.2.0
@@ -7469,7 +7410,7 @@ snapshots:
       '@toon-format/toon': 2.3.1
       tokenx: 1.6.0
       yaml: 2.9.0
-      zod: 4.4.3
+      zod: 4.5.4
 
   inherits@2.0.4: {}
 
@@ -7686,7 +7627,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-solid@1.35.0(solid-js@1.9.15):
+  lucide-solid@1.37.0(solid-js@1.9.15):
     dependencies:
       solid-js: 1.9.15
 
@@ -8060,7 +8001,7 @@ snapshots:
 
   nf3@0.3.24: {}
 
-  nitro@3.0.1-20260601-173724-a2597363(dotenv@17.4.2)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12)):
+  nitro@3.0.1-20260601-173724-a2597363(dotenv@17.4.2)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.12(srvx@0.11.22)
@@ -8077,42 +8018,12 @@ snapshots:
       srvx: 0.11.22
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.9
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
     transitivePeerDependencies:
       - '@libsql/client'
       - '@netlify/runtime'
       - '@vercel/queue'
       - better-sqlite3
-      - miniflare
-      - mysql2
-      - ocache
-      - sqlite3
-      - wrangler
-
-  nitro@3.0.1-20260601-173724-a2597363(vite@8.2.2):
-    dependencies:
-      consola: 3.4.2
-      crossws: 0.4.12(srvx@0.11.22)
-      db0: 0.3.4
-      env-runner: 0.1.16
-      h3: 2.0.1-rc.29(crossws@0.4.12(srvx@0.11.22))
-      hookable: 6.1.1
-      nf3: 0.3.24
-      ocache: 0.1.5
-      ofetch: 2.0.0-alpha.3
-      ohash: 2.0.12
-      rolldown: 1.2.6
-      srvx: 0.11.22
-      unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.9
-      vite: 8.2.2
-    transitivePeerDependencies:
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/runtime'
-      - '@vercel/queue'
-      - better-sqlite3
-      - drizzle-orm
       - miniflare
       - mysql2
       - ocache
@@ -8331,7 +8242,7 @@ snapshots:
     dependencies:
       parse-ms: 2.1.0
 
-  pretty-ms@9.3.0:
+  pretty-ms@9.3.1:
     dependencies:
       parse-ms: 4.0.0
 
@@ -8723,7 +8634,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.23.12:
+  tsx@4.23.13:
     dependencies:
       esbuild: 0.28.2
     optionalDependencies:
@@ -8847,11 +8758,11 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unplugin@3.3.0(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12)):
+  unplugin@3.3.0(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.7
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
       webpack-virtual-modules: 0.6.2
 
   unstorage@2.0.0-alpha.9: {}
@@ -8878,14 +8789,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-mkcert@2.1.0(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12)):
+  vite-plugin-mkcert@2.1.0(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       supports-color: 10.2.2
       undici: 8.10.0
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
 
-  vite-plugin-solid@2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12)):
+  vite-plugin-solid@2.11.14(solid-js@1.9.15)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13)):
     dependencies:
       '@babel/core': 7.29.7
       '@types/babel__core': 7.20.5
@@ -8893,8 +8804,8 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.15
       solid-refresh: 0.6.3(solid-js@1.9.15)
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
-      vitefu: 1.1.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
+      vitefu: 1.1.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
     transitivePeerDependencies:
       - supports-color
 
@@ -8919,7 +8830,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12):
+  vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13):
     dependencies:
       '@types/node': 26.4.0
       lightningcss: 1.33.0
@@ -8927,20 +8838,20 @@ snapshots:
       postcss: 8.5.26
       rolldown: 1.2.6
       tinyglobby: 0.2.17
-      tsx: 4.23.12
+      tsx: 4.23.13
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitefu@1.1.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12)):
+  vitefu@1.1.3(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13)):
     dependencies:
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
 
-  vitest@4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12)):
+  vitest@4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13)):
     dependencies:
       '@types/node': 26.4.0
       '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.13))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -8957,58 +8868,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.12)
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)):
-    dependencies:
-      '@types/node': 26.4.0
-      '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/runner': 4.1.11
-      '@vitest/snapshot': 4.1.11
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
-      es-module-lexer: 2.3.2
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.7
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.4.0)
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.11(vite@8.2.2):
-    dependencies:
-      '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(tsx@4.23.12))
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/runner': 4.1.11
-      '@vitest/snapshot': 4.1.11
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
-      es-module-lexer: 2.3.2
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.7
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 8.2.2
+      vite: 8.2.2(@types/node@26.4.0)(tsx@4.23.13)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw
@@ -9073,6 +8933,8 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.4.3: {}
+  zod@4.5.2: {}
+
+  zod@4.5.4: {}
 
   zwitch@2.0.4: {}

--- a/aube-workspace.yaml
+++ b/aube-workspace.yaml
@@ -4,4 +4,4 @@ packages:
   - packages/*
 
 allowBuilds:
-  dghs-imgutils-rs@https://codeload.github.com/hmjn023/dghs-imgutils-rs/tar.gz/457553648518c8df370391391443b6302e19b05a: true
+  dghs-imgutils-rs@https://codeload.github.com/hmjn023/dghs-imgutils-rs/tar.gz/49f435e51577ad26cb5e818aaa973a58902e1b1b: true

--- a/biome.json
+++ b/biome.json
@@ -30,6 +30,7 @@
 			"!**/gen",
 			"!**/.output",
 			"!**/db-data",
+			"!**/db-data*",
 			"!**/.worktree",
 			"!**/routeTree.gen.ts"
 		]

--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "solid-imager-monorepo",
       "devDependencies": {
-        "@biomejs/biome": "^2.5.0",
+        "@biomejs/biome": "^2.5.11",
         "@google/design.md": "^0.4.0",
         "@tanstack/cli": "^0.70.2",
         "husky": "^9.1.7",
-        "lint-staged": "^17.3.0",
+        "lint-staged": "^17.4.1",
         "nitro": "npm:nitro-nightly@3.0.1-20260601-173724-a2597363",
-        "typescript": "^7.0.0",
-        "vitest": "^4.1.10",
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.11",
       },
     },
     "apps/cli": {
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@types/bun": "1.4.0",
+        "@types/node": "^26.4.0",
         "typescript": "rc",
         "vitest": "^4.1.10",
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "bun --filter '*' build",
     "start": "bun --filter @solid-imager/server start",
     "lint": "biome lint .",
-    "check": "biome check . && bun run typecheck && bun run design:lint",
+    "check": "biome check --write --unsafe && bun run typecheck && bun run design:lint",
     "design:lint": "designmd lint DESIGN.md",
     "format": "biome format --write .",
     "test": "bun run --cwd apps/server test:unit && bun run --cwd apps/server test:integration && bun run --cwd apps/cli test && bun run --cwd apps/xtracter test && bun run --cwd packages/core test && bun run --cwd packages/ui test",

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.0",
+    "@biomejs/biome": "^2.5.11",
     "@google/design.md": "^0.4.0",
     "@tanstack/cli": "^0.70.2",
     "husky": "^9.1.7",
-    "lint-staged": "^17.3.0",
+    "lint-staged": "^17.4.1",
     "nitro": "npm:nitro-nightly@3.0.1-20260601-173724-a2597363",
-    "typescript": "^7.0.0",
-    "vitest": "^4.1.10"
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.11"
   },
   "overrides": {
     "nitro": "npm:nitro-nightly@3.0.1-20260601-173724-a2597363"


### PR DESCRIPTION
## Summary

依存関係更新後に壊れたAube/Bun workspaceの依存解決とtypecheckを復旧します。

## Changes

- Aube/Bun lockfileを全workspace importerが存在する状態に再同期
- Aubeのnative build許可対象を現在のdghs-imgutils-rs revisionに更新
- CLIのtypecheck script、Node型定義、workspace-aware tsconfigを追加
- CLIのoRPC、incur context、DB spawn、Web streamの型エラーを修正

## Verification

- aube -r run typecheck
- bun run typecheck
- bun run --cwd apps/cli build
- git diff --check

注: bun run check は既存の db-data-pg18/18/docker に対するBiomeの権限エラーで完走できないため、今回の変更とは別問題です。