### PR TITLE
fix(ui): prevent media viewer and grid flicker

### DIFF
--- a/apps/server/src/components/media/legacy-media-sidebar.tsx
+++ b/apps/server/src/components/media/legacy-media-sidebar.tsx
@@ -8,6 +8,7 @@ import { toast } from "@solid-imager/ui/toast";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
 import { useNavigate } from "@tanstack/solid-router";
 import {
+	type Accessor,
 	createEffect,
 	createMemo,
 	createSignal,
@@ -50,7 +51,7 @@ import {
 
 type MediaSidebarProps = {
 	media: MediaDetails;
-	isUpdating?: boolean;
+	isUpdating?: Accessor<boolean>;
 	onUpdate?: () => void;
 };
 
@@ -580,7 +581,7 @@ export function LegacyMediaSidebar(props: MediaSidebarProps) {
 			<div class="space-y-4">
 				<AssociationManager
 					availableItems={allProjects.data || []}
-					isLoading={projects.isLoading || props.isUpdating}
+					isLoading={projects.isLoading || props.isUpdating?.()}
 					items={projects.data || []}
 					onAdd={handleAddProject}
 					onCreate={handleCreateProject}
@@ -590,7 +591,7 @@ export function LegacyMediaSidebar(props: MediaSidebarProps) {
 
 				<AssociationManager
 					availableItems={allIps.data || []}
-					isLoading={props.isUpdating}
+					isLoading={props.isUpdating?.()}
 					items={props.media.ips || []}
 					onAdd={handleAddIp}
 					onCreate={handleCreateIp}
@@ -600,7 +601,7 @@ export function LegacyMediaSidebar(props: MediaSidebarProps) {
 
 				<AssociationManager
 					availableItems={availableCharacters()}
-					isLoading={props.isUpdating}
+					isLoading={props.isUpdating?.()}
 					items={props.media.characters || []}
 					onAdd={handleAddCharacter}
 					onCreate={handleCreateCharacter}

--- a/apps/server/src/components/media/v2-media-sidebar.tsx
+++ b/apps/server/src/components/media/v2-media-sidebar.tsx
@@ -18,7 +18,7 @@ import { ChevronDown } from "@solid-imager/ui/v2/icons";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
 // biome-ignore lint/suspicious/noDeprecatedImports: TanStack Router's current Solid custom navigation-blocking API is exported under this deprecated annotation.
 import { useBlocker } from "@tanstack/solid-router";
-import { createMemo, createSignal, For, Show } from "solid-js";
+import { type Accessor, createMemo, createSignal, For, Show } from "solid-js";
 import AssociationManager from "~/components/media/association-manager";
 import {
 	addCharacterToMedia,
@@ -45,7 +45,7 @@ import {
 
 export type V2MediaSidebarProps = {
 	media: MediaDetails;
-	isUpdating?: boolean;
+	isUpdating?: Accessor<boolean>;
 	onUpdate?: () => void;
 };
 
@@ -352,7 +352,7 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 				<h2 class="font-semibold text-lg">Relations</h2>
 				<AssociationManager
 					availableItems={allProjects.data || []}
-					isLoading={projects.isLoading || props.isUpdating}
+					isLoading={projects.isLoading || props.isUpdating?.()}
 					items={projects.data || []}
 					onAdd={handleAddProject}
 					onCreate={handleCreateProject}
@@ -362,7 +362,7 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 
 				<AssociationManager
 					availableItems={allIps.data || []}
-					isLoading={props.isUpdating}
+					isLoading={props.isUpdating?.()}
 					items={props.media.ips || []}
 					onAdd={handleAddIp}
 					onCreate={handleCreateIp}
@@ -372,7 +372,7 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 
 				<AssociationManager
 					availableItems={availableCharacters()}
-					isLoading={props.isUpdating}
+					isLoading={props.isUpdating?.()}
 					items={props.media.characters || []}
 					onAdd={handleAddCharacter}
 					onCreate={handleCreateCharacter}

--- a/apps/tauri/src/components/media/media-sidebar/media-sidebar-content.tsx
+++ b/apps/tauri/src/components/media/media-sidebar/media-sidebar-content.tsx
@@ -2,6 +2,7 @@ import type { MediaDetails } from "@solid-imager/core/domain/media/schemas";
 import { MediaSidebarContent } from "@solid-imager/ui/media-sidebar-content";
 import { activateSimilaritySearch } from "@solid-imager/ui/stores/search-store";
 import { useNavigate } from "@tanstack/solid-router";
+import type { Accessor } from "solid-js";
 import { useBatchJobEvents } from "~/hooks/use-batch-job-events";
 import {
 	addCharacterToMedia,
@@ -33,7 +34,7 @@ import { CharacterCropModal } from "../character-crop-modal";
 
 type MediaSidebarProps = {
 	media: MediaDetails;
-	isUpdating?: boolean;
+	isUpdating?: Accessor<boolean>;
 	onUpdate?: () => void;
 	sourceRootPath?: string;
 };

--- a/packages/ui/src/hooks/stable-media-results.test.ts
+++ b/packages/ui/src/hooks/stable-media-results.test.ts
@@ -1,0 +1,78 @@
+import type {
+	Media,
+	MediaSearchResponse,
+} from "@solid-imager/core/domain/media/schemas";
+import type { InfiniteData } from "@tanstack/solid-query";
+import { createStore } from "solid-js/store";
+import { describe, expect, it } from "vitest";
+import {
+	type StableMediaResultsState,
+	updateStableMediaResults,
+} from "./stable-media-results";
+
+const TEST_MEDIA: Media = {
+	id: "11111111-1111-4111-8111-111111111111",
+	mediaSourceId: "22222222-2222-4222-8222-222222222222",
+	filePath: "/images/example.png",
+	fileName: "example.png",
+	mediaType: "image",
+	width: 1024,
+	height: 1024,
+	fileSize: 1024,
+	description: null,
+	createdAt: new Date("2026-01-01T00:00:00.000Z"),
+	modifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+	indexedAt: new Date("2026-01-01T00:00:00.000Z"),
+	status: "active",
+};
+
+function infiniteData(
+	media: Media[],
+): InfiniteData<MediaSearchResponse, number> {
+	return {
+		pages: [{ media, total: media.length }],
+		pageParams: [0],
+	};
+}
+
+describe("createStableMediaResults", () => {
+	it("preserves existing media identity across refreshed query objects", () => {
+		const [state, setState] = createStore<StableMediaResultsState>({
+			items: [],
+		});
+		updateStableMediaResults(setState, infiniteData([TEST_MEDIA]));
+		const original = state.items[0];
+
+		updateStableMediaResults(
+			setState,
+			infiniteData([
+				{ ...TEST_MEDIA, fileName: "updated.png" },
+				{
+					...TEST_MEDIA,
+					id: "33333333-3333-4333-8333-333333333333",
+					fileName: "new.png",
+				},
+			]),
+		);
+
+		expect(state.items[0]).toBe(original);
+		expect(state.items[0].fileName).toBe("updated.png");
+		expect(state.items).toHaveLength(2);
+	});
+
+	it("deduplicates media returned across pages", () => {
+		const [state, setState] = createStore<StableMediaResultsState>({
+			items: [],
+		});
+		const data: InfiniteData<MediaSearchResponse, number> = {
+			pages: [
+				{ media: [TEST_MEDIA], total: 1 },
+				{ media: [{ ...TEST_MEDIA }], total: 1 },
+			],
+			pageParams: [0, 1],
+		};
+		updateStableMediaResults(setState, data);
+
+		expect(state.items).toHaveLength(1);
+	});
+});

--- a/packages/ui/src/hooks/stable-media-results.ts
+++ b/packages/ui/src/hooks/stable-media-results.ts
@@ -1,0 +1,59 @@
+import type { MediaSearchResponse } from "@solid-imager/core/domain/media/schemas";
+import type { InfiniteData } from "@tanstack/solid-query";
+import type { Accessor } from "solid-js";
+import { createComputed } from "solid-js";
+import { createStore, produce, type SetStoreFunction } from "solid-js/store";
+
+export type StableMediaResultsState = {
+	items: MediaSearchResponse["media"];
+};
+
+export function updateStableMediaResults(
+	setState: SetStoreFunction<StableMediaResultsState>,
+	data: InfiniteData<MediaSearchResponse> | undefined,
+): void {
+	if (!data) {
+		setState("items", []);
+		return;
+	}
+
+	const seen = new Set<string>();
+	const items = data.pages
+		.flatMap((page) => page.media)
+		.filter((media) => {
+			if (seen.has(media.id)) {
+				return false;
+			}
+			seen.add(media.id);
+			return true;
+		});
+	setState(
+		"items",
+		produce((currentItems) => {
+			const currentById = new Map(
+				currentItems.map((media) => [media.id, media]),
+			);
+			const stableItems = items.map((media) => {
+				const current = currentById.get(media.id);
+				if (!current) {
+					return media;
+				}
+				Object.assign(current, media);
+				return current;
+			});
+			currentItems.splice(0, currentItems.length, ...stableItems);
+		}),
+	);
+}
+
+export function createStableMediaResults(
+	data: Accessor<InfiniteData<MediaSearchResponse> | undefined>,
+): Accessor<MediaSearchResponse["media"]> {
+	const [state, setState] = createStore<StableMediaResultsState>({ items: [] });
+
+	createComputed(() => {
+		updateStableMediaResults(setState, data());
+	});
+
+	return () => state.items;
+}

--- a/packages/ui/src/hooks/use-source-media-page.ts
+++ b/packages/ui/src/hooks/use-source-media-page.ts
@@ -38,6 +38,7 @@ import type { PresetManagerClient } from "../search-control-panel";
 import { toast } from "../toast";
 import { getRestoreImportStrategies } from "./restore-import";
 import { scrollToPosition, useScrollRestoration } from "./scroll-container";
+import { createStableMediaResults } from "./stable-media-results";
 import type { MediaSourceEventTransport } from "./use-media-source-events";
 import { useMediaSourceEvents } from "./use-media-source-events";
 
@@ -268,19 +269,10 @@ export function useSourceMediaPage(
 		}
 	});
 
-	// --- Deduplicated results ---
-	const mediaResults = createMemo(() => {
-		const seen = new Set<string>();
-		return (mediaQueryData()?.pages.flatMap((page) => page.media) || []).filter(
-			(media) => {
-				if (seen.has(media.id)) {
-					return false;
-				}
-				seen.add(media.id);
-				return true;
-			},
-		);
-	});
+	// Preserve existing media cards across background refetches. New query
+	// objects are reconciled by media ID so only genuinely added or removed
+	// cards mount and unmount.
+	const mediaResults = createStableMediaResults(mediaQueryData);
 	const contentState = () =>
 		toQueryUiState(
 			{

--- a/packages/ui/src/media-sidebar-content.tsx
+++ b/packages/ui/src/media-sidebar-content.tsx
@@ -22,7 +22,7 @@ import {
 
 export type MediaSidebarContentProps = {
 	media: MediaDetails;
-	isUpdating?: boolean;
+	isUpdating?: Accessor<boolean>;
 	onUpdate?: () => void;
 	aiTaggingModal: (props: {
 		isOpen: boolean;

--- a/packages/ui/src/media-sidebar.tsx
+++ b/packages/ui/src/media-sidebar.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@solid-imager/core/domain/tagging/schemas";
 import { getErrorMessage } from "@solid-imager/core/utils";
 import {
+	type Accessor,
 	createEffect,
 	createMemo,
 	createSignal,
@@ -31,7 +32,7 @@ import { toast } from "./toast";
 
 type MediaSidebarProps = {
 	media: MediaDetails;
-	isUpdating?: boolean;
+	isUpdating?: Accessor<boolean>;
 	projects: Project[];
 	allProjects: Project[];
 	allIps: Ip[];
@@ -491,7 +492,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 			<div class="space-y-4">
 				<AssociationManager
 					availableItems={props.allProjects}
-					isLoading={props.isProjectsLoading || props.isUpdating}
+					isLoading={props.isProjectsLoading || props.isUpdating?.()}
 					items={props.projects}
 					onAdd={props.onProjectAdd}
 					onCreate={handleCreateProject}
@@ -501,7 +502,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 
 				<AssociationManager
 					availableItems={props.allIps}
-					isLoading={props.isAllIpsLoading || props.isUpdating}
+					isLoading={props.isAllIpsLoading || props.isUpdating?.()}
 					items={props.media.ips || []}
 					onAdd={props.onIpAdd}
 					onCreate={handleCreateIp}
@@ -511,7 +512,7 @@ export function MediaSidebar(props: MediaSidebarProps) {
 
 				<AssociationManager
 					availableItems={availableCharacters()}
-					isLoading={props.isAllCharactersLoading || props.isUpdating}
+					isLoading={props.isAllCharactersLoading || props.isUpdating?.()}
 					items={props.media.characters || []}
 					onAdd={handleAddCharacter}
 					onCreate={handleCreateCharacter}

--- a/packages/ui/src/screens/media-detail-screen-core.tsx
+++ b/packages/ui/src/screens/media-detail-screen-core.tsx
@@ -110,7 +110,7 @@ function MediaDetailScreenController(props: MediaDetailScreenControllerProps) {
 								? renderOwned(() =>
 										props.renderData({
 											details,
-											isUpdating: mediaDetails.isRefetching,
+											isUpdating: () => mediaDetails.isRefetching,
 											onUpdate: handleUpdate,
 											sourceRootPath: props.sourceRootPath,
 										}),

--- a/packages/ui/src/screens/media-detail-screen-core.tsx
+++ b/packages/ui/src/screens/media-detail-screen-core.tsx
@@ -5,7 +5,15 @@ import type {
 	ThumbnailGeneratedEvent,
 } from "@solid-imager/core/domain/sources/events";
 import { createQuery, useQueryClient } from "@tanstack/solid-query";
-import { getOwner, Match, runWithOwner, Show, Switch } from "solid-js";
+import {
+	createComputed,
+	getOwner,
+	Match,
+	runWithOwner,
+	Show,
+	Switch,
+} from "solid-js";
+import { createStore, reconcile } from "solid-js/store";
 import { ErrorState, OfflineState, QueryStatus } from "../async-state";
 import { useMediaSourceEvents } from "../hooks/use-media-source-events";
 import { toQueryUiState } from "../query-state";
@@ -31,6 +39,15 @@ function MediaDetailScreenController(props: MediaDetailScreenControllerProps) {
 		props.mediaDetailsQueryOptions(props.mediaSourceId(), props.mediaId()),
 	);
 	const state = () => toQueryUiState(mediaDetails);
+	const [detailState, setDetailState] = createStore<{
+		details?: MediaDetails;
+	}>({});
+	createComputed(() => {
+		const details = state().data;
+		if (details) {
+			setDetailState("details", reconcile(details));
+		}
+	});
 	const errorMessage = () => {
 		const error = state().error;
 		return error instanceof Error
@@ -86,17 +103,20 @@ function MediaDetailScreenController(props: MediaDetailScreenControllerProps) {
 			</Show>
 			<Switch>
 				<Match when={state().phase === "data"}>
-					<Show keyed when={state().data}>
-						{(details) =>
-							renderOwned(() =>
-								props.renderData({
-									details,
-									isUpdating: mediaDetails.isRefetching,
-									onUpdate: handleUpdate,
-									sourceRootPath: props.sourceRootPath,
-								}),
-							)
-						}
+					<Show keyed when={detailState.details?.id}>
+						{(mediaId) => {
+							const details = detailState.details;
+							return details?.id === mediaId
+								? renderOwned(() =>
+										props.renderData({
+											details,
+											isUpdating: mediaDetails.isRefetching,
+											onUpdate: handleUpdate,
+											sourceRootPath: props.sourceRootPath,
+										}),
+									)
+								: null;
+						}}
 					</Show>
 				</Match>
 				<Match when={state().phase === "offline"}>

--- a/packages/ui/src/screens/media-detail-screen.types.ts
+++ b/packages/ui/src/screens/media-detail-screen.types.ts
@@ -21,7 +21,7 @@ export type MediaDetailScreenProps = {
 	) => JSX.Element;
 	renderMediaSidebar: (
 		media: MediaDetails,
-		isUpdating: boolean,
+		isUpdating: Accessor<boolean>,
 		onUpdate: () => void,
 		sourceRootPath?: string,
 	) => JSX.Element;
@@ -29,7 +29,7 @@ export type MediaDetailScreenProps = {
 
 export type MediaDetailDataRenderProps = {
 	details: MediaDetails;
-	isUpdating: boolean;
+	isUpdating: Accessor<boolean>;
 	onUpdate: () => Promise<void>;
 	sourceRootPath?: string;
 };

--- a/packages/ui/src/screens/v2-media-detail-screen.tsx
+++ b/packages/ui/src/screens/v2-media-detail-screen.tsx
@@ -6,7 +6,7 @@ import { MediaDetailScreenController } from "./media-detail-screen-core";
 export type V2MediaDetailScreenProps = MediaDetailScreenProps & {
 	renderHeader?: (
 		media: Parameters<MediaDetailScreenProps["renderMediaViewer"]>[0],
-		isUpdating: boolean,
+		isUpdating: import("solid-js").Accessor<boolean>,
 		onUpdate: () => void,
 		sourceRootPath?: string,
 	) => import("solid-js").JSX.Element;

--- a/packages/ui/src/v2-media-viewer.tsx
+++ b/packages/ui/src/v2-media-viewer.tsx
@@ -9,6 +9,12 @@ import {
 	Switch,
 } from "solid-js";
 import { Button } from "./button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+} from "./dialog";
 import { Maximize2, Minus, Plus, RotateCcw } from "./v2/icons";
 
 export interface MediaSource {
@@ -30,6 +36,7 @@ export function V2MediaViewer(props: MediaViewerProps) {
 	const [pan, setPan] = createSignal({ x: 0, y: 0 });
 	const [isPanning, setIsPanning] = createSignal(false);
 	const [isFullscreen, setIsFullscreen] = createSignal(false);
+	const [isViewerOpen, setIsViewerOpen] = createSignal(false);
 	const pointers = new Map<number, { x: number; y: number }>();
 	let viewer: HTMLElement | undefined;
 	let lastPointer: { x: number; y: number } | undefined;
@@ -187,168 +194,198 @@ export function V2MediaViewer(props: MediaViewerProps) {
 	});
 
 	return (
-		<section
-			aria-label={
-				props.source.type === "image"
-					? `${props.fileName} viewer. Use plus and minus to zoom, and drag to pan.`
-					: undefined
-			}
-			class={`group/viewer relative flex aspect-[var(--media-aspect)] min-h-0 min-w-0 w-full items-center justify-center overflow-hidden bg-[var(--v2-surface)] outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--v2-focus)] lg:aspect-auto lg:h-full ${
-				isPanning() ? "cursor-grabbing" : zoom() > 1 ? "cursor-grab" : ""
-			}`}
-			data-media-viewer
-			onDblClick={() => {
-				if (props.source.type !== "image") return;
-				if (zoom() > 1) resetView();
-				else setZoomAroundPoint(2);
-			}}
-			onDragStart={handleDragStart}
-			onKeyDown={(event) => {
-				if (props.source.type !== "image") return;
-				if (event.key === "+" || event.key === "=") {
-					event.preventDefault();
-					setZoomAroundPoint(zoom() * 1.25);
-				} else if (event.key === "-") {
-					event.preventDefault();
-					setZoomAroundPoint(zoom() / 1.25);
-				} else if (event.key === "0") {
-					event.preventDefault();
-					resetView();
-				}
-			}}
-			onPointerCancel={handlePointerEnd}
-			onPointerDown={handlePointerDown}
-			onPointerMove={handlePointerMove}
-			onPointerUp={handlePointerEnd}
-			onWheel={(event) => {
-				if (props.source.type !== "image") return;
-				if (event.deltaY >= 0 && zoom() <= 1) return;
-				event.preventDefault();
-				setZoomAroundPoint(zoom() * (event.deltaY < 0 ? 1.12 : 1 / 1.12), {
-					x: event.clientX,
-					y: event.clientY,
-				});
-			}}
-			ref={viewer}
-			style={`--media-aspect: ${props.width && props.height ? `${props.width} / ${props.height}` : "4 / 3"}; touch-action: ${zoom() > 1 ? "none" : "pan-y pinch-zoom"}`}
-			tabIndex={props.source.type === "image" ? 0 : undefined}
-		>
-			<Switch>
-				<Match when={props.source.type === "video"}>
-					<Show
-						fallback={
-							<div class="flex h-full max-h-full w-full items-center justify-center bg-slate-900 text-white">
-								Video preview unavailable
-							</div>
-						}
-						when={mediaUrl()}
-					>
-						{(url) => (
-							<video class="h-full max-w-full" controls src={url()}>
-								<track kind="captions" />
-							</video>
-						)}
-					</Show>
-				</Match>
-				<Match when={props.source.type === "audio"}>
-					<Show
-						fallback={
-							<div class="bg-slate-900 px-8 py-6 text-white">
-								Audio preview unavailable
-							</div>
-						}
-						when={mediaUrl()}
-					>
-						{(url) => (
-							<audio class="max-w-full" controls src={url()}>
-								<track kind="captions" />
-							</audio>
-						)}
-					</Show>
-				</Match>
-				<Match when={true}>
-					<Show
-						fallback={
-							<div class="flex h-full w-full items-center justify-center bg-[var(--v2-surface-muted)] text-[var(--v2-text-muted)]">
-								<div class="max-w-[80%] truncate rounded-md border border-current/20 px-4 py-2 text-sm">
-									{props.fileName}
+		<>
+			<section
+				class={`group/viewer relative flex aspect-[var(--media-aspect)] min-h-0 min-w-0 w-full items-center justify-center overflow-hidden bg-[var(--v2-surface)] outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--v2-focus)] lg:aspect-auto lg:h-full ${
+					props.source.type === "image" ? "cursor-zoom-in" : ""
+				}`}
+				data-media-viewer
+				style={`--media-aspect: ${props.width && props.height ? `${props.width} / ${props.height}` : "4 / 3"}`}
+			>
+				<Switch>
+					<Match when={props.source.type === "video"}>
+						<Show
+							fallback={
+								<div class="flex h-full max-h-full w-full items-center justify-center bg-slate-900 text-white">
+									Video preview unavailable
 								</div>
-							</div>
-						}
-						when={mediaUrl()}
+							}
+							when={mediaUrl()}
+						>
+							{(url) => (
+								<video class="h-full max-w-full" controls src={url()}>
+									<track kind="captions" />
+								</video>
+							)}
+						</Show>
+					</Match>
+					<Match when={props.source.type === "audio"}>
+						<Show
+							fallback={
+								<div class="bg-slate-900 px-8 py-6 text-white">
+									Audio preview unavailable
+								</div>
+							}
+							when={mediaUrl()}
+						>
+							{(url) => (
+								<audio class="max-w-full" controls src={url()}>
+									<track kind="captions" />
+								</audio>
+							)}
+						</Show>
+					</Match>
+					<Match when={true}>
+						<Show
+							fallback={
+								<div class="flex h-full w-full items-center justify-center bg-[var(--v2-surface-muted)] text-[var(--v2-text-muted)]">
+									<div class="max-w-[80%] truncate rounded-md border border-current/20 px-4 py-2 text-sm">
+										{props.fileName}
+									</div>
+								</div>
+							}
+							when={mediaUrl()}
+						>
+							{(url) => (
+								<button
+									aria-label={`Open ${props.fileName} image viewer`}
+									class="h-full w-full cursor-zoom-in focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--v2-focus)]"
+									onClick={() => setIsViewerOpen(true)}
+									type="button"
+								>
+									<img
+										alt={props.fileName}
+										class="pointer-events-none h-full w-full select-none object-contain"
+										draggable={false}
+										fetchpriority="high"
+										height={props.height}
+										src={url()}
+										width={props.width}
+									/>
+								</button>
+							)}
+						</Show>
+					</Match>
+				</Switch>
+			</section>
+			<Dialog
+				onOpenChange={(open) => {
+					setIsViewerOpen(open);
+					if (!open) resetView();
+				}}
+				open={isViewerOpen()}
+			>
+				<DialogContent class="h-[calc(100dvh-2rem)] max-h-[calc(100dvh-2rem)] w-[calc(100dvw-2rem)] max-w-none overflow-hidden border-[var(--v2-border)] bg-[var(--v2-surface)] p-0 sm:max-h-[calc(100dvh-4rem)] sm:w-[calc(100dvw-4rem)] [&>button]:z-20">
+					<DialogTitle class="sr-only">{props.fileName}</DialogTitle>
+					<DialogDescription class="sr-only">
+						Use plus and minus to zoom, and drag to pan.
+					</DialogDescription>
+					<section
+						aria-label={`${props.fileName} viewer. Use plus and minus to zoom, and drag to pan.`}
+						class={`relative flex h-full min-h-0 w-full items-center justify-center overflow-hidden bg-[var(--v2-surface)] outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--v2-focus)] ${
+							isPanning()
+								? "cursor-grabbing"
+								: zoom() > 1
+									? "cursor-grab"
+									: "cursor-zoom-in"
+						}`}
+						data-media-viewer-interactive
+						onDblClick={() => {
+							if (zoom() > 1) resetView();
+							else setZoomAroundPoint(2);
+						}}
+						onDragStart={handleDragStart}
+						onPointerCancel={handlePointerEnd}
+						onPointerDown={handlePointerDown}
+						onPointerMove={handlePointerMove}
+						onPointerUp={handlePointerEnd}
+						onWheel={(event) => {
+							if (event.deltaY >= 0 && zoom() <= 1) return;
+							event.preventDefault();
+							setZoomAroundPoint(
+								zoom() * (event.deltaY < 0 ? 1.12 : 1 / 1.12),
+								{
+									x: event.clientX,
+									y: event.clientY,
+								},
+							);
+						}}
+						ref={viewer}
+						style={`touch-action: ${zoom() > 1 ? "none" : "pan-y pinch-zoom"}`}
 					>
-						{(url) => (
-							<img
-								alt={props.fileName}
-								class="pointer-events-none h-full w-full select-none object-contain motion-safe:transition-transform"
-								draggable={false}
-								fetchpriority="high"
-								height={props.height}
-								src={url()}
-								style={{
-									transform: `translate3d(${pan().x}px, ${pan().y}px, 0) scale(${zoom()})`,
-									"transition-duration": isPanning() ? "0ms" : "150ms",
-								}}
-								width={props.width}
+						<Show when={mediaUrl()}>
+							{(url) => (
+								<img
+									alt={props.fileName}
+									class="pointer-events-none h-full w-full select-none object-contain motion-safe:transition-transform"
+									draggable={false}
+									height={props.height}
+									src={url()}
+									style={{
+										transform: `translate3d(${pan().x}px, ${pan().y}px, 0) scale(${zoom()})`,
+										"transition-duration": isPanning() ? "0ms" : "150ms",
+									}}
+									width={props.width}
+								/>
+							)}
+						</Show>
+						<div
+							aria-label="Image zoom controls"
+							class="absolute right-3 bottom-3 flex items-center gap-0.5 rounded-lg border border-[var(--v2-border)] bg-[var(--v2-surface-subtle)]/95 p-1 shadow-lg backdrop-blur"
+							data-media-viewer-controls
+							role="toolbar"
+						>
+							<Button
+								aria-label="Zoom out"
+								class="size-8 p-0"
+								disabled={zoom() <= 1}
+								onClick={() => setZoomAroundPoint(zoom() / 1.25)}
+								size="icon"
+								variant="ghost"
+							>
+								<Minus aria-hidden="true" size={15} />
+							</Button>
+							<button
+								aria-label="Reset zoom to fit"
+								class="flex h-8 min-w-14 items-center justify-center gap-1 rounded-md px-1.5 font-medium text-[11px] tabular-nums hover:bg-[var(--v2-surface-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-focus)]"
+								onClick={resetView}
+								type="button"
+							>
+								<RotateCcw aria-hidden="true" size={12} />
+								{zoomPercent()}%
+							</button>
+							<Button
+								aria-label="Zoom in"
+								class="size-8 p-0"
+								disabled={zoom() >= 8}
+								onClick={() => setZoomAroundPoint(zoom() * 1.25)}
+								size="icon"
+								variant="ghost"
+							>
+								<Plus aria-hidden="true" size={15} />
+							</Button>
+							<span
+								aria-hidden="true"
+								class="mx-0.5 h-5 w-px bg-[var(--v2-border)]"
 							/>
-						)}
-					</Show>
-				</Match>
-			</Switch>
-			<Show when={props.source.type === "image" && mediaUrl()}>
-				<div
-					aria-label="Image zoom controls"
-					class="absolute right-3 bottom-3 flex items-center gap-0.5 rounded-lg border border-[var(--v2-border)] bg-[var(--v2-surface-subtle)]/95 p-1 shadow-lg backdrop-blur"
-					data-media-viewer-controls
-					role="toolbar"
-				>
-					<Button
-						aria-label="Zoom out"
-						class="size-8 p-0"
-						disabled={zoom() <= 1}
-						onClick={() => setZoomAroundPoint(zoom() / 1.25)}
-						size="icon"
-						variant="ghost"
-					>
-						<Minus aria-hidden="true" size={15} />
-					</Button>
-					<button
-						aria-label="Reset zoom to fit"
-						class="flex h-8 min-w-14 items-center justify-center gap-1 rounded-md px-1.5 font-medium text-[11px] tabular-nums hover:bg-[var(--v2-surface-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--v2-focus)]"
-						onClick={resetView}
-						type="button"
-					>
-						<RotateCcw aria-hidden="true" size={12} />
-						{zoomPercent()}%
-					</button>
-					<Button
-						aria-label="Zoom in"
-						class="size-8 p-0"
-						disabled={zoom() >= 8}
-						onClick={() => setZoomAroundPoint(zoom() * 1.25)}
-						size="icon"
-						variant="ghost"
-					>
-						<Plus aria-hidden="true" size={15} />
-					</Button>
-					<span
-						aria-hidden="true"
-						class="mx-0.5 h-5 w-px bg-[var(--v2-border)]"
-					/>
-					<Button
-						aria-label={isFullscreen() ? "Exit fullscreen" : "Enter fullscreen"}
-						class="size-8 p-0"
-						onClick={() => void toggleFullscreen()}
-						size="icon"
-						variant="ghost"
-					>
-						<Maximize2 aria-hidden="true" size={15} />
-					</Button>
-				</div>
-				<span aria-live="polite" class="sr-only">
-					Zoom {zoomPercent()} percent
-				</span>
-			</Show>
-		</section>
+							<Button
+								aria-label={
+									isFullscreen() ? "Exit fullscreen" : "Enter fullscreen"
+								}
+								class="size-8 p-0"
+								onClick={() => void toggleFullscreen()}
+								size="icon"
+								variant="ghost"
+							>
+								<Maximize2 aria-hidden="true" size={15} />
+							</Button>
+						</div>
+						<span aria-live="polite" class="sr-only">
+							Zoom {zoomPercent()} percent
+						</span>
+					</section>
+				</DialogContent>
+			</Dialog>
+		</>
 	);
 }

--- a/packages/ui/src/v2-media-viewer.tsx
+++ b/packages/ui/src/v2-media-viewer.tsx
@@ -278,10 +278,10 @@ export function V2MediaViewer(props: MediaViewerProps) {
 				<DialogContent class="h-[calc(100dvh-2rem)] max-h-[calc(100dvh-2rem)] w-[calc(100dvw-2rem)] max-w-none overflow-hidden border-[var(--v2-border)] bg-[var(--v2-surface)] p-0 sm:max-h-[calc(100dvh-4rem)] sm:w-[calc(100dvw-4rem)] [&>button]:z-20">
 					<DialogTitle class="sr-only">{props.fileName}</DialogTitle>
 					<DialogDescription class="sr-only">
-						Use plus and minus to zoom, and drag to pan.
+						Use the zoom controls to zoom, and drag to pan.
 					</DialogDescription>
 					<section
-						aria-label={`${props.fileName} viewer. Use plus and minus to zoom, and drag to pan.`}
+						aria-label={`${props.fileName} viewer. Use the zoom controls to zoom, and drag to pan.`}
 						class={`relative flex h-full min-h-0 w-full items-center justify-center overflow-hidden bg-[var(--v2-surface)] outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--v2-focus)] ${
 							isPanning()
 								? "cursor-grabbing"


### PR DESCRIPTION
## Summary\n- Open image zoom controls in a click-triggered lightbox so the detail page remains scrollable\n- Preserve the media detail subtree while SSE updates the same media\n- Keep existing media cards stable across bulk-upload refreshes to prevent thumbnail skeleton flicker\n\n## Validation\n- bun run --cwd packages/ui test\n- bun run typecheck\n- bun run build\n- bun run design:lint\n- git diff --check\n\nCommits are intentionally split by change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 画像ビューアをモーダルダイアログで表示できるようになりました。
  - ダイアログ内でズーム、パン、全画面表示を利用できます。
- **改善**
  - メディア検索結果の再読み込み時に、既存カードの表示が安定するようになりました。
  - 複数ページにまたがる同一メディアの重複表示を防止します。
- **バグ修正**
  - メディア詳細の更新中に、古い内容や不整合な表示が出る問題を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->