### PR TITLE
feat: add media sort options

### DIFF
--- a/apps/server/public/openapi.json
+++ b/apps/server/public/openapi.json
@@ -2289,8 +2289,11 @@
                       "sort": {
                         "enum": [
                           "date",
+                          "modifiedAt",
+                          "indexedAt",
                           "name",
                           "size",
+                          "resolution",
                           "rating",
                           "viewCount"
                         ],
@@ -9834,8 +9837,11 @@
                   "sort": {
                     "enum": [
                       "date",
+                      "modifiedAt",
+                      "indexedAt",
                       "name",
                       "size",
+                      "resolution",
                       "rating",
                       "viewCount"
                     ],
@@ -10150,8 +10156,11 @@
                       "sort": {
                         "enum": [
                           "date",
+                          "modifiedAt",
+                          "indexedAt",
                           "name",
                           "size",
+                          "resolution",
                           "rating",
                           "viewCount"
                         ],

--- a/apps/server/src/components/media/search-filters.tsx
+++ b/apps/server/src/components/media/search-filters.tsx
@@ -1,6 +1,7 @@
 import type { Author } from "@solid-imager/core/domain/authors/schemas";
 import type { Character } from "@solid-imager/core/domain/characters/schemas";
 import type { Ip } from "@solid-imager/core/domain/ips/schemas";
+import type { MediaSort } from "@solid-imager/core/domain/media/schemas";
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
 import type { TagResponse } from "@solid-imager/core/domain/tags/schemas";
 import { Badge } from "@solid-imager/ui/badge";
@@ -28,7 +29,7 @@ export type SearchFilterState = {
 	selectedIps: string[];
 	selectedCharacters: string[];
 	selectedAuthors: string[];
-	sortBy: "date" | "name" | "size" | "rating" | "viewCount";
+	sortBy: MediaSort;
 	sortOrder: "asc" | "desc";
 };
 

--- a/apps/server/src/components/media/sort-controls.tsx
+++ b/apps/server/src/components/media/sort-controls.tsx
@@ -6,11 +6,13 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@solid-imager/ui/select";
+import {
+	getSortLabel,
+	SORT_OPTIONS,
+	type SortOption,
+} from "@solid-imager/ui/sort-controls";
 import { parseSelectValue } from "@solid-imager/ui/utils";
 import { cn } from "@solid-imager/ui/utils/cn";
-
-const SORT_OPTIONS = ["date", "name", "size", "rating", "viewCount"] as const;
-type SortOption = (typeof SORT_OPTIONS)[number];
 
 type SortControlsProps = {
 	sortBy: SortOption;
@@ -27,24 +29,15 @@ export function SortControls(props: SortControlsProps) {
 			<div class="grid grid-cols-2 gap-2">
 				<Select
 					itemComponent={(itemProps) => {
-						const getSortLabel = (value: string) => {
-							if (value === "date") {
-								return "作成日";
-							}
-							if (value === "name") {
-								return "ファイル名";
-							}
-							if (value === "rating") {
-								return "評価";
-							}
-							if (value === "viewCount") {
-								return "閲覧数";
-							}
-							return "サイズ";
-						};
 						return (
 							<SelectItem item={itemProps.item}>
-								{getSortLabel(itemProps.item.rawValue)}
+								{getSortLabel(
+									parseSelectValue(
+										itemProps.item.rawValue,
+										SORT_OPTIONS,
+										"date",
+									),
+								)}
 							</SelectItem>
 						);
 					}}
@@ -57,22 +50,15 @@ export function SortControls(props: SortControlsProps) {
 				>
 					<SelectTrigger>
 						<SelectValue<string>>
-							{(state) => {
-								const value = state.selectedOption();
-								if (value === "date") {
-									return "作成日";
-								}
-								if (value === "name") {
-									return "ファイル名";
-								}
-								if (value === "rating") {
-									return "評価";
-								}
-								if (value === "viewCount") {
-									return "閲覧数";
-								}
-								return "サイズ";
-							}}
+							{(state) =>
+								getSortLabel(
+									parseSelectValue(
+										state.selectedOption(),
+										SORT_OPTIONS,
+										"date",
+									),
+								)
+							}
 						</SelectValue>
 					</SelectTrigger>
 					<SelectContent />

--- a/apps/server/src/routes/v2/jobs.tsx
+++ b/apps/server/src/routes/v2/jobs.tsx
@@ -14,6 +14,8 @@ import { createSignal } from "solid-js";
 import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import { jobsQueryOptions } from "~/infrastructure/api-clients/queries";
 
+const BULK_RETRY_CONCURRENCY = 8;
+
 export const Route = createFileRoute("/v2/jobs")({
 	component: V2JobsRoute,
 });
@@ -73,6 +75,41 @@ function V2JobsRoute() {
 					);
 					throw error;
 				}
+			}}
+			onRetryMany={async (jobIds) => {
+				let failedCount = 0;
+				let firstError: unknown;
+				for (
+					let index = 0;
+					index < jobIds.length;
+					index += BULK_RETRY_CONCURRENCY
+				) {
+					const results = await Promise.allSettled(
+						jobIds
+							.slice(index, index + BULK_RETRY_CONCURRENCY)
+							.map((jobId) => orpc.jobs.retry({ id: jobId })),
+					);
+					for (const result of results) {
+						if (result.status === "rejected") {
+							failedCount += 1;
+							if (firstError === undefined) {
+								firstError = result.reason;
+							}
+						}
+					}
+				}
+				await queryClient.invalidateQueries({
+					queryKey: jobsQueryKeys.all(),
+				});
+				if (failedCount > 0) {
+					toast.error(
+						`${failedCount} of ${jobIds.length} jobs failed to queue for retry`,
+					);
+					throw firstError instanceof Error
+						? firstError
+						: new Error("Failed to retry some jobs");
+				}
+				toast.success(`${jobIds.length} jobs queued for retry`);
 			}}
 			onCancel={async (jobId) => {
 				try {

--- a/apps/server/src/tests/integration/media/list-media-integration.test.ts
+++ b/apps/server/src/tests/integration/media/list-media-integration.test.ts
@@ -31,6 +31,9 @@ describe("listMedia Integration", () => {
 			width: 800,
 			height: 600,
 			description: "",
+			createdAt: new Date("2026-01-01T00:00:00.000Z"),
+			modifiedAt: new Date("2026-02-01T00:00:00.000Z"),
+			indexedAt: new Date("2026-03-01T00:00:00.000Z"),
 		},
 		{
 			mediaSourceId,
@@ -41,6 +44,9 @@ describe("listMedia Integration", () => {
 			width: 1024,
 			height: 768,
 			description: "",
+			createdAt: new Date("2026-02-01T00:00:00.000Z"),
+			modifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+			indexedAt: new Date("2026-04-01T00:00:00.000Z"),
 		},
 		{
 			mediaSourceId: "a0000000-0000-4000-8000-000000000000", // 別のmediaSourceId
@@ -118,6 +124,22 @@ describe("listMedia Integration", () => {
 			{},
 		);
 		expect(result.length).toBe(0);
+	});
+
+	it.each([
+		{ expected: ["image1.png", "image2.png"], sort: "date" },
+		{ expected: ["image2.png", "image1.png"], sort: "modifiedAt" },
+		{ expected: ["image1.png", "image2.png"], sort: "indexedAt" },
+		{ expected: ["image1.png", "image2.png"], sort: "size" },
+		{ expected: ["image1.png", "image2.png"], sort: "resolution" },
+	] as const)("should sort media by $sort", async ({ expected, sort }) => {
+		const result = await MediaService.searchMedia(mediaSourceId, {
+			sort,
+			order: "asc",
+			limit: 10,
+		});
+
+		expect(result.media.map((media) => media.fileName)).toEqual(expected);
 	});
 
 	it("should throw a ZodError if directoryPath is empty", async () => {

--- a/apps/tauri/src/routes/jobs.tsx
+++ b/apps/tauri/src/routes/jobs.tsx
@@ -18,6 +18,8 @@ import { createSignal } from "solid-js";
 import { orpc } from "~/infrastructure/api-clients/orpc-client";
 import { jobsQueryOptions } from "~/queries";
 
+const BULK_RETRY_CONCURRENCY = 8;
+
 export const Route = createFileRoute("/jobs")({
 	loader: ({ context }) => {
 		void context.queryClient.prefetchQuery(jobsQueryOptions());
@@ -103,6 +105,41 @@ function JobsRoute() {
 						);
 						throw error;
 					}
+				}}
+				onRetryMany={async (jobIds) => {
+					let failedCount = 0;
+					let firstError: unknown;
+					for (
+						let index = 0;
+						index < jobIds.length;
+						index += BULK_RETRY_CONCURRENCY
+					) {
+						const results = await Promise.allSettled(
+							jobIds
+								.slice(index, index + BULK_RETRY_CONCURRENCY)
+								.map((jobId) => orpc.jobs.retry({ id: jobId })),
+						);
+						for (const result of results) {
+							if (result.status === "rejected") {
+								failedCount += 1;
+								if (firstError === undefined) {
+									firstError = result.reason;
+								}
+							}
+						}
+					}
+					await queryClient.invalidateQueries({
+						queryKey: jobsQueryKeys.all(),
+					});
+					if (failedCount > 0) {
+						toast.error(
+							`${failedCount} of ${jobIds.length} jobs failed to queue for retry`,
+						);
+						throw firstError instanceof Error
+							? firstError
+							: new Error("Failed to retry some jobs");
+					}
+					toast.success(`${jobIds.length} jobs queued for retry`);
 				}}
 				onCancel={async (jobId) => {
 					try {

--- a/packages/application/src/ports/search-service.ts
+++ b/packages/application/src/ports/search-service.ts
@@ -1,8 +1,11 @@
-import type { MediaSearchResponse } from "@solid-imager/core/domain/media/schemas";
+import type {
+	MediaSearchRequest,
+	MediaSearchResponse,
+} from "@solid-imager/core/domain/media/schemas";
 
 export type SearchOptions = {
 	tags?: string[];
-	sortBy?: string;
+	sortBy?: MediaSearchRequest["sort"];
 	order?: "asc" | "desc";
 	page?: number;
 	limit?: number;

--- a/packages/application/src/services/search-service.ts
+++ b/packages/application/src/services/search-service.ts
@@ -20,10 +20,16 @@ export class SearchServiceImpl {
 		const limit = searchOptions.limit || DEFAULT_PAGE_LIMIT;
 		const offset = searchOptions.page ? (searchOptions.page - 1) * limit : 0;
 
-		let sort: "date" | "name" | "size";
+		let sort: NonNullable<MediaSearchRequest["sort"]>;
 		switch (searchOptions.sortBy) {
+			case "date":
 			case "name":
 			case "size":
+			case "modifiedAt":
+			case "indexedAt":
+			case "resolution":
+			case "rating":
+			case "viewCount":
 				sort = searchOptions.sortBy;
 				break;
 			default:

--- a/packages/core/src/domain/media/schemas.ts
+++ b/packages/core/src/domain/media/schemas.ts
@@ -12,6 +12,19 @@ import { z } from "zod";
 export const mediaTypeSchema = z.enum(["image", "video", "audio"]);
 export type MediaType = z.infer<typeof mediaTypeSchema>;
 
+/** Sort keys supported by media collections and saved search presets. */
+export const mediaSortSchema = z.enum([
+	"date",
+	"modifiedAt",
+	"indexedAt",
+	"name",
+	"size",
+	"resolution",
+	"rating",
+	"viewCount",
+]);
+export type MediaSort = z.infer<typeof mediaSortSchema>;
+
 export const authorPlatformSchema = z.enum([
 	"twitter",
 	"pixiv-fanbox",
@@ -343,7 +356,7 @@ export const searchGroupSchema: z.ZodType<SearchGroup> = z.lazy(() =>
 
 export const mediaSearchRequestSchema = z.object({
 	condition: searchGroupSchema.optional(),
-	sort: z.enum(["date", "name", "size", "rating", "viewCount"]).optional(),
+	sort: mediaSortSchema.optional(),
 	order: z.enum(["asc", "desc"]).default("desc"),
 	limit: z.coerce.number().int().positive().optional(),
 	offset: z.coerce.number().int().nonnegative().default(0),
@@ -583,7 +596,7 @@ export const presetSchema = z.object({
 	// Note: searchGroupSchema is lazy, so we use it directly.
 	// The database stores JSONB, so we validate it against the structure.
 	value: searchGroupSchema,
-	sort: z.enum(["date", "name", "size", "rating", "viewCount"]).optional(),
+	sort: mediaSortSchema.optional(),
 	order: z.enum(["asc", "desc"]).optional(),
 	mode: z.enum(["simple", "pro"]).optional(),
 	createdAt: z.coerce.date(),
@@ -594,7 +607,7 @@ export type Preset = z.infer<typeof presetSchema>;
 export const createPresetRequestSchema = z.object({
 	name: z.string().min(1, "Name is required"),
 	value: searchGroupSchema,
-	sort: z.enum(["date", "name", "size", "rating", "viewCount"]).optional(),
+	sort: mediaSortSchema.optional(),
 	order: z.enum(["asc", "desc"]).optional(),
 	mode: z.enum(["simple", "pro"]).optional(),
 });
@@ -604,7 +617,7 @@ export type CreatePresetRequest = z.infer<typeof createPresetRequestSchema>;
 export const updatePresetRequestSchema = z.object({
 	name: z.string().min(1, "Name is required").optional(),
 	value: searchGroupSchema.optional(),
-	sort: z.enum(["date", "name", "size", "rating", "viewCount"]).optional(),
+	sort: mediaSortSchema.optional(),
 	order: z.enum(["asc", "desc"]).optional(),
 	mode: z.enum(["simple", "pro"]).optional(),
 });

--- a/packages/core/src/domain/search/schema.ts
+++ b/packages/core/src/domain/search/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { searchGroupSchema } from "@/domain/media/schemas";
+import { mediaSortSchema, searchGroupSchema } from "@/domain/media/schemas";
 
 export const searchStateSchema = z.object({
 	// Modes
@@ -29,7 +29,7 @@ export const searchStateSchema = z.object({
 	offset: z.number(),
 
 	// Sorting
-	sortBy: z.enum(["date", "name", "size", "rating", "viewCount"]),
+	sortBy: mediaSortSchema,
 	sortOrder: z.enum(["asc", "desc"]),
 
 	// Scroll Position

--- a/packages/db/src/repositories/media-repository-utils.ts
+++ b/packages/db/src/repositories/media-repository-utils.ts
@@ -1,4 +1,5 @@
 import { UnexpectedError } from "@solid-imager/core/domain/errors";
+import type { MediaSort } from "@solid-imager/core/domain/media/schemas";
 import {
 	and,
 	asc,
@@ -36,7 +37,7 @@ type SearchOptions = {
 	projects?: string[];
 	ips?: string[];
 	characters?: string[];
-	sort?: "date" | "name" | "size";
+	sort?: Exclude<MediaSort, "rating" | "viewCount">;
 	order?: "asc" | "desc";
 	limit?: number;
 	offset?: number;
@@ -97,17 +98,27 @@ function buildWhereClause(
 }
 
 function buildOrderByClause(
-	sort?: "date" | "name" | "size",
+	sort?: Exclude<MediaSort, "rating" | "viewCount">,
 	order: "asc" | "desc" = "desc",
 ): SQL {
 	if (sort === "date") {
 		return order === "asc" ? asc(medias.createdAt) : desc(medias.createdAt);
+	}
+	if (sort === "modifiedAt") {
+		return order === "asc" ? asc(medias.modifiedAt) : desc(medias.modifiedAt);
+	}
+	if (sort === "indexedAt") {
+		return order === "asc" ? asc(medias.indexedAt) : desc(medias.indexedAt);
 	}
 	if (sort === "name") {
 		return order === "asc" ? asc(medias.fileName) : desc(medias.fileName);
 	}
 	if (sort === "size") {
 		return order === "asc" ? asc(medias.fileSize) : desc(medias.fileSize);
+	}
+	if (sort === "resolution") {
+		const resolution = sql`(${medias.width} * ${medias.height})`;
+		return order === "asc" ? asc(resolution) : desc(resolution);
 	}
 	return desc(medias.createdAt);
 }

--- a/packages/db/src/repositories/media-repository.ts
+++ b/packages/db/src/repositories/media-repository.ts
@@ -18,6 +18,7 @@ import {
 	type MediaGenerationInfo,
 	type MediaSearchRequest,
 	type MediaSearchResponse,
+	type MediaSort,
 	type MediaTag,
 	type MediaUrl,
 	mediaSearchResponseSchema,
@@ -572,7 +573,7 @@ function makeBuildSearchQuery(getExecutor: (tx?: unknown) => DrizzleExecutor) {
 	return buildSearchQueryInner;
 }
 
-function getOrderByClause(sort: string | undefined, order: "asc" | "desc") {
+function getOrderByClause(sort: MediaSort | undefined, order: "asc" | "desc") {
 	const direction = order === "asc" ? asc : desc;
 
 	if (!sort) {
@@ -580,10 +581,16 @@ function getOrderByClause(sort: string | undefined, order: "asc" | "desc") {
 	}
 
 	switch (sort) {
+		case "modifiedAt":
+			return direction(medias.modifiedAt);
+		case "indexedAt":
+			return direction(medias.indexedAt);
 		case "name":
 			return direction(medias.fileName);
 		case "size":
 			return direction(medias.fileSize);
+		case "resolution":
+			return direction(sql`(${medias.width} * ${medias.height})`);
 		case "date":
 			return direction(medias.createdAt);
 		case "rating":

--- a/packages/ui/src/preset-client.ts
+++ b/packages/ui/src/preset-client.ts
@@ -1,5 +1,8 @@
 import type { PresetOrpcLike } from "@solid-imager/core/domain/contract/presets-client";
-import type { SearchGroup } from "@solid-imager/core/domain/media/schemas";
+import type {
+	MediaSort,
+	SearchGroup,
+} from "@solid-imager/core/domain/media/schemas";
 
 export type { PresetOrpcLike } from "@solid-imager/core/domain/contract/presets-client";
 
@@ -11,7 +14,7 @@ export function createPresetClient(orpc: PresetOrpcLike) {
 		create: async (data: {
 			name: string;
 			value: SearchGroup;
-			sort?: "name" | "date" | "rating" | "viewCount" | "size";
+			sort?: MediaSort;
 			order?: "asc" | "desc";
 			mode?: "simple" | "pro";
 		}) => await orpc.presets.create(data),
@@ -20,7 +23,7 @@ export function createPresetClient(orpc: PresetOrpcLike) {
 			data: {
 				name?: string;
 				value?: SearchGroup;
-				sort?: "name" | "date" | "rating" | "viewCount" | "size";
+				sort?: MediaSort;
 				order?: "asc" | "desc";
 				mode?: "simple" | "pro";
 			},

--- a/packages/ui/src/preset-manager.tsx
+++ b/packages/ui/src/preset-manager.tsx
@@ -1,4 +1,5 @@
 import {
+	type MediaSort,
 	type Preset,
 	type SearchGroup,
 	searchGroupSchema,
@@ -52,7 +53,7 @@ export interface PresetManagerClient {
 	create(data: {
 		name: string;
 		value: SearchGroup;
-		sort?: "name" | "date" | "rating" | "viewCount" | "size";
+		sort?: MediaSort;
 		order?: "asc" | "desc";
 		mode?: "simple" | "pro";
 	}): Promise<unknown>;

--- a/packages/ui/src/screens/v2-jobs-screen.tsx
+++ b/packages/ui/src/screens/v2-jobs-screen.tsx
@@ -17,7 +17,15 @@ import { createMemo, createSignal, For, Match, Show, Switch } from "solid-js";
 import { EmptyState, ErrorState, OfflineState } from "../async-state";
 import { Badge } from "../badge";
 import { Button } from "../button";
+import { Checkbox, CheckboxControl, CheckboxLabel } from "../checkbox";
 import type { QueryUiState } from "../query-state";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../select";
 import { LoadingRegion } from "../skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../tabs";
 import {
@@ -25,6 +33,11 @@ import {
 	V2CategoryLabel,
 	V2ManagementHeader,
 } from "../v2/management-layout";
+import {
+	getRetryableJobIds,
+	toggleAllJobSelection,
+	toggleJobSelection,
+} from "./v2-jobs-selection";
 import { formatDate } from "./v2-manager/utils";
 
 const JOB_FILTERS = [
@@ -71,11 +84,19 @@ export type V2JobsScreenProps = {
 	jobs: Accessor<JobDto[]>;
 	onRefresh: () => void | Promise<void>;
 	onRetry: (jobId: string) => void | Promise<void>;
+	onRetryMany: (jobIds: string[]) => void | Promise<void>;
 	onCancel: (jobId: string) => void | Promise<void>;
 	onDownload: (job: JobDto) => void | Promise<void>;
 	page: Accessor<V2JobsPagination>;
 	state: Accessor<QueryUiState<JobListResponse>>;
 };
+
+const JOB_BULK_ACTIONS = ["retry"] as const;
+type JobBulkAction = (typeof JOB_BULK_ACTIONS)[number];
+
+function jobBulkActionLabel(action: JobBulkAction): string {
+	return action === "retry" ? "Retry failed jobs" : action;
+}
 
 function jobTypeLabel(type: string): string {
 	return type
@@ -161,17 +182,22 @@ function JobProgress(props: { progress: JobDto["progress"] }) {
 function JobsTable(props: {
 	jobs: JobDto[];
 	onSelect: (job: JobDto) => void;
+	onToggleSelect: (jobId: string) => void;
 	selectedJobId: string | null;
+	selectedJobIds: ReadonlySet<string>;
 }) {
 	return (
 		<div class="overflow-hidden rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface)]">
 			<div class="overflow-x-auto">
-				<table class="w-full min-w-[48rem] text-left text-sm">
+				<table class="w-full min-w-[50rem] text-left text-sm">
 					<caption class="sr-only">
 						ジョブの一覧。{props.jobs.length}件。
 					</caption>
 					<thead class="border-[var(--v2-border)] border-b bg-[var(--v2-surface-muted)] text-xs uppercase tracking-wide">
 						<tr>
+							<th class="w-12 px-2 py-3 font-medium" scope="col">
+								<span class="sr-only">Select</span>
+							</th>
 							<th class="px-4 py-3 font-medium" scope="col">
 								Type
 							</th>
@@ -197,6 +223,30 @@ function JobsTable(props: {
 									}
 									data-selected={props.selectedJobId === job.id}
 								>
+									<td class="px-2 py-2">
+										<Show
+											fallback={
+												<span
+													aria-hidden="true"
+													class="block text-center text-[var(--v2-text-muted)]"
+												>
+													—
+												</span>
+											}
+											when={job.status === "failed"}
+										>
+											<Checkbox
+												checked={props.selectedJobIds.has(job.id)}
+												class="flex min-h-11 items-center justify-center sm:min-h-9"
+												onChange={() => props.onToggleSelect(job.id)}
+											>
+												<CheckboxControl class="border-[var(--v2-border-strong)] bg-[var(--v2-surface)] data-[checked]:border-[var(--v2-primary)] data-[checked]:bg-[var(--v2-primary)]" />
+												<CheckboxLabel class="sr-only">
+													Select {jobTypeLabel(job.type)} job
+												</CheckboxLabel>
+											</Checkbox>
+										</Show>
+									</td>
 									<td class="px-2 py-2">
 										<button
 											aria-pressed={props.selectedJobId === job.id}
@@ -224,6 +274,81 @@ function JobsTable(props: {
 						</For>
 					</tbody>
 				</table>
+			</div>
+		</div>
+	);
+}
+
+function JobsBulkActions(props: {
+	action: JobBulkAction | null;
+	allSelected: boolean;
+	hasSelection: boolean;
+	isApplying: boolean;
+	onActionChange: (action: JobBulkAction | null) => void;
+	onApply: () => void | Promise<void>;
+	onToggleAll: () => void;
+	selectableCount: number;
+	selectedCount: number;
+}) {
+	return (
+		<div class="mb-3 flex flex-col gap-3 rounded-md border border-[var(--v2-border)] bg-[var(--v2-surface)] p-3 sm:flex-row sm:items-center sm:justify-between">
+			<div class="flex flex-wrap items-center gap-3">
+				<Checkbox
+					checked={props.allSelected}
+					class="flex min-h-11 items-center gap-2 sm:min-h-9"
+					indeterminate={props.hasSelection && !props.allSelected}
+					onChange={props.onToggleAll}
+				>
+					<CheckboxControl class="border-[var(--v2-border-strong)] bg-[var(--v2-surface)] data-[checked]:border-[var(--v2-primary)] data-[checked]:bg-[var(--v2-primary)]" />
+					<CheckboxLabel class="font-medium text-xs text-[var(--v2-text-secondary)]">
+						{props.allSelected
+							? "Clear failed selection"
+							: "Select all failed jobs"}
+					</CheckboxLabel>
+				</Checkbox>
+				<span aria-live="polite" class="text-xs text-[var(--v2-text-muted)]">
+					{props.selectedCount.toLocaleString()} of{" "}
+					{props.selectableCount.toLocaleString()} failed jobs selected
+				</span>
+			</div>
+			<div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+				<Select<JobBulkAction>
+					itemComponent={(selectProps) => (
+						<SelectItem item={selectProps.item}>
+							{jobBulkActionLabel(selectProps.item.rawValue)}
+						</SelectItem>
+					)}
+					onChange={props.onActionChange}
+					options={[...JOB_BULK_ACTIONS]}
+					placeholder="Choose action"
+					value={props.action}
+				>
+					<SelectTrigger
+						aria-label="Bulk job action"
+						class="w-full bg-[var(--v2-surface)] sm:min-h-9 sm:w-52"
+						disabled={props.isApplying || !props.hasSelection}
+					>
+						<SelectValue<JobBulkAction>>
+							{(state) => {
+								const action = state.selectedOption();
+								return action ? jobBulkActionLabel(action) : "Choose action";
+							}}
+						</SelectValue>
+					</SelectTrigger>
+					<SelectContent />
+				</Select>
+				<Button
+					aria-busy={props.isApplying}
+					class="min-h-11 sm:min-h-9"
+					disabled={
+						props.isApplying || !props.hasSelection || props.action === null
+					}
+					onClick={() => void props.onApply()}
+					size="sm"
+				>
+					<RotateCcw aria-hidden="true" size={14} />
+					{props.isApplying ? "Retrying..." : "Apply"}
+				</Button>
 			</div>
 		</div>
 	);
@@ -474,6 +599,11 @@ function JobsInspector(props: {
 export function V2JobsScreen(props: V2JobsScreenProps) {
 	const [activeFilter, setActiveFilter] = createSignal<JobFilter>("all");
 	const [selectedJobId, setSelectedJobId] = createSignal<string | null>(null);
+	const [selectedJobIds, setSelectedJobIds] = createSignal<Set<string>>(
+		new Set(),
+	);
+	const [bulkAction, setBulkAction] = createSignal<JobBulkAction | null>(null);
+	const [isApplyingBulkAction, setIsApplyingBulkAction] = createSignal(false);
 
 	const selectedJob = createMemo(() =>
 		props.jobs().find((job) => job.id === selectedJobId()),
@@ -495,6 +625,38 @@ export function V2JobsScreen(props: V2JobsScreenProps) {
 				return jobs;
 		}
 	});
+	const retryableJobIds = createMemo(() => getRetryableJobIds(filteredJobs()));
+	const selectedRetryableJobIds = createMemo(() =>
+		retryableJobIds().filter((jobId) => selectedJobIds().has(jobId)),
+	);
+	const clearBulkSelection = () => {
+		setSelectedJobIds(new Set<string>());
+		setBulkAction(null);
+	};
+	const toggleJob = (jobId: string) => {
+		setSelectedJobIds((current) => toggleJobSelection(current, jobId));
+	};
+	const toggleAllJobs = () => {
+		setSelectedJobIds((current) =>
+			toggleAllJobSelection(current, retryableJobIds()),
+		);
+	};
+	const applyBulkAction = async () => {
+		const action = bulkAction();
+		const jobIds = selectedRetryableJobIds();
+		if (action !== "retry" || jobIds.length === 0 || isApplyingBulkAction()) {
+			return;
+		}
+		setIsApplyingBulkAction(true);
+		try {
+			await props.onRetryMany(jobIds);
+			clearBulkSelection();
+		} catch {
+			// The route reports mutation failures; keep any remaining selection visible.
+		} finally {
+			setIsApplyingBulkAction(false);
+		}
+	};
 	const refresh = async () => {
 		await props.onRefresh();
 	};
@@ -530,7 +692,10 @@ export function V2JobsScreen(props: V2JobsScreenProps) {
 			<div class="grid min-h-0 flex-1 xl:grid-cols-[minmax(0,1fr)_22rem]">
 				<div class="min-h-0 overflow-y-auto overscroll-contain px-3 py-4 sm:px-4 lg:px-6 lg:py-5 xl:px-8 [scrollbar-gutter:stable]">
 					<Tabs
-						onChange={(value) => setActiveFilter(value as JobFilter)}
+						onChange={(value) => {
+							setActiveFilter(value as JobFilter);
+							clearBulkSelection();
+						}}
 						value={activeFilter()}
 					>
 						<div class="grid gap-6 lg:grid-cols-[12rem_minmax(0,1fr)] xl:gap-8">
@@ -595,10 +760,30 @@ export function V2JobsScreen(props: V2JobsScreenProps) {
 														}
 														when={filteredJobs().length > 0}
 													>
+														<Show when={retryableJobIds().length > 0}>
+															<JobsBulkActions
+																action={bulkAction()}
+																allSelected={
+																	selectedRetryableJobIds().length ===
+																	retryableJobIds().length
+																}
+																hasSelection={
+																	selectedRetryableJobIds().length > 0
+																}
+																isApplying={isApplyingBulkAction()}
+																onActionChange={setBulkAction}
+																onApply={applyBulkAction}
+																onToggleAll={toggleAllJobs}
+																selectableCount={retryableJobIds().length}
+																selectedCount={selectedRetryableJobIds().length}
+															/>
+														</Show>
 														<JobsTable
 															jobs={filteredJobs()}
 															onSelect={(job) => setSelectedJobId(job.id)}
+															onToggleSelect={toggleJob}
 															selectedJobId={selectedJobId()}
+															selectedJobIds={selectedJobIds()}
 														/>
 														<Show when={props.state().data?.total}>
 															{(total) => (
@@ -634,6 +819,7 @@ export function V2JobsScreen(props: V2JobsScreenProps) {
 																}
 																onClick={() => {
 																	if (props.page().canPrevious) {
+																		clearBulkSelection();
 																		props.page().onPrevious();
 																	}
 																}}
@@ -657,6 +843,7 @@ export function V2JobsScreen(props: V2JobsScreenProps) {
 																}
 																onClick={() => {
 																	if (props.page().canNext) {
+																		clearBulkSelection();
 																		props.page().onNext();
 																	}
 																}}

--- a/packages/ui/src/screens/v2-jobs-selection.test.ts
+++ b/packages/ui/src/screens/v2-jobs-selection.test.ts
@@ -1,0 +1,55 @@
+import type { JobDto } from "@solid-imager/core/domain/jobs/schemas";
+import { describe, expect, it } from "vitest";
+import {
+	getRetryableJobIds,
+	toggleAllJobSelection,
+	toggleJobSelection,
+} from "./v2-jobs-selection";
+
+const jobs: Pick<JobDto, "id" | "status">[] = [
+	{
+		id: "00000000-0000-4000-8000-000000000001",
+		status: "failed",
+	},
+	{
+		id: "00000000-0000-4000-8000-000000000002",
+		status: "completed",
+	},
+	{
+		id: "00000000-0000-4000-8000-000000000003",
+		status: "failed",
+	},
+];
+
+describe("job selection helpers", () => {
+	it("returns only failed job ids", () => {
+		expect(getRetryableJobIds(jobs)).toEqual([
+			"00000000-0000-4000-8000-000000000001",
+			"00000000-0000-4000-8000-000000000003",
+		]);
+	});
+
+	it("toggles an individual job", () => {
+		const selected = new Set(["00000000-0000-4000-8000-000000000001"]);
+
+		expect(
+			toggleJobSelection(selected, "00000000-0000-4000-8000-000000000003"),
+		).toEqual(
+			new Set([
+				"00000000-0000-4000-8000-000000000001",
+				"00000000-0000-4000-8000-000000000003",
+			]),
+		);
+		expect(
+			toggleJobSelection(selected, "00000000-0000-4000-8000-000000000001"),
+		).toEqual(new Set());
+	});
+
+	it("selects all retryable jobs and clears them on the next toggle", () => {
+		const retryableJobIds = getRetryableJobIds(jobs);
+		const selected = toggleAllJobSelection(new Set(), retryableJobIds);
+
+		expect(selected).toEqual(new Set(retryableJobIds));
+		expect(toggleAllJobSelection(selected, retryableJobIds)).toEqual(new Set());
+	});
+});

--- a/packages/ui/src/screens/v2-jobs-selection.ts
+++ b/packages/ui/src/screens/v2-jobs-selection.ts
@@ -1,0 +1,40 @@
+import type { JobDto } from "@solid-imager/core/domain/jobs/schemas";
+
+type JobSelectionCandidate = Pick<JobDto, "id" | "status">;
+
+export function getRetryableJobIds(
+	jobs: readonly JobSelectionCandidate[],
+): string[] {
+	return jobs.filter((job) => job.status === "failed").map((job) => job.id);
+}
+
+export function toggleJobSelection(
+	selectedJobIds: ReadonlySet<string>,
+	jobId: string,
+): Set<string> {
+	const nextSelectedJobIds = new Set(selectedJobIds);
+	if (nextSelectedJobIds.has(jobId)) {
+		nextSelectedJobIds.delete(jobId);
+	} else {
+		nextSelectedJobIds.add(jobId);
+	}
+	return nextSelectedJobIds;
+}
+
+export function toggleAllJobSelection(
+	selectedJobIds: ReadonlySet<string>,
+	retryableJobIds: readonly string[],
+): Set<string> {
+	const allRetryableJobsSelected =
+		retryableJobIds.length > 0 &&
+		retryableJobIds.every((jobId) => selectedJobIds.has(jobId));
+
+	if (allRetryableJobsSelected) {
+		const retryableJobIdSet = new Set(retryableJobIds);
+		return new Set(
+			[...selectedJobIds].filter((jobId) => !retryableJobIdSet.has(jobId)),
+		);
+	}
+
+	return new Set([...selectedJobIds, ...retryableJobIds]);
+}

--- a/packages/ui/src/sort-controls.tsx
+++ b/packages/ui/src/sort-controls.tsx
@@ -1,3 +1,4 @@
+import type { MediaSort } from "@solid-imager/core/domain/media/schemas";
 import { Show } from "solid-js";
 import { Button } from "./button";
 import { Input } from "./input";
@@ -11,9 +12,18 @@ import {
 } from "./select";
 import { parseSelectValue } from "./utils/parse-select-value";
 
-const SORT_OPTIONS = ["date", "name", "size", "rating", "viewCount"] as const;
+export const SORT_OPTIONS = [
+	"date",
+	"modifiedAt",
+	"indexedAt",
+	"size",
+	"resolution",
+	"name",
+	"rating",
+	"viewCount",
+] as const satisfies readonly MediaSort[];
 
-export type SortOption = "date" | "name" | "size" | "rating" | "viewCount";
+export type SortOption = (typeof SORT_OPTIONS)[number];
 
 type SortControlsProps = {
 	sortBy: SortOption;
@@ -28,15 +38,24 @@ type SortControlsProps = {
 	className?: string;
 };
 
-function getSortLabel(value: SortOption) {
+export function getSortLabel(value: SortOption) {
 	if (value === "date") {
-		return "作成日";
+		return "ファイル作成日時";
+	}
+	if (value === "modifiedAt") {
+		return "更新日時";
+	}
+	if (value === "indexedAt") {
+		return "登録日時";
 	}
 	if (value === "name") {
-		return "ファイル名";
+		return "名前";
 	}
 	if (value === "size") {
-		return "サイズ";
+		return "ファイルサイズ";
+	}
+	if (value === "resolution") {
+		return "解像度";
 	}
 	if (value === "rating") {
 		return "評価";
@@ -54,7 +73,13 @@ export function SortControls(props: SortControlsProps) {
 						disabled={Boolean(props.similarityAnchorMediaId)}
 						itemComponent={(itemProps) => (
 							<SelectItem item={itemProps.item}>
-								{getSortLabel(itemProps.item.rawValue as SortOption)}
+								{getSortLabel(
+									parseSelectValue(
+										itemProps.item.rawValue,
+										SORT_OPTIONS,
+										"date",
+									),
+								)}
 							</SelectItem>
 						)}
 						onChange={(value) =>
@@ -62,7 +87,7 @@ export function SortControls(props: SortControlsProps) {
 								parseSelectValue(value, SORT_OPTIONS, "date"),
 							)
 						}
-						options={["date", "name", "size", "rating", "viewCount"]}
+						options={[...SORT_OPTIONS]}
 						placeholder="項目"
 						value={props.sortBy}
 					>

--- a/packages/ui/src/v2/search-toolbar.tsx
+++ b/packages/ui/src/v2/search-toolbar.tsx
@@ -12,7 +12,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "../popover";
 import type { PresetManagerClient } from "../search-control-panel";
 import { SearchControlPanel } from "../search-control-panel";
 import { createAppShortcut } from "../shortcuts/create-app-shortcut";
-import { SortControls } from "../sort-controls";
+import { getSortLabel, SortControls } from "../sort-controls";
 import type { SourceMediaViewMode } from "../source-media-grid";
 import {
 	clearPresetFilters,
@@ -187,14 +187,7 @@ function sortLabel(state: SearchState): string {
 	if (state.similarityAnchorMediaId) {
 		return `類似度順・${state.similarityTopK}件`;
 	}
-	const labels: Record<SearchState["sortBy"], string> = {
-		date: "作成日",
-		name: "名前",
-		rating: "評価",
-		size: "サイズ",
-		viewCount: "閲覧数",
-	};
-	const field = labels[state.sortBy];
+	const field = getSortLabel(state.sortBy);
 	return `${field}・${state.sortOrder === "desc" ? "降順" : "昇順"}`;
 }
 


### PR DESCRIPTION
## 概要

メディア一覧と検索結果で、ファイル作成日時・管理用の更新日時・登録日時・ファイルサイズ・解像度による並べ替えを追加します。

## 変更内容

- 作成日時、更新日時、登録日時、ファイルサイズ、解像度のソートキーを追加
- 解像度は幅×高さの総画素数でソート
- 検索スキーマ、プリセット、セッション状態、OpenAPI仕様を同期
- 共有UIの並べ替えコントロールを拡張
- 各ソート条件のintegration testを追加

## 検証

- 全パッケージのtypecheck
- server unit test: 198件
- core test: 14件
- ui test: 101件
- design lint、OpenAPI JSON検証、差分チェック