### PR TITLE
fix(ui): prevent search status layout shift

### DIFF
--- a/packages/ui/src/screens/v2-search-screen.tsx
+++ b/packages/ui/src/screens/v2-search-screen.tsx
@@ -50,12 +50,9 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 		filterStates().some(
 			(state) => state.phase === "error" || state.phase === "offline",
 		);
-	const hasContentStatus = () => {
+	const hasOfflineStatus = () => {
 		const state = page().contentState();
-		return (
-			state.fetchState === "background-fetching" ||
-			(state.fetchState === "paused" && state.data !== undefined)
-		);
+		return state.fetchState === "paused" && state.data !== undefined;
 	};
 	const sourceName = () =>
 		props.sources?.find((source) => source.id === props.selectedSource)?.name ??
@@ -115,16 +112,18 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 				context="global"
 				filterData={props.filterData}
 				itemCount={page().totalCount()}
+				isUpdating={page().contentState().fetchState === "background-fetching"}
 				onSearch={page().handleSearch}
 				onSelectSource={props.onSelectSource}
 				presetClient={props.presetClient}
 				selectedSource={props.selectedSource ?? undefined}
 				sourceName={sourceName()}
 				sources={props.sources}
+				updatingLabel="検索結果を更新中..."
 				onViewModeChange={updateViewMode}
 				viewMode={viewMode()}
 			/>
-			<Show when={hasFilterError() || hasContentStatus()}>
+			<Show when={hasFilterError() || hasOfflineStatus()}>
 				<div class="shrink-0 px-3 pt-3 sm:px-4">
 					<Show when={hasFilterError()}>
 						<FilterErrorBanner
@@ -133,13 +132,15 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 							onRetry={page().retryFilters}
 						/>
 					</Show>
-					<QueryStatus
-						fetchState={page().contentState().fetchState}
-						hasData={page().contentState().data !== undefined}
-						hideWhenIdle
-						offlineLabel="オフラインのため保存済みの検索結果を表示しています"
-						updatingLabel="検索結果を更新中..."
-					/>
+					<Show when={hasOfflineStatus()}>
+						<QueryStatus
+							fetchState={page().contentState().fetchState}
+							hasData={page().contentState().data !== undefined}
+							hideWhenIdle
+							offlineLabel="オフラインのため保存済みの検索結果を表示しています"
+							updatingLabel="検索結果を更新中..."
+						/>
+					</Show>
 				</div>
 			</Show>
 

--- a/packages/ui/src/v2/search-toolbar.tsx
+++ b/packages/ui/src/v2/search-toolbar.tsx
@@ -49,12 +49,14 @@ export type V2SearchToolbarProps = {
 			| undefined;
 	};
 	itemCount?: number;
+	isUpdating?: boolean;
 	onSearch: () => void;
 	onSelectSource?: (id: string) => void;
 	presetClient: PresetManagerClient;
 	selectedSource?: string;
 	sourceName: string;
 	sources?: SafeMediaSource[];
+	updatingLabel?: string;
 	viewMode?: SourceMediaViewMode;
 	onViewModeChange?: (mode: SourceMediaViewMode) => void;
 };
@@ -312,7 +314,20 @@ export function V2SearchToolbar(props: V2SearchToolbarProps) {
 				<strong class="min-w-0 truncate font-semibold">
 					{props.sourceName}
 				</strong>
-				<Show when={props.itemCount !== undefined}>
+				<Show when={props.isUpdating}>
+					<p
+						class="ml-auto flex min-w-0 max-w-56 shrink-0 items-center gap-2 truncate text-xs text-[var(--v2-text-muted)]"
+						data-state-ui="background-fetching"
+						role="status"
+					>
+						<span
+							aria-hidden="true"
+							class="size-2 shrink-0 animate-pulse rounded-full bg-current motion-reduce:animate-none"
+						/>
+						<span class="truncate">{props.updatingLabel ?? "更新中..."}</span>
+					</p>
+				</Show>
+				<Show when={!props.isUpdating && props.itemCount !== undefined}>
 					<span class="ml-auto shrink-0 text-xs text-[var(--v2-text-muted)]">
 						{props.itemCount?.toLocaleString()} items
 					</span>


### PR DESCRIPTION
## 概要

V2検索画面で検索結果の更新状態を表示した際に、結果一覧が下へずれる問題を修正します。

## 変更内容

- 更新中表示を検索ツールバーの件数欄へ移動
- 更新中は件数表示と差し替え、結果一覧のレイアウトを維持
- オフライン表示は従来どおり維持

## 検証

- packages/ui lint
- packages/ui typecheck
- apps/server typecheck
- packages/ui tests（98 tests）