### PR TITLE
feat(search): add similarity search from media lists

### DIFF
--- a/apps/server/src/routes/search.tsx
+++ b/apps/server/src/routes/search.tsx
@@ -7,6 +7,7 @@ import { RouteDataPendingScreen } from "@solid-imager/ui/router-status";
 import { SearchScreen } from "@solid-imager/ui/screens/search-screen";
 import { createSearchHistoryClient } from "@solid-imager/ui/search-history-client";
 import { searchHistoryQuerySchema } from "@solid-imager/ui/search-history-route";
+import { activateSimilaritySearch } from "@solid-imager/ui/stores/search-store";
 import { createFileRoute } from "@tanstack/solid-router";
 import { createSignal, onMount, Show } from "solid-js";
 import { LegacyMediaGridItem } from "~/components/media/legacy-media-grid-item";
@@ -146,6 +147,7 @@ function SearchRoute() {
 		<SearchScreen
 			enableVirtualization
 			filterData={page.filterData}
+			onFindSimilar={(media) => activateSimilaritySearch(media.id)}
 			onSelectSource={(id) => setSearchState("selectedSource", id)}
 			page={page}
 			presetClient={PresetClient}

--- a/apps/server/src/routes/sources/$mediaSourceId/components/legacy-source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/legacy-source-media-page.tsx
@@ -1,5 +1,7 @@
 import { SourceMediaScreen } from "@solid-imager/ui/screens/source-media-screen";
 import { createSearchHistoryClient } from "@solid-imager/ui/search-history-client";
+import { activateSimilaritySearch } from "@solid-imager/ui/stores/search-store";
+import { useNavigate } from "@tanstack/solid-router";
 import type { Accessor } from "solid-js";
 import { LegacyMediaGridItem } from "~/components/media/legacy-media-grid-item";
 import { UploadMediaModal } from "~/components/upload-media-modal";
@@ -11,9 +13,15 @@ const SearchHistoryClient = createSearchHistoryClient(rawSearchHistoryClient);
 export function SourceMediaPage(
 	props: { mediaSourceId?: Accessor<string> } = {},
 ) {
+	const navigate = useNavigate();
+
 	return (
 		<SourceMediaPageController
 			mediaSourceId={props.mediaSourceId}
+			onFindSimilar={(media) => {
+				activateSimilaritySearch(media.id);
+				void navigate({ to: "/search" });
+			}}
 			persistenceSurface="legacy"
 			searchHistoryClient={SearchHistoryClient}
 			bulkActionsClass="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] left-1/2 z-50 flex w-[calc(100%-2rem)] max-w-md -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-2xl border border-primary/20 bg-background/95 px-3 py-3 shadow-lg backdrop-blur sm:bottom-[calc(1.5rem+env(safe-area-inset-bottom))] sm:w-auto sm:max-w-none sm:flex-nowrap sm:gap-4 sm:rounded-full sm:px-6"

--- a/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -66,6 +66,7 @@ export type SourceMediaPageControllerProps = {
 	scrollContainerSelector?: Accessor<string>;
 	onOpenMediaDetail?: SourceMediaScreenProps["onOpenMediaDetail"];
 	onPrepareMediaDetail?: SourceMediaScreenProps["onPrepareMediaDetail"];
+	onFindSimilar?: SourceMediaScreenProps["onFindSimilar"];
 	renderMediaPreview?: SourceMediaScreenProps["renderMediaPreview"];
 };
 
@@ -192,6 +193,7 @@ export function SourceMediaPageController(
 				}
 				onOpenMediaDetail={props.onOpenMediaDetail}
 				onPrepareMediaDetail={props.onPrepareMediaDetail}
+				onFindSimilar={props.onFindSimilar}
 				renderMediaPreview={props.renderMediaPreview}
 				moveCopyDialogComponent={MoveCopyMediaDialog}
 				uploadModalComponent={props.uploadModalComponent}

--- a/apps/server/src/routes/sources/$mediaSourceId/components/v2-source-media-page.tsx
+++ b/apps/server/src/routes/sources/$mediaSourceId/components/v2-source-media-page.tsx
@@ -1,5 +1,6 @@
 import { V2SourceMediaScreen } from "@solid-imager/ui/screens/v2-source-media-screen";
 import { createSearchHistoryClient } from "@solid-imager/ui/search-history-client";
+import { activateSimilaritySearch } from "@solid-imager/ui/stores/search-store";
 import { useLocation, useNavigate } from "@tanstack/solid-router";
 import type { Accessor } from "solid-js";
 import { ThumbnailImage } from "~/components/media/thumbnail-image";
@@ -43,10 +44,17 @@ export function V2SourceMediaPage(props: { mediaSourceId?: Accessor<string> }) {
 			rememberReturnPath(location().href);
 			saveV2MediaContext(location().href, context ?? [media]);
 		};
+	const onFindSimilar: SourceMediaPageControllerProps["onFindSimilar"] = (
+		media,
+	) => {
+		activateSimilaritySearch(media.id, { surface: "v2" });
+		void navigate({ to: "/v2/search" });
+	};
 
 	return (
 		<SourceMediaPageController
 			mediaSourceId={props.mediaSourceId}
+			onFindSimilar={onFindSimilar}
 			onOpenMediaDetail={onOpenMediaDetail}
 			onPrepareMediaDetail={onPrepareMediaDetail}
 			persistenceSurface="v2"

--- a/apps/server/src/routes/v2/components/v2-search-content.tsx
+++ b/apps/server/src/routes/v2/components/v2-search-content.tsx
@@ -19,6 +19,7 @@ import { useSearchPage } from "@solid-imager/ui/hooks/use-search-page";
 import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { V2SearchScreen } from "@solid-imager/ui/screens/v2-search-screen";
 import { createSearchHistoryClient } from "@solid-imager/ui/search-history-client";
+import { activateSimilaritySearch } from "@solid-imager/ui/stores/search-store";
 import { toast } from "@solid-imager/ui/toast";
 import { useLocation, useNavigate } from "@tanstack/solid-router";
 import { createSignal } from "solid-js";
@@ -225,6 +226,9 @@ export default function V2SearchContent() {
 				onClearSelection={clearSelection}
 				onCopyMove={handleCopyMove}
 				onDelete={handleDelete}
+				onFindSimilar={(media) =>
+					activateSimilaritySearch(media.id, { surface: "v2" })
+				}
 				onSelectAll={() => {
 					setIsBulkSelectMode(true);
 					selection.selectAll();

--- a/apps/server/src/tests/e2e/ccip-flow.spec.ts
+++ b/apps/server/src/tests/e2e/ccip-flow.spec.ts
@@ -4,8 +4,9 @@ import {
 	E2E_SIMILAR_FILE_NAME,
 	E2E_SIMILAR_MEDIA_ID,
 	mediaPath,
+	sourcePath,
 } from "./support/fixture";
-import { expect, test } from "./support/test";
+import { expect, test, waitForAppHydration } from "./support/test";
 
 const startCcipExtractionEndpoint =
 	/\/api\/rpc\/ai\/startCcipExtraction(?:\?|$)/;
@@ -132,4 +133,25 @@ test("extracts real CCIP vectors and finds a similar seeded image", async ({
 	await expect(
 		page.getByRole("link", { name: new RegExp(E2E_PRIMARY_FILE_NAME) }),
 	).toHaveCount(0);
+
+	await page.goto(sourcePath());
+	await waitForAppHydration(page);
+	await expect(page.getByText(/^\d+ 件の結果$/)).toBeVisible();
+	const primaryMedia = page.locator(
+		`[data-media-id="${E2E_PRIMARY_MEDIA_ID}"]`,
+	);
+	await expect(primaryMedia).toBeVisible();
+	await primaryMedia.click({ button: "right" });
+	const directSearchResponse = page.waitForResponse(
+		(response) =>
+			new URL(response.url()).pathname === "/api/rpc/media/searchSimilar" &&
+			response.status() === 200,
+		{ timeout: 30_000 },
+	);
+	await page.getByRole("menuitem", { name: "類似度検索", exact: true }).click();
+	await directSearchResponse;
+	await expect(page).toHaveURL(/\/search(?:\?.*)?$/);
+	await expect(
+		page.getByRole("link", { name: new RegExp(E2E_SIMILAR_FILE_NAME) }),
+	).toBeVisible({ timeout: 30_000 });
 });

--- a/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
+++ b/apps/server/src/tests/e2e/sources-source-media.responsive.spec.ts
@@ -265,5 +265,8 @@ for (const route of [
 
 		await expectRouteHealthy(page);
 		await expect(page.getByRole("menu")).toBeVisible();
+		await expect(
+			page.getByRole("menuitem", { name: "類似度検索", exact: true }),
+		).toBeVisible();
 	});
 }

--- a/apps/tauri/src/routes/search.tsx
+++ b/apps/tauri/src/routes/search.tsx
@@ -6,6 +6,7 @@ import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { SearchScreen } from "@solid-imager/ui/screens/search-screen";
 import { createSearchHistoryClient } from "@solid-imager/ui/search-history-client";
 import { searchHistoryQuerySchema } from "@solid-imager/ui/search-history-route";
+import { activateSimilaritySearch } from "@solid-imager/ui/stores/search-store";
 import { createFileRoute } from "@tanstack/solid-router";
 import { MediaGridItem } from "~/components/media/media-grid-item";
 import { useMediaSourceEvents } from "~/hooks/use-media-source-events";
@@ -99,6 +100,7 @@ function SearchRoute() {
 		<SearchScreen
 			enableVirtualization
 			filterData={page.filterData}
+			onFindSimilar={(media) => activateSimilaritySearch(media.id)}
 			onSelectSource={(id) => setSearchState("selectedSource", id)}
 			page={page}
 			presetClient={PresetClient}

--- a/apps/tauri/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
+++ b/apps/tauri/src/routes/sources/$mediaSourceId/components/source-media-page.tsx
@@ -3,7 +3,8 @@ import { createPresetClient } from "@solid-imager/ui/preset-client";
 import { SourceMediaScreen } from "@solid-imager/ui/screens/source-media-screen";
 import { createSearchHistoryClient } from "@solid-imager/ui/search-history-client";
 import { SourceMediaPage as SourceMediaPageComponent } from "@solid-imager/ui/source-media-page";
-import { useParams } from "@tanstack/solid-router";
+import { activateSimilaritySearch } from "@solid-imager/ui/stores/search-store";
+import { useNavigate, useParams } from "@tanstack/solid-router";
 import { MediaGridItem } from "~/components/media/media-grid-item";
 import { MoveCopyMediaDialog } from "~/components/media/move-copy-media-dialog";
 import { UploadMediaModal } from "~/components/upload-media-modal";
@@ -45,6 +46,7 @@ const searchHistoryClient = createSearchHistoryClient(rawSearchHistoryClient);
 
 export function SourceMediaPage() {
 	const params = useParams({ from: "/sources/$mediaSourceId/" });
+	const navigate = useNavigate();
 	const mediaSourceId = () => params().mediaSourceId;
 
 	const sourceRootPathResolver = useSourceRootPath(mediaSourcesQueryOptions);
@@ -74,6 +76,10 @@ export function SourceMediaPage() {
 				parseRestoreFile,
 			}}
 			getSearchCondition={getSearchCondition}
+			onFindSimilar={(media) => {
+				activateSimilaritySearch(media.id);
+				void navigate({ to: "/search" });
+			}}
 			sortBy={() => searchState.sortBy}
 			sortOrder={() => searchState.sortOrder}
 			onThumbnailReady={notifyThumbnailReady}

--- a/packages/ui/src/screens/search-screen.tsx
+++ b/packages/ui/src/screens/search-screen.tsx
@@ -112,13 +112,14 @@ export function SearchScreen(props: SearchScreenProps) {
 						when={canRenderContent()}
 					>
 						<SourceMediaGrid
-							disableContextMenu
+							disableContextMenu={!props.onFindSimilar}
 							enableVirtualization={props.enableVirtualization}
 							errorTitle="検索結果を取得できませんでした"
 							isFetchingNextPage={page().searchResultQuery.isFetchingNextPage}
 							mediaResults={page().searchResults}
 							mediaSourceId={() => undefined}
 							onLoadMore={page().fetchNextPage}
+							onFindSimilar={props.onFindSimilar}
 							onRetry={async () => {
 								await page().searchResultQuery.refetch();
 							}}

--- a/packages/ui/src/screens/search-screen.types.ts
+++ b/packages/ui/src/screens/search-screen.types.ts
@@ -24,6 +24,7 @@ export type SearchMediaItemOptions = {
 export type SearchWorkspaceProps = {
 	enableVirtualization?: boolean;
 	filterData: SearchPageFilterData;
+	onFindSimilar?: (media: Media) => void;
 	onSelectSource: (id: string) => void;
 	page: UseSearchPageResult;
 	presetClient: SourceMediaPagePresetClient;

--- a/packages/ui/src/screens/source-media-screen.tsx
+++ b/packages/ui/src/screens/source-media-screen.tsx
@@ -143,6 +143,7 @@ export function SourceMediaScreen(props: SourceMediaScreenProps) {
 							mediaSourceId={page().mediaSourceId}
 							onCopyMove={page().handleCopyMove}
 							onDelete={page().handleDelete}
+							onFindSimilar={props.onFindSimilar}
 							onLoadMore={() => page().fetchNextPage()}
 							onRetry={async () => {
 								await page().mediaQuery.refetch();

--- a/packages/ui/src/screens/source-media-screen.types.ts
+++ b/packages/ui/src/screens/source-media-screen.types.ts
@@ -23,6 +23,7 @@ export type SourceMediaScreenProps = {
 	onBulkAction?: () => void;
 	onClearSelection?: () => void;
 	onEnterBulkSelectMode?: () => void;
+	onFindSimilar?: (media: Media) => void;
 	onOpenMediaDetail?: (media: Media, context?: Media[]) => void;
 	onPrepareMediaDetail?: (media: Media, context?: Media[]) => void;
 	onRetryFilters: () => void | Promise<void>;

--- a/packages/ui/src/screens/v2-search-screen.tsx
+++ b/packages/ui/src/screens/v2-search-screen.tsx
@@ -179,6 +179,7 @@ export function V2SearchScreen(props: V2SearchScreenProps) {
 								onClearSelection={props.onClearSelection}
 								onCopyMove={props.onCopyMove}
 								onDelete={props.onDelete}
+								onFindSimilar={props.onFindSimilar}
 								onOpenMediaDetail={
 									props.onOpenMediaDetail ? openMediaDetail : undefined
 								}

--- a/packages/ui/src/screens/v2-source-media-screen.tsx
+++ b/packages/ui/src/screens/v2-source-media-screen.tsx
@@ -195,6 +195,7 @@ export function V2SourceMediaScreen(props: SourceMediaScreenProps) {
 								onClearSelection={props.onClearSelection}
 								onCopyMove={page().handleCopyMove}
 								onDelete={page().handleDelete}
+								onFindSimilar={props.onFindSimilar}
 								onLoadMore={() => page().fetchNextPage()}
 								onPreviewSelect={
 									props.renderMediaPreview ? selectPreviewMedia : undefined

--- a/packages/ui/src/source-media-grid.tsx
+++ b/packages/ui/src/source-media-grid.tsx
@@ -92,6 +92,7 @@ type SourceMediaGridProps = {
 	onDelete?: (mediaId: string) => void;
 	onCopyMove?: (mediaId: string, mode: "copy" | "move") => void;
 	onSyncSingleMedia?: (mediaId: string) => void;
+	onFindSimilar?: (media: Media) => void;
 	onToggleSelect?: (mediaId: string) => void;
 	isBulkSelectMode?: () => boolean;
 	isSelected?: (mediaId: string) => boolean;
@@ -173,6 +174,8 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 		const error = props.state().error;
 		return error instanceof Error ? error.message : "API接続に失敗しました";
 	};
+	const canFindSimilar = (media: Media) =>
+		props.onFindSimilar !== undefined && media.mediaType === "image";
 
 	// --- Virtual grid setup ---
 	const [windowWidth, setWindowWidth] = createSignal(0);
@@ -977,9 +980,10 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 			</table>
 		</div>
 	);
-	const hasContextMenuActions = () =>
+	const hasContextMenuActions = (media: Media) =>
 		Boolean(
 			props.onOpenMediaDetail ||
+				canFindSimilar(media) ||
 				props.onToggleSelect ||
 				props.onBulkAction ||
 				props.onClearSelection ||
@@ -1102,7 +1106,7 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 													{media.fileName}
 												</ContextMenuGroupLabel>
 												<ContextMenuSeparator />
-												<Show when={!hasContextMenuActions()}>
+												<Show when={!hasContextMenuActions(media)}>
 													<ContextMenuItem disabled>
 														利用できる操作はありません
 													</ContextMenuItem>
@@ -1122,6 +1126,13 @@ export function SourceMediaGrid(props: SourceMediaGridProps) {
 														onSelect={() => openMediaInNewTab(media)}
 													>
 														新しいタブで開く
+													</ContextMenuItem>
+												</Show>
+												<Show when={canFindSimilar(media)}>
+													<ContextMenuItem
+														onSelect={() => props.onFindSimilar?.(media)}
+													>
+														類似度検索
 													</ContextMenuItem>
 												</Show>
 												<Show when={props.onToggleSelect}>

--- a/packages/ui/src/source-media-page.tsx
+++ b/packages/ui/src/source-media-page.tsx
@@ -2,6 +2,7 @@ import type { Character } from "@solid-imager/core/domain/characters/schemas";
 import type { Ip } from "@solid-imager/core/domain/ips/schemas";
 import type {
 	Author,
+	Media,
 	MediaSearchRequest,
 } from "@solid-imager/core/domain/media/schemas";
 import type { Project } from "@solid-imager/core/domain/projects/schemas";
@@ -60,6 +61,7 @@ export type SourceMediaPageProps = {
 	renderMediaPreview?: SourceMediaScreenProps["renderMediaPreview"];
 	onOpenMediaDetail?: SourceMediaScreenProps["onOpenMediaDetail"];
 	onPrepareMediaDetail?: SourceMediaScreenProps["onPrepareMediaDetail"];
+	onFindSimilar?: (media: Media) => void;
 	showOpenInNewTab?: boolean;
 	onToggleSelect?: (mediaId: string) => void;
 	onSelectMedia?: (mediaId: string, mode: MediaCollectionSelectionMode) => void;
@@ -173,6 +175,7 @@ export function SourceMediaPage(props: SourceMediaPageProps): JSX.Element {
 			renderItem={props.renderItem}
 			onOpenMediaDetail={props.onOpenMediaDetail}
 			onPrepareMediaDetail={props.onPrepareMediaDetail}
+			onFindSimilar={props.onFindSimilar}
 			renderMediaPreview={props.renderMediaPreview}
 			moveCopyDialogComponent={props.moveCopyDialogComponent}
 			uploadModalComponent={props.uploadModalComponent}


### PR DESCRIPTION
## 概要

メディア一覧から画像を選択し、詳細画面を経由せず類似度検索を開始できるようにします。

## 変更内容

- 画像カード、V2の一覧行、検索結果のコンテキストメニューに「類似度検索」を追加
- V1、V2、Tauriの一覧画面から既存の類似検索状態と検索画面へ接続
- 検索結果からも同じ操作を利用可能に
- 一覧から検索結果表示までのE2Eを追加

## 技術詳細

- 画像メディアにのみ操作を表示
- V1は /search、V2は /v2/search へ遷移
- 既存の activateSimilaritySearch を再利用

## 検証

- bun run check
- packages/ui のテスト 101件
- 一覧から類似画像表示までのE2E確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 画像のコンテキストメニューから「類似度検索」を実行できるようになりました。
  - 選択した画像を基準に類似画像を検索し、検索結果画面へ移動できます。
  - Web版とデスクトップ版のソースメディア画面および検索画面で利用できます。

- **テスト**
  - 類似度検索メニューの表示、実行、検索結果への遷移を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->