### PR TITLE
fix(ui): remove idle detail status spacing

### DIFF
--- a/packages/ui/src/screens/media-detail-screen-core.tsx
+++ b/packages/ui/src/screens/media-detail-screen-core.tsx
@@ -97,6 +97,7 @@ function MediaDetailScreenController(props: MediaDetailScreenControllerProps) {
 					class="mb-2"
 					fetchState={state().fetchState}
 					hasData
+					hideWhenIdle
 					offlineLabel="オフラインのため保存済みデータを表示しています"
 					updatingLabel="メディア情報を更新中..."
 				/>


### PR DESCRIPTION
## 概要

詳細画面でも、アイドル状態の更新ステータス領域が上部に空白を作っていたため削除します。

## 変更内容

- メディア詳細の更新ステータスを、更新中またはオフライン時だけ表示
- 詳細ヘッダーとメディアビューアが不要な空白なしで始まるよう修正

## 検証

- UI/server lint
- UI/server typecheck
- UI unit tests