### PR TITLE
fix(server): run Nitro dev environment with Bun

### DIFF
--- a/apps/server/nitro.config.ts
+++ b/apps/server/nitro.config.ts
@@ -7,6 +7,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineNitroConfig({
   preset: "bun",
+  // Nitro's default development runner is a Node worker. The server uses
+  // Bun-only APIs such as Bun.SQL and Bun.Image, so keep the dev environment
+  // on Bun even when the package manager invokes Vite through Node.
+  devServer: {
+    runner: "bun-process",
+  },
   rollupConfig: {
 		external: ["dghs-imgutils-rs"],
   },


### PR DESCRIPTION
## 概要

Aube経由の開発時もNitroのSSR/環境runnerをBunで実行します。

## 変更内容

- NitroのdevServer runnerをbun-processに固定
- Bun.SQL / Bun.Imageを利用する開発サーバーのNode worker起動を防止

## 検証

- bun run lint
- bun run typecheck
- aube devの短時間起動