### PR TITLE
fix(v2): align design lab parity details

### DIFF
--- a/apps/server/src/components/media/v2-media-actions.tsx
+++ b/apps/server/src/components/media/v2-media-actions.tsx
@@ -248,7 +248,7 @@ export function V2MediaActions(props: MediaActionsProps) {
 					open={moreActionsOpen()}
 					placement="bottom-end"
 				>
-					<PopoverTrigger class="flex h-10 min-w-32 flex-1 items-center justify-center gap-2 rounded-md border border-input bg-white px-3 font-medium text-xs outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-[var(--v2-focus)] md:h-9 md:flex-none">
+					<PopoverTrigger class="flex h-10 min-w-32 flex-1 items-center justify-center gap-2 rounded-md border border-[var(--v2-border-strong)] bg-[var(--v2-surface)] px-3 font-medium text-[var(--v2-text)] text-xs outline-none hover:bg-[var(--v2-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--v2-focus)] md:h-9 md:flex-none">
 						More actions
 						<ChevronDown aria-hidden="true" size={14} />
 					</PopoverTrigger>
@@ -298,7 +298,7 @@ export function V2MediaActions(props: MediaActionsProps) {
 							Download original
 						</Button>
 						<Button
-							class="h-9 w-full justify-start px-2 text-destructive hover:bg-destructive/10 hover:text-destructive"
+							class="h-9 w-full justify-start px-2 text-[var(--v2-destructive)] hover:bg-[var(--v2-surface-muted)] hover:text-[var(--v2-destructive-hover)]"
 							onClick={() => setIsDeleteDialogOpen(true)}
 							size="sm"
 							variant="ghost"

--- a/apps/server/src/components/media/v2-media-sidebar.tsx
+++ b/apps/server/src/components/media/v2-media-sidebar.tsx
@@ -226,32 +226,14 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 	};
 
 	return (
-		<aside class="min-w-0 divide-y divide-[var(--v2-border)] bg-[var(--v2-surface-subtle)] px-4 pb-6 lg:h-full lg:overflow-y-auto lg:overscroll-contain [&>div]:py-4 [scrollbar-gutter:stable]">
-			<div class="space-y-2">
-				<h2 class="font-semibold text-lg">File information</h2>
-				<dl class="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-2 text-sm">
-					<dt class="font-medium text-muted-foreground">Resolution</dt>
-					<dd class="text-foreground">
-						{props.media.width} x {props.media.height}
-					</dd>
-					<dt class="font-medium text-muted-foreground">File Size</dt>
-					<dd class="text-foreground">
-						{props.media.fileSize ? formatBytes(props.media.fileSize) : "N/A"}
-					</dd>
-					<dt class="font-medium text-muted-foreground">Path</dt>
-					<dd class="min-w-0 max-w-52 break-all text-right text-foreground text-xs">
-						{props.media.filePath}
-					</dd>
-				</dl>
-			</div>
-
+		<aside class="min-w-0 divide-y divide-[var(--v2-border)] bg-[var(--v2-surface-subtle)] px-4 pb-6 text-[var(--v2-text)] lg:h-full lg:overflow-y-auto lg:overscroll-contain [&>div]:py-4 [scrollbar-gutter:stable]">
 			{/* Description Section */}
 			<div class="space-y-2">
 				<div class="flex items-start justify-between gap-2">
-					<h2 class="font-semibold text-lg">Description</h2>
+					<h2 class="font-semibold text-sm">Description</h2>
 					<Show when={!isEditingDescription()}>
 						<button
-							class="min-h-11 px-2 text-blue-600 text-sm hover:underline"
+							class="min-h-11 px-2 text-[var(--v2-primary)] text-sm hover:underline"
 							onClick={() => setIsEditingDescription(true)}
 							type="button"
 						>
@@ -284,7 +266,7 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 						/>
 						<div class="sticky bottom-0 z-10 -mx-3 flex flex-col gap-2 border-t bg-background px-3 py-3 sm:-mx-4 sm:px-4 lg:static lg:mx-0 lg:flex-row lg:border-0 lg:bg-transparent lg:p-0">
 							<button
-								class="min-h-11 w-full rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 lg:w-auto"
+								class="min-h-11 w-full rounded-md bg-[var(--v2-primary)] px-3 py-1 text-sm text-white hover:bg-[var(--v2-primary-hover)] lg:w-auto"
 								onClick={handleSaveDescription}
 								type="button"
 							>
@@ -305,13 +287,13 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 			{/* Source URLs Section */}
 			<Show when={props.media.urls?.length > 0}>
 				<div class="space-y-2">
-					<h2 class="font-semibold text-lg">Source URLs</h2>
+					<h2 class="font-semibold text-sm">Source URLs</h2>
 					<ul class="space-y-1">
 						<For each={props.media.urls}>
 							{(url) => (
 								<li>
 									<a
-										class="block break-all text-blue-600 text-sm hover:underline"
+										class="block break-all text-[var(--v2-primary)] text-sm hover:underline"
 										href={url.url}
 										rel="noopener noreferrer"
 										target="_blank"
@@ -328,7 +310,7 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 			{/* Authors Section */}
 			<Show when={props.media.authors?.length > 0}>
 				<div class="space-y-2">
-					<h2 class="font-semibold text-lg">Authors</h2>
+					<h2 class="font-semibold text-sm">Authors</h2>
 					<ul class="space-y-1">
 						<For each={props.media.authors}>
 							{(author) => (
@@ -349,7 +331,7 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 			</Show>
 
 			<div class="space-y-4">
-				<h2 class="font-semibold text-lg">Relations</h2>
+				<h2 class="font-semibold text-sm">Relations</h2>
 				<AssociationManager
 					availableItems={allProjects.data || []}
 					isLoading={projects.isLoading || props.isUpdating?.()}
@@ -383,17 +365,17 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 
 			<Show when={positiveTags().length > 0}>
 				<div class="space-y-2">
-					<h2 class="font-semibold text-lg">Positive Tags</h2>
+					<h2 class="font-semibold text-sm">Positive Tags</h2>
 					<div class="flex flex-wrap gap-2">
 						<For each={positiveTags()}>
 							{(tag) => {
 								let badgeClass = "";
 								if (tag.source === "AI") {
 									badgeClass =
-										"bg-blue-100 text-blue-800 hover:bg-blue-200 border-blue-200";
+										"border-[var(--v2-border-strong)] bg-[var(--v2-info-surface)] text-[var(--v2-info)]";
 								} else if (tag.source === "comfyui_workflow") {
 									badgeClass =
-										"bg-green-100 text-green-800 hover:bg-green-200 border-green-200";
+										"border-[var(--v2-border-strong)] bg-[var(--v2-surface-selected)] text-[var(--v2-primary)]";
 								}
 								return (
 									<Badge class={badgeClass} title={`Source: ${tag.source}`}>
@@ -413,17 +395,17 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 
 			<Show when={negativeTags().length > 0}>
 				<div class="space-y-2">
-					<h2 class="font-semibold text-lg">Negative Tags</h2>
+					<h2 class="font-semibold text-sm">Negative Tags</h2>
 					<div class="flex flex-wrap gap-2">
 						<For each={negativeTags()}>
 							{(tag) => {
 								let badgeClass = "";
 								if (tag.source === "AI") {
 									badgeClass =
-										"bg-blue-50 text-blue-800 hover:bg-blue-100 border-blue-200 border";
+										"border-[var(--v2-border-strong)] bg-[var(--v2-surface-muted)] text-[var(--v2-destructive)]";
 								} else if (tag.source === "comfyui_workflow") {
 									badgeClass =
-										"bg-green-50 text-green-800 hover:bg-green-100 border-green-200 border";
+										"border-[var(--v2-border-strong)] bg-[var(--v2-surface-muted)] text-[var(--v2-destructive)]";
 								}
 								return (
 									<Badge
@@ -448,7 +430,7 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 			<Show when={genInfo()}>
 				<div class="space-y-2">
 					<Collapsible.Root>
-						<Collapsible.Trigger class="flex w-full items-center justify-between font-semibold text-lg">
+						<Collapsible.Trigger class="flex w-full items-center justify-between font-semibold text-sm">
 							Generation Info
 							<ChevronDown
 								class="ui-expanded:rotate-180 transition-transform"
@@ -505,6 +487,24 @@ export function V2MediaSidebar(props: V2MediaSidebarProps) {
 					</Collapsible.Root>
 				</div>
 			</Show>
+
+			<div class="space-y-2">
+				<h2 class="font-semibold text-sm">File information</h2>
+				<dl class="grid grid-cols-[5rem_minmax(0,1fr)] gap-x-4 gap-y-2 text-sm">
+					<dt class="font-medium text-[var(--v2-text-muted)]">Resolution</dt>
+					<dd class="text-right text-[var(--v2-text)]">
+						{props.media.width} × {props.media.height}
+					</dd>
+					<dt class="font-medium text-[var(--v2-text-muted)]">File Size</dt>
+					<dd class="text-right text-[var(--v2-text)]">
+						{props.media.fileSize ? formatBytes(props.media.fileSize) : "N/A"}
+					</dd>
+					<dt class="font-medium text-[var(--v2-text-muted)]">Path</dt>
+					<dd class="min-w-0 break-all text-right text-[var(--v2-text)] text-xs">
+						{props.media.filePath}
+					</dd>
+				</dl>
+			</div>
 
 			<AlertDialog
 				onOpenChange={(open) => {

--- a/apps/server/src/tests/e2e/v2-interface-interactions.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/v2-interface-interactions.responsive.spec.ts
@@ -266,6 +266,11 @@ test("V2 settings exposes device-local shortcut configuration", async ({
 	await page.goto("/v2/config");
 	await waitForAppHydration(page);
 
+	await expect(page.locator("form")).toHaveCount(1);
+	await expect(
+		page.getByRole("group", { name: "Job Processing", exact: true }),
+	).toBeVisible();
+
 	await page.getByRole("tab", { name: /^Shortcuts\b/ }).click();
 	await expect(
 		page.getByRole("heading", { name: "Keyboard shortcuts", exact: true }),

--- a/packages/ui/src/screens/v2-config-screen.tsx
+++ b/packages/ui/src/screens/v2-config-screen.tsx
@@ -100,7 +100,8 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 	const [aiHealthError, setAiHealthError] = createSignal<string | null>(null);
 	const [isCheckingAiHealth, setIsCheckingAiHealth] = createSignal(false);
 	const [submitError, setSubmitError] = createSignal<string | null>(null);
-	const sectionClass = "space-y-5 border-b border-[var(--v2-border)] pb-8";
+	const sectionClass =
+		"min-w-0 space-y-5 border-b border-[var(--v2-border)] pb-8";
 	const form = createForm(() => ({
 		defaultValues: toFormValues(props.data),
 		validators: {
@@ -154,6 +155,13 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 		<div class="min-w-0 space-y-6 [&_input]:scroll-mt-28 [&_input]:text-base [&_select]:scroll-mt-28 [&_select]:text-base [&_textarea]:scroll-mt-28 [&_textarea]:text-base sm:[&_input]:text-sm sm:[&_select]:text-sm sm:[&_textarea]:text-sm">
 			<FormError message={submitError()} />
 
+			<form
+				class="min-w-0 space-y-6"
+				onSubmit={(event) => {
+					event.preventDefault();
+					void form.handleSubmit();
+				}}
+			>
 			<Tabs
 				class="grid min-w-0 w-full gap-6 lg:grid-cols-[12rem_minmax(0,1fr)] xl:gap-8"
 				onChange={setActiveTab}
@@ -185,8 +193,10 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 
 				<div class="min-w-0 space-y-6">
 					<TabsContent value="jobs">
-						<div class={sectionClass}>
-							<h2 class="mb-4 font-semibold text-xl">Job Processing</h2>
+						<fieldset class={sectionClass}>
+							<legend class="mb-4 block font-semibold text-xl">
+								Job Processing
+							</legend>
 
 							<form.Field name="jobs.concurrency">
 								{(field) => (
@@ -300,12 +310,14 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 									</div>
 								)}
 							</form.Field>
-						</div>
+						</fieldset>
 					</TabsContent>
 
 					<TabsContent value="ai">
-						<div class={sectionClass}>
-							<h2 class="mb-4 font-semibold text-xl">AI Service</h2>
+						<fieldset class={sectionClass}>
+							<legend class="mb-4 block font-semibold text-xl">
+								AI Service
+							</legend>
 							<div class="flex flex-wrap items-center justify-between gap-3 rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface-muted)] px-3 py-2.5">
 								<div>
 									<div class="font-medium text-sm">Connection status</div>
@@ -321,8 +333,8 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 											<div
 												class={
 													health().status === "available"
-														? "text-emerald-700 text-xs dark:text-emerald-300"
-														: "text-red-700 text-xs dark:text-red-300"
+														? "text-[var(--v2-primary)] text-xs"
+														: "text-[var(--v2-destructive)] text-xs"
 												}
 												role="status"
 											>
@@ -418,12 +430,14 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 									</form.Field>
 								)}
 							</form.Field>
-						</div>
+						</fieldset>
 					</TabsContent>
 
 					<TabsContent value="downloads">
-						<div class={sectionClass}>
-							<h2 class="mb-4 font-semibold text-xl">Downloads</h2>
+						<fieldset class={sectionClass}>
+							<legend class="mb-4 block font-semibold text-xl">
+								Downloads
+							</legend>
 
 							<form.Field name="downloads.rateLimitEnabled">
 								{(field) => (
@@ -467,12 +481,14 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 									</div>
 								)}
 							</form.Field>
-						</div>
+						</fieldset>
 					</TabsContent>
 
 					<TabsContent value="storage">
-						<div class={sectionClass}>
-							<h2 class="mb-4 font-semibold text-xl">Storage</h2>
+						<fieldset class={sectionClass}>
+							<legend class="mb-4 block font-semibold text-xl">
+								Storage
+							</legend>
 							<form.Field name="storage.thumbnailDir">
 								{(field) => (
 									<div class="space-y-2">
@@ -527,12 +543,14 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 									)}
 								</form.Field>
 							</div>
-						</div>
+						</fieldset>
 					</TabsContent>
 
 					<TabsContent value="media">
-						<div class={sectionClass}>
-							<h2 class="mb-4 font-semibold text-xl">Media Extensions</h2>
+						<fieldset class={sectionClass}>
+							<legend class="mb-4 block font-semibold text-xl">
+								Media Extensions
+							</legend>
 
 							<div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
 								<form.Field name="media.supportedExtensions.image">
@@ -668,12 +686,14 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 									</div>
 								)}
 							</form.Field>
-						</div>
+						</fieldset>
 					</TabsContent>
 
 					<TabsContent value="logging">
-						<div class={sectionClass}>
-							<h2 class="mb-4 font-semibold text-xl">Logging</h2>
+						<fieldset class={sectionClass}>
+							<legend class="mb-4 block font-semibold text-xl">
+								Logging
+							</legend>
 							<form.Field name="logging.level">
 								{(field) => (
 									<div class="space-y-2">
@@ -704,7 +724,7 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 									</div>
 								)}
 							</form.Field>
-						</div>
+						</fieldset>
 					</TabsContent>
 
 					<TabsContent value="shortcuts">
@@ -734,22 +754,22 @@ export function V2ConfigScreen(props: V2ConfigScreenProps) {
 									setSubmitError(null);
 									form.reset(toFormValues(props.data));
 								}}
+								type="button"
 								variant="outline"
 							>
 								Discard
 							</Button>
 							<Button
 								disabled={!state().canSubmit || state().isSubmitting}
-								onClick={() => {
-									void form.handleSubmit();
-								}}
+								type="submit"
 							>
 								{state().isSubmitting ? "Saving..." : "Save Changes"}
 							</Button>
 						</div>
 					</Show>
 				)}
-			</form.Subscribe>
+				</form.Subscribe>
+			</form>
 			<AlertDialog
 				onOpenChange={(open) => {
 					const resolver = navigationBlocker();

--- a/packages/ui/src/screens/v2-jobs-screen.tsx
+++ b/packages/ui/src/screens/v2-jobs-screen.tsx
@@ -96,15 +96,15 @@ function statusLabel(status: JobDto["status"]): string {
 function statusClass(status: JobDto["status"]): string {
 	return {
 		cancelled:
-			"border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300",
+			"border-[var(--v2-border-strong)] bg-[var(--v2-surface-muted)] text-[var(--v2-text-muted)]",
 		completed:
-			"border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
+			"border-[var(--v2-border-strong)] bg-[var(--v2-surface-selected)] text-[var(--v2-primary)]",
 		failed:
-			"border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300",
+			"border-[var(--v2-border-strong)] bg-[var(--v2-surface-muted)] text-[var(--v2-destructive)]",
 		in_progress:
-			"border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300",
+			"border-[var(--v2-border-strong)] bg-[var(--v2-info-surface)] text-[var(--v2-info)]",
 		pending:
-			"border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300",
+			"border-[var(--v2-border-strong)] bg-[var(--v2-warning-surface)] text-[var(--v2-warning)]",
 	}[status];
 }
 
@@ -386,7 +386,7 @@ function JobsInspector(props: {
 
 						<Show when={job().error}>
 							{(error) => (
-								<div class="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
+								<div class="mt-4 rounded-md border border-[var(--v2-border-strong)] bg-[var(--v2-surface-muted)] p-3 text-[var(--v2-destructive)] text-sm">
 									<div class="flex items-start gap-2">
 										<CircleAlert
 											aria-hidden="true"
@@ -400,7 +400,7 @@ function JobsInspector(props: {
 						</Show>
 
 						<Show when={job().cancelRequestedAt}>
-							<p class="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+							<p class="mt-4 rounded-md border border-[var(--v2-border-strong)] bg-[var(--v2-warning-surface)] p-3 text-[var(--v2-warning)] text-xs">
 								Cancellation requested at {formatDate(job().cancelRequestedAt)}.
 							</p>
 						</Show>

--- a/packages/ui/src/v2-media-grid-item.tsx
+++ b/packages/ui/src/v2-media-grid-item.tsx
@@ -100,7 +100,7 @@ export function V2MediaGridItem(props: MediaGridItemProps) {
 
 			<Show
 				fallback={
-					<div class="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400">
+					<div class="flex h-full w-full items-center justify-center bg-[var(--v2-surface-muted)] text-[var(--v2-text-muted)]">
 						{props.media.mediaType}
 					</div>
 				}

--- a/packages/ui/src/v2-media-viewer.tsx
+++ b/packages/ui/src/v2-media-viewer.tsx
@@ -206,7 +206,7 @@ export function V2MediaViewer(props: MediaViewerProps) {
 					<Match when={props.source.type === "video"}>
 						<Show
 							fallback={
-								<div class="flex h-full max-h-full w-full items-center justify-center bg-slate-900 text-white">
+								<div class="flex h-full max-h-full w-full items-center justify-center bg-[var(--v2-text)] text-[var(--v2-surface)]">
 									Video preview unavailable
 								</div>
 							}
@@ -222,7 +222,7 @@ export function V2MediaViewer(props: MediaViewerProps) {
 					<Match when={props.source.type === "audio"}>
 						<Show
 							fallback={
-								<div class="bg-slate-900 px-8 py-6 text-white">
+								<div class="bg-[var(--v2-text)] px-8 py-6 text-[var(--v2-surface)]">
 									Audio preview unavailable
 								</div>
 							}

--- a/packages/ui/src/v2-upload-media-modal.tsx
+++ b/packages/ui/src/v2-upload-media-modal.tsx
@@ -501,7 +501,7 @@ export function V2UploadMediaModalContent(props: UploadMediaModalContentProps) {
 								</form.Field>
 
 								<Show when={(props.conflicts?.length ?? 0) > 0}>
-									<div class="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-950 text-sm">
+									<div class="rounded-md border border-[var(--v2-border-strong)] bg-[var(--v2-warning-surface)] p-3 text-[var(--v2-warning)] text-sm">
 										<p class="font-medium">同名ファイルがあります</p>
 										<ul class="mt-2 list-disc space-y-1 pl-5">
 											<For each={props.conflicts}>

--- a/packages/ui/src/v2/search-composer.tsx
+++ b/packages/ui/src/v2/search-composer.tsx
@@ -160,12 +160,12 @@ export function SearchComposer(props: SearchComposerProps) {
 			>
 				<ComboboxControl<SearchSuggestion>
 					aria-label="メディアを検索"
-					class="flex h-auto min-h-11 flex-wrap items-center gap-1.5 rounded-md border border-[var(--v2-border-strong)] bg-white py-1 pr-8 pl-9 focus-within:ring-2 focus-within:ring-[var(--v2-focus)] focus-within:ring-offset-1 sm:min-h-9"
+					class="flex h-auto min-h-11 flex-wrap items-center gap-1.5 rounded-md border border-[var(--v2-border-strong)] bg-[var(--v2-surface)] py-1 pr-8 pl-9 focus-within:ring-2 focus-within:ring-[var(--v2-focus)] focus-within:ring-offset-1 sm:min-h-9"
 				>
 					<For each={props.tokens.slice(0, 4)}>
 						{(token) => (
 							<span
-								class={`inline-flex h-6 max-w-52 items-center gap-1 rounded px-1.5 font-medium text-[11px] ${token.destructive ? "bg-red-50 text-destructive" : "bg-[var(--v2-surface-selected)] text-[var(--v2-primary)]"}`}
+								class={`inline-flex h-6 max-w-52 items-center gap-1 rounded px-1.5 font-medium text-[11px] ${token.destructive ? "bg-[var(--v2-surface-muted)] text-[var(--v2-destructive)]" : "bg-[var(--v2-surface-selected)] text-[var(--v2-primary)]"}`}
 							>
 								<span class="truncate">
 									{token.prefix}:{token.value}

--- a/packages/ui/src/v2/search-toolbar.tsx
+++ b/packages/ui/src/v2/search-toolbar.tsx
@@ -359,7 +359,7 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 						aria-label={`検索フィルター、${tokens().length}件の条件`}
 						class={buttonVariants({
 							class:
-								"min-h-11 border-[var(--v2-border-strong)] bg-white px-3 shadow-none sm:min-h-9",
+								"min-h-11 border-[var(--v2-border-strong)] bg-[var(--v2-surface)] px-3 shadow-none sm:min-h-9",
 							size: "sm",
 							variant: "outline",
 						})}
@@ -409,7 +409,7 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 								usePopover={false}
 							/>
 						</div>
-						<div class="absolute right-0 bottom-0 left-0 z-[60] flex justify-end gap-2 border-[var(--v2-border)] border-t bg-white p-3 pointer-events-auto">
+						<div class="absolute right-0 bottom-0 left-0 z-[60] flex justify-end gap-2 border-[var(--v2-border)] border-t bg-[var(--v2-surface)] p-3 pointer-events-auto">
 							<Button
 								onClick={() => setFilterOpen(false)}
 								size="sm"
@@ -439,7 +439,7 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 						aria-label={`並び替え、現在は${sortLabel(searchState)}`}
 						class={buttonVariants({
 							class:
-								"min-h-11 border-[var(--v2-border-strong)] bg-white px-3 shadow-none sm:min-h-9",
+								"min-h-11 border-[var(--v2-border-strong)] bg-[var(--v2-surface)] px-3 shadow-none sm:min-h-9",
 							size: "sm",
 							variant: "outline",
 						})}
@@ -464,7 +464,7 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 						/>
 					</PopoverContent>
 				</Popover>
-				<div class="flex rounded-md border border-[var(--v2-border-strong)] bg-white p-0.5">
+				<div class="flex rounded-md border border-[var(--v2-border-strong)] bg-[var(--v2-surface)] p-0.5">
 					<Button
 						aria-label="グリッド表示"
 						aria-pressed={(props.viewMode ?? "grid") === "grid"}


### PR DESCRIPTION
## Summary

Design Labで先行していたV2の実装上の優位点を、実データを扱うV2 UIへ反映しました。

- V2 media detail inspectorの情報順序を `Description → Relations → Tags → Generation Info → File information` に整理
- inspectorの見出しとメタデータをコンパクト化し、V2のcanonical tokenへ統一
- jobs、検索、アップロード競合、viewer fallback、media actionsの状態色をV2 tokenへ統一
- V2 configをsemanticな`form` / `fieldset` / `legend`構造にし、submit/reset typeを明示
- V2設定のform構造をE2Eで回帰検証

## V1 safety

- V1のroute、legacy component、legacy themeは変更していません
- 変更対象はV2専用コンポーネントとV2 E2Eテストのみです

## Validation

- `bun run typecheck`
- `bun run --cwd apps/server build`
- `bun run --cwd apps/server lint`
- `bun run --cwd packages/ui lint`
- `bun run --cwd apps/server test:unit` — 197 passed
- `bun run --cwd apps/server test:integration` — 66 passed
- `bun run --cwd packages/ui test` — 98 passed
- V2 config production E2E — 4 passed

The existing broad V2 interaction E2E still reports unrelated baseline failures (the same interface failures were reproduced on `develop`); the new settings assertion passes in production E2E.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * V2テーマに対応し、メディア管理、検索、ジョブ、アップロード画面の色や背景を統一しました。
  * サイドバーの情報配置と見出しサイズを調整し、画面の視認性を改善しました。
  * 削除、警告、エラーなどの状態表示をテーマに合わせて整理しました。

* **改善**
  * 設定画面の保存・破棄操作を適切なフォーム操作に対応させました。
  * 設定画面の表示内容に関する検証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->