### PR TITLE
fix(ui): reduce mobile top spacing

### DIFF
--- a/packages/ui/src/layouts/app-nav.tsx
+++ b/packages/ui/src/layouts/app-nav.tsx
@@ -100,7 +100,7 @@ export function AppNav(props: AppNavProps) {
 					isVisible() ? "translate-y-0" : "-translate-y-full"
 				}`}
 			>
-				<div class="container flex min-h-16 items-center gap-2 px-3 pt-[env(safe-area-inset-top)] sm:px-4">
+				<div class="container flex min-h-[calc(4rem+env(safe-area-inset-top))] items-center gap-2 px-3 pt-[env(safe-area-inset-top)] sm:px-4">
 					<Link
 						class="ml-13 rounded-md px-2 py-2 font-semibold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:ml-0"
 						to="/"
@@ -166,7 +166,7 @@ export function AppNav(props: AppNavProps) {
 										aria-labelledby="mobile-navigation-title"
 										class="fixed inset-y-0 left-0 z-[70] flex w-[min(20rem,calc(100vw-1rem))] flex-col bg-background text-foreground pb-[env(safe-area-inset-bottom)] shadow-xl outline-none data-[closed]:animate-out data-[closed]:slide-out-to-left data-[expanded]:animate-in data-[expanded]:slide-in-from-left"
 									>
-										<div class="flex min-h-16 items-center justify-between border-b px-4 pt-[env(safe-area-inset-top)]">
+										<div class="flex min-h-[calc(4rem+env(safe-area-inset-top))] items-center justify-between border-b px-4 pt-[env(safe-area-inset-top)]">
 											<DialogTitle
 												class="font-semibold text-foreground text-lg"
 												id="mobile-navigation-title"

--- a/packages/ui/src/screens/v2-search-screen.tsx
+++ b/packages/ui/src/screens/v2-search-screen.tsx
@@ -46,6 +46,17 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 		page().filterStates.characters(),
 		page().filterStates.authors(),
 	];
+	const hasFilterError = () =>
+		filterStates().some(
+			(state) => state.phase === "error" || state.phase === "offline",
+		);
+	const hasContentStatus = () => {
+		const state = page().contentState();
+		return (
+			state.fetchState === "background-fetching" ||
+			(state.fetchState === "paused" && state.data !== undefined)
+		);
+	};
 	const sourceName = () =>
 		props.sources?.find((source) => source.id === props.selectedSource)?.name ??
 		"すべてのメディア";
@@ -113,19 +124,15 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 				onViewModeChange={updateViewMode}
 				viewMode={viewMode()}
 			/>
-			<div class="shrink-0 px-3 pt-3 sm:px-4">
-				<Show
-					when={filterStates().some(
-						(state) => state.phase === "error" || state.phase === "offline",
-					)}
-				>
-					<FilterErrorBanner
-						class="mb-2"
-						message="一部の検索フィルターを取得できませんでした。検索結果は引き続き利用できます。"
-						onRetry={page().retryFilters}
-					/>
-				</Show>
-				<div class="h-8">
+			<Show when={hasFilterError() || hasContentStatus()}>
+				<div class="shrink-0 px-3 pt-3 sm:px-4">
+					<Show when={hasFilterError()}>
+						<FilterErrorBanner
+							class="mb-2"
+							message="一部の検索フィルターを取得できませんでした。検索結果は引き続き利用できます。"
+							onRetry={page().retryFilters}
+						/>
+					</Show>
 					<QueryStatus
 						fetchState={page().contentState().fetchState}
 						hasData={page().contentState().data !== undefined}
@@ -134,7 +141,7 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 						updatingLabel="検索結果を更新中..."
 					/>
 				</div>
-			</div>
+			</Show>
 
 			<div
 				class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-3 sm:px-4 [scrollbar-gutter:stable]"

--- a/packages/ui/src/screens/v2-source-media-screen.tsx
+++ b/packages/ui/src/screens/v2-source-media-screen.tsx
@@ -29,6 +29,17 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 	const [viewMode, setViewMode] = createSignal<SourceMediaViewMode>("grid");
 	const page = () => props.page;
 	const filterStates = () => Object.values(page().filterStates());
+	const hasFilterError = () =>
+		filterStates().some(
+			(state) => state.phase === "error" || state.phase === "offline",
+		);
+	const hasContentStatus = () => {
+		const state = page().contentState();
+		return (
+			state.fetchState === "background-fetching" ||
+			(state.fetchState === "paused" && state.data !== undefined)
+		);
+	};
 	const shouldRenderGrid = () => !props.enableVirtualization || isMounted();
 	const previewMedia = () =>
 		page()
@@ -126,19 +137,15 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 			<Show when={props.renderJobProgress && page().jobProgress()}>
 				{props.renderJobProgress?.({ jobProgress: page().jobProgress })}
 			</Show>
-			<div class="shrink-0 px-3 pt-3 sm:px-4">
-				<Show
-					when={filterStates().some(
-						(state) => state.phase === "error" || state.phase === "offline",
-					)}
-				>
-					<FilterErrorBanner
-						class="mb-2"
-						message="一部の検索フィルターを取得できませんでした。メディア一覧は引き続き利用できます。"
-						onRetry={props.onRetryFilters}
-					/>
-				</Show>
-				<div class="h-8">
+			<Show when={hasFilterError() || hasContentStatus()}>
+				<div class="shrink-0 px-3 pt-3 sm:px-4">
+					<Show when={hasFilterError()}>
+						<FilterErrorBanner
+							class="mb-2"
+							message="一部の検索フィルターを取得できませんでした。メディア一覧は引き続き利用できます。"
+							onRetry={props.onRetryFilters}
+						/>
+					</Show>
 					<QueryStatus
 						fetchState={page().contentState().fetchState}
 						hasData={page().contentState().data !== undefined}
@@ -147,7 +154,7 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 						updatingLabel="メディア一覧を更新中..."
 					/>
 				</div>
-			</div>
+			</Show>
 
 			<div
 				class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 py-3 sm:px-4 [scrollbar-gutter:stable]"


### PR DESCRIPTION
## 概要

スマホ表示で発生していた上部の不要な空白を削減します。

## 変更内容

- V2検索・ソース一覧で、アイドル時のクエリステータス領域を描画しない
- 旧UIナビのsafe-area込み高さとシェルの予約領域を一致させる

## 検証

- UI/server lint
- UI/server typecheck
- UI unit tests
- DESIGN.md lint
- 375pxの旧ナビレスポンシブE2E

既存の320px旧ナビE2EとV2ルートE2Eには、今回触っていないSolid描画・遷移関連の失敗が残っています。