### PR TITLE
perf(server): enable Zod schema compilation

### DIFF
--- a/apps/server/src/infrastructure/api/app-router.ts
+++ b/apps/server/src/infrastructure/api/app-router.ts
@@ -1,3 +1,5 @@
+import "zod/compile";
+
 import { implement } from "@orpc/server";
 import { appContract } from "@solid-imager/core/domain/contract";
 import { aiRouter } from "~/infrastructure/api/routers/ai-router";


### PR DESCRIPTION
## Summary\n- enable Zod 4.5 lazy schema compilation for the server oRPC router\n- keep the compiler out of client bundles\n\n## Validation\n- bun --filter @solid-imager/server typecheck\n- bun --filter @solid-imager/server build\n- Zod compile valid/invalid-path smoke test